### PR TITLE
fix(parser): move go:generate directive out of doc.go

### DIFF
--- a/parser/doc.go
+++ b/parser/doc.go
@@ -115,6 +115,4 @@
 //   - [github.com/erraggy/oastools/differ] - Compare specifications and detect breaking changes
 //   - [github.com/erraggy/oastools/generator] - Generate Go code from specifications
 //   - [github.com/erraggy/oastools/builder] - Programmatically build specifications
-
-//go:generate go run ../internal/codegen/deepcopy
 package parser

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1,5 +1,7 @@
 package parser
 
+//go:generate go run ../internal/codegen/deepcopy
+
 import (
 	"bytes"
 	"crypto/tls"


### PR DESCRIPTION
## Summary

The `//go:generate` directive in `parser/doc.go` was breaking godoc documentation by separating the package documentation comment from the `package parser` declaration.

This caused:
- No package description in the pkg.go.dev directories table
- Only examples shown on the parser package page instead of full documentation

## Fix

Moved the `//go:generate` directive from `doc.go` to `parser.go` where it doesn't interfere with documentation parsing.

## Test Plan

- [x] `go doc github.com/erraggy/oastools/parser` shows full package documentation
- [x] Tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)