### PR TITLE
Week 1: Update all documentation to use *WithOptions APIs as primary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,7 +161,10 @@ Correct pattern:
 ```go
 func BenchmarkOperation(b *testing.B) {
     // Setup (parsing, creating instances, etc.)
-    source, _ := parser.Parse("file.yaml", false, true)
+    source, _ := parser.ParseWithOptions(
+        parser.WithFilePath("file.yaml"),
+        parser.WithValidateStructure(true),
+    )
 
     for b.Loop() {  // ✅ Modern Go 1.24+ pattern
         _, err := Operation(source)
@@ -455,27 +458,27 @@ Use struct-based API for: multiple files, reusable instances, advanced configura
 ### Key API Features
 
 **Parser Package:**
-- Convenience: `parser.Parse()`, `ParseReader()`, `ParseBytes()`
+- Functional options: `parser.ParseWithOptions(parser.WithFilePath(...), parser.WithResolveRefs(...), ...)`
 - Struct-based: `parser.New()`, `Parser.Parse()`, `Parser.ParseReader()`, `Parser.ParseBytes()`
 - `ParseResult.SourcePath` tracks source (`"ParseReader.yaml"` for readers, `"ParseBytes.yaml"` for bytes)
 
 **Validator Package:**
-- Convenience: `validator.Validate()`, `ValidateParsed()`
+- Functional options: `validator.ValidateWithOptions(validator.WithFilePath(...), validator.WithIncludeWarnings(...), ...)`
 - Struct-based: `validator.New()`, `Validator.Validate()`, `Validator.ValidateParsed()`
 
 **Joiner Package:**
-- Convenience: `joiner.Join()`, `JoinParsed()`
+- Functional options: `joiner.JoinWithOptions(joiner.WithFilePaths(...), joiner.WithPathStrategy(...), ...)`
 - Struct-based: `joiner.New()`, `Joiner.Join()`, `Joiner.JoinParsed()`, `Joiner.WriteResult()`
 - All input documents must be pre-validated (Errors slice must be empty)
 
 **Converter Package:**
-- Convenience: `converter.Convert()`, `ConvertParsed()`
+- Functional options: `converter.ConvertWithOptions(converter.WithFilePath(...), converter.WithTargetVersion(...), ...)`
 - Struct-based: `converter.New()`, `Converter.Convert()`, `Converter.ConvertParsed()`
 - Configuration: `StrictMode`, `IncludeInfo`
 - Returns ConversionResult with severity-tracked issues (Info, Warning, Critical)
 
 **Differ Package:**
-- Convenience: `differ.Diff()`, `DiffParsed()`
+- Functional options: `differ.DiffWithOptions(differ.WithSourceFilePath(...), differ.WithTargetFilePath(...), differ.WithMode(...), ...)`
 - Struct-based: `differ.New()`, `Differ.Diff()`, `Differ.DiffParsed()`
 - Returns DiffResult with changes categorized by severity (Critical, Error, Warning, Info)
 
@@ -484,19 +487,34 @@ Use struct-based API for: multiple files, reusable instances, advanced configura
 **Quick operations:**
 ```go
 // Parse
-result, _ := parser.Parse("openapi.yaml", false, true)
+result, _ := parser.ParseWithOptions(
+    parser.WithFilePath("openapi.yaml"),
+    parser.WithValidateStructure(true),
+)
 
 // Validate
-result, _ := validator.Validate("openapi.yaml", true, false)
+result, _ := validator.ValidateWithOptions(
+    validator.WithFilePath("openapi.yaml"),
+    validator.WithIncludeWarnings(true),
+)
 
 // Join
-result, _ := joiner.Join([]string{"base.yaml", "ext.yaml"}, config)
+result, _ := joiner.JoinWithOptions(
+    joiner.WithFilePaths([]string{"base.yaml", "ext.yaml"}),
+    joiner.WithConfig(joiner.DefaultConfig()),
+)
 
 // Convert
-result, _ := converter.Convert("swagger.yaml", "3.0.3")
+result, _ := converter.ConvertWithOptions(
+    converter.WithFilePath("swagger.yaml"),
+    converter.WithTargetVersion("3.0.3"),
+)
 
 // Diff
-result, _ := differ.Diff("v1.yaml", "v2.yaml")
+result, _ := differ.DiffWithOptions(
+    differ.WithSourceFilePath("v1.yaml"),
+    differ.WithTargetFilePath("v2.yaml"),
+)
 ```
 
 **Reusable instances:**

--- a/MIGRATION_V1_TO_V2.md
+++ b/MIGRATION_V1_TO_V2.md
@@ -1,0 +1,504 @@
+# Migration Guide: oastools v1.x → v2.0
+
+This guide helps you migrate from oastools v1.x to v2.0, which introduces a new functional options API pattern and removes deprecated convenience functions.
+
+## Overview of Changes
+
+v2.0 removes 11 deprecated package-level convenience functions and standardizes on the `*WithOptions` functional options API across all packages. This provides:
+
+- **Self-documenting code**: Named options make API calls clearer
+- **Flexible input sources**: File paths, io.Reader, byte slices, and parsed documents
+- **Extensible configuration**: Add new options without breaking changes
+- **Better IDE support**: Improved autocomplete and type safety
+
+## Breaking Changes
+
+### Removed Functions
+
+All deprecated package-level convenience functions have been removed:
+
+| Package | Removed Functions |
+|---------|-------------------|
+| **parser** | `Parse()`, `ParseReader()`, `ParseBytes()` |
+| **validator** | `Validate()`, `ValidateParsed()` |
+| **converter** | `Convert()`, `ConvertParsed()` |
+| **joiner** | `Join()`, `JoinParsed()` |
+| **differ** | `Diff()`, `DiffParsed()` |
+
+**Note**: Struct methods (e.g., `parser.New().Parse()`) are **NOT deprecated** and remain unchanged.
+
+## Migration Examples
+
+### Parser Package
+
+#### Basic File Parsing
+
+**v1.x (Removed):**
+```go
+result, err := parser.Parse("openapi.yaml", false, true)
+```
+
+**v2.0 (New):**
+```go
+result, err := parser.ParseWithOptions(
+    parser.WithFilePath("openapi.yaml"),
+    parser.WithValidateStructure(true),
+)
+```
+
+#### Parsing from io.Reader
+
+**v1.x (Removed):**
+```go
+file, _ := os.Open("openapi.yaml")
+result, err := parser.ParseReader(file, false, true)
+```
+
+**v2.0 (New):**
+```go
+file, _ := os.Open("openapi.yaml")
+result, err := parser.ParseWithOptions(
+    parser.WithReader(file),
+    parser.WithValidateStructure(true),
+)
+```
+
+#### Parsing from Byte Slice
+
+**v1.x (Removed):**
+```go
+data := []byte(`openapi: 3.0.0...`)
+result, err := parser.ParseBytes(data, false, true)
+```
+
+**v2.0 (New):**
+```go
+data := []byte(`openapi: 3.0.0...`)
+result, err := parser.ParseWithOptions(
+    parser.WithBytes(data),
+    parser.WithValidateStructure(true),
+)
+```
+
+#### Parser Options Reference
+
+| v1.x Parameter | v2.0 Option | Default |
+|----------------|-------------|---------|
+| `resolveRefs bool` | `parser.WithResolveRefs(bool)` | `false` |
+| `validateStructure bool` | `parser.WithValidateStructure(bool)` | `false` |
+| N/A | `parser.WithUserAgent(string)` | `"oastools"` |
+
+### Validator Package
+
+#### Basic Validation
+
+**v1.x (Removed):**
+```go
+result, err := validator.Validate("openapi.yaml", true, false)
+```
+
+**v2.0 (New):**
+```go
+result, err := validator.ValidateWithOptions(
+    validator.WithFilePath("openapi.yaml"),
+    validator.WithIncludeWarnings(true),
+)
+```
+
+#### Validating Parsed Document
+
+**v1.x (Removed):**
+```go
+parsed, _ := parser.Parse("openapi.yaml", false, true)
+result, err := validator.ValidateParsed(*parsed, true, false)
+```
+
+**v2.0 (New):**
+```go
+parsed, _ := parser.ParseWithOptions(
+    parser.WithFilePath("openapi.yaml"),
+    parser.WithValidateStructure(true),
+)
+result, err := validator.ValidateWithOptions(
+    validator.WithParsed(*parsed),
+    validator.WithIncludeWarnings(true),
+)
+```
+
+#### Validator Options Reference
+
+| v1.x Parameter | v2.0 Option | Default |
+|----------------|-------------|---------|
+| `includeWarnings bool` | `validator.WithIncludeWarnings(bool)` | `false` |
+| `strictMode bool` | `validator.WithStrictMode(bool)` | `false` |
+| N/A | `validator.WithUserAgent(string)` | `"oastools"` |
+
+### Converter Package
+
+#### Basic Conversion
+
+**v1.x (Removed):**
+```go
+result, err := converter.Convert("swagger.yaml", "3.0.3")
+```
+
+**v2.0 (New):**
+```go
+result, err := converter.ConvertWithOptions(
+    converter.WithFilePath("swagger.yaml"),
+    converter.WithTargetVersion("3.0.3"),
+)
+```
+
+#### Converting Parsed Document
+
+**v1.x (Removed):**
+```go
+parsed, _ := parser.Parse("swagger.yaml", false, true)
+result, err := converter.ConvertParsed(*parsed, "3.0.3")
+```
+
+**v2.0 (New):**
+```go
+parsed, _ := parser.ParseWithOptions(
+    parser.WithFilePath("swagger.yaml"),
+    parser.WithValidateStructure(true),
+)
+result, err := converter.ConvertWithOptions(
+    converter.WithParsed(*parsed),
+    converter.WithTargetVersion("3.0.3"),
+)
+```
+
+#### Converter Options Reference
+
+| v1.x Parameter | v2.0 Option | Default |
+|----------------|-------------|---------|
+| `targetVersion string` | `converter.WithTargetVersion(string)` | **Required** |
+| N/A | `converter.WithStrictMode(bool)` | `false` |
+| N/A | `converter.WithIncludeInfo(bool)` | `true` |
+| N/A | `converter.WithUserAgent(string)` | `"oastools"` |
+
+### Joiner Package
+
+#### Basic Joining
+
+**v1.x (Removed):**
+```go
+config := joiner.DefaultConfig()
+result, err := joiner.Join([]string{"base.yaml", "ext.yaml"}, config)
+```
+
+**v2.0 (New):**
+```go
+result, err := joiner.JoinWithOptions(
+    joiner.WithFilePaths([]string{"base.yaml", "ext.yaml"}),
+    joiner.WithConfig(joiner.DefaultConfig()),
+)
+```
+
+#### Joining with Custom Strategy
+
+**v1.x (Removed):**
+```go
+config := joiner.DefaultConfig()
+config.PathStrategy = joiner.StrategyAcceptLeft
+result, err := joiner.Join([]string{"base.yaml", "ext.yaml"}, config)
+```
+
+**v2.0 (New):**
+```go
+result, err := joiner.JoinWithOptions(
+    joiner.WithFilePaths([]string{"base.yaml", "ext.yaml"}),
+    joiner.WithPathStrategy(joiner.StrategyAcceptLeft),
+)
+```
+
+#### Joining Parsed Documents
+
+**v1.x (Removed):**
+```go
+doc1, _ := parser.Parse("base.yaml", false, true)
+doc2, _ := parser.Parse("ext.yaml", false, true)
+config := joiner.DefaultConfig()
+result, err := joiner.JoinParsed([]parser.ParseResult{*doc1, *doc2}, config)
+```
+
+**v2.0 (New):**
+```go
+doc1, _ := parser.ParseWithOptions(
+    parser.WithFilePath("base.yaml"),
+    parser.WithValidateStructure(true),
+)
+doc2, _ := parser.ParseWithOptions(
+    parser.WithFilePath("ext.yaml"),
+    parser.WithValidateStructure(true),
+)
+result, err := joiner.JoinWithOptions(
+    joiner.WithParsedDocs([]parser.ParseResult{*doc1, *doc2}),
+    joiner.WithConfig(joiner.DefaultConfig()),
+)
+```
+
+#### Joiner Options Reference
+
+| v1.x Parameter | v2.0 Option | Default |
+|----------------|-------------|---------|
+| `config JoinerConfig` | `joiner.WithConfig(JoinerConfig)` | `DefaultConfig()` |
+| N/A | `joiner.WithDefaultStrategy(CollisionStrategy)` | `StrategyFailOnCollision` |
+| N/A | `joiner.WithPathStrategy(CollisionStrategy)` | Uses default |
+| N/A | `joiner.WithSchemaStrategy(CollisionStrategy)` | Uses default |
+| N/A | `joiner.WithComponentStrategy(CollisionStrategy)` | Uses default |
+| N/A | `joiner.WithDeduplicateTags(bool)` | `true` |
+| N/A | `joiner.WithMergeArrays(bool)` | `true` |
+
+### Differ Package
+
+#### Basic Diff
+
+**v1.x (Removed):**
+```go
+result, err := differ.Diff("api-v1.yaml", "api-v2.yaml")
+```
+
+**v2.0 (New):**
+```go
+result, err := differ.DiffWithOptions(
+    differ.WithSourceFilePath("api-v1.yaml"),
+    differ.WithTargetFilePath("api-v2.yaml"),
+)
+```
+
+#### Diff with Breaking Change Detection
+
+**v1.x (Removed):**
+```go
+d := differ.New()
+d.Mode = differ.ModeBreaking
+result, err := d.Diff("api-v1.yaml", "api-v2.yaml")
+```
+
+**v2.0 (New):**
+```go
+result, err := differ.DiffWithOptions(
+    differ.WithSourceFilePath("api-v1.yaml"),
+    differ.WithTargetFilePath("api-v2.yaml"),
+    differ.WithMode(differ.ModeBreaking),
+)
+```
+
+#### Diffing Parsed Documents
+
+**v1.x (Removed):**
+```go
+source, _ := parser.Parse("api-v1.yaml", false, true)
+target, _ := parser.Parse("api-v2.yaml", false, true)
+result, err := differ.DiffParsed(*source, *target)
+```
+
+**v2.0 (New):**
+```go
+source, _ := parser.ParseWithOptions(
+    parser.WithFilePath("api-v1.yaml"),
+    parser.WithValidateStructure(true),
+)
+target, _ := parser.ParseWithOptions(
+    parser.WithFilePath("api-v2.yaml"),
+    parser.WithValidateStructure(true),
+)
+result, err := differ.DiffWithOptions(
+    differ.WithSourceParsed(*source),
+    differ.WithTargetParsed(*target),
+)
+```
+
+#### Differ Options Reference
+
+| v1.x Parameter | v2.0 Option | Default |
+|----------------|-------------|---------|
+| N/A | `differ.WithMode(DiffMode)` | `ModeSimple` |
+| N/A | `differ.WithIncludeInfo(bool)` | `true` |
+| N/A | `differ.WithUserAgent(string)` | `"oastools"` |
+
+## Struct Method API (Unchanged)
+
+The struct-based API remains **unchanged** and is the recommended approach for reusable instances:
+
+### Parser
+```go
+p := parser.New()
+p.ResolveRefs = false
+p.ValidateStructure = true
+result1, _ := p.Parse("api1.yaml")
+result2, _ := p.Parse("api2.yaml")
+```
+
+### Validator
+```go
+v := validator.New()
+v.IncludeWarnings = true
+v.StrictMode = false
+result1, _ := v.Validate("api1.yaml")
+result2, _ := v.Validate("api2.yaml")
+```
+
+### Converter
+```go
+c := converter.New()
+c.StrictMode = false
+c.IncludeInfo = true
+result1, _ := c.Convert("swagger1.yaml", "3.0.3")
+result2, _ := c.Convert("swagger2.yaml", "3.0.3")
+```
+
+### Joiner
+```go
+j := joiner.New(joiner.DefaultConfig())
+result1, _ := j.Join([]string{"base1.yaml", "ext1.yaml"})
+result2, _ := j.Join([]string{"base2.yaml", "ext2.yaml"})
+```
+
+### Differ
+```go
+d := differ.New()
+d.Mode = differ.ModeBreaking
+d.IncludeInfo = false
+result1, _ := d.Diff("api-v1.yaml", "api-v2.yaml")
+result2, _ := d.Diff("api-v2.yaml", "api-v3.yaml")
+```
+
+## Benefits of the New API
+
+### 1. Self-Documenting Code
+
+**v1.x:**
+```go
+result, err := parser.Parse("api.yaml", false, true)  // What do these bools mean?
+```
+
+**v2.0:**
+```go
+result, err := parser.ParseWithOptions(
+    parser.WithFilePath("api.yaml"),
+    parser.WithResolveRefs(false),           // Clear intent
+    parser.WithValidateStructure(true),      // Self-documenting
+)
+```
+
+### 2. Flexible Input Sources
+
+**v2.0** allows mixing input sources in a single call:
+```go
+// Parse from URL with custom user agent
+result, err := parser.ParseWithOptions(
+    parser.WithFilePath("https://api.example.com/openapi.yaml"),
+    parser.WithUserAgent("myapp/1.0"),
+)
+
+// Parse from bytes
+data := []byte(`openapi: 3.0.0...`)
+result, err := parser.ParseWithOptions(
+    parser.WithBytes(data),
+)
+
+// Parse from reader
+file, _ := os.Open("spec.yaml")
+result, err := parser.ParseWithOptions(
+    parser.WithReader(file),
+)
+```
+
+### 3. Backward-Compatible Extensions
+
+New options can be added without breaking existing code:
+```go
+// v2.0
+result, err := parser.ParseWithOptions(
+    parser.WithFilePath("api.yaml"),
+)
+
+// v2.1+ (hypothetical) - adds new option without breaking v2.0 code
+result, err := parser.ParseWithOptions(
+    parser.WithFilePath("api.yaml"),
+    parser.WithCacheTTL(5 * time.Minute),  // New option, old code still works
+)
+```
+
+### 4. Better IDE Autocomplete
+
+With functional options, IDEs can suggest available options as you type, making the API more discoverable.
+
+## Migration Strategy
+
+### For Small Codebases
+
+1. Update all deprecated function calls to use `*WithOptions` variants
+2. Run tests to ensure behavior is unchanged
+3. Update to v2.0
+
+### For Large Codebases
+
+1. **Phase 1**: Identify all deprecated usage with:
+   ```bash
+   # Search for deprecated parser calls
+   grep -r "parser\.Parse(" . --include="*.go"
+   grep -r "parser\.ParseReader(" . --include="*.go"
+   grep -r "parser\.ParseBytes(" . --include="*.go"
+
+   # Repeat for validator, converter, joiner, differ
+   ```
+
+2. **Phase 2**: Migrate incrementally by package:
+   - Start with parser (most common)
+   - Then validator
+   - Then converter, joiner, differ
+
+3. **Phase 3**: Test thoroughly after each package migration
+
+4. **Phase 4**: Update to v2.0
+
+### Automated Migration
+
+For simple cases, you can use sed to automate parts of the migration:
+
+```bash
+# Example: parser.Parse() → parser.ParseWithOptions()
+# Note: This is a simple example and may not cover all cases
+sed -i '' 's/parser\.Parse(\([^,]*\), false, true)/parser.ParseWithOptions(parser.WithFilePath(\1), parser.WithValidateStructure(true))/g' *.go
+```
+
+**Warning**: Automated migration may not handle all cases correctly. Always review and test changes.
+
+## Staying on v1.x
+
+If you're not ready to migrate immediately, v1.x will remain available:
+
+```go
+// Continue using v1.x
+go get github.com/erraggy/oastools@v1.6.0
+```
+
+However, v1.x will no longer receive new features. Security patches may be provided for critical issues.
+
+## Getting Help
+
+- **GitHub Issues**: [github.com/erraggy/oastools/issues](https://github.com/erraggy/oastools/issues)
+- **Documentation**: Package docs at [pkg.go.dev/github.com/erraggy/oastools](https://pkg.go.dev/github.com/erraggy/oastools)
+- **Examples**: See `*_test.go` files for comprehensive usage examples
+
+## Version Compatibility
+
+| oastools Version | Go Version | API Style |
+|------------------|------------|-----------|
+| v1.x | ≥ 1.24 | Boolean parameters + struct methods |
+| v2.0 | ≥ 1.24 | Functional options + struct methods |
+
+## Summary
+
+The v2.0 migration removes deprecated convenience functions in favor of a more flexible, maintainable functional options API. The struct method API remains unchanged, providing a smooth migration path for codebases already using that pattern.
+
+**Key Takeaways:**
+- Replace `Package.Function(args...)` with `Package.FunctionWithOptions(Package.WithOption(...), ...)`
+- Struct methods (`New().Method()`) remain unchanged
+- New API provides better clarity, flexibility, and extensibility
+- v1.x remains available for gradual migration

--- a/README.md
+++ b/README.md
@@ -109,20 +109,34 @@ import (
 )
 
 // Parse
-result, err := parser.Parse("openapi.yaml", false, true)
+result, err := parser.ParseWithOptions(
+    parser.WithFilePath("openapi.yaml"),
+    parser.WithValidateStructure(true),
+)
 
 // Validate
-vResult, err := validator.Validate("openapi.yaml", true, false)
+vResult, err := validator.ValidateWithOptions(
+    validator.WithFilePath("openapi.yaml"),
+    validator.WithIncludeWarnings(true),
+)
 
 // Convert
-cResult, err := converter.Convert("swagger.yaml", "3.0.3")
+cResult, err := converter.ConvertWithOptions(
+    converter.WithFilePath("swagger.yaml"),
+    converter.WithTargetVersion("3.0.3"),
+)
 
 // Join
-config := joiner.DefaultConfig()
-jResult, err := joiner.Join([]string{"base.yaml", "ext.yaml"}, config)
+jResult, err := joiner.JoinWithOptions(
+    joiner.WithFilePaths([]string{"base.yaml", "ext.yaml"}),
+    joiner.WithConfig(joiner.DefaultConfig()),
+)
 
 // Diff
-dResult, err := differ.Diff("api-v1.yaml", "api-v2.yaml")
+dResult, err := differ.DiffWithOptions(
+    differ.WithSourceFilePath("api-v1.yaml"),
+    differ.WithTargetFilePath("api-v2.yaml"),
+)
 ```
 
 #### Advanced API (Reusable Instances)

--- a/converter/converter_bench_test.go
+++ b/converter/converter_bench_test.go
@@ -78,7 +78,9 @@ func BenchmarkConvertOAS3ToOAS2Medium(b *testing.B) {
 // BenchmarkConvertParsedOAS2ToOAS3Small benchmarks converting already-parsed OAS 2.0 to 3.0.3
 func BenchmarkConvertParsedOAS2ToOAS3Small(b *testing.B) {
 	// Parse once
-	parseResult, err := parser.Parse(smallOAS2Path, false, false)
+	parseResult, err := parser.ParseWithOptions(
+		parser.WithFilePath(smallOAS2Path),
+	)
 	if err != nil {
 		b.Fatalf("Failed to parse: %v", err)
 	}
@@ -98,7 +100,9 @@ func BenchmarkConvertParsedOAS2ToOAS3Small(b *testing.B) {
 // BenchmarkConvertParsedOAS2ToOAS3Medium benchmarks converting already-parsed medium OAS 2.0
 func BenchmarkConvertParsedOAS2ToOAS3Medium(b *testing.B) {
 	// Parse once
-	parseResult, err := parser.Parse(mediumOAS2Path, false, false)
+	parseResult, err := parser.ParseWithOptions(
+		parser.WithFilePath(mediumOAS2Path),
+	)
 	if err != nil {
 		b.Fatalf("Failed to parse: %v", err)
 	}
@@ -118,7 +122,9 @@ func BenchmarkConvertParsedOAS2ToOAS3Medium(b *testing.B) {
 // BenchmarkConvertParsedOAS3ToOAS2Small benchmarks converting already-parsed OAS 3.0 to 2.0
 func BenchmarkConvertParsedOAS3ToOAS2Small(b *testing.B) {
 	// Parse once
-	parseResult, err := parser.Parse(smallOAS3Path, false, false)
+	parseResult, err := parser.ParseWithOptions(
+		parser.WithFilePath(smallOAS3Path),
+	)
 	if err != nil {
 		b.Fatalf("Failed to parse: %v", err)
 	}
@@ -138,7 +144,9 @@ func BenchmarkConvertParsedOAS3ToOAS2Small(b *testing.B) {
 // BenchmarkConvertParsedOAS3ToOAS2Medium benchmarks converting already-parsed medium OAS 3.0
 func BenchmarkConvertParsedOAS3ToOAS2Medium(b *testing.B) {
 	// Parse once
-	parseResult, err := parser.Parse(mediumOAS3Path, false, false)
+	parseResult, err := parser.ParseWithOptions(
+		parser.WithFilePath(mediumOAS3Path),
+	)
 	if err != nil {
 		b.Fatalf("Failed to parse: %v", err)
 	}

--- a/converter/doc.go
+++ b/converter/doc.go
@@ -8,9 +8,12 @@
 //
 // # Quick Start
 //
-// Convert a file:
+// Convert a file using functional options:
 //
-//	result, err := converter.Convert("swagger.yaml", "3.0.3")
+//	result, err := converter.ConvertWithOptions(
+//		converter.WithFilePath("swagger.yaml"),
+//		converter.WithTargetVersion("3.0.3"),
+//	)
 //	if err != nil {
 //		log.Fatal(err)
 //	}
@@ -37,11 +40,17 @@
 //
 // Always validate converted documents for the target version:
 //
-//	convResult, _ := converter.Convert("swagger.yaml", "3.0.3")
+//	convResult, _ := converter.ConvertWithOptions(
+//		converter.WithFilePath("swagger.yaml"),
+//		converter.WithTargetVersion("3.0.3"),
+//	)
 //	data, _ := yaml.Marshal(convResult.Document)
 //	tmpFile := "temp.yaml"
 //	os.WriteFile(tmpFile, data, 0600)
-//	valResult, _ := validator.Validate(tmpFile, true, false)
+//	valResult, _ := validator.ValidateWithOptions(
+//		validator.WithFilePath(tmpFile),
+//		validator.WithIncludeWarnings(true),
+//	)
 //	if !valResult.Valid {
 //		fmt.Printf("Conversion produced invalid document\n")
 //	}

--- a/converter/example_test.go
+++ b/converter/example_test.go
@@ -7,10 +7,13 @@ import (
 	"github.com/erraggy/oastools/converter"
 )
 
-// Example demonstrates basic conversion using the convenience function
+// Example demonstrates basic conversion using functional options
 func Example() {
 	// Convert an OAS 2.0 specification to OAS 3.0.3
-	result, err := converter.Convert("testdata/petstore-2.0.yaml", "3.0.3")
+	result, err := converter.ConvertWithOptions(
+		converter.WithFilePath("testdata/petstore-2.0.yaml"),
+		converter.WithTargetVersion("3.0.3"),
+	)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -28,7 +31,10 @@ func Example() {
 
 // Example_handleConversionIssues demonstrates processing conversion issues
 func Example_handleConversionIssues() {
-	result, _ := converter.Convert("openapi.yaml", "2.0")
+	result, _ := converter.ConvertWithOptions(
+		converter.WithFilePath("openapi.yaml"),
+		converter.WithTargetVersion("2.0"),
+	)
 
 	// Categorize issues by severity
 	for _, issue := range result.Issues {

--- a/differ/differ_bench_test.go
+++ b/differ/differ_bench_test.go
@@ -23,11 +23,17 @@ func BenchmarkDiffConvenience(b *testing.B) {
 
 func BenchmarkDiffParsedConvenience(b *testing.B) {
 	// Parse once, then benchmark diff many times
-	source, err := parser.Parse("../testdata/petstore-v1.yaml", false, true)
+	source, err := parser.ParseWithOptions(
+		parser.WithFilePath("../testdata/petstore-v1.yaml"),
+		parser.WithValidateStructure(true),
+	)
 	if err != nil {
 		b.Fatal(err)
 	}
-	target, err := parser.Parse("../testdata/petstore-v2.yaml", false, true)
+	target, err := parser.ParseWithOptions(
+		parser.WithFilePath("../testdata/petstore-v2.yaml"),
+		parser.WithValidateStructure(true),
+	)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -58,11 +64,17 @@ func BenchmarkDifferDiffParsed(b *testing.B) {
 	d.Mode = ModeSimple
 
 	// Parse once
-	source, err := parser.Parse("../testdata/petstore-v1.yaml", false, true)
+	source, err := parser.ParseWithOptions(
+		parser.WithFilePath("../testdata/petstore-v1.yaml"),
+		parser.WithValidateStructure(true),
+	)
 	if err != nil {
 		b.Fatal(err)
 	}
-	target, err := parser.Parse("../testdata/petstore-v2.yaml", false, true)
+	target, err := parser.ParseWithOptions(
+		parser.WithFilePath("../testdata/petstore-v2.yaml"),
+		parser.WithValidateStructure(true),
+	)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -80,11 +92,17 @@ func BenchmarkDifferSimpleMode(b *testing.B) {
 	d := New()
 	d.Mode = ModeSimple
 
-	source, err := parser.Parse("../testdata/petstore-v1.yaml", false, true)
+	source, err := parser.ParseWithOptions(
+		parser.WithFilePath("../testdata/petstore-v1.yaml"),
+		parser.WithValidateStructure(true),
+	)
 	if err != nil {
 		b.Fatal(err)
 	}
-	target, err := parser.Parse("../testdata/petstore-v2.yaml", false, true)
+	target, err := parser.ParseWithOptions(
+		parser.WithFilePath("../testdata/petstore-v2.yaml"),
+		parser.WithValidateStructure(true),
+	)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -101,11 +119,17 @@ func BenchmarkDifferBreakingMode(b *testing.B) {
 	d := New()
 	d.Mode = ModeBreaking
 
-	source, err := parser.Parse("../testdata/petstore-v1.yaml", false, true)
+	source, err := parser.ParseWithOptions(
+		parser.WithFilePath("../testdata/petstore-v1.yaml"),
+		parser.WithValidateStructure(true),
+	)
 	if err != nil {
 		b.Fatal(err)
 	}
-	target, err := parser.Parse("../testdata/petstore-v2.yaml", false, true)
+	target, err := parser.ParseWithOptions(
+		parser.WithFilePath("../testdata/petstore-v2.yaml"),
+		parser.WithValidateStructure(true),
+	)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -124,11 +148,17 @@ func BenchmarkDifferWithInfo(b *testing.B) {
 	d.Mode = ModeBreaking
 	d.IncludeInfo = true
 
-	source, err := parser.Parse("../testdata/petstore-v1.yaml", false, true)
+	source, err := parser.ParseWithOptions(
+		parser.WithFilePath("../testdata/petstore-v1.yaml"),
+		parser.WithValidateStructure(true),
+	)
 	if err != nil {
 		b.Fatal(err)
 	}
-	target, err := parser.Parse("../testdata/petstore-v2.yaml", false, true)
+	target, err := parser.ParseWithOptions(
+		parser.WithFilePath("../testdata/petstore-v2.yaml"),
+		parser.WithValidateStructure(true),
+	)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -146,11 +176,17 @@ func BenchmarkDifferWithoutInfo(b *testing.B) {
 	d.Mode = ModeBreaking
 	d.IncludeInfo = false
 
-	source, err := parser.Parse("../testdata/petstore-v1.yaml", false, true)
+	source, err := parser.ParseWithOptions(
+		parser.WithFilePath("../testdata/petstore-v1.yaml"),
+		parser.WithValidateStructure(true),
+	)
 	if err != nil {
 		b.Fatal(err)
 	}
-	target, err := parser.Parse("../testdata/petstore-v2.yaml", false, true)
+	target, err := parser.ParseWithOptions(
+		parser.WithFilePath("../testdata/petstore-v2.yaml"),
+		parser.WithValidateStructure(true),
+	)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -168,7 +204,10 @@ func BenchmarkDifferIdenticalSpecs(b *testing.B) {
 	d := New()
 	d.Mode = ModeSimple
 
-	source, err := parser.Parse("../testdata/petstore-v1.yaml", false, true)
+	source, err := parser.ParseWithOptions(
+		parser.WithFilePath("../testdata/petstore-v1.yaml"),
+		parser.WithValidateStructure(true),
+	)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -184,11 +223,17 @@ func BenchmarkDifferIdenticalSpecs(b *testing.B) {
 // Benchmark parse-once pattern efficiency
 func BenchmarkParseOnceDiffMany(b *testing.B) {
 	// Parse once
-	source, err := parser.Parse("../testdata/petstore-v1.yaml", false, true)
+	source, err := parser.ParseWithOptions(
+		parser.WithFilePath("../testdata/petstore-v1.yaml"),
+		parser.WithValidateStructure(true),
+	)
 	if err != nil {
 		b.Fatal(err)
 	}
-	target, err := parser.Parse("../testdata/petstore-v2.yaml", false, true)
+	target, err := parser.ParseWithOptions(
+		parser.WithFilePath("../testdata/petstore-v2.yaml"),
+		parser.WithValidateStructure(true),
+	)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/differ/doc.go
+++ b/differ/doc.go
@@ -55,8 +55,11 @@ In ModeBreaking, changes are assigned severity levels:
 	)
 
 	func main() {
-		// Simple diff using convenience function
-		result, err := differ.Diff("api-v1.yaml", "api-v2.yaml")
+		// Simple diff using functional options
+		result, err := differ.DiffWithOptions(
+			differ.WithSourceFilePath("api-v1.yaml"),
+			differ.WithTargetFilePath("api-v2.yaml"),
+		)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -79,12 +82,13 @@ In ModeBreaking, changes are assigned severity levels:
 	)
 
 	func main() {
-		// Create differ with breaking mode
-		d := differ.New()
-		d.Mode = differ.ModeBreaking
-		d.IncludeInfo = true
-
-		result, err := d.Diff("api-v1.yaml", "api-v2.yaml")
+		// Diff with breaking mode using functional options
+		result, err := differ.DiffWithOptions(
+			differ.WithSourceFilePath("api-v1.yaml"),
+			differ.WithTargetFilePath("api-v2.yaml"),
+			differ.WithMode(differ.ModeBreaking),
+			differ.WithIncludeInfo(true),
+		)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -144,7 +148,7 @@ In ModeBreaking, changes are assigned severity levels:
 
 # Working with Parsed Documents
 
-For efficiency when documents are already parsed, use DiffParsed:
+For efficiency when documents are already parsed, use WithSourceParsed and WithTargetParsed:
 
 	package main
 
@@ -158,18 +162,27 @@ For efficiency when documents are already parsed, use DiffParsed:
 
 	func main() {
 		// Parse documents once
-		source, err := parser.Parse("api-v1.yaml", false, true)
+		source, err := parser.ParseWithOptions(
+			parser.WithFilePath("api-v1.yaml"),
+			parser.WithValidateStructure(true),
+		)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		target, err := parser.Parse("api-v2.yaml", false, true)
+		target, err := parser.ParseWithOptions(
+			parser.WithFilePath("api-v2.yaml"),
+			parser.WithValidateStructure(true),
+		)
 		if err != nil {
 			log.Fatal(err)
 		}
 
 		// Compare parsed documents
-		result, err := differ.DiffParsed(*source, *target)
+		result, err := differ.DiffWithOptions(
+			differ.WithSourceParsed(*source),
+			differ.WithTargetParsed(*target),
+		)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/differ/example_test.go
+++ b/differ/example_test.go
@@ -8,10 +8,13 @@ import (
 	"github.com/erraggy/oastools/parser"
 )
 
-// Example demonstrates basic diff usage with the convenience function
+// Example demonstrates basic diff usage with functional options
 func Example() {
 	// Compare two OpenAPI specifications
-	result, err := differ.Diff("../testdata/petstore-v1.yaml", "../testdata/petstore-v2.yaml")
+	result, err := differ.DiffWithOptions(
+		differ.WithSourceFilePath("../testdata/petstore-v1.yaml"),
+		differ.WithTargetFilePath("../testdata/petstore-v2.yaml"),
+	)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -23,10 +26,11 @@ func Example() {
 
 // Example_simple demonstrates simple diff mode
 func Example_simple() {
-	d := differ.New()
-	d.Mode = differ.ModeSimple
-
-	result, err := d.Diff("../testdata/petstore-v1.yaml", "../testdata/petstore-v2.yaml")
+	result, err := differ.DiffWithOptions(
+		differ.WithSourceFilePath("../testdata/petstore-v1.yaml"),
+		differ.WithTargetFilePath("../testdata/petstore-v2.yaml"),
+		differ.WithMode(differ.ModeSimple),
+	)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -44,11 +48,12 @@ func Example_simple() {
 
 // Example_breaking demonstrates breaking change detection
 func Example_breaking() {
-	d := differ.New()
-	d.Mode = differ.ModeBreaking
-	d.IncludeInfo = true
-
-	result, err := d.Diff("../testdata/petstore-v1.yaml", "../testdata/petstore-v2.yaml")
+	result, err := differ.DiffWithOptions(
+		differ.WithSourceFilePath("../testdata/petstore-v1.yaml"),
+		differ.WithTargetFilePath("../testdata/petstore-v2.yaml"),
+		differ.WithMode(differ.ModeBreaking),
+		differ.WithIncludeInfo(true),
+	)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -66,18 +71,27 @@ func Example_breaking() {
 // Example_parsed demonstrates comparing already-parsed documents
 func Example_parsed() {
 	// Parse documents once
-	source, err := parser.Parse("../testdata/petstore-v1.yaml", false, true)
+	source, err := parser.ParseWithOptions(
+		parser.WithFilePath("../testdata/petstore-v1.yaml"),
+		parser.WithValidateStructure(true),
+	)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	target, err := parser.Parse("../testdata/petstore-v2.yaml", false, true)
+	target, err := parser.ParseWithOptions(
+		parser.WithFilePath("../testdata/petstore-v2.yaml"),
+		parser.WithValidateStructure(true),
+	)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	// Compare parsed documents
-	result, err := differ.DiffParsed(*source, *target)
+	result, err := differ.DiffWithOptions(
+		differ.WithSourceParsed(*source),
+		differ.WithTargetParsed(*target),
+	)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/joiner/doc.go
+++ b/joiner/doc.go
@@ -8,19 +8,29 @@
 //
 // # Quick Start
 //
-// Join files with a config:
+// Join files using functional options:
 //
-//	config := joiner.DefaultConfig()
-//	config.PathStrategy = joiner.StrategyAcceptLeft
-//	result, err := joiner.Join([]string{"base.yaml", "ext.yaml"}, config)
+//	result, err := joiner.JoinWithOptions(
+//		joiner.WithFilePaths([]string{"base.yaml", "ext.yaml"}),
+//		joiner.WithPathStrategy(joiner.StrategyAcceptLeft),
+//	)
 //	if err != nil {
 //		log.Fatal(err)
 //	}
 //	_ = joiner.WriteResult(result, "merged.yaml")
 //
+// Or use a full config with options:
+//
+//	config := joiner.DefaultConfig()
+//	config.PathStrategy = joiner.StrategyAcceptLeft
+//	result, err := joiner.JoinWithOptions(
+//		joiner.WithFilePaths([]string{"base.yaml", "ext.yaml"}),
+//		joiner.WithConfig(config),
+//	)
+//
 // Or create a reusable Joiner instance:
 //
-//	j := joiner.New(config)
+//	j := joiner.New(joiner.DefaultConfig())
 //	result1, _ := j.Join([]string{"api1-base.yaml", "api1-ext.yaml"})
 //	result2, _ := j.Join([]string{"api2-base.yaml", "api2-ext.yaml"})
 //	j.WriteResult(result1, "merged1.yaml")

--- a/joiner/joiner_bench_test.go
+++ b/joiner/joiner_bench_test.go
@@ -54,11 +54,15 @@ func BenchmarkJoinThreeSmallDocs(b *testing.B) {
 // BenchmarkJoinParsedTwoSmallDocs benchmarks joining already-parsed documents
 func BenchmarkJoinParsedTwoSmallDocs(b *testing.B) {
 	// Parse once
-	doc1, err := parser.Parse(joinBaseOAS3Path, false, false)
+	doc1, err := parser.ParseWithOptions(
+		parser.WithFilePath(joinBaseOAS3Path),
+	)
 	if err != nil {
 		b.Fatalf("Failed to parse doc1: %v", err)
 	}
-	doc2, err := parser.Parse(joinExt1OAS3Path, false, false)
+	doc2, err := parser.ParseWithOptions(
+		parser.WithFilePath(joinExt1OAS3Path),
+	)
 	if err != nil {
 		b.Fatalf("Failed to parse doc2: %v", err)
 	}
@@ -80,15 +84,21 @@ func BenchmarkJoinParsedTwoSmallDocs(b *testing.B) {
 // BenchmarkJoinParsedThreeSmallDocs benchmarks joining 3 already-parsed documents
 func BenchmarkJoinParsedThreeSmallDocs(b *testing.B) {
 	// Parse once
-	doc1, err := parser.Parse(joinBaseOAS3Path, false, false)
+	doc1, err := parser.ParseWithOptions(
+		parser.WithFilePath(joinBaseOAS3Path),
+	)
 	if err != nil {
 		b.Fatalf("Failed to parse doc1: %v", err)
 	}
-	doc2, err := parser.Parse(joinExt1OAS3Path, false, false)
+	doc2, err := parser.ParseWithOptions(
+		parser.WithFilePath(joinExt1OAS3Path),
+	)
 	if err != nil {
 		b.Fatalf("Failed to parse doc2: %v", err)
 	}
-	doc3, err := parser.Parse(joinExt2OAS3Path, false, false)
+	doc3, err := parser.ParseWithOptions(
+		parser.WithFilePath(joinExt2OAS3Path),
+	)
 	if err != nil {
 		b.Fatalf("Failed to parse doc3: %v", err)
 	}

--- a/joiner/joiner_test.go
+++ b/joiner/joiner_test.go
@@ -718,9 +718,15 @@ func TestJoinParsedConvenience(t *testing.T) {
 		{
 			name: "join two parsed OAS 3.0 documents",
 			setupDocs: func(t *testing.T) []parser.ParseResult {
-				doc1, err := parser.Parse(filepath.Join(testdataDir, "join-base-3.0.yaml"), false, true)
+				doc1, err := parser.ParseWithOptions(
+					parser.WithFilePath(filepath.Join(testdataDir, "join-base-3.0.yaml")),
+					parser.WithValidateStructure(true),
+				)
 				require.NoError(t, err)
-				doc2, err := parser.Parse(filepath.Join(testdataDir, "join-extension-3.0.yaml"), false, true)
+				doc2, err := parser.ParseWithOptions(
+					parser.WithFilePath(filepath.Join(testdataDir, "join-extension-3.0.yaml")),
+					parser.WithValidateStructure(true),
+				)
 				require.NoError(t, err)
 				return []parser.ParseResult{*doc1, *doc2}
 			},
@@ -737,11 +743,20 @@ func TestJoinParsedConvenience(t *testing.T) {
 		{
 			name: "join three parsed documents",
 			setupDocs: func(t *testing.T) []parser.ParseResult {
-				doc1, err := parser.Parse(filepath.Join(testdataDir, "join-base-3.0.yaml"), false, true)
+				doc1, err := parser.ParseWithOptions(
+					parser.WithFilePath(filepath.Join(testdataDir, "join-base-3.0.yaml")),
+					parser.WithValidateStructure(true),
+				)
 				require.NoError(t, err)
-				doc2, err := parser.Parse(filepath.Join(testdataDir, "join-extension-3.0.yaml"), false, true)
+				doc2, err := parser.ParseWithOptions(
+					parser.WithFilePath(filepath.Join(testdataDir, "join-extension-3.0.yaml")),
+					parser.WithValidateStructure(true),
+				)
 				require.NoError(t, err)
-				doc3, err := parser.Parse(filepath.Join(testdataDir, "join-additional-3.0.yaml"), false, true)
+				doc3, err := parser.ParseWithOptions(
+					parser.WithFilePath(filepath.Join(testdataDir, "join-additional-3.0.yaml")),
+					parser.WithValidateStructure(true),
+				)
 				require.NoError(t, err)
 				return []parser.ParseResult{*doc1, *doc2, *doc3}
 			},
@@ -757,9 +772,15 @@ func TestJoinParsedConvenience(t *testing.T) {
 		{
 			name: "join parsed OAS 2.0 documents",
 			setupDocs: func(t *testing.T) []parser.ParseResult {
-				doc1, err := parser.Parse(filepath.Join(testdataDir, "join-base-2.0.yaml"), false, true)
+				doc1, err := parser.ParseWithOptions(
+					parser.WithFilePath(filepath.Join(testdataDir, "join-base-2.0.yaml")),
+					parser.WithValidateStructure(true),
+				)
 				require.NoError(t, err)
-				doc2, err := parser.Parse(filepath.Join(testdataDir, "join-extension-2.0.yaml"), false, true)
+				doc2, err := parser.ParseWithOptions(
+					parser.WithFilePath(filepath.Join(testdataDir, "join-extension-2.0.yaml")),
+					parser.WithValidateStructure(true),
+				)
 				require.NoError(t, err)
 				return []parser.ParseResult{*doc1, *doc2}
 			},
@@ -776,9 +797,15 @@ func TestJoinParsedConvenience(t *testing.T) {
 		{
 			name: "join with collision resolution",
 			setupDocs: func(t *testing.T) []parser.ParseResult {
-				doc1, err := parser.Parse(filepath.Join(testdataDir, "join-base-3.0.yaml"), false, true)
+				doc1, err := parser.ParseWithOptions(
+					parser.WithFilePath(filepath.Join(testdataDir, "join-base-3.0.yaml")),
+					parser.WithValidateStructure(true),
+				)
 				require.NoError(t, err)
-				doc2, err := parser.Parse(filepath.Join(testdataDir, "join-collision-3.0.yaml"), false, true)
+				doc2, err := parser.ParseWithOptions(
+					parser.WithFilePath(filepath.Join(testdataDir, "join-collision-3.0.yaml")),
+					parser.WithValidateStructure(true),
+				)
 				require.NoError(t, err)
 				return []parser.ParseResult{*doc1, *doc2}
 			},
@@ -820,9 +847,15 @@ paths:
         '200':
           description: Success
 `)
-				doc1, err := parser.ParseBytes(data1, false, true)
+				doc1, err := parser.ParseWithOptions(
+					parser.WithBytes(data1),
+					parser.WithValidateStructure(true),
+				)
 				require.NoError(t, err)
-				doc2, err := parser.ParseBytes(data2, false, true)
+				doc2, err := parser.ParseWithOptions(
+					parser.WithBytes(data2),
+					parser.WithValidateStructure(true),
+				)
 				require.NoError(t, err)
 				return []parser.ParseResult{*doc1, *doc2}
 			},
@@ -838,7 +871,10 @@ paths:
 		{
 			name: "join insufficient documents - should error",
 			setupDocs: func(t *testing.T) []parser.ParseResult {
-				doc1, err := parser.Parse(filepath.Join(testdataDir, "join-base-3.0.yaml"), false, true)
+				doc1, err := parser.ParseWithOptions(
+					parser.WithFilePath(filepath.Join(testdataDir, "join-base-3.0.yaml")),
+					parser.WithValidateStructure(true),
+				)
 				require.NoError(t, err)
 				return []parser.ParseResult{*doc1}
 			},
@@ -849,10 +885,16 @@ paths:
 		{
 			name: "join documents with parse errors - should error",
 			setupDocs: func(t *testing.T) []parser.ParseResult {
-				doc1, err := parser.Parse(filepath.Join(testdataDir, "join-base-3.0.yaml"), false, true)
+				doc1, err := parser.ParseWithOptions(
+					parser.WithFilePath(filepath.Join(testdataDir, "join-base-3.0.yaml")),
+					parser.WithValidateStructure(true),
+				)
 				require.NoError(t, err)
 				// Create a document with errors
-				doc2, err := parser.Parse(filepath.Join(testdataDir, "invalid-oas3.yaml"), false, true)
+				doc2, err := parser.ParseWithOptions(
+					parser.WithFilePath(filepath.Join(testdataDir, "invalid-oas3.yaml")),
+					parser.WithValidateStructure(true),
+				)
 				require.NoError(t, err)
 				return []parser.ParseResult{*doc1, *doc2}
 			},
@@ -863,9 +905,15 @@ paths:
 		{
 			name: "join incompatible versions - should error",
 			setupDocs: func(t *testing.T) []parser.ParseResult {
-				doc1, err := parser.Parse(filepath.Join(testdataDir, "join-base-2.0.yaml"), false, true)
+				doc1, err := parser.ParseWithOptions(
+					parser.WithFilePath(filepath.Join(testdataDir, "join-base-2.0.yaml")),
+					parser.WithValidateStructure(true),
+				)
 				require.NoError(t, err)
-				doc2, err := parser.Parse(filepath.Join(testdataDir, "join-base-3.0.yaml"), false, true)
+				doc2, err := parser.ParseWithOptions(
+					parser.WithFilePath(filepath.Join(testdataDir, "join-base-3.0.yaml")),
+					parser.WithValidateStructure(true),
+				)
 				require.NoError(t, err)
 				return []parser.ParseResult{*doc1, *doc2}
 			},
@@ -1044,4 +1092,109 @@ func TestMergeUniqueStrings_OverflowSafety(t *testing.T) {
 				"Result should not contain duplicates")
 		})
 	}
+}
+
+// TestJoinWithOptions_FilePaths tests the functional options API with file paths
+func TestJoinWithOptions_FilePaths(t *testing.T) {
+	result, err := JoinWithOptions(
+		WithFilePaths("../testdata/join-base-3.0.yaml", "../testdata/join-extension-3.0.yaml"),
+	)
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.NotNil(t, result.Document)
+}
+
+// TestJoinWithOptions_Parsed tests the functional options API with parsed documents
+func TestJoinWithOptions_Parsed(t *testing.T) {
+	doc1, err := parser.ParseWithOptions(
+		parser.WithFilePath("../testdata/join-base-3.0.yaml"),
+		parser.WithValidateStructure(true),
+	)
+	require.NoError(t, err)
+
+	doc2, err := parser.ParseWithOptions(
+		parser.WithFilePath("../testdata/join-extension-3.0.yaml"),
+		parser.WithValidateStructure(true),
+	)
+	require.NoError(t, err)
+
+	result, err := JoinWithOptions(
+		WithParsed(*doc1, *doc2),
+	)
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+}
+
+// TestJoinWithOptions_MixedSources tests mixing file paths and parsed docs
+func TestJoinWithOptions_MixedSources(t *testing.T) {
+	doc1, err := parser.ParseWithOptions(
+		parser.WithFilePath("../testdata/join-base-3.0.yaml"),
+		parser.WithValidateStructure(true),
+	)
+	require.NoError(t, err)
+
+	result, err := JoinWithOptions(
+		WithParsed(*doc1),
+		WithFilePaths("../testdata/join-extension-3.0.yaml"),
+	)
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+}
+
+// TestJoinWithOptions_WithConfig tests using WithConfig option
+func TestJoinWithOptions_WithConfig(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.PathStrategy = StrategyAcceptLeft
+	cfg.DeduplicateTags = false
+
+	result, err := JoinWithOptions(
+		WithFilePaths("../testdata/join-base-3.0.yaml", "../testdata/join-extension-3.0.yaml"),
+		WithConfig(cfg),
+	)
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+}
+
+// TestJoinWithOptions_IndividualStrategies tests setting individual strategies
+func TestJoinWithOptions_IndividualStrategies(t *testing.T) {
+	result, err := JoinWithOptions(
+		WithFilePaths("../testdata/join-base-3.0.yaml", "../testdata/join-extension-3.0.yaml"),
+		WithPathStrategy(StrategyAcceptLeft),
+		WithSchemaStrategy(StrategyAcceptRight),
+		WithComponentStrategy(StrategyFailOnCollision),
+	)
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+}
+
+// TestJoinWithOptions_NotEnoughDocuments tests error when < 2 documents
+func TestJoinWithOptions_NotEnoughDocuments(t *testing.T) {
+	_, err := JoinWithOptions(
+		WithFilePaths("../testdata/join-base-3.0.yaml"),
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least 2 documents are required")
+}
+
+// TestJoinWithOptions_BackwardCompatibility tests that new API produces same results as old API
+func TestJoinWithOptions_BackwardCompatibility(t *testing.T) {
+	paths := []string{"../testdata/join-base-3.0.yaml", "../testdata/join-extension-3.0.yaml"}
+
+	// Old API
+	oldConfig := DefaultConfig()
+	oldConfig.PathStrategy = StrategyAcceptLeft
+	oldResult, err := Join(paths, oldConfig)
+	require.NoError(t, err)
+
+	// New API
+	newResult, err := JoinWithOptions(
+		WithFilePaths(paths...),
+		WithPathStrategy(StrategyAcceptLeft),
+	)
+	require.NoError(t, err)
+
+	// Compare results
+	assert.Equal(t, oldResult.Version, newResult.Version)
+	assert.Equal(t, oldResult.SourceFormat, newResult.SourceFormat)
+	assert.Equal(t, oldResult.CollisionCount, newResult.CollisionCount)
 }

--- a/parser/doc.go
+++ b/parser/doc.go
@@ -7,9 +7,12 @@
 //
 // # Quick Start
 //
-// Parse a file:
+// Parse a file using functional options:
 //
-//	result, err := parser.Parse("openapi.yaml", false, true)
+//	result, err := parser.ParseWithOptions(
+//		parser.WithFilePath("openapi.yaml"),
+//		parser.WithValidateStructure(true),
+//	)
 //	if err != nil {
 //		log.Fatal(err)
 //	}
@@ -19,7 +22,10 @@
 //
 // Parse from a URL:
 //
-//	result, err := parser.Parse("https://example.com/api/openapi.yaml", false, true)
+//	result, err := parser.ParseWithOptions(
+//		parser.WithFilePath("https://example.com/api/openapi.yaml"),
+//		parser.WithValidateStructure(true),
+//	)
 //	if err != nil {
 //		log.Fatal(err)
 //	}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -2605,3 +2605,370 @@ func TestParseBytesSize(t *testing.T) {
 		t.Errorf("SourceSize = %d, expected %d", result.SourceSize, len(data))
 	}
 }
+
+// TestParseWithOptions_FilePath tests the functional options API with file path
+func TestParseWithOptions_FilePath(t *testing.T) {
+	result, err := ParseWithOptions(
+		WithFilePath("../testdata/petstore-3.0.yaml"),
+		WithResolveRefs(false),
+		WithValidateStructure(true),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "3.0.3", result.Version)
+
+	doc, ok := result.Document.(*OAS3Document)
+	require.True(t, ok, "Expected OAS3Document, got %T", result.Document)
+	assert.NotNil(t, doc.Info)
+	assert.Equal(t, "Petstore API", doc.Info.Title)
+	assert.Empty(t, result.Errors)
+}
+
+// TestParseWithOptions_Reader tests the functional options API with io.Reader
+func TestParseWithOptions_Reader(t *testing.T) {
+	file, err := os.Open("../testdata/petstore-3.0.yaml")
+	require.NoError(t, err)
+	defer func() { _ = file.Close() }()
+
+	result, err := ParseWithOptions(
+		WithReader(file),
+		WithValidateStructure(true),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "3.0.3", result.Version)
+	assert.Equal(t, "ParseReader.yaml", result.SourcePath)
+	assert.Empty(t, result.Errors)
+}
+
+// TestParseWithOptions_Bytes tests the functional options API with byte slice
+func TestParseWithOptions_Bytes(t *testing.T) {
+	data, err := os.ReadFile("../testdata/petstore-3.0.yaml")
+	require.NoError(t, err)
+
+	result, err := ParseWithOptions(
+		WithBytes(data),
+		WithResolveRefs(false),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "3.0.3", result.Version)
+	assert.Equal(t, "ParseBytes.yaml", result.SourcePath)
+}
+
+// TestParseWithOptions_UserAgent tests that user agent option is applied
+func TestParseWithOptions_UserAgent(t *testing.T) {
+	// Create a test HTTP server that records the User-Agent header
+	receivedUA := ""
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedUA = r.Header.Get("User-Agent")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`openapi: "3.0.0"
+info:
+  title: Test API
+  version: 1.0.0
+paths: {}`))
+	}))
+	defer server.Close()
+
+	customUA := "custom-user-agent/1.0"
+	_, err := ParseWithOptions(
+		WithFilePath(server.URL),
+		WithUserAgent(customUA),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, customUA, receivedUA)
+}
+
+// TestParseWithOptions_DefaultValues tests that default values are applied correctly
+func TestParseWithOptions_DefaultValues(t *testing.T) {
+	result, err := ParseWithOptions(
+		WithFilePath("../testdata/petstore-3.0.yaml"),
+		// Not specifying WithResolveRefs or WithValidateStructure to test defaults
+	)
+	require.NoError(t, err)
+
+	// Default: ValidateStructure = true, so no structural errors
+	assert.Empty(t, result.Errors)
+
+	// Default: ResolveRefs = false (hard to test directly, but would be visible
+	// in documents with $refs if we had a test case with unresolved refs)
+	assert.NotNil(t, result.Document)
+}
+
+// TestParseWithOptions_NoInputSource tests error when no input source is specified
+func TestParseWithOptions_NoInputSource(t *testing.T) {
+	_, err := ParseWithOptions(
+		WithResolveRefs(true),
+		WithValidateStructure(false),
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must specify an input source")
+}
+
+// TestParseWithOptions_MultipleInputSources tests error when multiple input sources are specified
+func TestParseWithOptions_MultipleInputSources(t *testing.T) {
+	data := []byte(`openapi: "3.0.0"`)
+
+	_, err := ParseWithOptions(
+		WithFilePath("../testdata/petstore-3.0.yaml"),
+		WithBytes(data),
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must specify exactly one input source")
+}
+
+// TestParseWithOptions_NilReader tests error when nil reader is provided
+func TestParseWithOptions_NilReader(t *testing.T) {
+	_, err := ParseWithOptions(
+		WithReader(nil),
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reader cannot be nil")
+}
+
+// TestParseWithOptions_NilBytes tests error when nil bytes are provided
+func TestParseWithOptions_NilBytes(t *testing.T) {
+	_, err := ParseWithOptions(
+		WithBytes(nil),
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bytes cannot be nil")
+}
+
+// TestParseWithOptions_ResolveRefs tests that ref resolution can be enabled
+func TestParseWithOptions_ResolveRefs(t *testing.T) {
+	// This test uses a document with external $refs to verify resolution works
+	result, err := ParseWithOptions(
+		WithFilePath("../testdata/petstore-3.0.yaml"),
+		WithResolveRefs(true),
+	)
+	require.NoError(t, err)
+	assert.NotNil(t, result.Data)
+	// If there were $refs, they would be resolved in result.Data
+}
+
+// TestParseWithOptions_DisableValidation tests that validation can be disabled
+func TestParseWithOptions_DisableValidation(t *testing.T) {
+	// Create an invalid spec (missing required fields)
+	invalidSpec := `openapi: "3.0.0"
+info:
+  title: Test
+  # Missing version field
+paths:
+  /test:
+    get:
+      # Missing responses field
+      operationId: test`
+
+	result, err := ParseWithOptions(
+		WithBytes([]byte(invalidSpec)),
+		WithValidateStructure(false), // Disable validation
+	)
+	require.NoError(t, err)
+
+	// With validation disabled, structural errors should not be in result.Errors
+	// (though the parsing itself should succeed)
+	assert.NotNil(t, result.Document)
+}
+
+// TestParseWithOptions_JSONFormat tests parsing JSON format with options
+func TestParseWithOptions_JSONFormat(t *testing.T) {
+	jsonSpec := `{
+		"openapi": "3.0.0",
+		"info": {
+			"title": "Test API",
+			"version": "1.0.0"
+		},
+		"paths": {}
+	}`
+
+	result, err := ParseWithOptions(
+		WithBytes([]byte(jsonSpec)),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, SourceFormatJSON, result.SourceFormat)
+	assert.Equal(t, "ParseBytes.json", result.SourcePath)
+}
+
+// TestParseWithOptions_AllOptions tests using all options together
+func TestParseWithOptions_AllOptions(t *testing.T) {
+	data, err := os.ReadFile("../testdata/petstore-3.0.yaml")
+	require.NoError(t, err)
+
+	result, err := ParseWithOptions(
+		WithBytes(data),
+		WithResolveRefs(false),
+		WithValidateStructure(true),
+		WithUserAgent("test-agent/1.0"),
+	)
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, "3.0.3", result.Version)
+	assert.Empty(t, result.Errors)
+}
+
+// TestWithFilePath tests the WithFilePath option function
+func TestWithFilePath(t *testing.T) {
+	cfg := &parseConfig{}
+	opt := WithFilePath("test.yaml")
+	err := opt(cfg)
+
+	require.NoError(t, err)
+	require.NotNil(t, cfg.filePath)
+	assert.Equal(t, "test.yaml", *cfg.filePath)
+}
+
+// TestWithReader tests the WithReader option function
+func TestWithReader(t *testing.T) {
+	reader := strings.NewReader("test")
+	cfg := &parseConfig{}
+	opt := WithReader(reader)
+	err := opt(cfg)
+
+	require.NoError(t, err)
+	assert.Equal(t, reader, cfg.reader)
+}
+
+// TestWithReader_Nil tests that WithReader rejects nil readers
+func TestWithReader_Nil(t *testing.T) {
+	cfg := &parseConfig{}
+	opt := WithReader(nil)
+	err := opt(cfg)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reader cannot be nil")
+}
+
+// TestWithBytes tests the WithBytes option function
+func TestWithBytes(t *testing.T) {
+	data := []byte("test")
+	cfg := &parseConfig{}
+	opt := WithBytes(data)
+	err := opt(cfg)
+
+	require.NoError(t, err)
+	assert.Equal(t, data, cfg.bytes)
+}
+
+// TestWithBytes_Nil tests that WithBytes rejects nil byte slices
+func TestWithBytes_Nil(t *testing.T) {
+	cfg := &parseConfig{}
+	opt := WithBytes(nil)
+	err := opt(cfg)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bytes cannot be nil")
+}
+
+// TestWithResolveRefs tests the WithResolveRefs option function
+func TestWithResolveRefs(t *testing.T) {
+	tests := []struct {
+		name    string
+		enabled bool
+	}{
+		{"enabled", true},
+		{"disabled", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &parseConfig{}
+			opt := WithResolveRefs(tt.enabled)
+			err := opt(cfg)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.enabled, cfg.resolveRefs)
+		})
+	}
+}
+
+// TestWithValidateStructure tests the WithValidateStructure option function
+func TestWithValidateStructure(t *testing.T) {
+	tests := []struct {
+		name    string
+		enabled bool
+	}{
+		{"enabled", true},
+		{"disabled", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &parseConfig{}
+			opt := WithValidateStructure(tt.enabled)
+			err := opt(cfg)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.enabled, cfg.validateStructure)
+		})
+	}
+}
+
+// TestWithUserAgent tests the WithUserAgent option function
+func TestWithUserAgent(t *testing.T) {
+	cfg := &parseConfig{}
+	opt := WithUserAgent("custom-agent/2.0")
+	err := opt(cfg)
+
+	require.NoError(t, err)
+	assert.Equal(t, "custom-agent/2.0", cfg.userAgent)
+}
+
+// TestApplyOptions_Defaults tests that default values are set correctly
+func TestApplyOptions_Defaults(t *testing.T) {
+	cfg, err := applyOptions(WithFilePath("test.yaml"))
+
+	require.NoError(t, err)
+	assert.False(t, cfg.resolveRefs, "default resolveRefs should be false")
+	assert.True(t, cfg.validateStructure, "default validateStructure should be true")
+	assert.NotEmpty(t, cfg.userAgent, "default userAgent should be set")
+}
+
+// TestApplyOptions_OverrideDefaults tests that options override defaults
+func TestApplyOptions_OverrideDefaults(t *testing.T) {
+	cfg, err := applyOptions(
+		WithFilePath("test.yaml"),
+		WithResolveRefs(true),
+		WithValidateStructure(false),
+		WithUserAgent("custom/1.0"),
+	)
+
+	require.NoError(t, err)
+	assert.True(t, cfg.resolveRefs)
+	assert.False(t, cfg.validateStructure)
+	assert.Equal(t, "custom/1.0", cfg.userAgent)
+}
+
+// TestParseWithOptions_BackwardCompatibility tests that new API produces same results as old API
+func TestParseWithOptions_BackwardCompatibility(t *testing.T) {
+	testCases := []struct {
+		name              string
+		resolveRefs       bool
+		validateStructure bool
+	}{
+		{"default", false, true},
+		{"resolve_refs", true, true},
+		{"no_validation", false, false},
+		{"all_enabled", true, true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Old API
+			oldResult, err := Parse("../testdata/petstore-3.0.yaml", tc.resolveRefs, tc.validateStructure)
+			require.NoError(t, err)
+
+			// New API
+			newResult, err := ParseWithOptions(
+				WithFilePath("../testdata/petstore-3.0.yaml"),
+				WithResolveRefs(tc.resolveRefs),
+				WithValidateStructure(tc.validateStructure),
+			)
+			require.NoError(t, err)
+
+			// Compare results
+			assert.Equal(t, oldResult.Version, newResult.Version)
+			assert.Equal(t, oldResult.SourceFormat, newResult.SourceFormat)
+			assert.Equal(t, len(oldResult.Errors), len(newResult.Errors))
+			assert.Equal(t, len(oldResult.Warnings), len(newResult.Warnings))
+		})
+	}
+}

--- a/validator/doc.go
+++ b/validator/doc.go
@@ -6,9 +6,12 @@
 //
 // # Quick Start
 //
-// Validate a file with warnings enabled:
+// Validate a file with warnings enabled using functional options:
 //
-//	result, err := validator.Validate("openapi.yaml", true, false)
+//	result, err := validator.ValidateWithOptions(
+//		validator.WithFilePath("openapi.yaml"),
+//		validator.WithIncludeWarnings(true),
+//	)
 //	if err != nil {
 //		log.Fatal(err)
 //	}

--- a/validator/validator_bench_test.go
+++ b/validator/validator_bench_test.go
@@ -121,7 +121,9 @@ func BenchmarkValidateMediumOAS3NoWarnings(b *testing.B) {
 // BenchmarkValidateParsedSmallOAS3 benchmarks validating an already-parsed document
 func BenchmarkValidateParsedSmallOAS3(b *testing.B) {
 	// Parse once
-	parseResult, err := parser.Parse(smallOAS3Path, false, false)
+	parseResult, err := parser.ParseWithOptions(
+		parser.WithFilePath(smallOAS3Path),
+	)
 	if err != nil {
 		b.Fatalf("Failed to parse: %v", err)
 	}
@@ -141,7 +143,9 @@ func BenchmarkValidateParsedSmallOAS3(b *testing.B) {
 // BenchmarkValidateParsedMediumOAS3 benchmarks validating an already-parsed medium doc
 func BenchmarkValidateParsedMediumOAS3(b *testing.B) {
 	// Parse once
-	parseResult, err := parser.Parse(mediumOAS3Path, false, false)
+	parseResult, err := parser.ParseWithOptions(
+		parser.WithFilePath(mediumOAS3Path),
+	)
 	if err != nil {
 		b.Fatalf("Failed to parse: %v", err)
 	}
@@ -161,7 +165,9 @@ func BenchmarkValidateParsedMediumOAS3(b *testing.B) {
 // BenchmarkValidateParsedLargeOAS3 benchmarks validating an already-parsed large doc
 func BenchmarkValidateParsedLargeOAS3(b *testing.B) {
 	// Parse once
-	parseResult, err := parser.Parse(largeOAS3Path, false, false)
+	parseResult, err := parser.ParseWithOptions(
+		parser.WithFilePath(largeOAS3Path),
+	)
 	if err != nil {
 		b.Fatalf("Failed to parse: %v", err)
 	}


### PR DESCRIPTION
## Summary

This PR completes Week 1 deliverables of the v2.0 migration plan, updating all documentation, examples, tests, and benchmarks to use the new `*WithOptions` functional options API pattern as primary.

## What's Changed

### Documentation Updates
- **Package docs** (`doc.go`): Updated all 5 packages (parser, validator, converter, joiner, differ) to show `*WithOptions` as the primary API
- **Examples** (`example_test.go`): Migrated converter and differ examples to functional options pattern
- **Migration Guide**: Created comprehensive `MIGRATION_V1_TO_V2.md` (600+ lines) with before/after examples for all packages
- **Project Docs**: Updated `CLAUDE.md` and `README.md` to reflect new API patterns

### Code Migration
- **Benchmarks**: Migrated all benchmarks in converter, differ, validator, and joiner packages to use `ParseWithOptions`
  - Removed benchmarks for deprecated convenience functions (differ package)
  - All benchmarks now use modern Go 1.24+ `for b.Loop()` pattern with new API
- **Tests**: Migrated all test files to use `*WithOptions` APIs
  - converter_test.go, validator_test.go, joiner_test.go, differ_test.go
  - Systematic migration using targeted sed replacements
- **Production Code**: Updated `joiner/joiner.go` to use `ParseWithOptions` internally

## Impact

- ✅ Zero linter warnings (`make check` passes cleanly)
- ✅ All tests pass
- ✅ No breaking changes - deprecated APIs remain available
- ✅ Documentation now exclusively promotes the new, more flexible API

## Migration Guide

See `MIGRATION_V1_TO_V2.md` for comprehensive migration examples and strategies.

## Related

- Part of v2.0 migration plan (Week 1 complete)
- All deprecated package-level convenience functions remain available but are no longer documented
- Next phase (Week 2): Remove deprecated APIs and release v2.0-alpha

## Test Plan

- [x] `make check` passes with 0 warnings
- [x] All unit tests pass
- [x] All benchmarks compile and run
- [x] Documentation renders correctly in godoc
- [x] Examples in godoc work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)