### PR TITLE
fix(goreleaser): create releases as drafts to allow asset uploads

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -72,8 +72,5 @@ changelog:
 
 release:
   # Let GoReleaser create and manage the release
-  mode: replace
-  # Create as draft first, then publish after verification
-  draft: false
-  # Replace existing release if present
-  replace_existing_draft: true
+  # Create as draft to allow asset uploads before publishing
+  draft: true


### PR DESCRIPTION
## Summary

Fixes the persistent "Cannot upload assets to an immutable release" error by creating releases as drafts.

## Problem

Even with `mode: replace`, GoReleaser creates releases that become immutable before assets can be uploaded, causing 422 errors.

## Solution

Set `draft: true` in `.goreleaser.yaml` so releases are created as drafts, allowing asset uploads to succeed.

## Workflow

1. Push tag triggers GoReleaser
2. GoReleaser creates DRAFT release with all assets
3. Manually publish release when ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)