### PR TITLE
docs: update benchmark counts to reflect current suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ See [pkg.go.dev](https://pkg.go.dev/github.com/erraggy/oastools) for complete AP
 
 ## Benchmarks
 
-The library includes comprehensive performance benchmarking (70+ benchmarks across all packages). As of v1.9.1, significant optimizations have been implemented:
+The library includes comprehensive performance benchmarking (100+ benchmarks across all packages). As of v1.9.1, significant optimizations have been implemented:
 
 **Performance Highlights**:
 - **25-32% faster** JSON marshaling (v1.7.0 optimization)

--- a/benchmarks.md
+++ b/benchmarks.md
@@ -35,7 +35,7 @@ The v1.7.0 release includes a major optimization to JSON marshaling that elimina
 
 ## Benchmark Suite
 
-The benchmark suite includes **103 benchmarks** across seven main packages:
+The benchmark suite includes **100+ benchmarks** (48 benchmark functions with many sub-benchmarks) across seven main packages:
 
 ### Parser Package (33 benchmarks)
 


### PR DESCRIPTION
## Summary

- Update benchmark count in README.md from "70+" to "100+" 
- Update benchmark count in benchmarks.md to reflect "100+ benchmarks (48 benchmark functions with many sub-benchmarks)"

This aligns documentation with the benchmark refactoring done in PR #92, which reorganized flat benchmarks into grouped sub-benchmarks using `b.Run()`.

## Documentation Review

A comprehensive documentation review was performed as pre-release preparation:

| File | Status | Notes |
|------|--------|-------|
| README.md | ✓ Accurate | Features, installation, CLI, library examples verified |
| Root doc.go | ✓ Accurate | Concise, properly delegates to packages |
| parser/doc.go | ✓ Accurate | URL loading, cross-links correct |
| validator/doc.go | ✓ Accurate | Strict mode, warnings documented |
| converter/doc.go | ✓ Accurate | Issue severity levels documented |
| joiner/doc.go | ✓ Accurate | Collision strategies documented |
| differ/doc.go | ✓ Comprehensive | Categories, severity, extensions documented |
| generator/doc.go | ✓ Accurate | Generation modes, type mappings documented |
| builder/doc.go | ✓ Comprehensive | Extensive feature documentation |
| All example_test.go | ✓ Pass | All 16 examples compile and pass |

**pkg.go.dev Duplication Assessment**: No problematic duplication found. README.md and package doc.go files serve different purposes.

## Test plan

- [x] `make check` passes
- [x] All example tests pass
- [x] `go doc` renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)