### PR TITLE
feat(parser,converter,joiner): preserve input format in output

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,27 @@ OpenAPI Specification (OAS) tools for validation, parsing, converting, and joini
 - **Join** - Join multiple OpenAPI Specification documents
 - **Library** - Use as a Go library in your own applications
 
+## Format Preservation
+
+When converting or joining OpenAPI specifications, oastools automatically preserves the input file format:
+
+- **JSON input → JSON output**: If your source file is in JSON format, the converted or joined output will also be in JSON format
+- **YAML input → YAML output**: If your source file is in YAML format, the converted or joined output will also be in YAML format
+
+This ensures format consistency across your toolchain and makes it easier to maintain version-controlled API specifications.
+
+**Example:**
+```bash
+# Convert a JSON file - output will also be JSON
+oastools convert -t 3.0.3 swagger.json -o openapi.json
+
+# Convert a YAML file - output will also be YAML
+oastools convert -t 3.0.3 swagger.yaml -o openapi.yaml
+
+# Join JSON files - output will be JSON (format from first file)
+oastools join -o merged.json api1.json api2.json
+```
+
 ## Supported OpenAPI Specification Versions
 
 This tool supports all official OpenAPI Specification releases:

--- a/converter/converter.go
+++ b/converter/converter.go
@@ -31,6 +31,8 @@ type ConversionResult struct {
 	SourceVersion string
 	// SourceOASVersion is the enumerated source OAS version
 	SourceOASVersion parser.OASVersion
+	// SourceFormat is the format of the source file (JSON or YAML)
+	SourceFormat parser.SourceFormat
 	// TargetVersion is the target OAS version string
 	TargetVersion string
 	// TargetOASVersion is the enumerated target OAS version
@@ -135,6 +137,7 @@ func (c *Converter) ConvertParsed(parseResult parser.ParseResult, targetVersionS
 	result := &ConversionResult{
 		SourceVersion:    parseResult.Version,
 		SourceOASVersion: parseResult.OASVersion,
+		SourceFormat:     parseResult.SourceFormat,
 		TargetVersion:    targetVersionStr,
 		TargetOASVersion: targetVersion,
 		Issues:           make([]ConversionIssue, 0),

--- a/converter/converter_test.go
+++ b/converter/converter_test.go
@@ -819,3 +819,37 @@ func TestRefRewritingParameters(t *testing.T) {
 
 	t.Logf("Successfully verified parameter $ref rewriting")
 }
+
+// TestJSONFormatPreservation tests that JSON input produces JSON output
+func TestJSONFormatPreservation(t *testing.T) {
+	// Test with JSON file
+	c := New()
+	result, err := c.Convert("../testdata/minimal-oas2.json", "3.0.3")
+	if err != nil {
+		t.Fatalf("Conversion failed: %v", err)
+	}
+
+	// Verify source format was detected as JSON
+	if result.SourceFormat != parser.SourceFormatJSON {
+		t.Errorf("Expected source format to be JSON, got %s", result.SourceFormat)
+	}
+
+	t.Logf("Successfully verified JSON format detection")
+}
+
+// TestYAMLFormatPreservation tests that YAML input preserves YAML format
+func TestYAMLFormatPreservation(t *testing.T) {
+	// Test with YAML file
+	c := New()
+	result, err := c.Convert("../testdata/minimal-oas2.yaml", "3.0.3")
+	if err != nil {
+		t.Fatalf("Conversion failed: %v", err)
+	}
+
+	// Verify source format was detected as YAML
+	if result.SourceFormat != parser.SourceFormatYAML {
+		t.Errorf("Expected source format to be YAML, got %s", result.SourceFormat)
+	}
+
+	t.Logf("Successfully verified YAML format detection")
+}

--- a/converter/doc.go
+++ b/converter/doc.go
@@ -2,7 +2,9 @@
 //
 // The converter supports OAS 2.0 ↔ OAS 3.x conversions, performing best-effort
 // conversion with detailed issue tracking. Features converted include servers,
-// schemas, parameters, security schemes, and request/response bodies.
+// schemas, parameters, security schemes, and request/response bodies. The converter
+// preserves the input file format (JSON or YAML) in the ConversionResult.SourceFormat
+// field, allowing tools to maintain format consistency when writing output.
 //
 // # Quick Start
 //

--- a/joiner/doc.go
+++ b/joiner/doc.go
@@ -2,8 +2,9 @@
 //
 // The joiner merges multiple OAS documents of the same major version into a single
 // document. It supports OAS 2.0 documents with other 2.0 documents, and all OAS 3.x
-// versions together (3.0.x, 3.1.x, 3.2.x). It uses the version from the first
-// document as the result version.
+// versions together (3.0.x, 3.1.x, 3.2.x). It uses the version and format (JSON or YAML)
+// from the first document as the result version and format, ensuring format consistency
+// when writing output with WriteResult.
 //
 // # Quick Start
 //

--- a/joiner/oas2.go
+++ b/joiner/oas2.go
@@ -14,6 +14,7 @@ func (j *Joiner) joinOAS2Documents(docs []parser.ParseResult) (*JoinResult, erro
 	result := &JoinResult{
 		Version:       docs[0].Version,
 		OASVersion:    docs[0].OASVersion,
+		SourceFormat:  docs[0].SourceFormat,
 		Warnings:      make([]string, 0),
 		firstFilePath: docs[0].SourcePath,
 	}

--- a/joiner/oas3.go
+++ b/joiner/oas3.go
@@ -14,6 +14,7 @@ func (j *Joiner) joinOAS3Documents(docs []parser.ParseResult) (*JoinResult, erro
 	result := &JoinResult{
 		Version:       docs[0].Version,
 		OASVersion:    docs[0].OASVersion,
+		SourceFormat:  docs[0].SourceFormat,
 		Warnings:      make([]string, 0),
 		firstFilePath: docs[0].SourcePath,
 	}

--- a/parser/doc.go
+++ b/parser/doc.go
@@ -33,7 +33,9 @@
 //
 // # ParseResult Fields
 //
-// ParseResult includes the detected Version, OASVersion, and any parsing Errors
-// or Warnings. The Document field contains the parsed OAS2Document or OAS3Document.
-// See the exported ParseResult and document type fields for complete details.
+// ParseResult includes the detected Version, OASVersion, SourceFormat (JSON or YAML),
+// and any parsing Errors or Warnings. The Document field contains the parsed OAS2Document
+// or OAS3Document. The SourceFormat field can be used by conversion and joining tools to
+// preserve the original file format. See the exported ParseResult and document type fields
+// for complete details.
 package parser

--- a/testdata/minimal-oas2.json
+++ b/testdata/minimal-oas2.json
@@ -1,0 +1,8 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Minimal API",
+    "version": "1.0.0"
+  },
+  "paths": {}
+}

--- a/testdata/minimal-oas3.json
+++ b/testdata/minimal-oas3.json
@@ -1,0 +1,8 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Minimal API",
+    "version": "1.0.0"
+  },
+  "paths": {}
+}


### PR DESCRIPTION
## Overview

This PR implements automatic format preservation for the `convert` and `join` commands, ensuring that JSON input produces JSON output and YAML input produces YAML output. Previously, the output was always in YAML format regardless of the input format.

## Motivation

Users working with JSON OpenAPI specifications were finding that the `convert` and `join` commands always output YAML, forcing them to manually convert back to JSON. This breaks format consistency in toolchains and version-controlled API specifications where format consistency is important.

## Implementation

### 1. Parser Package (`parser/parser.go`)

- **Added `SourceFormat` type** with constants:
  - `SourceFormatJSON` - JSON format
  - `SourceFormatYAML` - YAML format  
  - `SourceFormatUnknown` - Unknown/undetectable format

- **Added `SourceFormat` field to `ParseResult`** to track the detected input format

- **Implemented format detection**:
  - `detectFormatFromPath()` - Detects from file extension (`.json`, `.yaml`, `.yml`)
  - `detectFormatFromContent()` - Detects from content for readers/bytes (JSON starts with `{` or `[`)

- **Updated parsing methods** to detect and store format:
  - `Parse()` - Uses file extension
  - `ParseReader()` - Uses content detection
  - `ParseBytes()` - Uses content detection

### 2. Converter Package (`converter/converter.go`)

- **Added `SourceFormat` field to `ConversionResult`**
- **Updated `ConvertParsed()`** to copy `SourceFormat` from `ParseResult`
- Preserves format through the conversion pipeline

### 3. Joiner Package (`joiner/joiner.go`, `joiner/oas2.go`, `joiner/oas3.go`)

- **Added `SourceFormat` field to `JoinResult`**
- **Updated join methods** to copy `SourceFormat` from the first document:
  - `joinOAS2Documents()` in `oas2.go`
  - `joinOAS3Documents()` in `oas3.go`

- **Added `marshalJSON()` helper** for consistent JSON formatting with 2-space indentation

- **Updated `WriteResult()`** to marshal based on `SourceFormat`:
  - JSON format → `json.MarshalIndent()` with 2-space indentation
  - YAML format → `yaml.Marshal()`

### 4. CLI (`cmd/oastools/main.go`)

- **Updated `handleConvert()`** to check `result.SourceFormat` and choose appropriate marshaler
- Maintains format consistency for both file output and stdout

## Test Coverage

### New Test Files
- `testdata/minimal-oas2.json` - JSON test fixture for OAS 2.0
- `testdata/minimal-oas3.json` - JSON test fixture for OAS 3.0

### New Tests
- `converter/converter_test.go`:
  - `TestJSONFormatPreservation()` - Verifies JSON input → JSON format in result
  - `TestYAMLFormatPreservation()` - Verifies YAML input → YAML format in result

- `joiner/joiner_test.go`:
  - `TestJSONFormatPreservation()` - Verifies JSON input → JSON format in result
  - `TestYAMLFormatPreservation()` - Verifies YAML input → YAML format in result

All existing tests continue to pass ✅

## Documentation Updates

### Package Documentation
- **`parser/doc.go`** - Added note about `SourceFormat` field in `ParseResult`
- **`converter/doc.go`** - Explained format preservation behavior
- **`joiner/doc.go`** - Explained format preservation behavior

### User Documentation
- **`README.md`** - Added "Format Preservation" section with examples showing JSON→JSON and YAML→YAML conversions

### Developer Documentation  
- **`CLAUDE.md`** - Added comprehensive "Format Preservation" section with:
  - Implementation details for all packages
  - Format detection logic
  - Test coverage information
  - Key design decisions

## Behavior

### Convert Command
```bash
# JSON input → JSON output
oastools convert -t 3.0.3 swagger.json -o openapi.json

# YAML input → YAML output  
oastools convert -t 3.0.3 swagger.yaml -o openapi.yaml
```

### Join Command
```bash
# JSON inputs → JSON output (format from first file)
oastools join -o merged.json api1.json api2.json

# YAML inputs → YAML output
oastools join -o merged.yaml api1.yaml api2.yaml

# Mixed formats → Format of first file (api1.json is JSON)
oastools join -o merged.json api1.json api2.yaml
```

## Key Design Decisions

1. **First file wins for joiner** - When joining multiple files with different formats, the format of the first file determines the output format

2. **Default to YAML on unknown** - If format cannot be determined, default to YAML (most common for OpenAPI specs)

3. **Consistent indentation** - JSON output uses 2-space indentation to match common formatting standards

4. **Content detection for readers** - When parsing from `io.Reader` or byte slices, format is detected by checking if content starts with `{` or `[` (JSON) vs other characters (YAML)

## Files Changed

**Core Implementation:**
- `parser/parser.go` - Format detection and tracking
- `converter/converter.go` - Format preservation in ConversionResult
- `joiner/joiner.go` - Format preservation in JoinResult  
- `joiner/oas2.go` - Format tracking for OAS 2.0 joins
- `joiner/oas3.go` - Format tracking for OAS 3.x joins
- `cmd/oastools/main.go` - CLI format-aware output

**Tests:**
- `converter/converter_test.go` - Added format preservation tests
- `joiner/joiner_test.go` - Added format preservation tests
- `testdata/minimal-oas2.json` - New JSON test fixture
- `testdata/minimal-oas3.json` - New JSON test fixture

**Documentation:**
- `parser/doc.go` - Updated package docs
- `converter/doc.go` - Updated package docs
- `joiner/doc.go` - Updated package docs
- `README.md` - Added user-facing format preservation section
- `CLAUDE.md` - Added implementation documentation

## Breaking Changes

None - this is a backwards-compatible enhancement. Existing YAML workflows continue to work exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)