### PR TITLE
feat: add timing and size metrics to parse results

### DIFF
--- a/cmd/oastools/main.go
+++ b/cmd/oastools/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/erraggy/oastools/converter"
 	"github.com/erraggy/oastools/differ"
@@ -72,7 +73,9 @@ func handleParse(args []string) {
 	fmt.Printf("OpenAPI Specification Parser\n")
 	fmt.Printf("============================\n\n")
 	fmt.Printf("Specification: %s\n", specPath)
-	fmt.Printf("Version: %s\n\n", result.Version)
+	fmt.Printf("Version: %s\n", result.Version)
+	fmt.Printf("Source Size: %s\n", parser.FormatBytes(result.SourceSize))
+	fmt.Printf("Load Time: %v\n\n", result.LoadTime)
 
 	// Print warnings
 	if len(result.Warnings) > 0 {
@@ -173,8 +176,10 @@ func handleValidate(args []string) {
 	v.IncludeWarnings = !noWarnings
 	v.UserAgent = fmt.Sprintf("oastools/%s", version)
 
-	// Validate the file or URL
+	// Validate the file or URL with timing
+	startTime := time.Now()
 	result, err := v.Validate(specPath)
+	totalTime := time.Since(startTime)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error validating file: %v\n", err)
 		os.Exit(1)
@@ -184,7 +189,10 @@ func handleValidate(args []string) {
 	fmt.Printf("OpenAPI Specification Validator\n")
 	fmt.Printf("================================\n\n")
 	fmt.Printf("Specification: %s\n", specPath)
-	fmt.Printf("Version: %s\n\n", result.Version)
+	fmt.Printf("Version: %s\n", result.Version)
+	fmt.Printf("Source Size: %s\n", parser.FormatBytes(result.SourceSize))
+	fmt.Printf("Load Time: %v\n", result.LoadTime)
+	fmt.Printf("Total Time: %v\n\n", totalTime)
 
 	// Print errors
 	if len(result.Errors) > 0 {
@@ -370,7 +378,8 @@ func handleJoin(args []string) {
 		os.Exit(1)
 	}
 
-	// Create joiner and execute
+	// Create joiner and execute with timing
+	startTime := time.Now()
 	j := joiner.New(config)
 	result, err := j.Join(filePaths)
 	if err != nil {
@@ -380,6 +389,7 @@ func handleJoin(args []string) {
 
 	// Write result to file
 	err = j.WriteResult(result, outputPath)
+	totalTime := time.Since(startTime)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error writing output file: %v\n", err)
 		os.Exit(1)
@@ -390,7 +400,8 @@ func handleJoin(args []string) {
 	fmt.Printf("============================\n\n")
 	fmt.Printf("Successfully joined %d specification files\n", len(filePaths))
 	fmt.Printf("Output: %s\n", outputPath)
-	fmt.Printf("Version: %s\n\n", result.Version)
+	fmt.Printf("Version: %s\n", result.Version)
+	fmt.Printf("Total Time: %v\n\n", totalTime)
 
 	if result.CollisionCount > 0 {
 		fmt.Printf("Collisions resolved: %d\n\n", result.CollisionCount)
@@ -515,8 +526,10 @@ func handleConvert(args []string) {
 	c.IncludeInfo = !noWarnings
 	c.UserAgent = fmt.Sprintf("oastools/%s", version)
 
-	// Convert the file or URL
+	// Convert the file or URL with timing
+	startTime := time.Now()
 	result, err := c.Convert(specPath, targetVersion)
+	totalTime := time.Since(startTime)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error converting file: %v\n", err)
 		os.Exit(1)
@@ -527,7 +540,10 @@ func handleConvert(args []string) {
 	fmt.Printf("===============================\n\n")
 	fmt.Printf("Specification: %s\n", specPath)
 	fmt.Printf("Source Version: %s\n", result.SourceVersion)
-	fmt.Printf("Target Version: %s\n\n", result.TargetVersion)
+	fmt.Printf("Target Version: %s\n", result.TargetVersion)
+	fmt.Printf("Source Size: %s\n", parser.FormatBytes(result.SourceSize))
+	fmt.Printf("Load Time: %v\n", result.LoadTime)
+	fmt.Printf("Total Time: %v\n\n", totalTime)
 
 	// Print issues
 	if len(result.Issues) > 0 {
@@ -657,8 +673,10 @@ func handleDiff(args []string) {
 	d.IncludeInfo = !noInfo
 	d.UserAgent = fmt.Sprintf("oastools/%s", version)
 
-	// Diff the files
+	// Diff the files with timing
+	startTime := time.Now()
 	result, err := d.Diff(sourcePath, targetPath)
+	totalTime := time.Since(startTime)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error comparing specifications: %v\n", err)
 		os.Exit(1)
@@ -668,7 +686,8 @@ func handleDiff(args []string) {
 	fmt.Printf("OpenAPI Specification Diff\n")
 	fmt.Printf("==========================\n\n")
 	fmt.Printf("Source: %s (%s)\n", sourcePath, result.SourceVersion)
-	fmt.Printf("Target: %s (%s)\n\n", targetPath, result.TargetVersion)
+	fmt.Printf("Target: %s (%s)\n", targetPath, result.TargetVersion)
+	fmt.Printf("Total Time: %v\n\n", totalTime)
 
 	if len(result.Changes) == 0 {
 		fmt.Println("✓ No differences found - specifications are identical")

--- a/converter/converter.go
+++ b/converter/converter.go
@@ -2,6 +2,7 @@ package converter
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/erraggy/oastools/internal/issues"
 	"github.com/erraggy/oastools/internal/severity"
@@ -47,6 +48,10 @@ type ConversionResult struct {
 	CriticalCount int
 	// Success is true if conversion completed without critical issues
 	Success bool
+	// LoadTime is the time taken to load the source data
+	LoadTime time.Duration
+	// SourceSize is the size of the source data in bytes
+	SourceSize int64
 }
 
 // HasCriticalIssues returns true if there are any critical issues
@@ -150,6 +155,8 @@ func (c *Converter) ConvertParsed(parseResult parser.ParseResult, targetVersionS
 		TargetVersion:    targetVersionStr,
 		TargetOASVersion: targetVersion,
 		Issues:           make([]ConversionIssue, 0),
+		LoadTime:         parseResult.LoadTime,
+		SourceSize:       parseResult.SourceSize,
 	}
 
 	// Check if conversion is needed

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/erraggy/oastools/internal/httputil"
 	"github.com/erraggy/oastools/internal/issues"
@@ -52,6 +53,10 @@ type ValidationResult struct {
 	ErrorCount int
 	// WarningCount is the total number of warnings
 	WarningCount int
+	// LoadTime is the time taken to load the source data
+	LoadTime time.Duration
+	// SourceSize is the size of the source data in bytes
+	SourceSize int64
 }
 
 // Validator handles OpenAPI specification validation
@@ -120,6 +125,8 @@ func (v *Validator) ValidateParsed(parseResult parser.ParseResult) (*ValidationR
 		OASVersion: parseResult.OASVersion,
 		Errors:     make([]ValidationError, 0, defaultErrorCapacity),
 		Warnings:   make([]ValidationError, 0, defaultWarningCapacity),
+		LoadTime:   parseResult.LoadTime,
+		SourceSize: parseResult.SourceSize,
 	}
 
 	// Add parser errors to validation result


### PR DESCRIPTION
## Summary

Adds load time and source size tracking to provide visibility into performance characteristics of OAS document loading and processing for v1.9.2.

## What's New

- **Timing Metrics**: Track time spent loading source documents (files, URLs, readers)
- **Size Metrics**: Track source document size in bytes
- **Human-Readable Formatting**: Added `parser.FormatBytes()` helper for size display
- **CLI Integration**: All CLI commands now show relevant timing and size information

## Changes

### Library Changes

**parser package:**
- Added `LoadTime time.Duration` field to `ParseResult`
- Added `SourceSize int64` field to `ParseResult`
- Updated `Parse()`, `ParseReader()`, and `ParseBytes()` to capture metrics
- Added `FormatBytes()` function for human-readable size formatting

**validator package:**
- Added `LoadTime` and `SourceSize` fields to `ValidationResult`
- Propagates metrics from `ParseResult`

**converter package:**
- Added `LoadTime` and `SourceSize` fields to `ConversionResult`
- Propagates metrics from `ParseResult`

### CLI Changes

All commands now display timing information:

**parse command:**
```
Source Size: 15.2 KB
Load Time: 2.5ms
```

**validate command:**
```
Source Size: 15.2 KB
Load Time: 2.5ms
Total Time: 45.3ms
```

**convert command:**
```
Source Size: 15.2 KB
Load Time: 2.5ms
Total Time: 127.8ms
```

**join command:**
```
Total Time: 89.2ms
```

**diff command:**
```
Total Time: 156.4ms
```

## Technical Details

- Load time captures file I/O, URL fetching, or reader operations
- Total time includes parsing, validation/conversion/joining, and output
- Size is measured in bytes of raw source data
- Timing uses `time.Duration` for precision
- Format helper uses 1024-based units (KiB, MiB, etc.)

## Test Plan

- [x] All existing tests pass
- [x] `make check` passes (lint, fmt, test)
- [x] gopls diagnostics clean
- [x] No breaking changes to public API
- [x] Backward compatible (new fields only)

## Related Issues

Addresses the need for performance visibility in document loading vs processing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)