### PR TITLE
ci: increase Go workflow timeout from 5m to 10m for first-run module downloads

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 5  # Fast tests should complete in under 5 minutes
+    timeout-minutes: 10  # Allow time for module downloads on first run; cached runs complete in ~30s
     steps:
     - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary

Fixes the Go workflow timeout issue that's causing test failures on pushes to main.

## Problem

The Go workflow has a 5-minute timeout, which is insufficient for first runs when Go modules need to be downloaded. Even with caching enabled (added in PR #53), the first run after any dependency change times out because:

1. Module download takes ~2-3 minutes
2. Test execution takes ~2-3 minutes  
3. Total: ~5-7 minutes > 5-minute timeout

Subsequent runs with cached modules complete in ~30 seconds.

## Solution

Increase the timeout from 5 to 10 minutes. This:
- Allows first runs to succeed even when downloading all dependencies
- Still catches genuinely hung tests (anything taking more than 10 minutes is abnormal)
- Doesn't impact cached runs (they still complete in ~30s)

## Testing

- Local test run completes in ~30s with warm cache
- First CI run (no cache) took >5 minutes and timed out
- With 10-minute timeout, first runs should complete successfully

## Related

- PR #53 enabled Go module caching to speed up subsequent runs
- This complements that fix by allowing the first run to succeed