### PR TITLE
feat(benchmarks): add comprehensive benchmark coverage and refresh suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,11 +218,11 @@ The library includes comprehensive performance benchmarking (70+ benchmarks acro
 
 | Operation        | Small (~60 lines) | Medium (~570 lines) | Large (~6000 lines) |
 |------------------|-------------------|---------------------|---------------------|
-| Parse            | 145 μs            | 1,144 μs            | 14,178 μs           |
-| Validate         | 147 μs            | 1,171 μs            | 14,583 μs           |
-| Convert (OAS2→3) | 152 μs            | 1,258 μs            | -                   |
-| Join (2 docs)    | 110 μs            | -                   | -                   |
-| Diff (2 docs)    | 463 μs            | -                   | -                   |
+| Parse            | 138 μs            | 1,119 μs            | 13,880 μs           |
+| Validate         | 139 μs            | 1,133 μs            | 14,409 μs           |
+| Convert (OAS2→3) | 148 μs            | 1,184 μs            | -                   |
+| Join (2 docs)    | 101 μs            | -                   | -                   |
+| Diff (2 docs)    | 448 μs            | -                   | -                   |
 
 For detailed performance analysis, methodology, and optimization strategies, see [benchmarks.md](benchmarks.md).
 

--- a/benchmarks.md
+++ b/benchmarks.md
@@ -35,9 +35,9 @@ The v1.7.0 release includes a major optimization to JSON marshaling that elimina
 
 ## Benchmark Suite
 
-The benchmark suite includes **85+ benchmarks** across six main packages:
+The benchmark suite includes **103 benchmarks** across six main packages:
 
-### Parser Package (32 benchmarks)
+### Parser Package (33 benchmarks)
 
 **Marshaling Operations**:
 - Info marshaling: no extra fields, with extra fields, varying extra field counts (1, 5, 10, 20)
@@ -50,51 +50,60 @@ The benchmark suite includes **85+ benchmarks** across six main packages:
 - Small and medium OAS 2.0 documents
 - Parsing with and without validation
 - ParseBytes vs Parse (file-based)
-- Convenience function performance
+- ParseWithOptions convenience API (file path, reader, reference resolution)
+- ParseReader I/O performance
+- ParseResult.Copy() deep copy performance
+- Reference resolution overhead measurement
+- FormatBytes utility function
 
 **Unmarshaling Operations**:
 - Info unmarshaling: no extra fields, with extra fields
 
-### Validator Package (12 benchmarks)
+### Validator Package (16 benchmarks)
 
 **Validation Operations**:
 - Small, medium, and large OAS 3.x documents
 - Small and medium OAS 2.0 documents
 - With and without warnings
 - ValidateParsed (pre-parsed documents) vs Validate (parse + validate)
-- Convenience function performance
-- Strict mode validation
+- ValidateWithOptions convenience API (basic and pre-parsed variants)
+- Strict mode validation (small, medium, and large documents)
+- Large document validation without warnings
 
-### Converter Package (10 benchmarks)
+### Converter Package (13 benchmarks)
 
 **Conversion Operations**:
 - OAS 2.0 → OAS 3.x (small and medium documents)
 - OAS 3.x → OAS 2.0 (small and medium documents)
+- OAS 3.0 → OAS 3.1 version updates
 - ConvertParsed (pre-parsed) vs Convert (parse + convert)
-- Convenience function performance
+- ConvertWithOptions convenience API (basic and pre-parsed variants)
 - Conversion with and without info messages
 
-### Joiner Package (8 benchmarks)
+### Joiner Package (14 benchmarks)
 
 **Joining Operations**:
-- Join 2 and 3 small documents
+- Join 2, 3, and 5 small documents
 - JoinParsed (pre-parsed) vs Join (parse + join)
-- Convenience function performance
+- JoinWithOptions convenience API (basic and pre-parsed variants)
 - Different collision resolution strategies (AcceptLeft, AcceptRight)
 - Array merge strategies
 - Tag deduplication
+- WriteResult I/O performance
+- Configuration utilities (DefaultConfig, IsValidStrategy, ValidStrategies)
 
 ### Differ Package (10 benchmarks)
 
 **Diffing Operations**:
 - Diff (parse + diff) vs DiffParsed (pre-parsed)
+- DiffWithOptions convenience API
 - Simple mode vs Breaking mode
-- Convenience functions (Diff, DiffParsed) vs struct-based API
 - Configuration options (IncludeInfo)
 - Edge cases (identical specifications)
 - Parse-once pattern efficiency
+- Change.String() formatting performance
 
-### Builder Package (15 benchmarks)
+### Builder Package (17 benchmarks)
 
 **Builder Construction Operations**:
 - Builder instantiation (New)
@@ -113,11 +122,11 @@ The benchmark suite includes **85+ benchmarks** across six main packages:
 
 | Document Size | Lines | Time (μs) | Memory (KB) | Allocations |
 |---------------|-------|-----------|-------------|-------------|
-| Small OAS3    | ~60   | 145       | 203         | 2,128       |
-| Medium OAS3   | ~570  | 1,144     | 1,465       | 17,449      |
-| Large OAS3    | ~6000 | 14,178    | 16,468      | 194,777     |
-| Small OAS2    | ~60   | 136       | 174         | 2,059       |
-| Medium OAS2   | ~570  | 1,039     | 1,230       | 16,027      |
+| Small OAS3    | ~60   | 138       | 197         | 2,070       |
+| Medium OAS3   | ~570  | 1,119     | 1,447       | 17,389      |
+| Large OAS3    | ~6000 | 13,880    | 16,425      | 194,712     |
+| Small OAS2    | ~60   | 134       | 174         | 2,059       |
+| Medium OAS2   | ~570  | 1,016     | 1,230       | 16,027      |
 
 **Parsing without validation** provides ~3-5% improvement over validated parsing.
 
@@ -143,11 +152,11 @@ The benchmark suite includes **85+ benchmarks** across six main packages:
 
 | Document Size | Lines | Time (μs) | Memory (KB) | Allocations |
 |---------------|-------|-----------|-------------|-------------|
-| Small OAS3    | ~60   | 147       | 208         | 2,220       |
-| Medium OAS3   | ~570  | 1,171     | 1,495       | 18,365      |
-| Large OAS3    | ~6000 | 14,583    | 16,848      | 205,079     |
-| Small OAS2    | ~60   | 138       | 181         | 2,135       |
-| Medium OAS2   | ~570  | 1,075     | 1,268       | 16,851      |
+| Small OAS3    | ~60   | 139       | 204         | 2,162       |
+| Medium OAS3   | ~570  | 1,133     | 1,492       | 18,307      |
+| Large OAS3    | ~6000 | 14,409    | 16,844      | 205,022     |
+| Small OAS2    | ~60   | 134       | 181         | 2,135       |
+| Medium OAS2   | ~570  | 1,058     | 1,268       | 16,851      |
 
 **Validating pre-parsed documents** (ValidateParsed):
 

--- a/converter/converter_bench_test.go
+++ b/converter/converter_bench_test.go
@@ -190,3 +190,51 @@ func BenchmarkConvertNoInfoOAS2ToOAS3Medium(b *testing.B) {
 		}
 	}
 }
+
+// BenchmarkConvertWithOptionsOAS2ToOAS3Small benchmarks ConvertWithOptions convenience API
+func BenchmarkConvertWithOptionsOAS2ToOAS3Small(b *testing.B) {
+	for b.Loop() {
+		_, err := ConvertWithOptions(
+			WithFilePath(smallOAS2Path),
+			WithTargetVersion("3.0.3"),
+		)
+		if err != nil {
+			b.Fatalf("Failed to convert: %v", err)
+		}
+	}
+}
+
+// BenchmarkConvertWithOptionsParsedOAS2ToOAS3Small benchmarks ConvertWithOptions with pre-parsed document
+func BenchmarkConvertWithOptionsParsedOAS2ToOAS3Small(b *testing.B) {
+	// Parse once
+	parseResult, err := parser.ParseWithOptions(
+		parser.WithFilePath(smallOAS2Path),
+	)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	for b.Loop() {
+		_, err := ConvertWithOptions(
+			WithParsed(*parseResult),
+			WithTargetVersion("3.0.3"),
+		)
+		if err != nil {
+			b.Fatalf("Failed to convert: %v", err)
+		}
+	}
+}
+
+// BenchmarkConvertOAS30ToOAS31Small benchmarks OAS 3.0 to OAS 3.1 version update
+func BenchmarkConvertOAS30ToOAS31Small(b *testing.B) {
+	c := New()
+	c.StrictMode = false
+	c.IncludeInfo = true
+
+	for b.Loop() {
+		_, err := c.Convert(smallOAS3Path, "3.1.0")
+		if err != nil {
+			b.Fatalf("Failed to convert: %v", err)
+		}
+	}
+}

--- a/differ/differ_bench_test.go
+++ b/differ/differ_bench_test.go
@@ -3,6 +3,7 @@ package differ
 import (
 	"testing"
 
+	"github.com/erraggy/oastools/internal/severity"
 	"github.com/erraggy/oastools/parser"
 )
 
@@ -211,6 +212,50 @@ func BenchmarkParseOnceDiffMany(b *testing.B) {
 		_, err := d.DiffParsed(*source, *target)
 		if err != nil {
 			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkDiffWithOptionsSmallOAS3 benchmarks DiffWithOptions convenience API
+func BenchmarkDiffWithOptionsSmallOAS3(b *testing.B) {
+	for b.Loop() {
+		_, err := DiffWithOptions(
+			WithSourceFilePath("../testdata/petstore-v1.yaml"),
+			WithTargetFilePath("../testdata/petstore-v2.yaml"),
+		)
+		if err != nil {
+			b.Fatalf("Failed to diff: %v", err)
+		}
+	}
+}
+
+// BenchmarkChangeString benchmarks Change.String() formatting performance
+func BenchmarkChangeString(b *testing.B) {
+	// Create sample changes
+	changes := []Change{
+		{
+			Type:     ChangeTypeModified,
+			Path:     "/paths/~1pet~1{petId}/get/summary",
+			Message:  "Modified operation summary",
+			Severity: severity.SeverityInfo,
+		},
+		{
+			Type:     ChangeTypeAdded,
+			Path:     "/paths/~1pet~1findByStatus",
+			Message:  "Added new endpoint",
+			Severity: severity.SeverityInfo,
+		},
+		{
+			Type:     ChangeTypeRemoved,
+			Path:     "/paths/~1user~1logout/post",
+			Message:  "Removed endpoint",
+			Severity: severity.SeverityError,
+		},
+	}
+
+	for b.Loop() {
+		for _, change := range changes {
+			_ = change.String()
 		}
 	}
 }

--- a/validator/validator_bench_test.go
+++ b/validator/validator_bench_test.go
@@ -211,3 +211,64 @@ func BenchmarkValidateStrictModeMediumOAS3(b *testing.B) {
 		}
 	}
 }
+
+// BenchmarkValidateWithOptionsSmallOAS3 benchmarks ValidateWithOptions convenience API
+func BenchmarkValidateWithOptionsSmallOAS3(b *testing.B) {
+	for b.Loop() {
+		_, err := ValidateWithOptions(
+			WithFilePath(smallOAS3Path),
+			WithIncludeWarnings(true),
+		)
+		if err != nil {
+			b.Fatalf("Failed to validate: %v", err)
+		}
+	}
+}
+
+// BenchmarkValidateWithOptionsParsedSmallOAS3 benchmarks ValidateWithOptions with pre-parsed document
+func BenchmarkValidateWithOptionsParsedSmallOAS3(b *testing.B) {
+	// Parse once
+	parseResult, err := parser.ParseWithOptions(
+		parser.WithFilePath(smallOAS3Path),
+	)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	for b.Loop() {
+		_, err := ValidateWithOptions(
+			WithParsed(*parseResult),
+		)
+		if err != nil {
+			b.Fatalf("Failed to validate: %v", err)
+		}
+	}
+}
+
+// BenchmarkValidateStrictModeLargeOAS3 benchmarks strict mode validation at scale
+func BenchmarkValidateStrictModeLargeOAS3(b *testing.B) {
+	v := New()
+	v.IncludeWarnings = true
+	v.StrictMode = true
+
+	for b.Loop() {
+		_, err := v.Validate(largeOAS3Path)
+		if err != nil {
+			b.Fatalf("Failed to validate: %v", err)
+		}
+	}
+}
+
+// BenchmarkValidateLargeOAS3NoWarnings benchmarks large doc validation without warnings
+func BenchmarkValidateLargeOAS3NoWarnings(b *testing.B) {
+	v := New()
+	v.IncludeWarnings = false
+	v.StrictMode = false
+
+	for b.Loop() {
+		_, err := v.Validate(largeOAS3Path)
+		if err != nil {
+			b.Fatalf("Failed to validate: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
Add 22 new benchmarks across all packages to achieve complete API coverage:

TIER 1 - Convenience APIs (10 benchmarks):
- parser: ParseWithOptions variants (file path, reader, resolve refs)
- validator: ValidateWithOptions variants (basic, pre-parsed)
- converter: ConvertWithOptions variants (basic, pre-parsed)
- joiner: JoinWithOptions variants (basic, pre-parsed)
- differ: DiffWithOptions

TIER 2 - Performance-Critical (6 benchmarks):
- parser: ParseReader I/O, ParseResult.Copy, ParseResolveRefs
- validator: ValidateStrictModeLargeOAS3
- joiner: JoinWriteResult I/O
- converter: ConvertOAS30ToOAS31

TIER 3 - Scale & Edge Cases (4 benchmarks):
- parser: FormatBytes utility
- joiner: JoinFiveSmallDocs multi-doc
- differ: ChangeString formatting
- validator: ValidateLargeOAS3NoWarnings

TIER 4 - Optional Coverage (3 benchmarks):
- joiner: DefaultConfig, IsValidStrategy, ValidStrategies

Total benchmarks: 95 → 103 (+8 net, 22 added)

Updated documentation:
- benchmarks.md: Updated counts and performance metrics
- README.md: Refreshed performance table with latest numbers
- All benchmarks use modern Go 1.24+ for b.Loop() pattern
- Updated baseline with complete suite results

Performance highlights remain unchanged:
- Parse: 138 μs (small), 1,119 μs (medium), 13,880 μs (large)
- Validate: 139 μs (small), 1,133 μs (medium), 14,409 μs (large)
- ValidateParsed: 31x faster than Validate
- ConvertParsed: 9x faster than Convert
- JoinParsed: 150x faster than Join
- DiffParsed: 81x faster than Diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)