### PR TITLE
chore: backfill benchmark results for v1.10.0, v1.10.1, v1.11.0

### DIFF
--- a/benchmarks/benchmark-v1.10.0.txt
+++ b/benchmarks/benchmark-v1.10.0.txt
@@ -1,0 +1,102 @@
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/parser
+cpu: Apple M4
+BenchmarkMarshalInfoNoExtra-10             	13480827	       453.8 ns/op	     192 B/op	       2 allocs/op
+BenchmarkMarshalInfoWithExtra-10           	 3323821	      1794 ns/op	    1737 B/op	      26 allocs/op
+BenchmarkMarshalInfoExtra1-10              	 6485982	       926.3 ns/op	     896 B/op	      16 allocs/op
+BenchmarkMarshalInfoExtra5-10              	 3399550	      1747 ns/op	    1705 B/op	      26 allocs/op
+BenchmarkMarshalInfoExtra10-10             	 2003828	      2988 ns/op	    2987 B/op	      36 allocs/op
+BenchmarkMarshalInfoExtra20-10             	 1000000	      5427 ns/op	    4333 B/op	      56 allocs/op
+BenchmarkMarshalContactNoExtra-10          	12981175	       454.3 ns/op	     192 B/op	       2 allocs/op
+BenchmarkMarshalContactWithExtra-10        	 3599870	      1671 ns/op	    1377 B/op	      24 allocs/op
+BenchmarkMarshalServerNoExtra-10           	16129058	       373.1 ns/op	     160 B/op	       2 allocs/op
+BenchmarkMarshalServerWithExtra-10         	 2653417	      2239 ns/op	    2010 B/op	      29 allocs/op
+BenchmarkMarshalOAS3DocumentSmall-10       	  307282	     19530 ns/op	    7002 B/op	      66 allocs/op
+BenchmarkMarshalOAS3DocumentMedium-10      	   27813	    216781 ns/op	   65744 B/op	     471 allocs/op
+BenchmarkMarshalOAS3DocumentLarge-10       	    2232	   2689712 ns/op	  839336 B/op	    5336 allocs/op
+BenchmarkMarshalOAS2DocumentSmall-10       	  335906	     17671 ns/op	    6370 B/op	      58 allocs/op
+BenchmarkMarshalOAS2DocumentMedium-10      	   34125	    175522 ns/op	   53606 B/op	     396 allocs/op
+BenchmarkUnmarshalInfoNoExtra-10           	 4098405	      1465 ns/op	    1224 B/op	      29 allocs/op
+BenchmarkUnmarshalInfoWithExtra-10         	 1820823	      3289 ns/op	    1736 B/op	      46 allocs/op
+BenchmarkParseSmallOAS3-10                 	   41836	    144084 ns/op	  202657 B/op	    2128 allocs/op
+BenchmarkParseMediumOAS3-10                	    5232	   1151359 ns/op	 1464870 B/op	   17449 allocs/op
+BenchmarkParseLargeOAS3-10                 	     424	  14081756 ns/op	16467560 B/op	  194777 allocs/op
+BenchmarkParseSmallOAS2-10                 	   44170	    135749 ns/op	  174165 B/op	    2059 allocs/op
+BenchmarkParseMediumOAS2-10                	    5806	   1033239 ns/op	 1229968 B/op	   16027 allocs/op
+BenchmarkParseSmallOAS3NoValidation-10     	   42811	    140100 ns/op	  196277 B/op	    2047 allocs/op
+BenchmarkParseMediumOAS3NoValidation-10    	    5317	   1131141 ns/op	 1442319 B/op	   17296 allocs/op
+BenchmarkParseBytesSmallOAS3-10            	   44698	    134534 ns/op	  201024 B/op	    2123 allocs/op
+BenchmarkParseBytesMediumOAS3-10           	    5264	   1126536 ns/op	 1446666 B/op	   17443 allocs/op
+BenchmarkConvenienceParseSmallOAS3-10      	   41344	    145036 ns/op	  202759 B/op	    2128 allocs/op
+BenchmarkConvenienceParseMediumOAS3-10     	    5232	   1139896 ns/op	 1459995 B/op	   17448 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/parser	167.570s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/validator
+cpu: Apple M4
+BenchmarkValidateSmallOAS3-10                	   41017	    146311 ns/op	  208070 B/op	    2220 allocs/op
+BenchmarkValidateMediumOAS3-10               	    5144	   1159943 ns/op	 1494475 B/op	   18365 allocs/op
+BenchmarkValidateLargeOAS3-10                	     412	  14588273 ns/op	16848529 B/op	  205079 allocs/op
+BenchmarkValidateSmallOAS2-10                	   43524	    137434 ns/op	  180592 B/op	    2135 allocs/op
+BenchmarkValidateMediumOAS2-10               	    5734	   1047096 ns/op	 1268541 B/op	   16851 allocs/op
+BenchmarkValidateSmallOAS3NoWarnings-10      	   40827	    147084 ns/op	  208353 B/op	    2220 allocs/op
+BenchmarkValidateMediumOAS3NoWarnings-10     	    5104	   1172011 ns/op	 1494318 B/op	   18365 allocs/op
+BenchmarkValidateParsedSmallOAS3-10          	 1281325	      4681 ns/op	    5262 B/op	      90 allocs/op
+BenchmarkValidateParsedMediumOAS3-10         	  150466	     39933 ns/op	   33428 B/op	     914 allocs/op
+BenchmarkValidateParsedLargeOAS3-10          	   13178	    455646 ns/op	  376011 B/op	   10297 allocs/op
+BenchmarkConvenienceValidateSmallOAS3-10     	   40574	    147856 ns/op	  208373 B/op	    2220 allocs/op
+BenchmarkConvenienceValidateMediumOAS3-10    	    5073	   1170547 ns/op	 1494264 B/op	   18365 allocs/op
+BenchmarkValidateStrictModeSmallOAS3-10      	   40701	    148336 ns/op	  208303 B/op	    2220 allocs/op
+BenchmarkValidateStrictModeMediumOAS3-10     	    5040	   1171597 ns/op	 1493650 B/op	   18364 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/validator	84.230s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/converter
+cpu: Apple M4
+BenchmarkConvertOAS2ToOAS3Small-10                	   39303	    151688 ns/op	  195514 B/op	    2359 allocs/op
+BenchmarkConvertOAS2ToOAS3Medium-10               	    4795	   1252435 ns/op	 1496356 B/op	   19641 allocs/op
+BenchmarkConvertOAS3ToOAS2Small-10                	   37635	    160002 ns/op	  221388 B/op	    2390 allocs/op
+BenchmarkConvertOAS3ToOAS2Medium-10               	    4137	   1441968 ns/op	 1735959 B/op	   21369 allocs/op
+BenchmarkConvertParsedOAS2ToOAS3Small-10          	  369334	     16131 ns/op	   21115 B/op	     297 allocs/op
+BenchmarkConvertParsedOAS2ToOAS3Medium-10         	   23392	    256204 ns/op	  265134 B/op	    3608 allocs/op
+BenchmarkConvertParsedOAS3ToOAS2Small-10          	  435151	     13682 ns/op	   17472 B/op	     258 allocs/op
+BenchmarkConvertParsedOAS3ToOAS2Medium-10         	   21584	    278134 ns/op	  268558 B/op	    3909 allocs/op
+BenchmarkConvenienceConvertOAS2ToOAS3Small-10     	   39416	    152386 ns/op	  195520 B/op	    2359 allocs/op
+BenchmarkConvenienceConvertOAS2ToOAS3Medium-10    	    4579	   1258826 ns/op	 1496280 B/op	   19640 allocs/op
+BenchmarkConvertNoInfoOAS2ToOAS3Small-10          	   39313	    152721 ns/op	  195524 B/op	    2359 allocs/op
+BenchmarkConvertNoInfoOAS2ToOAS3Medium-10         	    4744	   1259335 ns/op	 1496300 B/op	   19640 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/converter	72.026s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/joiner
+cpu: Apple M4
+BenchmarkJoinTwoSmallDocs-10               	   54483	    110035 ns/op	  144416 B/op	    1602 allocs/op
+BenchmarkJoinThreeSmallDocs-10             	   36849	    163637 ns/op	  214890 B/op	    2363 allocs/op
+BenchmarkJoinParsedTwoSmallDocs-10         	 8300179	       723.4 ns/op	    1816 B/op	      22 allocs/op
+BenchmarkJoinParsedThreeSmallDocs-10       	 6567250	       911.9 ns/op	    1960 B/op	      23 allocs/op
+BenchmarkConvenienceJoinTwoSmallDocs-10    	   54800	    109799 ns/op	  144598 B/op	    1602 allocs/op
+BenchmarkJoinStrategyAcceptRight-10        	   54930	    110137 ns/op	  144757 B/op	    1602 allocs/op
+BenchmarkJoinWithArrayMerge-10             	   54586	    110086 ns/op	  144970 B/op	    1602 allocs/op
+BenchmarkJoinWithDeduplicateTags-10        	   54453	    110206 ns/op	  145092 B/op	    1602 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/joiner	48.428s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/differ
+cpu: Apple M4
+BenchmarkDiffConvenience-10          	   12901	    465051 ns/op	  616189 B/op	    7317 allocs/op
+BenchmarkDiffParsedConvenience-10    	  577591	     10396 ns/op	   15022 B/op	     297 allocs/op
+BenchmarkDifferDiff-10               	   12774	    469619 ns/op	  618895 B/op	    7318 allocs/op
+BenchmarkDifferDiffParsed-10         	  579768	     10365 ns/op	   15021 B/op	     297 allocs/op
+BenchmarkDifferSimpleMode-10         	  580089	     10393 ns/op	   15021 B/op	     297 allocs/op
+BenchmarkDifferBreakingMode-10       	  577581	     10370 ns/op	   15021 B/op	     297 allocs/op
+BenchmarkDifferWithInfo-10           	  578253	     10383 ns/op	   15021 B/op	     297 allocs/op
+BenchmarkDifferWithoutInfo-10        	  566352	     10527 ns/op	   16430 B/op	     298 allocs/op
+BenchmarkDifferIdenticalSpecs-10     	  734815	      8201 ns/op	   10643 B/op	     247 allocs/op
+BenchmarkParseOnceDiffMany-10        	  580269	     10376 ns/op	   15021 B/op	     297 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/differ	60.373s

--- a/benchmarks/benchmark-v1.10.1.txt
+++ b/benchmarks/benchmark-v1.10.1.txt
@@ -1,0 +1,102 @@
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/parser
+cpu: Apple M4
+BenchmarkMarshalInfoNoExtra-10             	12294734	       441.0 ns/op	     192 B/op	       2 allocs/op
+BenchmarkMarshalInfoWithExtra-10           	 3362661	      1785 ns/op	    1737 B/op	      26 allocs/op
+BenchmarkMarshalInfoExtra1-10              	 6433219	       935.9 ns/op	     896 B/op	      16 allocs/op
+BenchmarkMarshalInfoExtra5-10              	 3442767	      1739 ns/op	    1705 B/op	      26 allocs/op
+BenchmarkMarshalInfoExtra10-10             	 2039331	      2966 ns/op	    2987 B/op	      36 allocs/op
+BenchmarkMarshalInfoExtra20-10             	 1000000	      5443 ns/op	    4333 B/op	      56 allocs/op
+BenchmarkMarshalContactNoExtra-10          	13447478	       444.5 ns/op	     192 B/op	       2 allocs/op
+BenchmarkMarshalContactWithExtra-10        	 3604584	      1661 ns/op	    1377 B/op	      24 allocs/op
+BenchmarkMarshalServerNoExtra-10           	16361404	       368.9 ns/op	     160 B/op	       2 allocs/op
+BenchmarkMarshalServerWithExtra-10         	 2690550	      2282 ns/op	    2010 B/op	      29 allocs/op
+BenchmarkMarshalOAS3DocumentSmall-10       	  304126	     19631 ns/op	    7002 B/op	      66 allocs/op
+BenchmarkMarshalOAS3DocumentMedium-10      	   27663	    216461 ns/op	   65732 B/op	     471 allocs/op
+BenchmarkMarshalOAS3DocumentLarge-10       	    2268	   2655956 ns/op	  838575 B/op	    5336 allocs/op
+BenchmarkMarshalOAS2DocumentSmall-10       	  351643	     17050 ns/op	    6369 B/op	      58 allocs/op
+BenchmarkMarshalOAS2DocumentMedium-10      	   34645	    173013 ns/op	   53607 B/op	     396 allocs/op
+BenchmarkUnmarshalInfoNoExtra-10           	 4108042	      1465 ns/op	    1224 B/op	      29 allocs/op
+BenchmarkUnmarshalInfoWithExtra-10         	 1813440	      3309 ns/op	    1736 B/op	      46 allocs/op
+BenchmarkParseSmallOAS3-10                 	   42579	    141041 ns/op	  197167 B/op	    2070 allocs/op
+BenchmarkParseMediumOAS3-10                	    5276	   1138811 ns/op	 1447276 B/op	   17389 allocs/op
+BenchmarkParseLargeOAS3-10                 	     422	  14218710 ns/op	16424522 B/op	  194712 allocs/op
+BenchmarkParseSmallOAS2-10                 	   43981	    135943 ns/op	  174163 B/op	    2059 allocs/op
+BenchmarkParseMediumOAS2-10                	    5794	   1035668 ns/op	 1229977 B/op	   16027 allocs/op
+BenchmarkParseSmallOAS3NoValidation-10     	   42708	    140457 ns/op	  196277 B/op	    2047 allocs/op
+BenchmarkParseMediumOAS3NoValidation-10    	    5252	   1130884 ns/op	 1442318 B/op	   17296 allocs/op
+BenchmarkParseBytesSmallOAS3-10            	   46518	    130297 ns/op	  195398 B/op	    2065 allocs/op
+BenchmarkParseBytesMediumOAS3-10           	    5269	   1129287 ns/op	 1433285 B/op	   17383 allocs/op
+BenchmarkConvenienceParseSmallOAS3-10      	   42800	    141794 ns/op	  197167 B/op	    2070 allocs/op
+BenchmarkConvenienceParseMediumOAS3-10     	    5239	   1148237 ns/op	 1447212 B/op	   17388 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/parser	167.399s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/validator
+cpu: Apple M4
+BenchmarkValidateSmallOAS3-10                	   41720	    142958 ns/op	  203978 B/op	    2162 allocs/op
+BenchmarkValidateMediumOAS3-10               	    5180	   1163276 ns/op	 1490301 B/op	   18307 allocs/op
+BenchmarkValidateLargeOAS3-10                	     415	  14509094 ns/op	16842889 B/op	  205021 allocs/op
+BenchmarkValidateSmallOAS2-10                	   43614	    137224 ns/op	  180561 B/op	    2135 allocs/op
+BenchmarkValidateMediumOAS2-10               	    5774	   1040825 ns/op	 1268236 B/op	   16851 allocs/op
+BenchmarkValidateSmallOAS3NoWarnings-10      	   41876	    143387 ns/op	  204078 B/op	    2162 allocs/op
+BenchmarkValidateMediumOAS3NoWarnings-10     	    5167	   1163782 ns/op	 1489993 B/op	   18306 allocs/op
+BenchmarkValidateParsedSmallOAS3-10          	 1277488	      4694 ns/op	    5261 B/op	      90 allocs/op
+BenchmarkValidateParsedMediumOAS3-10         	  151777	     39911 ns/op	   33415 B/op	     914 allocs/op
+BenchmarkValidateParsedLargeOAS3-10          	   13033	    459690 ns/op	  376023 B/op	   10297 allocs/op
+BenchmarkConvenienceValidateSmallOAS3-10     	   41724	    144033 ns/op	  204242 B/op	    2162 allocs/op
+BenchmarkConvenienceValidateMediumOAS3-10    	    5108	   1168018 ns/op	 1490220 B/op	   18307 allocs/op
+BenchmarkValidateStrictModeSmallOAS3-10      	   41742	    143850 ns/op	  204097 B/op	    2162 allocs/op
+BenchmarkValidateStrictModeMediumOAS3-10     	    5130	   1166885 ns/op	 1489831 B/op	   18306 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/validator	84.432s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/converter
+cpu: Apple M4
+BenchmarkConvertOAS2ToOAS3Small-10                	   38604	    153313 ns/op	  195513 B/op	    2359 allocs/op
+BenchmarkConvertOAS2ToOAS3Medium-10               	    4756	   1257877 ns/op	 1496337 B/op	   19640 allocs/op
+BenchmarkConvertOAS3ToOAS2Small-10                	   38452	    156901 ns/op	  217123 B/op	    2332 allocs/op
+BenchmarkConvertOAS3ToOAS2Medium-10               	    4142	   1436603 ns/op	 1731304 B/op	   21310 allocs/op
+BenchmarkConvertParsedOAS2ToOAS3Small-10          	  373165	     16093 ns/op	   21115 B/op	     297 allocs/op
+BenchmarkConvertParsedOAS2ToOAS3Medium-10         	   23620	    254003 ns/op	  265141 B/op	    3608 allocs/op
+BenchmarkConvertParsedOAS3ToOAS2Small-10          	  415969	     13669 ns/op	   17475 B/op	     258 allocs/op
+BenchmarkConvertParsedOAS3ToOAS2Medium-10         	   21676	    276740 ns/op	  268567 B/op	    3909 allocs/op
+BenchmarkConvenienceConvertOAS2ToOAS3Small-10     	   39452	    152382 ns/op	  195519 B/op	    2359 allocs/op
+BenchmarkConvenienceConvertOAS2ToOAS3Medium-10    	    4741	   1261993 ns/op	 1496296 B/op	   19640 allocs/op
+BenchmarkConvertNoInfoOAS2ToOAS3Small-10          	   39349	    152840 ns/op	  195523 B/op	    2359 allocs/op
+BenchmarkConvertNoInfoOAS2ToOAS3Medium-10         	    4732	   1264187 ns/op	 1496316 B/op	   19640 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/converter	71.904s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/joiner
+cpu: Apple M4
+BenchmarkJoinTwoSmallDocs-10               	   58280	    102488 ns/op	  135332 B/op	    1486 allocs/op
+BenchmarkJoinThreeSmallDocs-10             	   39477	    151745 ns/op	  201202 B/op	    2189 allocs/op
+BenchmarkJoinParsedTwoSmallDocs-10         	 8367396	       725.8 ns/op	    1816 B/op	      22 allocs/op
+BenchmarkJoinParsedThreeSmallDocs-10       	 6534316	       918.6 ns/op	    1960 B/op	      23 allocs/op
+BenchmarkConvenienceJoinTwoSmallDocs-10    	   56662	    103029 ns/op	  135333 B/op	    1486 allocs/op
+BenchmarkJoinStrategyAcceptRight-10        	   58459	    102340 ns/op	  135334 B/op	    1486 allocs/op
+BenchmarkJoinWithArrayMerge-10             	   58432	    102571 ns/op	  135336 B/op	    1486 allocs/op
+BenchmarkJoinWithDeduplicateTags-10        	   58233	    102937 ns/op	  135339 B/op	    1486 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/joiner	48.219s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/differ
+cpu: Apple M4
+BenchmarkDiffConvenience-10          	   13094	    458062 ns/op	  603518 B/op	    7200 allocs/op
+BenchmarkDiffParsedConvenience-10    	  583105	     10293 ns/op	   15021 B/op	     297 allocs/op
+BenchmarkDifferDiff-10               	   13047	    459711 ns/op	  603564 B/op	    7200 allocs/op
+BenchmarkDifferDiffParsed-10         	  580468	     10332 ns/op	   15022 B/op	     297 allocs/op
+BenchmarkDifferSimpleMode-10         	  586995	     10326 ns/op	   15022 B/op	     297 allocs/op
+BenchmarkDifferBreakingMode-10       	  579247	     10337 ns/op	   15021 B/op	     297 allocs/op
+BenchmarkDifferWithInfo-10           	  579068	     10330 ns/op	   15021 B/op	     297 allocs/op
+BenchmarkDifferWithoutInfo-10        	  570111	     10496 ns/op	   16430 B/op	     298 allocs/op
+BenchmarkDifferIdenticalSpecs-10     	  734582	      8155 ns/op	   10643 B/op	     247 allocs/op
+BenchmarkParseOnceDiffMany-10        	  580113	     10282 ns/op	   15021 B/op	     297 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/differ	60.331s

--- a/benchmarks/benchmark-v1.11.0.txt
+++ b/benchmarks/benchmark-v1.11.0.txt
@@ -1,0 +1,71 @@
+signal: killed
+FAIL	github.com/erraggy/oastools/parser	165.599s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/validator
+cpu: Apple M4
+BenchmarkValidateSmallOAS3-10                	   40768	    153744 ns/op	  203852 B/op	    2162 allocs/op
+BenchmarkValidateMediumOAS3-10               	    5068	   1166360 ns/op	 1489793 B/op	   18306 allocs/op
+BenchmarkValidateLargeOAS3-10                	     408	  14520079 ns/op	16841457 B/op	  205021 allocs/op
+BenchmarkValidateSmallOAS2-10                	   43216	    137681 ns/op	  180645 B/op	    2135 allocs/op
+BenchmarkValidateMediumOAS2-10               	    5701	   1039590 ns/op	 1268229 B/op	   16851 allocs/op
+BenchmarkValidateSmallOAS3NoWarnings-10      	   41724	    143844 ns/op	  204208 B/op	    2162 allocs/op
+BenchmarkValidateMediumOAS3NoWarnings-10     	    5179	   1164321 ns/op	 1490180 B/op	   18307 allocs/op
+BenchmarkValidateParsedSmallOAS3-10          	 1269890	      4723 ns/op	    5292 B/op	      90 allocs/op
+BenchmarkValidateParsedMediumOAS3-10         	  150914	     40070 ns/op	   33454 B/op	     914 allocs/op
+BenchmarkValidateParsedLargeOAS3-10          	   13138	    457495 ns/op	  375888 B/op	   10297 allocs/op
+BenchmarkConvenienceValidateSmallOAS3-10     	   41492	    144494 ns/op	  204217 B/op	    2162 allocs/op
+BenchmarkConvenienceValidateMediumOAS3-10    	    5139	   1170554 ns/op	 1490221 B/op	   18307 allocs/op
+BenchmarkValidateStrictModeSmallOAS3-10      	   41661	    144470 ns/op	  204159 B/op	    2162 allocs/op
+BenchmarkValidateStrictModeMediumOAS3-10     	    5107	   1171657 ns/op	 1490525 B/op	   18307 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/validator	84.546s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/converter
+cpu: Apple M4
+BenchmarkConvertOAS2ToOAS3Small-10                	   39114	    152517 ns/op	  195557 B/op	    2359 allocs/op
+BenchmarkConvertOAS2ToOAS3Medium-10               	    4743	   1260842 ns/op	 1496391 B/op	   19641 allocs/op
+BenchmarkConvertOAS3ToOAS2Small-10                	   38234	    156973 ns/op	  217264 B/op	    2332 allocs/op
+BenchmarkConvertOAS3ToOAS2Medium-10               	    4152	   1438366 ns/op	 1732383 B/op	   21311 allocs/op
+BenchmarkConvertParsedOAS2ToOAS3Small-10          	  371346	     16088 ns/op	   21131 B/op	     297 allocs/op
+BenchmarkConvertParsedOAS2ToOAS3Medium-10         	   23479	    255888 ns/op	  265151 B/op	    3608 allocs/op
+BenchmarkConvertParsedOAS3ToOAS2Small-10          	  438691	     13620 ns/op	   17486 B/op	     258 allocs/op
+BenchmarkConvertParsedOAS3ToOAS2Medium-10         	   21613	    277907 ns/op	  268484 B/op	    3909 allocs/op
+BenchmarkConvenienceConvertOAS2ToOAS3Small-10     	   39152	    153390 ns/op	  195568 B/op	    2359 allocs/op
+BenchmarkConvenienceConvertOAS2ToOAS3Medium-10    	    4747	   1263962 ns/op	 1496311 B/op	   19640 allocs/op
+BenchmarkConvertNoInfoOAS2ToOAS3Small-10          	   39091	    153671 ns/op	  195570 B/op	    2359 allocs/op
+BenchmarkConvertNoInfoOAS2ToOAS3Medium-10         	    4732	   1264336 ns/op	 1496313 B/op	   19640 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/converter	72.265s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/joiner
+cpu: Apple M4
+BenchmarkJoinTwoSmallDocs-10               	   57774	    102971 ns/op	  135829 B/op	    1494 allocs/op
+BenchmarkJoinThreeSmallDocs-10             	   39388	    152197 ns/op	  201956 B/op	    2201 allocs/op
+BenchmarkJoinParsedTwoSmallDocs-10         	 7843497	       765.5 ns/op	    1896 B/op	      22 allocs/op
+BenchmarkJoinParsedThreeSmallDocs-10       	 6204858	       965.3 ns/op	    2072 B/op	      23 allocs/op
+BenchmarkConvenienceJoinTwoSmallDocs-10    	   58516	    102629 ns/op	  135831 B/op	    1494 allocs/op
+BenchmarkJoinStrategyAcceptRight-10        	   58506	    102720 ns/op	  135831 B/op	    1494 allocs/op
+BenchmarkJoinWithArrayMerge-10             	   58311	    102937 ns/op	  135834 B/op	    1494 allocs/op
+BenchmarkJoinWithDeduplicateTags-10        	   58021	    103133 ns/op	  135837 B/op	    1494 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/joiner	48.508s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/differ
+cpu: Apple M4
+BenchmarkDiffConvenience-10          	   13137	    456645 ns/op	  603580 B/op	    7200 allocs/op
+BenchmarkDiffParsedConvenience-10    	  581638	     10259 ns/op	   15021 B/op	     297 allocs/op
+BenchmarkDifferDiff-10               	   13068	    458892 ns/op	  603629 B/op	    7200 allocs/op
+BenchmarkDifferDiffParsed-10         	  582805	     10283 ns/op	   15022 B/op	     297 allocs/op
+BenchmarkDifferSimpleMode-10         	  588319	     10259 ns/op	   15021 B/op	     297 allocs/op
+BenchmarkDifferBreakingMode-10       	  583200	     10277 ns/op	   15021 B/op	     297 allocs/op
+BenchmarkDifferWithInfo-10           	  584414	     10284 ns/op	   15021 B/op	     297 allocs/op
+BenchmarkDifferWithoutInfo-10        	  573016	     10449 ns/op	   16430 B/op	     298 allocs/op
+BenchmarkDifferIdenticalSpecs-10     	  733358	      8105 ns/op	   10643 B/op	     247 allocs/op
+BenchmarkParseOnceDiffMany-10        	  582508	     10305 ns/op	   15021 B/op	     297 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/differ	60.295s
+FAIL


### PR DESCRIPTION
## Summary

Backfill benchmark results for versions v1.10.0, v1.10.1, and v1.11.0 in preparation for the next release.

## Changes

- Added `benchmarks/benchmark-v1.10.0.txt` - Benchmark results for v1.10.0
- Added `benchmarks/benchmark-v1.10.1.txt` - Benchmark results for v1.10.1  
- Added `benchmarks/benchmark-v1.11.0.txt` - Benchmark results for v1.11.0

## Notes

- This PR uses `[skip ci]` to avoid running unnecessary CI checks
- These benchmarks fill the gap since v1.9.12 and bring us current for release preparation
- All benchmarks were generated using the backfill script on the same hardware (Apple M4)

## Related

Part of pre-release preparation.