### PR TITLE
docs: comprehensive documentation update for pipeline and CLI features

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,12 +83,22 @@ oastools diff --breaking api-v1.yaml api-v2.yaml
 # Generate Go client and server code
 oastools generate --client --server -o ./generated -p api openapi.yaml
 
+# Pipeline support (stdin with quiet mode)
+cat swagger.yaml | oastools convert -q -t 3.0.3 - > openapi.yaml
+curl -s https://example.com/openapi.yaml | oastools validate -q -
+
+# Structured output for scripting
+oastools validate --format json openapi.yaml | jq '.valid'
+oastools diff --format json --breaking v1.yaml v2.yaml | jq '.HasBreakingChanges'
+
 # Show all commands
 oastools help
 ```
 
 **CLI Features**:
-- **Load from files or URLs** (HTTP/HTTPS) for parse, validate, and convert commands
+- **Load from files, URLs, or stdin** (HTTP/HTTPS) for parse, validate, convert, diff, and generate commands
+- **Pipeline support** with stdin (`-`) and quiet mode (`-q`) for shell scripting
+- **Structured output** with `--format json/yaml` for programmatic processing
 - Automatic format detection (JSON/YAML)
 - Format preservation (JSON input → JSON output, YAML → YAML)
 - Detailed validation error messages with spec references

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -64,6 +64,9 @@ oastools validate openapi.yaml
 
 # Validate from a URL
 oastools validate https://example.com/api/openapi.yaml
+
+# Validate from stdin
+cat openapi.yaml | oastools validate -
 ```
 
 **Options:**
@@ -74,6 +77,15 @@ oastools validate --strict openapi.yaml
 
 # Suppress warnings (show only errors)
 oastools validate --no-warnings openapi.yaml
+
+# Quiet mode for pipelines
+oastools validate -q openapi.yaml
+
+# Output as JSON for programmatic processing
+oastools validate --format json openapi.yaml | jq '.valid'
+
+# Output as YAML
+oastools validate --format yaml openapi.yaml
 ```
 
 **Understanding Output:**
@@ -129,6 +141,12 @@ oastools parse --resolve-refs openapi.yaml
 
 # Parse with structure validation
 oastools parse --validate-structure openapi.yaml
+
+# Parse from stdin
+cat openapi.yaml | oastools parse -
+
+# Quiet mode for pipelines (outputs only JSON)
+cat openapi.yaml | oastools parse -q - | jq '.info.title'
 ```
 
 **Output Explanation:**
@@ -174,6 +192,12 @@ oastools convert --strict -t 3.0.3 swagger.yaml -o openapi.yaml
 
 # Suppress info messages
 oastools convert --no-warnings -t 3.0.3 swagger.yaml -o openapi.yaml
+
+# Convert from stdin (for pipelines)
+cat swagger.yaml | oastools convert -t 3.0.3 - -o openapi.yaml
+
+# Pipeline with quiet mode (output to stdout)
+cat swagger.yaml | oastools convert -q -t 3.0.3 - > openapi.yaml
 ```
 
 **Understanding Conversion Issues:**
@@ -293,6 +317,12 @@ oastools diff --breaking --no-info api-v1.yaml api-v2.yaml
 
 # Compare from URLs
 oastools diff https://example.com/api/v1.yaml https://example.com/api/v2.yaml
+
+# Output as JSON for CI/CD pipelines
+oastools diff --format json --breaking api-v1.yaml api-v2.yaml | jq '.HasBreakingChanges'
+
+# Output as YAML
+oastools diff --format yaml api-v1.yaml api-v2.yaml
 ```
 
 **Understanding Breaking Change Severity:**


### PR DESCRIPTION
## Summary

- Add stdin support (`-`) documentation for validate, parse, convert commands
- Add `--format json/yaml` flag documentation for validate and diff commands
- Add `-q/--quiet` mode documentation for pipeline-friendly output
- Add new "Stdin and Pipeline Support" section to CLI reference
- Update version output to show commit, build time, and go version
- Add generate command to help output and URL support section
- Update version numbers to v1.17.1 throughout documentation
- Add pipeline examples to README Quick Start section

## Files Changed

- `README.md` - Added pipeline examples and updated CLI features list
- `docs/cli-reference.md` - Comprehensive updates for all new CLI features
- `docs/developer-guide.md` - Added stdin and format examples to CLI sections

## Test plan

- [x] All `make check` tests pass
- [x] All `example_test.go` examples compile and pass
- [x] Verified `doc.go` files are already up-to-date

🤖 Generated with [Claude Code](https://claude.com/claude-code)