### PR TITLE
docs: update release process for immutable releases with tag-first workflow

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,132 +1,165 @@
-# Release Process and GitHub Immutability Guide
+# Release Process Guide
 
-This document provides comprehensive guidance on creating releases for oastools with GitHub's release immutability setting enabled. It includes lessons learned, best practices, and technical references.
-
-## Table of Contents
-
-- [Overview](#overview)
-- [GitHub Release Immutability](#github-release-immutability)
-- [Release Workflow](#release-workflow)
-- [Configuration](#configuration)
-- [Testing and Verification](#testing-and-verification)
-- [Troubleshooting](#troubleshooting)
-- [Technical References](#technical-references)
+This document describes the release workflow for oastools, which is compatible with GitHub's **immutable releases** security feature.
 
 ## Overview
 
-The oastools project uses a **draft-based release workflow** to maintain compatibility with GitHub's release immutability security feature while preserving the ability to create hand-crafted, high-quality release notes.
+The oastools project uses a **tag-first release workflow** that maintains compatibility with GitHub's release immutability while preserving control over release quality through a human-in-the-loop publish step.
 
 ### Key Benefits
 
 ✅ **Security**: Releases are immutable after publishing (tamper-proof)
-✅ **Quality**: Hand-crafted markdown release notes
+✅ **Quality**: Claude Code-generated or hand-crafted markdown release notes
 ✅ **Automation**: Binaries built and distributed automatically
 ✅ **Control**: Manual publish step allows verification before going public
 
-## GitHub Release Immutability
-
-### What is Release Immutability?
-
-GitHub's release immutability is a supply chain security feature that protects releases from tampering after publication. Once a release is published with immutability enabled, its assets and tags cannot be modified or deleted.
-
-**Announced**: August 2024 (Public Preview)
-**Generally Available**: October 2024
-
 ### How It Works
 
-1. **Draft releases remain mutable**: You can add, modify, or delete assets
-2. **Published releases become immutable**: Assets and tags are locked
-3. **Protection applies to**:
-   - Release assets (binaries, archives, etc.)
-   - Git tags associated with the release
-   - Pre-release releases are also immutable once published
+```
+Human pushes tag → Workflow creates draft + uploads assets → Human reviews → Human publishes
+```
 
-### Why It Matters for GoReleaser
+1. Human creates and pushes a semver tag
+2. Tag push triggers GitHub Actions workflow
+3. GoReleaser creates a draft release and uploads all assets
+4. Human generates/edits release notes and reviews the draft
+5. Human publishes the release (hands-on-keyboard)
+6. Release becomes immutable (assets already attached, no 422 errors)
 
-**The Problem**: GoReleaser traditionally creates a release and then uploads assets to it. With immutability enabled, this two-step process fails because:
+## Prerequisites
 
-1. GoReleaser creates and publishes the release
-2. GitHub marks it as immutable
-3. GoReleaser tries to add assets → **Error: "Cannot modify immutable release"**
+### Release Immutability (Already Enabled)
 
-**The Solution**: Use draft releases as an intermediary:
+Release immutability is already enabled on this repository. This means:
+- **Draft releases** remain fully mutable until published
+- **Published releases** become immutable (assets and tags cannot be modified or deleted)
+- **Release notes** remain editable for the life of the release
 
-1. Create draft release (remains mutable)
-2. GoReleaser adds assets to the draft
-3. Manually publish the draft (becomes immutable)
+### Required Configuration
 
-### Immutability Behavior
+All required configuration is already in place:
 
-| Action | Draft Release | Published Release |
-|--------|---------------|-------------------|
-| Add assets | ✅ Allowed | ❌ Blocked |
-| Delete assets | ✅ Allowed | ❌ Blocked |
-| Modify assets | ✅ Allowed | ❌ Blocked |
-| Edit release notes | ✅ Allowed | ❌ Blocked* |
-| Delete tag | ✅ Allowed | ❌ Blocked |
-| Move tag | ✅ Allowed | ❌ Blocked |
-| Delete entire release | ✅ Allowed | ✅ Allowed** |
-
-\* Release notes may be editable depending on repository settings
-\*\* You can delete immutable releases entirely, just not modify them
+- [x] Release immutability enabled in repository settings
+- [x] `.goreleaser.yaml` has `draft: true` in the `release` section
+- [x] `.github/workflows/release.yml` triggers on `push: tags: - 'v*'`
+- [x] `HOMEBREW_TAP_TOKEN` secret exists with `repo` scope
+- [x] No tag rulesets block manual tag pushes
 
 ## Release Workflow
 
-### Complete Step-by-Step Process
+### Step 1: Prepare for Release
 
-#### 1. Determine Version Number
+```bash
+# Ensure you're on main and up-to-date
+git checkout main
+git pull origin main
+
+# Run all checks
+make check
+
+# Review changes since last release
+git log $(git describe --tags --abbrev=0)..HEAD --oneline
+```
+
+### Step 2: Determine Version Number
 
 Follow [Semantic Versioning (SemVer)](https://semver.org/):
 
-- **PATCH** (`v1.2.3` → `v1.2.4`): Bug fixes, docs, minor changes
-- **MINOR** (`v1.2.3` → `v1.3.0`): New features, backward-compatible changes
-- **MAJOR** (`v1.2.3` → `v2.0.0`): Breaking changes to public APIs
+- **PATCH** (`v1.2.3` → `v1.2.4`): Bug fixes, docs, refactors without API changes
+- **MINOR** (`v1.2.3` → `v1.3.0`): New features, optimizations, new public APIs (backward compatible)
+- **MAJOR** (`v1.2.3` → `v2.0.0`): Breaking changes to public APIs (rare)
 
-#### 2. Test Locally (Optional but Recommended)
+### Step 3: Create and Push the Tag
 
 ```bash
-make release-test
+# Create the tag
+git tag v1.X.Y
+
+# Push the tag (this triggers the workflow)
+git push origin v1.X.Y
 ```
 
-This runs GoReleaser in snapshot mode to verify builds without publishing.
+**What happens:**
+- Tag is pushed to GitHub
+- GitHub Actions workflow is triggered automatically
+- Workflow begins building binaries and creating draft release
 
-#### 3. Create Draft Release with Custom Notes
+### Step 4: Monitor the Workflow
 
 ```bash
-gh release create v1.7.1 --draft \
-  --title "v1.7.1 - Brief summary within 72 chars" \
-  --notes "$(cat <<'EOF'
-## Summary
+# Watch the workflow run
+gh run list --workflow=release.yml --limit=1
 
-High-level overview of what this release delivers.
+# Get the run ID and monitor progress
+gh run watch <RUN_ID>
+```
+
+The workflow will:
+- Build binaries for all platforms (Darwin arm64/x86_64, Linux arm64/i386/x86_64, Windows i386/x86_64)
+- Create a **draft** release on GitHub
+- Upload all binary assets to the draft
+- Push the Homebrew formula to `erraggy/homebrew-oastools`
+
+### Step 5: Verify the Draft Release
+
+```bash
+# Confirm draft status and assets
+gh release view v1.X.Y --json isDraft,assets --jq '{isDraft, assetCount: (.assets | length), assets: [.assets[].name]}'
+```
+
+**Expected output:**
+- `isDraft: true`
+- `assetCount: 8`
+- Assets: checksums.txt + binaries for all platforms
+
+### Step 6: Generate and Set Release Notes
+
+Ask Claude Code to generate release notes based on commits and PRs since the last release.
+
+**Example prompt:**
+```
+Generate release notes for v1.X.Y based on changes since the last release
+```
+
+Claude Code will:
+1. Review git log and merged PRs
+2. Categorize changes (features, bug fixes, improvements, breaking changes)
+3. Generate well-formatted markdown release notes
+4. Apply them to the draft release using:
+
+```bash
+gh release edit v1.X.Y --notes "$(cat <<'EOF'
+## Summary
+[High-level overview of what this release delivers]
 
 ## What's New
+- [Feature 1: Description]
+- [Feature 2: Description]
 
-- Feature 1: Description
-- Feature 2: Description
-- Performance: Improvements achieved
+## Bug Fixes
+- [Fix 1]
 
-## Changes
+## Improvements
+- [Improvement 1]
 
-- Change 1
-- Change 2
-
-## Technical Details
-
-Additional context, benchmark results, migration notes, etc.
+## Breaking Changes
+- [If any]
 
 ## Related PRs
-
-- #17 - PR title
-- #18 - PR title
+- #XX - [PR title]
 
 ## Installation
 
 ### Homebrew
-```bash
+\`\`\`bash
 brew tap erraggy/oastools
 brew install oastools
-```
+\`\`\`
+
+### Go Module
+\`\`\`bash
+go get github.com/erraggy/oastools@v1.X.Y
+\`\`\`
 
 ### Binary Download
 Download the appropriate binary for your platform from the assets below.
@@ -134,96 +167,113 @@ EOF
 )"
 ```
 
-**What happens**:
-- Git tag is created (e.g., `v1.7.1`)
-- Draft release is created with your custom notes
-- GitHub Actions workflow is triggered automatically
-- Draft remains **mutable** (compatible with immutability setting)
+**Note:** Release notes can be edited before or after publishing via `gh release edit` or the GitHub web UI.
 
-#### 4. Monitor Automated Build
-
-The GitHub Actions workflow automatically:
-- Builds binaries for all platforms (Linux, macOS, Windows)
-- Adds binary archives to your draft release
-- Updates the Homebrew Cask in `homebrew-oastools` repository
+### Step 7: Publish the Release (Hands-on-Keyboard)
 
 ```bash
-# Watch the workflow
-gh run watch
-
-# Or monitor at:
-# - Workflow: https://github.com/erraggy/oastools/actions
-# - Draft release: https://github.com/erraggy/oastools/releases
+# This makes the release immutable (tags and assets are locked)
+gh release edit v1.X.Y --draft=false
 ```
 
-#### 5. Verify Draft Release
+**⚠️ Once published:**
+- The release becomes **immutable**
+- Assets and tags cannot be modified or deleted
+- Release notes can still be edited
+- This action is permanent
 
-```bash
-gh release view v1.7.1 --json assets,isDraft
-```
-
-**Confirm**:
-- `isDraft: true`
-- All platform binaries are attached (8 assets expected):
-  - Darwin (macOS): arm64, x86_64
-  - Linux: arm64, i386, x86_64
-  - Windows: i386, x86_64
-  - Checksums file
-
-#### 6. Publish the Release
-
-Once verified, publish the draft:
-
-```bash
-gh release edit v1.7.1 --draft=false
-```
-
-**⚠️ Once published, the release becomes IMMUTABLE**:
-- Assets cannot be added, modified, or deleted
-- Tags cannot be deleted or moved
-- This is permanent and cannot be undone
-
-#### 7. Verify Published Release
+### Step 8: Verify Published Release
 
 ```bash
 # Check release is published
-gh release view v1.7.1 --json isDraft,publishedAt
+gh release view v1.X.Y --json isDraft,publishedAt
 
-# Test Homebrew installation (optional)
-brew tap erraggy/oastools
-brew install oastools
+# Test Homebrew installation
+brew update
+brew upgrade oastools || brew install erraggy/oastools/oastools
 oastools --version
 ```
 
-### After Release
+## Troubleshooting
 
-- Announce the release (if applicable)
-- Update project documentation if needed
-- Monitor issue tracker for user feedback
-- Check Homebrew tap repository for formula updates
+### Workflow Failed Before Creating Draft
 
-## Configuration
+```bash
+# Delete the tag and start over
+git push origin :refs/tags/v1.X.Y
+git tag -d v1.X.Y
+
+# Fix the issue, then repeat from Step 3
+```
+
+### Workflow Failed After Creating Draft (Missing Assets)
+
+```bash
+# Delete the draft release and tag
+gh release delete v1.X.Y --yes
+git push origin :refs/tags/v1.X.Y
+git tag -d v1.X.Y
+
+# Fix the issue, then repeat from Step 3
+```
+
+### Accidentally Published Too Early
+
+With immutability enabled, this cannot be fixed without consequences:
+
+1. You may need to temporarily disable immutability to delete the release
+2. Delete the tag
+3. Increment the version number
+4. Start over from Step 3
+
+**This is why the workflow uploads assets to a draft first, then requires manual publishing.**
+
+### GoReleaser Can't Push to homebrew-oastools
+
+**Possible causes:**
+- `HOMEBREW_TAP_TOKEN` secret not configured or expired
+- PAT doesn't have `repo` scope
+- Commit author email in `.goreleaser.yaml` doesn't match verified GitHub email
+
+**Solution:**
+```bash
+# Verify secret exists
+gh secret list --repo erraggy/oastools
+
+# Check .goreleaser.yaml commit_author.email matches your verified GitHub email
+# Regenerate PAT if needed
+```
+
+### Build Fails
+
+**Solution:**
+- Review GitHub Actions logs: `gh run view --log-failed`
+- Check CGO dependencies
+- Test locally: `make release-test`
+
+### Formula Doesn't Work
+
+**Solution:**
+- Verify formula was pushed to `erraggy/homebrew-oastools`
+- Test in a clean environment
+- Check formula syntax
+
+## Configuration Reference
 
 ### GoReleaser Configuration
 
-**File**: `.goreleaser.yaml`
+**File:** `.goreleaser.yaml`
 
 ```yaml
 release:
-  # Create as draft to allow custom release notes via gh release create --draft
-  # GoReleaser adds binaries to the draft, then manually publish with gh release edit
-  # Compatible with GitHub's immutability setting (drafts remain mutable until published)
+  # CRITICAL: Must be true for immutable releases workflow
+  # GoReleaser uploads assets to a draft, human publishes afterward
   draft: true
 ```
 
-**Key points**:
-- `draft: true` is **required** for immutability compatibility
-- GoReleaser will add assets to the draft without publishing
-- Manual publish step gives you control and verification time
-
 ### GitHub Actions Workflow
 
-**File**: `.github/workflows/release.yml`
+**File:** `.github/workflows/release.yml`
 
 ```yaml
 name: Release
@@ -235,7 +285,6 @@ on:
 
 permissions:
   contents: write
-  # Required for GoReleaser to push to homebrew-oastools tap
 
 jobs:
   goreleaser:
@@ -261,341 +310,83 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
 ```
 
-**Key configuration**:
-- Triggers on tag push (pattern: `v*`)
-- Uses `HOMEBREW_TAP_TOKEN` secret (PAT with `repo` scope)
-- Requires `contents: write` permission
-- Fetches full git history (`fetch-depth: 0`) for changelog generation
+### Repository Settings
 
-### GitHub Repository Settings
+**Required settings:**
 
-**Required settings for releases**:
+1. **Release immutability:** ENABLED (Settings → General → Releases)
+2. **Workflow permissions:** "Read and write permissions" (Settings → Actions → General)
+3. **Branch protection:** Enabled on `main` (does not affect tag creation)
 
-#### 1. Enable Release Immutability
+### Personal Access Token Setup
 
-**Location**: Settings → General → Releases
+**Why needed:** The default `GITHUB_TOKEN` cannot push to the separate `homebrew-oastools` repository.
 
-- ✅ **Check** "Enable release immutability"
-- Once enabled, all new published releases become immutable
-- Draft releases remain mutable until published
-- **Recommendation**: Keep this enabled for security best practices
+**Creating the PAT:**
 
-#### 2. Workflow Permissions
+1. GitHub Settings → Developer settings → Personal access tokens → Tokens (classic)
+2. Generate new token with `repo` scope
+3. Add to repository: Settings → Secrets and variables → Actions
+4. Name: `HOMEBREW_TAP_TOKEN`
 
-**Location**: Settings → Actions → General → Workflow permissions
-
-- ✅ Select "Read and write permissions"
-- Required for the release workflow to create releases and attach assets
-- The workflow's `permissions: contents: write` supplements this
-
-#### 3. Branch Protection and Rulesets
-
-**Location**: Settings → Rules
-
-- ✅ Branch protection rules can be safely enabled
-- ✅ Repository rulesets (like `main-protections`) can be enabled
-- These apply to branch operations, **not tag creation**
-- Release workflow triggers on tag push, which bypasses branch protection
-
-### Personal Access Token (PAT) Setup
-
-**Required**: A GitHub Personal Access Token for pushing to the Homebrew tap repository.
-
-#### Why a PAT is Needed
-
-The default `GITHUB_TOKEN` provided by GitHub Actions only has permissions for the current repository. It **cannot** push to the separate `homebrew-oastools` repository. You must create a PAT with `repo` scope.
-
-#### Creating the PAT
-
-1. Go to GitHub Settings → Developer settings → Personal access tokens → Tokens (classic)
-2. Click "Generate new token (classic)"
-3. Set name: "GoReleaser - oastools Homebrew Publishing"
-4. Select scopes: **`repo`** (full control of private repositories)
-5. Click "Generate token" and **copy immediately** (won't be shown again)
-
-#### Adding to Repository
-
-1. Go to oastools repository → Settings → Secrets and variables → Actions
-2. Click "New repository secret"
-3. Name: `HOMEBREW_TAP_TOKEN`
-4. Value: Paste the token
-5. Click "Add secret"
-
-#### Verification
-
+**Verification:**
 ```bash
 gh secret list --repo erraggy/oastools
 ```
 
-Should show `HOMEBREW_TAP_TOKEN` in the list.
+## Why This Workflow Works
 
-## Testing and Verification
+### The Tag-First Approach
 
-### Pre-Release Checklist
+**Previous problematic approaches:**
 
-Before creating your first release, ensure:
+1. **Create published release first:** Release is immediately immutable → 422 errors when uploading
+2. **Create draft via gh release create --draft:** Draft doesn't push tag → workflow doesn't trigger until published → release is immutable when workflow runs → 422 errors
 
-- [ ] `HOMEBREW_TAP_TOKEN` secret is created and added to repository secrets
-- [ ] Secret verified with: `gh secret list --repo erraggy/oastools`
-- [ ] Local test successful: `make release-test`
-- [ ] Commit author email in `.goreleaser.yaml` matches a verified email in your GitHub account
-- [ ] All changes committed and pushed to `main`
-- [ ] All tests pass: `make check`
-- [ ] "Enable release immutability" setting is enabled in repository settings
+**Current solution: Tag-first workflow**
 
-### Testing the Complete Workflow
+1. Push tag first → triggers workflow immediately
+2. Workflow creates draft release (mutable)
+3. Workflow uploads assets to draft (still mutable)
+4. Human reviews and publishes when ready
+5. Immutability only applies after publish
 
-#### 1. Create Test Draft Release
+This sequence ensures assets are always uploaded while the release is still mutable.
 
-```bash
-gh release create v1.9.9-test --draft \
-  --title "v1.9.9-test - Test Release" \
-  --notes "Test of draft workflow with immutability enabled"
-```
+## Security Benefits
 
-#### 2. Verify Workflow Triggered
+With immutability enabled:
 
-```bash
-# Watch the workflow
-gh run watch
+- **Tag integrity:** Tags cannot be moved to different commits after publication
+- **Asset integrity:** Binary artifacts cannot be replaced with malicious versions
+- **Release attestations:** GitHub automatically generates cryptographically verifiable records
+- **Repository resurrection protection:** Deleted repos cannot reuse tags from immutable releases
 
-# Or check workflow status
-gh run list --workflow=release.yml --limit 1
-```
+## References
 
-#### 3. Verify Draft Has Assets
+### GitHub Documentation
 
-```bash
-gh release view v1.9.9-test --json isDraft,assets
-```
-
-Expected output:
-- `isDraft: true`
-- 8 assets (binaries for all platforms + checksums)
-
-#### 4. Publish the Draft
-
-```bash
-gh release edit v1.9.9-test --draft=false
-```
-
-#### 5. Test Immutability
-
-**Attempt to delete an asset** (should fail):
-
-```bash
-gh release delete-asset v1.9.9-test oastools_Windows_i386.zip --yes
-```
-
-Expected error:
-```
-HTTP 422: Validation Failed
-Cannot delete asset from an immutable release
-```
-
-**Attempt to delete the tag** (should fail):
-
-```bash
-git push origin :refs/tags/v1.9.9-test
-```
-
-Expected error:
-```
-remote: error: GH013: Repository rule violations found for refs/tags/v1.9.9-test.
-remote: - Cannot delete this tag
-```
-
-#### 6. Clean Up Test Release
-
-```bash
-# Delete the entire release (this is allowed)
-gh release delete v1.9.9-test --yes
-
-# Delete the tag (allowed after release is deleted)
-git push origin :refs/tags/v1.9.9-test
-git tag -d v1.9.9-test
-```
-
-### Verification Results
-
-From actual testing (November 2024):
-
-✅ **Draft creation**: Works correctly
-✅ **GoReleaser asset upload**: Successfully adds 8 assets to draft
-✅ **Custom notes**: Preserved exactly as written
-✅ **Publishing**: Draft converts to published release
-✅ **Asset deletion blocked**: "Cannot delete asset from an immutable release"
-✅ **Tag deletion blocked**: "Cannot delete this tag"
-✅ **Release deletion allowed**: Entire immutable releases can be deleted
-
-## Troubleshooting
-
-### Common Issues and Solutions
-
-#### Issue: "Cannot modify immutable release"
-
-**Cause**: Trying to add assets to a published release with immutability enabled.
-
-**Solution**:
-1. Ensure `.goreleaser.yaml` has `draft: true`
-2. Use the draft workflow (create draft → add assets → publish)
-3. Never try to add assets after publishing
-
-#### Issue: "Not Found (HTTP 404)" when viewing release
-
-**Cause**: Using `gh release create --draft` without proper tag creation.
-
-**Solution**:
-- The `gh release create` command should automatically create the tag
-- Verify tag exists: `git tag -l v1.x.x`
-- If tag doesn't exist, create and push it: `git tag v1.x.x && git push origin v1.x.x`
-
-#### Issue: Workflow doesn't trigger
-
-**Cause**: Tag wasn't pushed to remote repository.
-
-**Solution**:
-```bash
-# Verify tag exists locally
-git tag -l v1.x.x
-
-# Push tag to trigger workflow
-git push origin v1.x.x
-```
-
-#### Issue: GoReleaser can't push to homebrew-oastools
-
-**Possible causes**:
-1. `HOMEBREW_TAP_TOKEN` secret not configured
-2. PAT doesn't have `repo` scope
-3. PAT expired or revoked
-4. Commit author email doesn't match verified GitHub email
-
-**Solution**:
-```bash
-# Verify secret exists
-gh secret list --repo erraggy/oastools
-
-# Check .goreleaser.yaml commit_author.email matches your verified GitHub email
-# Regenerate PAT if needed
-```
-
-#### Issue: Draft release shows as "untagged-*"
-
-**Cause**: This is normal behavior for draft releases without an associated tag.
-
-**Solution**:
-- Draft releases may show `untagged-*` identifier until published
-- This is expected GitHub behavior
-- Tag will be properly associated when the draft is published
-
-### Getting Help
-
-If you encounter issues:
-
-1. **Check workflow logs**: `gh run view --log-failed`
-2. **Verify configuration**: Review `.goreleaser.yaml` and workflow file
-3. **Test locally**: Run `make release-test` to verify builds
-4. **Consult documentation**: See [Technical References](#technical-references) below
-
-## Technical References
-
-### Official Documentation
-
-**GitHub**:
-- [Immutable Releases Documentation](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/immutable-releases)
+- [Immutable Releases](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/immutable-releases)
+- [Events that trigger workflows - Release](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release)
 - [Managing Releases in a Repository](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository)
-- [GitHub REST API - Releases](https://docs.github.com/rest/releases/releases)
 
-**GoReleaser**:
-- [Release Configuration](https://goreleaser.com/customization/release/)
-- [Homebrew Casks Documentation](https://goreleaser.com/customization/homebrew_casks/)
-- [GitHub Actions Integration](https://goreleaser.com/ci/actions/)
-- [Deprecation Notice: brews → homebrew_casks](https://goreleaser.com/deprecations#brews)
+### GoReleaser Documentation
 
-**Semantic Versioning**:
-- [Semantic Versioning 2.0.0](https://semver.org/)
+- [Release Customization](https://goreleaser.com/customization/release/)
+- [GitHub Actions](https://goreleaser.com/ci/actions/)
+- [Homebrew Formulas](https://goreleaser.com/customization/homebrew/)
 
-### GitHub Changelog Announcements
-
-- [Immutable Releases - Public Preview (August 2024)](https://github.blog/changelog/2025-08-26-releases-now-support-immutability-in-public-preview/)
-- [Immutable Releases - Generally Available (October 2024)](https://github.blog/changelog/2025-10-28-immutable-releases-are-now-generally-available/)
-
-### GitHub Community Discussions
-
-- [🎉 Immutable Releases: Public Preview is Here!](https://github.com/orgs/community/discussions/171210)
-- [🚀 Immutable Releases Are Now Generally Available!](https://github.com/orgs/community/discussions/178351)
-
-### GoReleaser Community
-
-- [Keep existing release notes · Issue #929](https://github.com/goreleaser/goreleaser/issues/929)
-- [Upload artifacts to existing release · Discussion #4524](https://github.com/orgs/goreleaser/discussions/4524)
-- [Disabling GitHub Release + Publish · Discussion #2570](https://github.com/orgs/goreleaser/discussions/2570)
-
-### Related Tools and Actions
-
-- [softprops/action-gh-release](https://github.com/softprops/action-gh-release) - GitHub Action for creating releases
-  - [Issue #641: Update release workflow for compatibility with Immutable Releases](https://github.com/softprops/action-gh-release/issues/641)
-
-### Articles and Guides
-
-- [WebProNews: GitHub Launches Immutable Releases for Supply Chain Security](https://www.webpronews.com/github-launches-immutable-releases-for-supply-chain-security/)
-- [Automated GitHub Releases with GoReleaser](https://www.mslinn.com/golang/3000-go-github-release.html)
-
-### oastools-Specific Documentation
+### oastools Documentation
 
 - [CLAUDE.md](./CLAUDE.md) - Complete project documentation including release process
-- [planning/homebrew-cask-migration.md](./planning/homebrew-cask-migration.md) - Homebrew Cask migration notes
+- [planning/releases-with-immutability.md](./planning/releases-with-immutability.md) - Detailed release workflow analysis
 
-## Evolution of the Release Process
+### Related Issues
 
-### Historical Context
-
-This section documents the evolution of our release process to provide context for current decisions.
-
-#### v1.9.4 and Earlier: Formula-based Releases
-
-- Used `brews` configuration in GoReleaser (deprecated)
-- Generated Homebrew Formulas in `Formula/oastools.rb`
-- Pre-compiled binaries disguised as formulas ("hackyish" approach)
-
-#### v1.9.5: Migration to Casks
-
-- Migrated to `homebrew_casks` configuration (GoReleaser v2.10+)
-- Modern approach for distributing pre-compiled binaries
-- Disabled old Formula with `disable!` directive to guide users to Cask
-
-#### v1.9.6-v1.9.7: Exploring Immutability
-
-- Initial attempts with `mode: replace` to handle existing releases
-- Encountered "immutable release" errors
-- Learned about GitHub's new immutability feature
-
-#### v1.9.8: Draft Releases Attempt
-
-- Switched to `draft: true` in GoReleaser
-- Allowed asset uploads before publishing
-- Still required manual release creation via `gh release create`
-
-#### Current (v1.9.9+): Immutability-Compatible Workflow
-
-- Configuration: `draft: true` in GoReleaser
-- Workflow: Create draft → GoReleaser adds assets → Publish manually
-- Fully compatible with GitHub's immutability setting
-- Preserves hand-crafted release notes
-- Balances automation with control and security
-
-### Lessons Learned
-
-1. **Draft releases are the key**: Only published releases are immutable; drafts remain mutable
-2. **Two-step publishing is necessary**: Trying to publish immediately conflicts with immutability
-3. **Tag creation triggers workflows**: `gh release create` creates both release and tag
-4. **Asset modification is strictly blocked**: Once published, no changes allowed
-5. **PAT scope matters**: Default `GITHUB_TOKEN` can't push to other repositories
-6. **Immutability enhances security**: Prevents supply chain attacks via release tampering
+- [GitHub Issue #39](https://github.com/erraggy/oastools/issues/39) - Release management discussion
+- [planning/release-issues.md](./planning/release-issues.md) - Historical context and lessons learned
 
 ---
 
-**Document Version**: 1.0
-**Last Updated**: 2024-11-24
-**Tested with**: GoReleaser v2.x, GitHub Release Immutability (GA)
+**Last Updated:** 2025-11-25
+**Workflow Version:** Tag-first with immutability support

--- a/planning/releases-with-immutability.md
+++ b/planning/releases-with-immutability.md
@@ -1,0 +1,330 @@
+# Release Process with GitHub Immutable Releases
+
+## Overview
+
+This document describes a release workflow that is compatible with GitHub's **immutable releases** feature while maintaining a human-in-the-loop for the final publish action.
+
+### Key Insight
+
+With immutable releases enabled:
+- **Immutable at publish time:** Git tags and release assets cannot be modified or deleted after publication
+- **Always editable:** Release notes/description can be edited for the life of the release
+- **Draft releases:** Remain fully mutable until published
+
+This means we can upload all assets to a draft release, then have a human publish it when ready.
+
+## Workflow Summary
+
+```
+Human pushes tag → Workflow creates draft + uploads assets → Human reviews → Human publishes
+```
+
+1. Human creates and pushes a semver tag
+2. Tag push triggers GitHub Actions workflow
+3. GoReleaser creates a draft release and uploads all assets
+4. Human reviews the draft release on GitHub
+5. Human publishes the release (hands-on-keyboard)
+6. Release becomes immutable (assets already attached, no 422 errors)
+
+## Prerequisites
+
+### 1. Release Immutability (Already Enabled)
+
+Release immutability is already enabled on this repository. No action needed.
+
+To verify: **Settings → General → Releases** should show "Release immutability" checked.
+
+### 2. Verify No Tag Protection Rules Block Manual Pushes
+
+```bash
+# Check for tag-targeting rulesets
+gh api repos/erraggy/oastools/rulesets --jq '.[] | select(.target == "tag")'
+```
+
+If empty, manual tag pushes are allowed. If rules exist, they may need adjustment.
+
+### 3. Ensure HOMEBREW_TAP_TOKEN Secret Exists
+
+```bash
+gh secret list --repo erraggy/oastools | grep HOMEBREW_TAP_TOKEN
+```
+
+This PAT needs `repo` scope to push the Homebrew formula to `erraggy/homebrew-oastools`.
+
+## Implementation Changes
+
+### File 1: `.github/workflows/release.yml`
+
+The workflow trigger remains on tag push (not release events). GoReleaser's `draft: true` setting ensures assets are uploaded to a draft.
+
+```yaml
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.24'
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: '~> v2'
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+```
+
+**No changes required** - the current workflow is already correct.
+
+### File 2: `.goreleaser.yaml`
+
+Ensure `draft: true` is set in the release section. This is critical for immutable releases.
+
+```yaml
+# ... existing configuration ...
+
+release:
+  # CRITICAL: Must be true for immutable releases workflow
+  # GoReleaser uploads assets to a draft, human publishes afterward
+  draft: true
+```
+
+**No changes required** - the current configuration already has `draft: true`.
+
+## Release Process Steps
+
+### Step 1: Prepare for Release
+
+```bash
+# Ensure you're on main and up-to-date
+git checkout main
+git pull origin main
+
+# Run all checks
+make check
+
+# Review changes since last release
+git log $(git describe --tags --abbrev=0)..HEAD --oneline
+```
+
+### Step 2: Create and Push the Tag
+
+```bash
+# Determine the next version (follow semver)
+# PATCH: bug fixes, docs, refactors without API changes
+# MINOR: new features, optimizations (backward compatible)
+# MAJOR: breaking changes to public APIs
+
+# Create the tag
+git tag v1.X.Y
+
+# Push the tag (this triggers the workflow)
+git push origin v1.X.Y
+```
+
+### Step 3: Monitor the Workflow
+
+```bash
+# Watch the workflow run
+gh run list --workflow=release.yml --limit=1
+
+# Get the run ID and monitor it
+gh run watch <RUN_ID>
+```
+
+The workflow will:
+1. Build binaries for all platforms (Darwin, Linux, Windows)
+2. Create a **draft** release on GitHub
+3. Upload all binary assets to the draft
+4. Push the Homebrew formula to `erraggy/homebrew-oastools`
+
+### Step 4: Verify the Draft Release
+
+```bash
+# Confirm draft status and assets
+gh release view v1.X.Y --json isDraft,assets --jq '{isDraft, assetCount: (.assets | length), assets: [.assets[].name]}'
+```
+
+Expected output:
+```json
+{
+  "isDraft": true,
+  "assetCount": 8,
+  "assets": [
+    "checksums.txt",
+    "oastools_Darwin_arm64.tar.gz",
+    "oastools_Darwin_x86_64.tar.gz",
+    "oastools_Linux_arm64.tar.gz",
+    "oastools_Linux_i386.tar.gz",
+    "oastools_Linux_x86_64.tar.gz",
+    "oastools_Windows_i386.zip",
+    "oastools_Windows_x86_64.zip"
+  ]
+}
+```
+
+### Step 5: Edit Release Notes (Optional)
+
+You can edit the release notes before or after publishing:
+
+```bash
+# Edit release notes before publishing
+gh release edit v1.X.Y --notes "$(cat <<'EOF'
+## Summary
+Brief description of this release.
+
+## What's New
+- Feature 1
+- Feature 2
+
+## Bug Fixes
+- Fix 1
+
+## Related PRs
+- #XX - PR title
+EOF
+)"
+```
+
+Or edit via the GitHub web UI at: `https://github.com/erraggy/oastools/releases/tag/v1.X.Y`
+
+### Step 6: Publish the Release (Human Action)
+
+**This is the hands-on-keyboard step that makes the release immutable:**
+
+```bash
+gh release edit v1.X.Y --draft=false
+```
+
+After this command:
+- The release is published and visible to users
+- The tag and assets become **immutable**
+- Release notes remain editable
+
+### Step 7: Verify Publication
+
+```bash
+# Confirm release is published
+gh release view v1.X.Y --json isDraft,publishedAt
+
+# Test Homebrew installation
+brew update
+brew upgrade oastools || brew install erraggy/oastools/oastools
+oastools --version
+```
+
+## Troubleshooting
+
+### Workflow Failed Before Creating Draft
+
+If the workflow fails before creating the release:
+
+```bash
+# Delete the tag
+git push origin :refs/tags/v1.X.Y
+git tag -d v1.X.Y
+
+# Fix the issue, then start over from Step 2
+```
+
+### Workflow Failed After Creating Draft (Assets Missing)
+
+If the workflow partially succeeded (draft exists but missing assets):
+
+```bash
+# Check what assets exist
+gh release view v1.X.Y --json assets
+
+# Delete the draft release
+gh release delete v1.X.Y --yes
+
+# Delete the tag
+git push origin :refs/tags/v1.X.Y
+git tag -d v1.X.Y
+
+# Fix the issue, then start over from Step 2
+```
+
+### Accidentally Published Too Early
+
+If you published the draft before assets were uploaded:
+
+**With immutability enabled, this cannot be fixed.** You must:
+
+1. Delete the release (if possible - may require temporarily disabling immutability)
+2. Delete the tag
+3. Increment the version number and start over
+
+This is why the workflow is designed to upload assets first, publish last.
+
+### 422 Error: Cannot Upload Assets to Immutable Release
+
+This error means the release was published before assets were uploaded. See "Accidentally Published Too Early" above.
+
+## Why This Workflow Works
+
+### The Problem with Previous Approaches
+
+**Approach 1: Create published release first, then upload assets**
+- With immutability: Release is immediately immutable → 422 errors when uploading
+
+**Approach 2: Create draft via `gh release create --draft`, then publish**
+- Draft releases don't push tags
+- Tag is only pushed when draft is published
+- Workflow triggers on tag push, but release is already published/immutable → 422 errors
+
+### The Solution: Tag-First Workflow
+
+1. Push tag first → triggers workflow immediately
+2. Workflow creates draft release (mutable)
+3. Workflow uploads assets to draft (still mutable)
+4. Human publishes when ready
+5. Immutability only applies after publish
+
+This sequence ensures assets are always uploaded while the release is still mutable.
+
+## Security Benefits of Immutable Releases
+
+With immutability enabled:
+
+1. **Tag integrity:** Tags cannot be moved to different commits after publication
+2. **Asset integrity:** Binary artifacts cannot be replaced with malicious versions
+3. **Release attestations:** GitHub automatically generates cryptographically verifiable records
+4. **Repository resurrection protection:** Deleted repos cannot reuse tags from immutable releases
+
+## References
+
+- [GitHub Docs: Immutable Releases](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/immutable-releases)
+- [GitHub Docs: Events that trigger workflows - Release](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release)
+- [GoReleaser: Release Customization](https://goreleaser.com/customization/release/)
+- [GoReleaser: GitHub Actions](https://goreleaser.com/ci/actions/)
+- [GitHub Issue #39](https://github.com/erraggy/oastools/issues/39)
+
+## Implementation Checklist
+
+When implementing this plan, verify the following:
+
+- [x] Release immutability is enabled in repository settings (already enabled)
+- [x] `.goreleaser.yaml` has `draft: true` in the `release` section (already configured)
+- [x] `.github/workflows/release.yml` triggers on `push: tags: - 'v*'` (already configured)
+- [x] `HOMEBREW_TAP_TOKEN` secret exists with `repo` scope (already configured)
+- [x] No tag rulesets block manual tag pushes (verified - only branch protection exists)
+- [x] Update `CLAUDE.md` "Creating a New Release" section to reflect this workflow


### PR DESCRIPTION
## Summary

Updates release documentation to implement a tag-first workflow compatible with GitHub's immutable releases feature.

## Changes

### CLAUDE.md
- Updated "Creating a New Release" section with tag-first workflow
- Step 5 now instructs users to ask Claude Code to generate release notes
- Added troubleshooting for tag-first workflow failures

### RELEASES.md
- Complete rewrite (602 lines → 392 lines)
- Removed outdated draft-first approach documentation
- Streamlined 8-step process with tag-first workflow
- Updated configuration reference with actual YAML

### planning/releases-with-immutability.md
- New planning document with detailed analysis
- Research findings from GitHub and GoReleaser docs
- Explanation of why tag-first works vs previous approaches
- Implementation checklist (all items verified complete)

## Why Tag-First Works

**The Problem:** With immutable releases enabled, previous approaches failed because:
1. Creating published release first → immediately immutable → 422 errors when uploading assets
2. Creating draft via `gh release create --draft` → doesn't push tag → workflow doesn't trigger until published → release immutable when workflow runs → 422 errors

**The Solution:** Tag-first workflow:
1. Push tag first → triggers workflow immediately
2. Workflow creates draft release (mutable)
3. Workflow uploads assets to draft (still mutable)
4. Human reviews and publishes when ready
5. Immutability only applies after publish

## Testing Plan

After merge, we'll test with `v1.10.0-rc1` to verify the workflow before creating the actual v1.10.0 release.

## Related

- Closes #39
- See also: `planning/release-issues.md` for historical context

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>