### PR TITLE
fix(parser): skip validation on $ref parameters and requestBodies

### DIFF
--- a/internal/corpusutil/corpus.go
+++ b/internal/corpusutil/corpus.go
@@ -53,7 +53,7 @@ var Corpus = []SpecInfo{
 		OASVersion:     "3.0.0",
 		Format:         "yaml",
 		ExpectedValid:  false,
-		ExpectedErrors: 1918,
+		ExpectedErrors: 496, // Reduced from 1918 after fixing $ref parameter validation
 		IsLarge:        false,
 		SizeBytes:      2_500_000,
 		// Note: Uses bundled version from DigitalOcean's CI. The unbundled source
@@ -76,8 +76,8 @@ var Corpus = []SpecInfo{
 		URL:            "https://raw.githubusercontent.com/googlemaps/openapi-specification/main/dist/google-maps-platform-openapi3.json",
 		OASVersion:     "3.0.3",
 		Format:         "json",
-		ExpectedValid:  false,
-		ExpectedErrors: 228,
+		ExpectedValid:  true, // Now valid after fixing $ref parameter validation (was 228 false positives)
+		ExpectedErrors: 0,
 		IsLarge:        false,
 		SizeBytes:      500_000,
 	},
@@ -88,7 +88,7 @@ var Corpus = []SpecInfo{
 		OASVersion:     "3.0.3",
 		Format:         "json",
 		ExpectedValid:  false,
-		ExpectedErrors: 156,
+		ExpectedErrors: 44, // Reduced from 156 after fixing $ref parameter validation
 		IsLarge:        false,
 		SizeBytes:      800_000,
 	},
@@ -121,7 +121,7 @@ var Corpus = []SpecInfo{
 		OASVersion:     "3.0.3",
 		Format:         "json",
 		ExpectedValid:  false,
-		ExpectedErrors: 8000,
+		ExpectedErrors: 2224, // Reduced from 8000 after fixing $ref parameter/requestBody validation
 		IsLarge:        false,
 		SizeBytes:      5_000_000,
 	},
@@ -142,8 +142,8 @@ var Corpus = []SpecInfo{
 		URL:            "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/openapi/v1.0/openapi.yaml",
 		OASVersion:     "3.0.4",
 		Format:         "yaml",
-		ExpectedValid:  false,
-		ExpectedErrors: 30000,
+		ExpectedValid:  true, // Now valid after fixing $ref parameter/requestBody validation (was 30,000 false positives!)
+		ExpectedErrors: 0,
 		IsLarge:        true,
 		SizeBytes:      15_000_000,
 	},

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -915,6 +915,11 @@ func (p *Parser) validateOAS2Parameter(param *Parameter, opPath string, index in
 	errors := make([]error, 0)
 	paramPath := fmt.Sprintf("%s.parameters[%d]", opPath, index)
 
+	// Skip validation for $ref parameters - they reference definitions elsewhere
+	if param.Ref != "" {
+		return errors
+	}
+
 	if param.Name == "" {
 		errors = append(errors, fmt.Errorf("oas 2.0: missing required field '%s.name': Parameter must have a name", paramPath))
 	}
@@ -1072,8 +1077,8 @@ func (p *Parser) validateOAS3Operation(op *Operation, opPath string, operationID
 		errors = append(errors, p.validateOAS3Parameter(param, opPath, i, version)...)
 	}
 
-	// Validate requestBody if present
-	if op.RequestBody != nil {
+	// Validate requestBody if present (skip if it's a $ref)
+	if op.RequestBody != nil && op.RequestBody.Ref == "" {
 		rbPath := fmt.Sprintf("%s.requestBody", opPath)
 		if len(op.RequestBody.Content) == 0 {
 			errors = append(errors, fmt.Errorf("oas %s: missing required field '%s.content': RequestBody must have at least one media type", version, rbPath))
@@ -1086,6 +1091,11 @@ func (p *Parser) validateOAS3Operation(op *Operation, opPath string, operationID
 func (p *Parser) validateOAS3Parameter(param *Parameter, opPath string, index int, version string) []error {
 	errors := make([]error, 0)
 	paramPath := fmt.Sprintf("%s.parameters[%d]", opPath, index)
+
+	// Skip validation for $ref parameters - they reference definitions elsewhere
+	if param.Ref != "" {
+		return errors
+	}
 
 	if param.Name == "" {
 		errors = append(errors, fmt.Errorf("oas %s: missing required field '%s.name': Parameter must have a name", version, paramPath))

--- a/validator/corpus_large_test.go
+++ b/validator/corpus_large_test.go
@@ -83,10 +83,9 @@ func TestCorpus_MicrosoftGraph_Validate(t *testing.T) {
 	result, err := v.Validate(spec.GetLocalPath())
 	require.NoError(t, err)
 
-	// Microsoft Graph has many validation errors (path params)
-	assert.False(t, result.Valid, "Microsoft Graph should have validation errors")
-	assert.Greater(t, result.ErrorCount, 1000,
-		"Microsoft Graph should have many errors")
+	// Microsoft Graph is now valid after fixing $ref parameter/requestBody validation
+	// (previously had 30,000+ false positives)
+	assert.True(t, result.Valid, "Microsoft Graph should pass validation")
 
 	t.Logf("Microsoft Graph: Valid=%v, Errors=%d",
 		result.Valid, result.ErrorCount)


### PR DESCRIPTION
## Summary

- Fix parser structure validation to skip required field checks for `$ref` parameters and requestBodies
- Parameters/requestBodies using `$ref` reference definitions elsewhere - they don't have `name`, `in`, or `content` fields directly

## Problem

When validating specs like `https://api.weather.gov/openapi.json`, the parser was incorrectly reporting errors like:
```
oas 3.0.3: missing required field 'paths./gridpoints/{wfo}/{x},{y}/forecast.get.parameters[1].name': Parameter must have a name
```

For parameters that correctly use `$ref` to reference component definitions:
```json
"parameters": [
  { "$ref": "#/components/parameters/GridpointForecastFeatureFlags" }
]
```

## Changes

1. **`validateOAS2Parameter()`** - Added early return if `param.Ref != ""`
2. **`validateOAS3Parameter()`** - Added early return if `param.Ref != ""`
3. **`validateOAS3Operation()`** - Added `op.RequestBody.Ref == ""` check for requestBody validation

## Impact

Eliminates ~40,000 false positives across real-world corpus specs:

| Spec | Before | After | Change |
|------|--------|-------|--------|
| MicrosoftGraph | 30,000 errors | 0 (valid!) | -100% |
| GitHub | 8,000 errors | 2,224 | -72% |
| DigitalOcean | 1,918 errors | 496 | -74% |
| GoogleMaps | 228 errors | 0 (valid!) | -100% |
| USNWS | 156 errors | 44 | -72% |

## Test plan

- [x] Added `TestParameterRefValidation` with 4 test cases (OAS 2.0/3.0, ref/inline)
- [x] Added `TestRequestBodyRefValidation` with 2 test cases (ref/inline)
- [x] Updated corpus expected error counts
- [x] Updated MicrosoftGraph test to expect valid
- [x] All 2271 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)