### PR TITLE
perf: optimize make check from ~30s to ~14s

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,9 @@ make build    # Build binary to bin/oastools
 make install  # Install to $GOPATH/bin
 
 # Testing
-make test          # Run all tests with race detection and coverage
+make test          # Run tests with coverage (parallel, fast)
+make test-quick    # Run tests quickly (no coverage, for rapid iteration)
+make test-full     # Run comprehensive tests with race detection
 make test-coverage # Generate and view HTML coverage report
 
 # Code Quality

--- a/generator/client_user_agent_test.go
+++ b/generator/client_user_agent_test.go
@@ -151,13 +151,6 @@ paths:
 	assert.Contains(t, content, `UserAgent:  "`+expectedUserAgent+`"`, "NewClient should use full title in UserAgent")
 }
 
-func TestGeneratedClientUserAgentWithEmptyTitle(t *testing.T) {
-	// Note: Empty title will trigger a parse error in validation,
-	// so we skip this test and rely on the unit test for buildDefaultUserAgent
-	// which tests the fallback behavior directly
-	t.Skip("Empty title triggers parse validation error - tested in TestBuildDefaultUserAgent")
-}
-
 func TestGeneratedClientWithUserAgentOption(t *testing.T) {
 	spec := `openapi: "3.0.0"
 info:

--- a/generator/helpers_test.go
+++ b/generator/helpers_test.go
@@ -331,6 +331,10 @@ func TestSchemaTypeFromMap(t *testing.T) {
 	}
 }
 
+// TestBuildDefaultUserAgent tests the buildDefaultUserAgent helper function.
+// This test covers empty/nil title cases which cannot be tested via integration
+// tests (e.g., GenerateWithOptions) because the parser rejects specs with empty
+// info.title as invalid before reaching user agent generation.
 func TestBuildDefaultUserAgent(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary

- Enable parallel test execution by removing `-p=1 -parallel=1` constraints (57% speedup)
- Reduce test timeout from 10m to 5m (tests complete in ~12s)
- Add `test-quick` target for rapid iteration during development
- Add `test-full` target for comprehensive validation with race detection
- Fix two previously skipped tests

## Performance Results

| Scenario | Before | After | Improvement |
|----------|--------|-------|-------------|
| `make check` (test cache cleared) | ~30s | ~14s | **53% faster** |
| `make check` (full cache cleared) | ~38s | ~19s | **50% faster** |

## New Test Tiers

| Target | Use Case | Time |
|--------|----------|------|
| `make test-quick` | Rapid iteration during development | ~12s |
| `make test` | Standard development with coverage | ~12s |
| `make check` | Quality gate before push | ~14s |
| `make test-full` | Comprehensive validation with race detection | ~3-5min |

## Test Fixes

- **Removed** always-skipped `TestGeneratedClientUserAgentWithEmptyTitle` (empty titles fail parser validation before reaching user agent generation - covered by `TestBuildDefaultUserAgent`)
- **Fixed** `TestCorpus_JoinSameVersionSpecs` to use embedded test fixtures instead of requiring corpus download

## Test plan

- [x] Run `make check` 3x to verify consistent ~14s timing
- [x] Verify all tests pass with parallel execution
- [x] Verify previously skipped `TestCorpus_JoinSameVersionSpecs` now runs
- [x] Verify coverage output is still generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)