### PR TITLE
docs: fix builder API reference and update package count

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ spec := builder.New(parser.OASVersion320).
         builder.WithOperationID("listUsers"),
         builder.WithResponse(http.StatusOK, []User{}),
     )
-doc, err := spec.Build()
+doc, err := spec.BuildOAS3()  // Returns *parser.OAS3Document
 ```
 
 #### Advanced API (Reusable Instances)

--- a/doc.go
+++ b/doc.go
@@ -1,13 +1,14 @@
 // Package oastools provides tools for parsing, validating, converting, joining,
-// and comparing OpenAPI Specification (OAS) documents from OAS 2.0 through OAS 3.2.0.
+// comparing, and building OpenAPI Specification (OAS) documents from OAS 2.0 through OAS 3.2.0.
 //
-// The library consists of five packages:
+// The library consists of six packages:
 //
 //   - parser: Parse OpenAPI specifications from YAML or JSON
 //   - validator: Validate OpenAPI specifications against their declared version
 //   - converter: Convert OpenAPI specifications between different OAS versions
 //   - joiner: Join multiple OpenAPI specifications into a single document
 //   - differ: Compare OpenAPI specifications and detect breaking changes
+//   - builder: Programmatically construct OpenAPI specifications with reflection-based schema generation
 //
 // For installation, CLI usage, and examples, see: https://github.com/erraggy/oastools
 //


### PR DESCRIPTION
## Summary

Fixes documentation inaccuracies found during review of the README and godocs for pkg.go.dev.

## Issues Fixed

### 1. Incorrect Builder API in README.md

**Location:** Line 158  
**Issue:** Example code uses `spec.Build()` which was removed in PR #52  
**Fix:** Changed to `spec.BuildOAS3()` with clarifying comment

**Before:**
```go
doc, err := spec.Build()
```

**After:**
```go
doc, err := spec.BuildOAS3()  // Returns *parser.OAS3Document
```

**Why this matters:** 
- The `Build()` method that returned `any` was intentionally removed in PR #52 to provide type safety
- Users following the README would get a compilation error
- The fix makes it clear which method to use for OAS 3.x specs

### 2. Outdated Package Count in doc.go

**Location:** Line 4  
**Issue:** States "five packages" but we now have six (added builder in v1.12.0)  
**Fix:** Updated to "six packages" and added builder to the list

**Before:**
```go
// The library consists of five packages:
//
//   - parser: Parse OpenAPI specifications from YAML or JSON
//   - validator: Validate OpenAPI specifications against their declared version
//   - converter: Convert OpenAPI specifications between different OAS versions
//   - joiner: Join multiple OpenAPI specifications into a single document
//   - differ: Compare OpenAPI specifications and detect breaking changes
```

**After:**
```go
// The library consists of six packages:
//
//   - parser: Parse OpenAPI specifications from YAML or JSON
//   - validator: Validate OpenAPI specifications against their declared version
//   - converter: Convert OpenAPI specifications between different OAS versions
//   - joiner: Join multiple OpenAPI specifications into a single document
//   - differ: Compare OpenAPI specifications and detect breaking changes
//   - builder: Programmatically construct OpenAPI specifications with reflection-based schema generation
```

**Why this matters:**
- The root package documentation on pkg.go.dev incorrectly listed only 5 packages
- This is the first thing developers see when browsing the package
- Missing the builder package made it less discoverable

## Testing

- ✅ Verified examples compile correctly
- ✅ Checked pkg.go.dev rendering (will update after merge)
- ✅ No code changes - documentation only

## Impact

These changes improve the accuracy of documentation that appears on:
- https://pkg.go.dev/github.com/erraggy/oastools (root package)
- GitHub README.md
- Package discovery for new users