### PR TITLE
chore: add benchmark files for v1.20.3 through v1.22.2

### DIFF
--- a/benchmarks/benchmark-v1.20.3.txt
+++ b/benchmarks/benchmark-v1.20.3.txt
@@ -1,0 +1,173 @@
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/parser
+cpu: Apple M4
+BenchmarkMarshalInfo/NoExtra-10    	13468188	       446.3 ns/op	     192 B/op	       2 allocs/op
+BenchmarkMarshalInfo/Extra1-10     	 4928077	      1216 ns/op	    1105 B/op	      20 allocs/op
+BenchmarkMarshalInfo/Extra5-10     	 2698317	      2221 ns/op	    2218 B/op	      31 allocs/op
+BenchmarkMarshalInfo/Extra10-10    	 1584297	      3791 ns/op	    4077 B/op	      43 allocs/op
+BenchmarkMarshalInfo/Extra20-10    	  953342	      6264 ns/op	    5423 B/op	      63 allocs/op
+BenchmarkMarshalContact/NoExtra-10 	13246578	       456.9 ns/op	     192 B/op	       2 allocs/op
+BenchmarkMarshalContact/WithExtra-10         	 3549321	      1698 ns/op	    1377 B/op	      24 allocs/op
+BenchmarkMarshalServer/NoExtra-10            	15963096	       379.7 ns/op	     160 B/op	       2 allocs/op
+BenchmarkMarshalServer/WithExtra-10          	 2464869	      2437 ns/op	    2298 B/op	      30 allocs/op
+BenchmarkMarshalOAS3Document/Small-10        	  298611	     20182 ns/op	    7004 B/op	      66 allocs/op
+BenchmarkMarshalOAS3Document/Medium-10       	   27368	    220444 ns/op	   65817 B/op	     471 allocs/op
+BenchmarkMarshalOAS3Document/Large-10        	    2204	   2701300 ns/op	  844729 B/op	    5336 allocs/op
+BenchmarkMarshalOAS2Document/Small-10        	  343378	     17523 ns/op	    6370 B/op	      58 allocs/op
+BenchmarkMarshalOAS2Document/Medium-10       	   33703	    177357 ns/op	   53629 B/op	     396 allocs/op
+BenchmarkUnmarshalInfo/NoExtra-10            	 4064096	      1481 ns/op	    1224 B/op	      29 allocs/op
+BenchmarkUnmarshalInfo/WithExtra-10          	 1751856	      3422 ns/op	    1736 B/op	      46 allocs/op
+BenchmarkParse/SmallOAS3-10                  	   42537	    141064 ns/op	  197209 B/op	    2070 allocs/op
+BenchmarkParse/MediumOAS3-10                 	    5342	   1131240 ns/op	 1447262 B/op	   17388 allocs/op
+BenchmarkParse/LargeOAS3-10                  	     434	  13803954 ns/op	16424527 B/op	  194712 allocs/op
+BenchmarkParse/SmallOAS2-10                  	   44154	    135756 ns/op	  174202 B/op	    2059 allocs/op
+BenchmarkParse/MediumOAS2-10                 	    5809	   1029317 ns/op	 1230037 B/op	   16027 allocs/op
+BenchmarkParseNoValidation/SmallOAS3-10      	   42980	    139620 ns/op	  196312 B/op	    2047 allocs/op
+BenchmarkParseNoValidation/MediumOAS3-10     	    5346	   1118807 ns/op	 1442355 B/op	   17296 allocs/op
+BenchmarkParseBytes/SmallOAS3-10             	   46112	    130335 ns/op	  195439 B/op	    2065 allocs/op
+BenchmarkParseBytes/MediumOAS3-10            	    5352	   1120271 ns/op	 1433348 B/op	   17383 allocs/op
+BenchmarkParseWithOptions/FilePath/SmallOAS3-10         	   42326	    141874 ns/op	  197394 B/op	    2077 allocs/op
+BenchmarkParseWithOptions/Bytes/SmallOAS3-10            	   45915	    130792 ns/op	  195624 B/op	    2071 allocs/op
+BenchmarkParseWithOptions/ResolveRefs/SmallOAS3-10      	   31339	    191277 ns/op	  364927 B/op	    2454 allocs/op
+BenchmarkParseReader/MediumOAS3-10                      	    5144	   1170455 ns/op	 1496347 B/op	   17396 allocs/op
+BenchmarkParseResultCopy/SmallOAS3-10                   	 1000000	      5629 ns/op	   18088 B/op	     113 allocs/op
+BenchmarkParseResolveRefs/MediumOAS3-10                 	    3286	   1832914 ns/op	 3178812 B/op	   22140 allocs/op
+BenchmarkFormatBytes-10                                 	17591133	       338.9 ns/op	      64 B/op	       8 allocs/op
+BenchmarkDeepCopy/SmallOAS3-10                          	 3414058	      1760 ns/op	    7376 B/op	      44 allocs/op
+BenchmarkDeepCopy/MediumOAS3-10                         	  243717	     24608 ns/op	  108561 B/op	     466 allocs/op
+BenchmarkDeepCopy/LargeOAS3-10                          	   17419	    343699 ns/op	 1163520 B/op	    4877 allocs/op
+BenchmarkDeepCopy/SmallOAS2-10                          	 4048471	      1483 ns/op	    6352 B/op	      38 allocs/op
+BenchmarkDeepCopy/MediumOAS2-10                         	  293014	     20470 ns/op	   94769 B/op	     387 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/parser	225.452s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/validator
+cpu: Apple M4
+BenchmarkValidate/SmallOAS3-10     	   41574	    143375 ns/op	  204356 B/op	    2163 allocs/op
+BenchmarkValidate/MediumOAS3-10    	    5180	   1154802 ns/op	 1490775 B/op	   18308 allocs/op
+BenchmarkValidate/LargeOAS3-10     	     418	  14318346 ns/op	16839312 B/op	  205020 allocs/op
+BenchmarkValidate/SmallOAS2-10     	   43879	    136608 ns/op	  180487 B/op	    2136 allocs/op
+BenchmarkValidate/MediumOAS2-10    	    5782	   1037763 ns/op	 1269213 B/op	   16852 allocs/op
+BenchmarkValidateNoWarnings/SmallOAS3-10         	   41824	    143308 ns/op	  204335 B/op	    2163 allocs/op
+BenchmarkValidateNoWarnings/MediumOAS3-10        	    5182	   1157142 ns/op	 1490091 B/op	   18307 allocs/op
+BenchmarkValidateNoWarnings/LargeOAS3-10         	     418	  14379028 ns/op	16837638 B/op	  205020 allocs/op
+BenchmarkValidateParsed/SmallOAS3-10             	 1256455	      4770 ns/op	    5298 B/op	      90 allocs/op
+BenchmarkValidateParsed/MediumOAS3-10            	  147993	     40389 ns/op	   33475 B/op	     914 allocs/op
+BenchmarkValidateParsed/LargeOAS3-10             	   13100	    457571 ns/op	  376012 B/op	   10297 allocs/op
+BenchmarkValidateStrictMode/SmallOAS3-10         	   41878	    143552 ns/op	  204236 B/op	    2163 allocs/op
+BenchmarkValidateStrictMode/MediumOAS3-10        	    5194	   1157524 ns/op	 1490482 B/op	   18308 allocs/op
+BenchmarkValidateStrictMode/LargeOAS3-10         	     418	  14351812 ns/op	16839066 B/op	  205020 allocs/op
+BenchmarkValidateWithOptions/FilePath/SmallOAS3-10         	   41782	    143735 ns/op	  204368 B/op	    2167 allocs/op
+BenchmarkValidateWithOptions/Parsed/SmallOAS3-10           	 1237761	      4848 ns/op	    5539 B/op	      93 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/validator	98.523s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/fixer
+cpu: Apple M4
+BenchmarkFixDocuments/SmallOAS3-10         	   42750	    140873 ns/op	  207875 B/op	    2126 allocs/op
+BenchmarkFixDocuments/MediumOAS3-10        	    5326	   1127190 ns/op	 1576067 B/op	   17924 allocs/op
+BenchmarkFixDocuments/LargeOAS3-10         	     417	  14325103 ns/op	17647415 B/op	  199744 allocs/op
+BenchmarkFixDocuments/SmallOAS2-10         	   44502	    134793 ns/op	  183026 B/op	    2108 allocs/op
+BenchmarkFixDocuments/MediumOAS2-10        	    5829	   1024392 ns/op	 1339917 B/op	   16477 allocs/op
+BenchmarkFixWithInferTypes/SmallOAS3-10    	   42852	    139759 ns/op	  207295 B/op	    2125 allocs/op
+BenchmarkFixWithInferTypes/MediumOAS3-10   	    5241	   1124476 ns/op	 1572923 B/op	   17926 allocs/op
+BenchmarkFixWithInferTypes/LargeOAS3-10    	     427	  14166375 ns/op	17645697 B/op	  199743 allocs/op
+BenchmarkFixParsed/SmallOAS3-10            	 2524210	      2381 ns/op	    8364 B/op	      52 allocs/op
+BenchmarkFixParsed/MediumOAS3-10           	  206373	     29021 ns/op	  117806 B/op	     530 allocs/op
+BenchmarkFixParsed/LargeOAS3-10            	   17324	    344819 ns/op	 1187824 B/op	    5021 allocs/op
+BenchmarkFixWithOptions/FilePath/SmallOAS3-10         	   42590	    140281 ns/op	  207396 B/op	    2129 allocs/op
+BenchmarkFixWithOptions/Parsed/SmallOAS3-10           	 2427622	      2465 ns/op	    8624 B/op	      55 allocs/op
+BenchmarkFix-10                                       	 1450593	      4130 ns/op	   12876 B/op	      96 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/fixer	85.485s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/converter
+cpu: Apple M4
+BenchmarkConvertOAS2ToOAS3/Small-10    	   44196	    135555 ns/op	  184521 B/op	    2145 allocs/op
+BenchmarkConvertOAS2ToOAS3/Medium-10   	    5816	   1033337 ns/op	 1351383 B/op	   16717 allocs/op
+BenchmarkConvertOAS3ToOAS2/Small-10    	   42592	    141981 ns/op	  207940 B/op	    2163 allocs/op
+BenchmarkConvertOAS3ToOAS2/Medium-10   	    5174	   1137640 ns/op	 1577433 B/op	   18216 allocs/op
+BenchmarkConvertParsedOAS2ToOAS3/Small-10         	 1883491	      3195 ns/op	   10277 B/op	      83 allocs/op
+BenchmarkConvertParsedOAS2ToOAS3/Medium-10        	  159691	     37666 ns/op	  121460 B/op	     687 allocs/op
+BenchmarkConvertParsedOAS3ToOAS2/Small-10         	 1686735	      3560 ns/op	    8610 B/op	      89 allocs/op
+BenchmarkConvertParsedOAS3ToOAS2/Medium-10        	  132015	     45348 ns/op	  117216 B/op	     821 allocs/op
+BenchmarkConvertNoInfo/Small-10                   	   44017	    135840 ns/op	  184526 B/op	    2145 allocs/op
+BenchmarkConvertNoInfo/Medium-10                  	    5770	   1029138 ns/op	 1351375 B/op	   16717 allocs/op
+BenchmarkConvertWithOptions/FilePath/Small-10     	   44188	    135567 ns/op	  184642 B/op	    2149 allocs/op
+BenchmarkConvertWithOptions/Parsed/Small-10       	 1823119	      3293 ns/op	   10557 B/op	      87 allocs/op
+BenchmarkConvertOAS30ToOAS31/Small-10             	   43692	    137485 ns/op	  204996 B/op	    2122 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/converter	78.403s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/joiner
+cpu: Apple M4
+BenchmarkJoin/TwoDocs-10       	   58693	    102195 ns/op	  135703 B/op	    1495 allocs/op
+BenchmarkJoin/ThreeDocs-10     	   39546	    151405 ns/op	  201310 B/op	    2202 allocs/op
+BenchmarkJoin/FiveDocs-10      	   23557	    255022 ns/op	  336760 B/op	    3713 allocs/op
+BenchmarkJoinParsed/TwoDocs-10 	 7770804	       770.0 ns/op	    1896 B/op	      22 allocs/op
+BenchmarkJoinParsed/ThreeDocs-10         	 6229452	       965.5 ns/op	    2072 B/op	      23 allocs/op
+BenchmarkJoinStrategy/AcceptLeft-10      	   58564	    102524 ns/op	  135708 B/op	    1495 allocs/op
+BenchmarkJoinStrategy/AcceptRight-10     	   58174	    102883 ns/op	  135711 B/op	    1495 allocs/op
+BenchmarkJoinOptions/MergeArrays-10      	   58179	    103167 ns/op	  135711 B/op	    1495 allocs/op
+BenchmarkJoinOptions/DeduplicateTags-10  	   58383	    104535 ns/op	  135709 B/op	    1495 allocs/op
+BenchmarkJoinWithOptions/FilePaths-10    	   58201	    102864 ns/op	  135994 B/op	    1501 allocs/op
+BenchmarkJoinWithOptions/Parsed-10       	 6382678	       940.9 ns/op	    2824 B/op	      28 allocs/op
+BenchmarkJoinWriteResult-10              	   93710	     65562 ns/op	   90265 B/op	     404 allocs/op
+BenchmarkJoinHelpers/DefaultConfig-10    	1000000000	         5.000 ns/op	       0 B/op	       0 allocs/op
+BenchmarkJoinHelpers/IsValidStrategy-10  	866002473	         6.325 ns/op	       0 B/op	       0 allocs/op
+BenchmarkJoinHelpers/ValidStrategies-10  	462885189	        12.96 ns/op	      64 B/op	       1 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/joiner	89.320s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/differ
+cpu: Apple M4
+BenchmarkDiff/FilePath-10      	   13222	    453596 ns/op	  603652 B/op	    7201 allocs/op
+BenchmarkDiff/Parsed-10        	  578317	     10358 ns/op	   15022 B/op	     297 allocs/op
+BenchmarkDiffMode/Simple-10    	  576981	     10350 ns/op	   15022 B/op	     297 allocs/op
+BenchmarkDiffMode/Breaking-10  	  580063	     10392 ns/op	   15022 B/op	     297 allocs/op
+BenchmarkDiffIncludeInfo/WithInfo-10         	  575826	     10381 ns/op	   15022 B/op	     297 allocs/op
+BenchmarkDiffIncludeInfo/WithoutInfo-10      	  571189	     10563 ns/op	   16431 B/op	     298 allocs/op
+BenchmarkDiffIdentical-10                    	  736753	      8196 ns/op	   10643 B/op	     247 allocs/op
+BenchmarkDiffWithOptions/FilePath-10         	   13291	    451089 ns/op	  603818 B/op	    7209 allocs/op
+BenchmarkChangeString-10                     	14703954	       411.0 ns/op	     400 B/op	      15 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/differ	55.034s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/generator
+cpu: Apple M4
+BenchmarkGenerate/Types-10         	  147222	     40732 ns/op	   28092 B/op	     724 allocs/op
+BenchmarkGenerate/Client-10        	   20716	    289504 ns/op	  187478 B/op	    4088 allocs/op
+BenchmarkGenerate/Server-10        	  100141	     59777 ns/op	   47777 B/op	    1040 allocs/op
+BenchmarkGenerate/All-10           	   23066	    261544 ns/op	  181959 B/op	    3882 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/generator	27.949s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/builder
+cpu: Apple M4
+BenchmarkBuilderNew-10             	26557382	       221.1 ns/op	     800 B/op	      14 allocs/op
+BenchmarkBuilderSetInfo-10         	24845684	       241.9 ns/op	     912 B/op	      15 allocs/op
+BenchmarkSchemaFrom/Primitive-10   	18884878	       318.0 ns/op	    1568 B/op	      15 allocs/op
+BenchmarkSchemaFrom/Struct-10      	 1713852	      3504 ns/op	   15368 B/op	      77 allocs/op
+BenchmarkSchemaFrom/NestedStruct-10         	 1000000	      5210 ns/op	   23096 B/op	      99 allocs/op
+BenchmarkSchemaFrom/Slice-10                	 1660605	      3612 ns/op	   16136 B/op	      78 allocs/op
+BenchmarkSchemaFrom/Map-10                  	 1654711	      3624 ns/op	   16136 B/op	      78 allocs/op
+BenchmarkBuilderAddOperation/Simple-10      	 1377945	      4351 ns/op	   18441 B/op	     100 allocs/op
+BenchmarkBuilderAddOperation/WithParams-10  	  996756	      6036 ns/op	   25958 B/op	     139 allocs/op
+BenchmarkBuilderAddOperation/WithRequestBody-10         	  807036	      7299 ns/op	   30776 B/op	     153 allocs/op
+BenchmarkBuilderBuild-10                                	  742876	      8078 ns/op	   33650 B/op	     208 allocs/op
+BenchmarkBuilderMarshal/YAML-10                         	  180734	     32894 ns/op	   93877 B/op	     482 allocs/op
+BenchmarkBuilderMarshal/JSON-10                         	  313624	     19082 ns/op	    8476 B/op	      38 allocs/op
+BenchmarkOASTag/Apply-10                                	21608882	       279.4 ns/op	    1184 B/op	       6 allocs/op
+BenchmarkOASTag/Parse-10                                	32471083	       184.5 ns/op	     432 B/op	       3 allocs/op
+BenchmarkBuilderFormParams/OAS2-10                      	 2824963	      2123 ns/op	   10373 B/op	      75 allocs/op
+BenchmarkBuilderFormParams/OAS3-10                      	 2498160	      2404 ns/op	   13023 B/op	      81 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/builder	101.269s

--- a/benchmarks/benchmark-v1.21.0.txt
+++ b/benchmarks/benchmark-v1.21.0.txt
@@ -1,0 +1,173 @@
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/parser
+cpu: Apple M4
+BenchmarkMarshalInfo/NoExtra-10    	12673054	       474.3 ns/op	     192 B/op	       2 allocs/op
+BenchmarkMarshalInfo/Extra1-10     	 4532992	      1330 ns/op	    1105 B/op	      20 allocs/op
+BenchmarkMarshalInfo/Extra5-10     	 2457384	      2446 ns/op	    2218 B/op	      31 allocs/op
+BenchmarkMarshalInfo/Extra10-10    	 1421980	      4223 ns/op	    4077 B/op	      43 allocs/op
+BenchmarkMarshalInfo/Extra20-10    	  878988	      7020 ns/op	    5423 B/op	      63 allocs/op
+BenchmarkMarshalContact/NoExtra-10 	11822038	       508.2 ns/op	     192 B/op	       2 allocs/op
+BenchmarkMarshalContact/WithExtra-10         	 3082668	      1991 ns/op	    1377 B/op	      24 allocs/op
+BenchmarkMarshalServer/NoExtra-10            	14663469	       399.8 ns/op	     160 B/op	       2 allocs/op
+BenchmarkMarshalServer/WithExtra-10          	 2369653	      2662 ns/op	    2299 B/op	      30 allocs/op
+BenchmarkMarshalOAS3Document/Small-10        	  261956	     22157 ns/op	    7005 B/op	      66 allocs/op
+BenchmarkMarshalOAS3Document/Medium-10       	   24718	    243238 ns/op	   65865 B/op	     471 allocs/op
+BenchmarkMarshalOAS3Document/Large-10        	    2020	   2975277 ns/op	  849048 B/op	    5337 allocs/op
+BenchmarkMarshalOAS2Document/Small-10        	  309120	     19088 ns/op	    6371 B/op	      58 allocs/op
+BenchmarkMarshalOAS2Document/Medium-10       	   30681	    195635 ns/op	   53671 B/op	     396 allocs/op
+BenchmarkUnmarshalInfo/NoExtra-10            	 3593580	      1682 ns/op	    1224 B/op	      29 allocs/op
+BenchmarkUnmarshalInfo/WithExtra-10          	 1537328	      3903 ns/op	    1736 B/op	      46 allocs/op
+BenchmarkParse/SmallOAS3-10                  	   36986	    162514 ns/op	  197220 B/op	    2070 allocs/op
+BenchmarkParse/MediumOAS3-10                 	    4596	   1314030 ns/op	 1447380 B/op	   17388 allocs/op
+BenchmarkParse/LargeOAS3-10                  	     375	  16338314 ns/op	16424503 B/op	  194712 allocs/op
+BenchmarkParse/SmallOAS2-10                  	   37959	    156995 ns/op	  174212 B/op	    2059 allocs/op
+BenchmarkParse/MediumOAS2-10                 	    5050	   1186973 ns/op	 1230057 B/op	   16027 allocs/op
+BenchmarkParseNoValidation/SmallOAS3-10      	   36822	    164460 ns/op	  196319 B/op	    2047 allocs/op
+BenchmarkParseNoValidation/MediumOAS3-10     	    4557	   1326256 ns/op	 1442373 B/op	   17296 allocs/op
+BenchmarkParseBytes/SmallOAS3-10             	   38937	    159952 ns/op	  195452 B/op	    2065 allocs/op
+BenchmarkParseBytes/MediumOAS3-10            	    4158	   1381258 ns/op	 1433407 B/op	   17383 allocs/op
+BenchmarkParseWithOptions/FilePath/SmallOAS3-10         	   34048	    175230 ns/op	  197481 B/op	    2077 allocs/op
+BenchmarkParseWithOptions/Bytes/SmallOAS3-10            	   36736	    163697 ns/op	  195708 B/op	    2071 allocs/op
+BenchmarkParseWithOptions/ResolveRefs/SmallOAS3-10      	   25244	    236853 ns/op	  365028 B/op	    2455 allocs/op
+BenchmarkParseReader/MediumOAS3-10                      	    4087	   1490116 ns/op	 1496560 B/op	   17397 allocs/op
+BenchmarkParseResultCopy/SmallOAS3-10                   	  810565	      7398 ns/op	   18088 B/op	     113 allocs/op
+BenchmarkParseResolveRefs/MediumOAS3-10                 	    2514	   2380235 ns/op	 3182018 B/op	   22172 allocs/op
+BenchmarkFormatBytes-10                                 	14373066	       409.7 ns/op	      64 B/op	       8 allocs/op
+BenchmarkDeepCopy/SmallOAS3-10                          	 2600959	      2303 ns/op	    7376 B/op	      44 allocs/op
+BenchmarkDeepCopy/MediumOAS3-10                         	  184730	     33047 ns/op	  108561 B/op	     466 allocs/op
+BenchmarkDeepCopy/LargeOAS3-10                          	   12760	    470499 ns/op	 1163520 B/op	    4877 allocs/op
+BenchmarkDeepCopy/SmallOAS2-10                          	 3048268	      1936 ns/op	    6352 B/op	      38 allocs/op
+BenchmarkDeepCopy/MediumOAS2-10                         	  225926	     28236 ns/op	   94769 B/op	     387 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/parser	226.664s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/validator
+cpu: Apple M4
+BenchmarkValidate/SmallOAS3-10     	   34212	    176953 ns/op	  204250 B/op	    2163 allocs/op
+BenchmarkValidate/MediumOAS3-10    	    4053	   1454320 ns/op	 1490191 B/op	   18308 allocs/op
+BenchmarkValidate/LargeOAS3-10     	     328	  27275676 ns/op	16838681 B/op	  205019 allocs/op
+BenchmarkValidate/SmallOAS2-10     	   27916	    205479 ns/op	  180347 B/op	    2136 allocs/op
+BenchmarkValidate/MediumOAS2-10    	    4525	   1268885 ns/op	 1267948 B/op	   16852 allocs/op
+BenchmarkValidateNoWarnings/SmallOAS3-10         	   34537	    173986 ns/op	  204105 B/op	    2163 allocs/op
+BenchmarkValidateNoWarnings/MediumOAS3-10        	    4246	   1417834 ns/op	 1490046 B/op	   18308 allocs/op
+BenchmarkValidateNoWarnings/LargeOAS3-10         	     340	  17771585 ns/op	16835739 B/op	  205019 allocs/op
+BenchmarkValidateParsed/SmallOAS3-10             	 1000000	      5758 ns/op	    5311 B/op	      90 allocs/op
+BenchmarkValidateParsed/MediumOAS3-10            	  124207	     48292 ns/op	   33537 B/op	     914 allocs/op
+BenchmarkValidateParsed/LargeOAS3-10             	   10000	    563610 ns/op	  376714 B/op	   10297 allocs/op
+BenchmarkValidateStrictMode/SmallOAS3-10         	   34436	    172265 ns/op	  204178 B/op	    2163 allocs/op
+BenchmarkValidateStrictMode/MediumOAS3-10        	    4292	   1408736 ns/op	 1490366 B/op	   18308 allocs/op
+BenchmarkValidateStrictMode/LargeOAS3-10         	     338	  17543663 ns/op	16837095 B/op	  205019 allocs/op
+BenchmarkValidateWithOptions/FilePath/SmallOAS3-10         	   34902	    170848 ns/op	  204268 B/op	    2167 allocs/op
+BenchmarkValidateWithOptions/Parsed/SmallOAS3-10           	 1000000	      5811 ns/op	    5552 B/op	      93 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/validator	100.666s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/fixer
+cpu: Apple M4
+BenchmarkFixDocuments/SmallOAS3-10         	   35330	    167838 ns/op	  207641 B/op	    2125 allocs/op
+BenchmarkFixDocuments/MediumOAS3-10        	    4425	   1354540 ns/op	 1577696 B/op	   17925 allocs/op
+BenchmarkFixDocuments/LargeOAS3-10         	     343	  17426565 ns/op	17646054 B/op	  199744 allocs/op
+BenchmarkFixDocuments/SmallOAS2-10         	   37212	    160421 ns/op	  182892 B/op	    2108 allocs/op
+BenchmarkFixDocuments/MediumOAS2-10        	    4676	   1279912 ns/op	 1339935 B/op	   16477 allocs/op
+BenchmarkFixWithInferTypes/SmallOAS3-10    	   34876	    173350 ns/op	  207099 B/op	    2125 allocs/op
+BenchmarkFixWithInferTypes/MediumOAS3-10   	    4077	   1475596 ns/op	 1574175 B/op	   17927 allocs/op
+BenchmarkFixWithInferTypes/LargeOAS3-10    	     331	  18048736 ns/op	17647014 B/op	  199743 allocs/op
+BenchmarkFixParsed/SmallOAS3-10            	 1949173	      3084 ns/op	    8380 B/op	      52 allocs/op
+BenchmarkFixParsed/MediumOAS3-10           	  161708	     38066 ns/op	  118072 B/op	     530 allocs/op
+BenchmarkFixParsed/LargeOAS3-10            	   12292	    488699 ns/op	 1191339 B/op	    5021 allocs/op
+BenchmarkFixWithOptions/FilePath/SmallOAS3-10         	   33854	    175521 ns/op	  207353 B/op	    2129 allocs/op
+BenchmarkFixWithOptions/Parsed/SmallOAS3-10           	 1885963	      3191 ns/op	    8639 B/op	      55 allocs/op
+BenchmarkFix-10                                       	 1000000	      5426 ns/op	   12905 B/op	      96 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/fixer	85.385s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/converter
+cpu: Apple M4
+BenchmarkConvertOAS2ToOAS3/Small-10    	   35887	    169036 ns/op	  184565 B/op	    2145 allocs/op
+BenchmarkConvertOAS2ToOAS3/Medium-10   	    4576	   1331491 ns/op	 1351467 B/op	   16717 allocs/op
+BenchmarkConvertOAS3ToOAS2/Small-10    	   33250	    181862 ns/op	  207694 B/op	    2162 allocs/op
+BenchmarkConvertOAS3ToOAS2/Medium-10   	    3976	   1533684 ns/op	 1578212 B/op	   18217 allocs/op
+BenchmarkConvertParsedOAS2ToOAS3/Small-10         	 1411917	      4242 ns/op	   10277 B/op	      83 allocs/op
+BenchmarkConvertParsedOAS2ToOAS3/Medium-10        	  125637	     48036 ns/op	  121468 B/op	     687 allocs/op
+BenchmarkConvertParsedOAS3ToOAS2/Small-10         	 1242864	      4841 ns/op	    8616 B/op	      89 allocs/op
+BenchmarkConvertParsedOAS3ToOAS2/Medium-10        	   95022	     62558 ns/op	  116815 B/op	     821 allocs/op
+BenchmarkConvertNoInfo/Small-10                   	   30537	    196618 ns/op	  184566 B/op	    2145 allocs/op
+BenchmarkConvertNoInfo/Medium-10                  	    4225	   1424480 ns/op	 1351455 B/op	   16717 allocs/op
+BenchmarkConvertWithOptions/FilePath/Small-10     	   31796	    188183 ns/op	  184684 B/op	    2149 allocs/op
+BenchmarkConvertWithOptions/Parsed/Small-10       	 1428906	      4182 ns/op	   10557 B/op	      87 allocs/op
+BenchmarkConvertOAS30ToOAS31/Small-10             	   34300	    177049 ns/op	  205597 B/op	    2145 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/converter	78.928s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/joiner
+cpu: Apple M4
+BenchmarkJoin/TwoDocs-10       	   48392	    126741 ns/op	  135851 B/op	    1495 allocs/op
+BenchmarkJoin/ThreeDocs-10     	   31136	    187789 ns/op	  201531 B/op	    2202 allocs/op
+BenchmarkJoin/FiveDocs-10      	   19250	    311901 ns/op	  337125 B/op	    3713 allocs/op
+BenchmarkJoinParsed/TwoDocs-10 	 6147406	       982.7 ns/op	    1896 B/op	      22 allocs/op
+BenchmarkJoinParsed/ThreeDocs-10         	 4923570	      1226 ns/op	    2072 B/op	      23 allocs/op
+BenchmarkJoinStrategy/AcceptLeft-10      	   47659	    129720 ns/op	  135855 B/op	    1495 allocs/op
+BenchmarkJoinStrategy/AcceptRight-10     	   45463	    127286 ns/op	  135856 B/op	    1495 allocs/op
+BenchmarkJoinOptions/MergeArrays-10      	   48415	    124438 ns/op	  135856 B/op	    1495 allocs/op
+BenchmarkJoinOptions/DeduplicateTags-10  	   48236	    126050 ns/op	  135855 B/op	    1495 allocs/op
+BenchmarkJoinWithOptions/FilePaths-10    	   44679	    128583 ns/op	  136140 B/op	    1501 allocs/op
+BenchmarkJoinWithOptions/Parsed-10       	 4973246	      1214 ns/op	    2824 B/op	      28 allocs/op
+BenchmarkJoinWriteResult-10              	   74488	     81181 ns/op	   90267 B/op	     404 allocs/op
+BenchmarkJoinHelpers/DefaultConfig-10    	1000000000	         5.000 ns/op	       0 B/op	       0 allocs/op
+BenchmarkJoinHelpers/IsValidStrategy-10  	892705424	         6.860 ns/op	       0 B/op	       0 allocs/op
+BenchmarkJoinHelpers/ValidStrategies-10  	357493399	        16.93 ns/op	      64 B/op	       1 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/joiner	89.766s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/differ
+cpu: Apple M4
+BenchmarkDiff/FilePath-10      	   10000	    571482 ns/op	  603687 B/op	    7201 allocs/op
+BenchmarkDiff/Parsed-10        	  449047	     13515 ns/op	   15022 B/op	     297 allocs/op
+BenchmarkDiffMode/Simple-10    	  430407	     13860 ns/op	   15022 B/op	     297 allocs/op
+BenchmarkDiffMode/Breaking-10  	  456682	     12894 ns/op	   15022 B/op	     297 allocs/op
+BenchmarkDiffIncludeInfo/WithInfo-10         	  442498	     13349 ns/op	   15022 B/op	     297 allocs/op
+BenchmarkDiffIncludeInfo/WithoutInfo-10      	  452674	     13455 ns/op	   16431 B/op	     298 allocs/op
+BenchmarkDiffIdentical-10                    	  593493	     10512 ns/op	   10643 B/op	     247 allocs/op
+BenchmarkDiffWithOptions/FilePath-10         	   10000	    589035 ns/op	  603907 B/op	    7209 allocs/op
+BenchmarkChangeString-10                     	11847537	       523.3 ns/op	     400 B/op	      15 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/differ	54.955s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/generator
+cpu: Apple M4
+BenchmarkGenerate/Types-10         	   98347	     57784 ns/op	   28114 B/op	     724 allocs/op
+BenchmarkGenerate/Client-10        	   17098	    357442 ns/op	  187675 B/op	    4088 allocs/op
+BenchmarkGenerate/Server-10        	   80078	     74815 ns/op	   47869 B/op	    1040 allocs/op
+BenchmarkGenerate/All-10           	   18604	    321768 ns/op	  182203 B/op	    3882 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/generator	28.812s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/builder
+cpu: Apple M4
+BenchmarkBuilderNew-10             	23619826	       277.0 ns/op	     800 B/op	      14 allocs/op
+BenchmarkBuilderSetInfo-10         	19359506	       305.9 ns/op	     912 B/op	      15 allocs/op
+BenchmarkSchemaFrom/Primitive-10   	15095743	       398.6 ns/op	    1568 B/op	      15 allocs/op
+BenchmarkSchemaFrom/Struct-10      	 1359680	      4435 ns/op	   15368 B/op	      77 allocs/op
+BenchmarkSchemaFrom/NestedStruct-10         	  904503	      6720 ns/op	   23096 B/op	      99 allocs/op
+BenchmarkSchemaFrom/Slice-10                	 1299794	      4614 ns/op	   16136 B/op	      78 allocs/op
+BenchmarkSchemaFrom/Map-10                  	 1290042	      4653 ns/op	   16136 B/op	      78 allocs/op
+BenchmarkBuilderAddOperation/Simple-10      	 1000000	      5517 ns/op	   18441 B/op	     100 allocs/op
+BenchmarkBuilderAddOperation/WithParams-10  	  800352	      7589 ns/op	   25958 B/op	     139 allocs/op
+BenchmarkBuilderAddOperation/WithRequestBody-10         	  636865	      9298 ns/op	   30776 B/op	     153 allocs/op
+BenchmarkBuilderBuild-10                                	  588798	     10369 ns/op	   33650 B/op	     208 allocs/op
+BenchmarkBuilderMarshal/YAML-10                         	  140013	     41846 ns/op	   93879 B/op	     482 allocs/op
+BenchmarkBuilderMarshal/JSON-10                         	  254474	     22338 ns/op	    8477 B/op	      38 allocs/op
+BenchmarkOASTag/Apply-10                                	17604778	       348.4 ns/op	    1184 B/op	       6 allocs/op
+BenchmarkOASTag/Parse-10                                	26283424	       228.2 ns/op	     432 B/op	       3 allocs/op
+BenchmarkBuilderFormParams/OAS2-10                      	 2179153	      2759 ns/op	   10373 B/op	      75 allocs/op
+BenchmarkBuilderFormParams/OAS3-10                      	 1930600	      3178 ns/op	   13023 B/op	      81 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/builder	102.313s

--- a/benchmarks/benchmark-v1.21.1.txt
+++ b/benchmarks/benchmark-v1.21.1.txt
@@ -1,0 +1,173 @@
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/parser
+cpu: Apple M4
+BenchmarkMarshalInfo/NoExtra-10    	11352975	       532.8 ns/op	     192 B/op	       2 allocs/op
+BenchmarkMarshalInfo/Extra1-10     	 4054208	      1485 ns/op	    1105 B/op	      20 allocs/op
+BenchmarkMarshalInfo/Extra5-10     	 2035561	      2835 ns/op	    2218 B/op	      31 allocs/op
+BenchmarkMarshalInfo/Extra10-10    	 1308630	      4587 ns/op	    4077 B/op	      43 allocs/op
+BenchmarkMarshalInfo/Extra20-10    	  799154	      7695 ns/op	    5424 B/op	      63 allocs/op
+BenchmarkMarshalContact/NoExtra-10 	10805179	       549.1 ns/op	     192 B/op	       2 allocs/op
+BenchmarkMarshalContact/WithExtra-10         	 2834008	      2078 ns/op	    1377 B/op	      24 allocs/op
+BenchmarkMarshalServer/NoExtra-10            	14441854	       414.0 ns/op	     160 B/op	       2 allocs/op
+BenchmarkMarshalServer/WithExtra-10          	 2152885	      2943 ns/op	    2299 B/op	      30 allocs/op
+BenchmarkMarshalOAS3Document/Small-10        	  243072	     23702 ns/op	    7005 B/op	      66 allocs/op
+BenchmarkMarshalOAS3Document/Medium-10       	   22785	    262951 ns/op	   65854 B/op	     471 allocs/op
+BenchmarkMarshalOAS3Document/Large-10        	    1882	   3229027 ns/op	  847086 B/op	    5337 allocs/op
+BenchmarkMarshalOAS2Document/Small-10        	  286382	     20736 ns/op	    6371 B/op	      58 allocs/op
+BenchmarkMarshalOAS2Document/Medium-10       	   28438	    211477 ns/op	   53673 B/op	     396 allocs/op
+BenchmarkUnmarshalInfo/NoExtra-10            	 3311239	      1819 ns/op	    1224 B/op	      29 allocs/op
+BenchmarkUnmarshalInfo/WithExtra-10          	 1438902	      4166 ns/op	    1736 B/op	      46 allocs/op
+BenchmarkParse/SmallOAS3-10                  	   34008	    177963 ns/op	  197218 B/op	    2070 allocs/op
+BenchmarkParse/MediumOAS3-10                 	    4274	   1406663 ns/op	 1447327 B/op	   17388 allocs/op
+BenchmarkParse/LargeOAS3-10                  	     348	  17447975 ns/op	16424499 B/op	  194712 allocs/op
+BenchmarkParse/SmallOAS2-10                  	   35032	    168291 ns/op	  174209 B/op	    2059 allocs/op
+BenchmarkParse/MediumOAS2-10                 	    4753	   1266195 ns/op	 1230066 B/op	   16027 allocs/op
+BenchmarkParseNoValidation/SmallOAS3-10      	   34633	    173514 ns/op	  196317 B/op	    2047 allocs/op
+BenchmarkParseNoValidation/MediumOAS3-10     	    4371	   1392312 ns/op	 1442390 B/op	   17296 allocs/op
+BenchmarkParseBytes/SmallOAS3-10             	   38149	    164254 ns/op	  195450 B/op	    2065 allocs/op
+BenchmarkParseBytes/MediumOAS3-10            	    4216	   1424616 ns/op	 1433356 B/op	   17383 allocs/op
+BenchmarkParseWithOptions/FilePath/SmallOAS3-10         	   33254	    181006 ns/op	  197476 B/op	    2077 allocs/op
+BenchmarkParseWithOptions/Bytes/SmallOAS3-10            	   35768	    168105 ns/op	  195705 B/op	    2071 allocs/op
+BenchmarkParseWithOptions/ResolveRefs/SmallOAS3-10      	   24494	    243389 ns/op	  365017 B/op	    2454 allocs/op
+BenchmarkParseReader/MediumOAS3-10                      	    4014	   1525021 ns/op	 1496517 B/op	   17397 allocs/op
+BenchmarkParseResultCopy/SmallOAS3-10                   	  802153	      7448 ns/op	   18088 B/op	     113 allocs/op
+BenchmarkParseResolveRefs/MediumOAS3-10                 	    2436	   2411203 ns/op	 3182019 B/op	   22168 allocs/op
+BenchmarkFormatBytes-10                                 	14229025	       415.2 ns/op	      64 B/op	       8 allocs/op
+BenchmarkDeepCopy/SmallOAS3-10                          	 2590190	      2316 ns/op	    7376 B/op	      44 allocs/op
+BenchmarkDeepCopy/MediumOAS3-10                         	  186344	     33247 ns/op	  108561 B/op	     466 allocs/op
+BenchmarkDeepCopy/LargeOAS3-10                          	   12650	    473321 ns/op	 1163521 B/op	    4877 allocs/op
+BenchmarkDeepCopy/SmallOAS2-10                          	 2973397	      1978 ns/op	    6352 B/op	      38 allocs/op
+BenchmarkDeepCopy/MediumOAS2-10                         	  222728	     28055 ns/op	   94769 B/op	     387 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/parser	226.828s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/validator
+cpu: Apple M4
+BenchmarkValidate/SmallOAS3-10     	   33070	    181932 ns/op	  204556 B/op	    2164 allocs/op
+BenchmarkValidate/MediumOAS3-10    	    3988	   1501772 ns/op	 1491523 B/op	   18308 allocs/op
+BenchmarkValidate/LargeOAS3-10     	     322	  22569557 ns/op	16838351 B/op	  205019 allocs/op
+BenchmarkValidate/SmallOAS2-10     	   13414	    380419 ns/op	  180433 B/op	    2136 allocs/op
+BenchmarkValidate/MediumOAS2-10    	    4275	   1330739 ns/op	 1268596 B/op	   16852 allocs/op
+BenchmarkValidateNoWarnings/SmallOAS3-10         	   34311	    175895 ns/op	  204198 B/op	    2163 allocs/op
+BenchmarkValidateNoWarnings/MediumOAS3-10        	    4154	   1465104 ns/op	 1489730 B/op	   18307 allocs/op
+BenchmarkValidateNoWarnings/LargeOAS3-10         	     328	  18256907 ns/op	16839675 B/op	  205020 allocs/op
+BenchmarkValidateParsed/SmallOAS3-10             	  984631	      5937 ns/op	    5308 B/op	      90 allocs/op
+BenchmarkValidateParsed/MediumOAS3-10            	  122389	     49199 ns/op	   33536 B/op	     914 allocs/op
+BenchmarkValidateParsed/LargeOAS3-10             	   10000	    573368 ns/op	  376716 B/op	   10297 allocs/op
+BenchmarkValidateStrictMode/SmallOAS3-10         	   33616	    176357 ns/op	  204168 B/op	    2163 allocs/op
+BenchmarkValidateStrictMode/MediumOAS3-10        	    4327	   1440223 ns/op	 1490086 B/op	   18308 allocs/op
+BenchmarkValidateStrictMode/LargeOAS3-10         	     337	  18282638 ns/op	16838498 B/op	  205020 allocs/op
+BenchmarkValidateWithOptions/FilePath/SmallOAS3-10         	   34582	    177918 ns/op	  204310 B/op	    2167 allocs/op
+BenchmarkValidateWithOptions/Parsed/SmallOAS3-10           	 1000000	      5834 ns/op	    5550 B/op	      93 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/validator	99.375s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/fixer
+cpu: Apple M4
+BenchmarkFixDocuments/SmallOAS3-10         	   35301	    168915 ns/op	  207609 B/op	    2125 allocs/op
+BenchmarkFixDocuments/MediumOAS3-10        	    4300	   1370075 ns/op	 1578043 B/op	   17925 allocs/op
+BenchmarkFixDocuments/LargeOAS3-10         	     338	  17756610 ns/op	17646836 B/op	  199744 allocs/op
+BenchmarkFixDocuments/SmallOAS2-10         	   36240	    162587 ns/op	  182940 B/op	    2108 allocs/op
+BenchmarkFixDocuments/MediumOAS2-10        	    4843	   1275725 ns/op	 1340191 B/op	   16477 allocs/op
+BenchmarkFixWithInferTypes/SmallOAS3-10    	   34484	    175270 ns/op	  207213 B/op	    2125 allocs/op
+BenchmarkFixWithInferTypes/MediumOAS3-10   	    4132	   1479409 ns/op	 1573750 B/op	   17926 allocs/op
+BenchmarkFixWithInferTypes/LargeOAS3-10    	     320	  18432821 ns/op	17648215 B/op	  199744 allocs/op
+BenchmarkFixParsed/SmallOAS3-10            	 1943179	      3090 ns/op	    8380 B/op	      52 allocs/op
+BenchmarkFixParsed/MediumOAS3-10           	  157489	     38595 ns/op	  118132 B/op	     530 allocs/op
+BenchmarkFixParsed/LargeOAS3-10            	   12044	    498551 ns/op	 1191542 B/op	    5021 allocs/op
+BenchmarkFixWithOptions/FilePath/SmallOAS3-10         	   33232	    180385 ns/op	  207335 B/op	    2129 allocs/op
+BenchmarkFixWithOptions/Parsed/SmallOAS3-10           	 1865466	      3221 ns/op	    8639 B/op	      55 allocs/op
+BenchmarkFix-10                                       	 1000000	      5481 ns/op	   12903 B/op	      96 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/fixer	85.412s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/converter
+cpu: Apple M4
+BenchmarkConvertOAS2ToOAS3/Small-10    	   35230	    172719 ns/op	  184563 B/op	    2145 allocs/op
+BenchmarkConvertOAS2ToOAS3/Medium-10   	    4514	   1342180 ns/op	 1351454 B/op	   16717 allocs/op
+BenchmarkConvertOAS3ToOAS2/Small-10    	   32980	    182909 ns/op	  207728 B/op	    2162 allocs/op
+BenchmarkConvertOAS3ToOAS2/Medium-10   	    4082	   1548453 ns/op	 1577379 B/op	   18217 allocs/op
+BenchmarkConvertParsedOAS2ToOAS3/Small-10         	 1391846	      4310 ns/op	   10277 B/op	      83 allocs/op
+BenchmarkConvertParsedOAS2ToOAS3/Medium-10        	  116296	     48686 ns/op	  121469 B/op	     687 allocs/op
+BenchmarkConvertParsedOAS3ToOAS2/Small-10         	 1242982	      4838 ns/op	    8618 B/op	      89 allocs/op
+BenchmarkConvertParsedOAS3ToOAS2/Medium-10        	   97758	     62404 ns/op	  116938 B/op	     821 allocs/op
+BenchmarkConvertNoInfo/Small-10                   	   30763	    197960 ns/op	  184568 B/op	    2145 allocs/op
+BenchmarkConvertNoInfo/Medium-10                  	    3949	   1459839 ns/op	 1351460 B/op	   16717 allocs/op
+BenchmarkConvertWithOptions/FilePath/Small-10     	   31897	    189233 ns/op	  184685 B/op	    2149 allocs/op
+BenchmarkConvertWithOptions/Parsed/Small-10       	 1386886	      4293 ns/op	   10557 B/op	      87 allocs/op
+BenchmarkConvertOAS30ToOAS31/Small-10             	   33939	    176400 ns/op	  205597 B/op	    2145 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/converter	78.617s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/joiner
+cpu: Apple M4
+BenchmarkJoin/TwoDocs-10       	   47750	    126820 ns/op	  135850 B/op	    1495 allocs/op
+BenchmarkJoin/ThreeDocs-10     	   30799	    191748 ns/op	  201533 B/op	    2202 allocs/op
+BenchmarkJoin/FiveDocs-10      	   19192	    312905 ns/op	  337128 B/op	    3714 allocs/op
+BenchmarkJoinParsed/TwoDocs-10 	 6068280	       980.9 ns/op	    1896 B/op	      22 allocs/op
+BenchmarkJoinParsed/ThreeDocs-10         	 4961870	      1225 ns/op	    2072 B/op	      23 allocs/op
+BenchmarkJoinStrategy/AcceptLeft-10      	   47325	    128350 ns/op	  135856 B/op	    1495 allocs/op
+BenchmarkJoinStrategy/AcceptRight-10     	   44606	    130877 ns/op	  135857 B/op	    1495 allocs/op
+BenchmarkJoinOptions/MergeArrays-10      	   47988	    125367 ns/op	  135856 B/op	    1495 allocs/op
+BenchmarkJoinOptions/DeduplicateTags-10  	   47624	    127158 ns/op	  135853 B/op	    1495 allocs/op
+BenchmarkJoinWithOptions/FilePaths-10    	   45825	    130192 ns/op	  136140 B/op	    1501 allocs/op
+BenchmarkJoinWithOptions/Parsed-10       	 4908202	      1214 ns/op	    2824 B/op	      28 allocs/op
+BenchmarkJoinWriteResult-10              	   77434	     80404 ns/op	   90266 B/op	     404 allocs/op
+BenchmarkJoinHelpers/DefaultConfig-10    	1000000000	         5.000 ns/op	       0 B/op	       0 allocs/op
+BenchmarkJoinHelpers/IsValidStrategy-10  	868192832	         6.904 ns/op	       0 B/op	       0 allocs/op
+BenchmarkJoinHelpers/ValidStrategies-10  	355887488	        16.82 ns/op	      64 B/op	       1 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/joiner	89.737s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/differ
+cpu: Apple M4
+BenchmarkDiff/FilePath-10      	   10000	    570687 ns/op	  603686 B/op	    7201 allocs/op
+BenchmarkDiff/Parsed-10        	  458067	     13265 ns/op	   15022 B/op	     297 allocs/op
+BenchmarkDiffMode/Simple-10    	  443136	     13748 ns/op	   15022 B/op	     297 allocs/op
+BenchmarkDiffMode/Breaking-10  	  453666	     13213 ns/op	   15022 B/op	     297 allocs/op
+BenchmarkDiffIncludeInfo/WithInfo-10         	  454939	     13264 ns/op	   15022 B/op	     297 allocs/op
+BenchmarkDiffIncludeInfo/WithoutInfo-10      	  449139	     13504 ns/op	   16431 B/op	     298 allocs/op
+BenchmarkDiffIdentical-10                    	  552348	     10327 ns/op	   10643 B/op	     247 allocs/op
+BenchmarkDiffWithOptions/FilePath-10         	   10000	    607030 ns/op	  603903 B/op	    7209 allocs/op
+BenchmarkChangeString-10                     	11406070	       531.5 ns/op	     400 B/op	      15 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/differ	54.790s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/generator
+cpu: Apple M4
+BenchmarkGenerate/Types-10         	  113050	     55493 ns/op	   28119 B/op	     724 allocs/op
+BenchmarkGenerate/Client-10        	   15996	    366683 ns/op	  187692 B/op	    4088 allocs/op
+BenchmarkGenerate/Server-10        	   81042	     74666 ns/op	   47859 B/op	    1040 allocs/op
+BenchmarkGenerate/All-10           	   18128	    328919 ns/op	  182209 B/op	    3882 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/generator	28.928s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/builder
+cpu: Apple M4
+BenchmarkBuilderNew-10             	22559931	       276.0 ns/op	     800 B/op	      14 allocs/op
+BenchmarkBuilderSetInfo-10         	19671111	       308.5 ns/op	     912 B/op	      15 allocs/op
+BenchmarkSchemaFrom/Primitive-10   	14796776	       401.9 ns/op	    1568 B/op	      15 allocs/op
+BenchmarkSchemaFrom/Struct-10      	 1365211	      4391 ns/op	   15368 B/op	      77 allocs/op
+BenchmarkSchemaFrom/NestedStruct-10         	  918498	      6683 ns/op	   23096 B/op	      99 allocs/op
+BenchmarkSchemaFrom/Slice-10                	 1284828	      4668 ns/op	   16136 B/op	      78 allocs/op
+BenchmarkSchemaFrom/Map-10                  	 1294011	      4630 ns/op	   16136 B/op	      78 allocs/op
+BenchmarkBuilderAddOperation/Simple-10      	 1000000	      5611 ns/op	   18441 B/op	     100 allocs/op
+BenchmarkBuilderAddOperation/WithParams-10  	  761348	      7666 ns/op	   25958 B/op	     139 allocs/op
+BenchmarkBuilderAddOperation/WithRequestBody-10         	  618195	      9454 ns/op	   30776 B/op	     153 allocs/op
+BenchmarkBuilderBuild-10                                	  560302	     10353 ns/op	   33650 B/op	     208 allocs/op
+BenchmarkBuilderMarshal/YAML-10                         	  141938	     42455 ns/op	   93879 B/op	     482 allocs/op
+BenchmarkBuilderMarshal/JSON-10                         	  254410	     23119 ns/op	    8477 B/op	      38 allocs/op
+BenchmarkOASTag/Apply-10                                	17489736	       350.5 ns/op	    1184 B/op	       6 allocs/op
+BenchmarkOASTag/Parse-10                                	26014662	       232.0 ns/op	     432 B/op	       3 allocs/op
+BenchmarkBuilderFormParams/OAS2-10                      	 2168605	      2760 ns/op	   10373 B/op	      75 allocs/op
+BenchmarkBuilderFormParams/OAS3-10                      	 1936053	      3110 ns/op	   13023 B/op	      81 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/builder	101.798s

--- a/benchmarks/benchmark-v1.22.1.txt
+++ b/benchmarks/benchmark-v1.22.1.txt
@@ -1,0 +1,173 @@
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/parser
+cpu: Apple M4
+BenchmarkMarshalInfo/NoExtra-10    	11020147	       538.5 ns/op	     192 B/op	       2 allocs/op
+BenchmarkMarshalInfo/Extra1-10     	 4012054	      1519 ns/op	    1105 B/op	      20 allocs/op
+BenchmarkMarshalInfo/Extra5-10     	 2169542	      2819 ns/op	    2218 B/op	      31 allocs/op
+BenchmarkMarshalInfo/Extra10-10    	 1257090	      4779 ns/op	    4077 B/op	      43 allocs/op
+BenchmarkMarshalInfo/Extra20-10    	  773090	      7618 ns/op	    5423 B/op	      63 allocs/op
+BenchmarkMarshalContact/NoExtra-10 	11237232	       550.3 ns/op	     192 B/op	       2 allocs/op
+BenchmarkMarshalContact/WithExtra-10         	 2844524	      2091 ns/op	    1377 B/op	      24 allocs/op
+BenchmarkMarshalServer/NoExtra-10            	13503876	       448.5 ns/op	     160 B/op	       2 allocs/op
+BenchmarkMarshalServer/WithExtra-10          	 2055148	      2995 ns/op	    2299 B/op	      30 allocs/op
+BenchmarkMarshalOAS3Document/Small-10        	  208543	     24630 ns/op	    7005 B/op	      66 allocs/op
+BenchmarkMarshalOAS3Document/Medium-10       	   22110	    265176 ns/op	   65864 B/op	     471 allocs/op
+BenchmarkMarshalOAS3Document/Large-10        	    1894	   3178423 ns/op	  848671 B/op	    5337 allocs/op
+BenchmarkMarshalOAS2Document/Small-10        	  291242	     20633 ns/op	    6371 B/op	      58 allocs/op
+BenchmarkMarshalOAS2Document/Medium-10       	   28440	    213266 ns/op	   53684 B/op	     396 allocs/op
+BenchmarkUnmarshalInfo/NoExtra-10            	 3182850	      1870 ns/op	    1224 B/op	      29 allocs/op
+BenchmarkUnmarshalInfo/WithExtra-10          	 1442874	      4156 ns/op	    1736 B/op	      46 allocs/op
+BenchmarkParse/SmallOAS3-10                  	   33843	    178755 ns/op	  197219 B/op	    2070 allocs/op
+BenchmarkParse/MediumOAS3-10                 	    4104	   1429341 ns/op	 1447348 B/op	   17388 allocs/op
+BenchmarkParse/LargeOAS3-10                  	     338	  17859710 ns/op	16424514 B/op	  194712 allocs/op
+BenchmarkParse/SmallOAS2-10                  	   32871	    180443 ns/op	  174216 B/op	    2059 allocs/op
+BenchmarkParse/MediumOAS2-10                 	    4562	   1339632 ns/op	 1230064 B/op	   16027 allocs/op
+BenchmarkParseNoValidation/SmallOAS3-10      	   32115	    190091 ns/op	  196318 B/op	    2047 allocs/op
+BenchmarkParseNoValidation/MediumOAS3-10     	    3600	   1618607 ns/op	 1442430 B/op	   17296 allocs/op
+BenchmarkParseBytes/SmallOAS3-10             	   35480	    169625 ns/op	  195452 B/op	    2065 allocs/op
+BenchmarkParseBytes/MediumOAS3-10            	    4087	   1470559 ns/op	 1433446 B/op	   17383 allocs/op
+BenchmarkParseWithOptions/FilePath/SmallOAS3-10         	   32660	    181365 ns/op	  197479 B/op	    2077 allocs/op
+BenchmarkParseWithOptions/Bytes/SmallOAS3-10            	   35751	    168007 ns/op	  195706 B/op	    2071 allocs/op
+BenchmarkParseWithOptions/ResolveRefs/SmallOAS3-10      	   24339	    247021 ns/op	  365023 B/op	    2455 allocs/op
+BenchmarkParseReader/MediumOAS3-10                      	    4030	   1514661 ns/op	 1496518 B/op	   17397 allocs/op
+BenchmarkParseResultCopy/SmallOAS3-10                   	  783830	      7558 ns/op	   18088 B/op	     113 allocs/op
+BenchmarkParseResolveRefs/MediumOAS3-10                 	    2419	   2474255 ns/op	 3178007 B/op	   22127 allocs/op
+BenchmarkFormatBytes-10                                 	13610589	       428.0 ns/op	      64 B/op	       8 allocs/op
+BenchmarkDeepCopy/SmallOAS3-10                          	 2462554	      2429 ns/op	    7376 B/op	      44 allocs/op
+BenchmarkDeepCopy/MediumOAS3-10                         	  175436	     34217 ns/op	  108561 B/op	     466 allocs/op
+BenchmarkDeepCopy/LargeOAS3-10                          	   12541	    479886 ns/op	 1163519 B/op	    4877 allocs/op
+BenchmarkDeepCopy/SmallOAS2-10                          	 2930773	      2049 ns/op	    6352 B/op	      38 allocs/op
+BenchmarkDeepCopy/MediumOAS2-10                         	  216906	     28331 ns/op	   94769 B/op	     387 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/parser	225.556s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/validator
+cpu: Apple M4
+BenchmarkValidate/SmallOAS3-10     	   32656	    180918 ns/op	  204217 B/op	    2163 allocs/op
+BenchmarkValidate/MediumOAS3-10    	    4192	   1430250 ns/op	 1490314 B/op	   18308 allocs/op
+BenchmarkValidate/LargeOAS3-10     	     338	  17932485 ns/op	16839524 B/op	  205020 allocs/op
+BenchmarkValidate/SmallOAS2-10     	   35281	    168731 ns/op	  180356 B/op	    2136 allocs/op
+BenchmarkValidate/MediumOAS2-10    	    4669	   1319518 ns/op	 1268853 B/op	   16852 allocs/op
+BenchmarkValidateNoWarnings/SmallOAS3-10         	   33256	    180073 ns/op	  204146 B/op	    2163 allocs/op
+BenchmarkValidateNoWarnings/MediumOAS3-10        	    4070	   1455379 ns/op	 1490130 B/op	   18308 allocs/op
+BenchmarkValidateNoWarnings/LargeOAS3-10         	     333	  18135108 ns/op	16838641 B/op	  205020 allocs/op
+BenchmarkValidateParsed/SmallOAS3-10             	 1000000	      5900 ns/op	    5307 B/op	      90 allocs/op
+BenchmarkValidateParsed/MediumOAS3-10            	  120387	     50040 ns/op	   33579 B/op	     914 allocs/op
+BenchmarkValidateParsed/LargeOAS3-10             	   10000	    580951 ns/op	  377401 B/op	   10297 allocs/op
+BenchmarkValidateStrictMode/SmallOAS3-10         	   33382	    183075 ns/op	  204256 B/op	    2163 allocs/op
+BenchmarkValidateStrictMode/MediumOAS3-10        	    4011	   1481724 ns/op	 1491303 B/op	   18308 allocs/op
+BenchmarkValidateStrictMode/LargeOAS3-10         	     326	  18117089 ns/op	16838536 B/op	  205020 allocs/op
+BenchmarkValidateWithOptions/FilePath/SmallOAS3-10         	   35833	    164915 ns/op	  204241 B/op	    2167 allocs/op
+BenchmarkValidateWithOptions/Parsed/SmallOAS3-10           	 1000000	      6113 ns/op	    5556 B/op	      93 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/validator	98.994s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/fixer
+cpu: Apple M4
+BenchmarkFixDocuments/SmallOAS3-10         	   33640	    176269 ns/op	  207521 B/op	    2125 allocs/op
+BenchmarkFixDocuments/MediumOAS3-10        	    4153	   1414665 ns/op	 1576769 B/op	   17924 allocs/op
+BenchmarkFixDocuments/LargeOAS3-10         	     334	  18101235 ns/op	17648248 B/op	  199744 allocs/op
+BenchmarkFixDocuments/SmallOAS2-10         	   35466	    168833 ns/op	  182929 B/op	    2108 allocs/op
+BenchmarkFixDocuments/MediumOAS2-10        	    4645	   1292647 ns/op	 1340609 B/op	   16477 allocs/op
+BenchmarkFixWithInferTypes/SmallOAS3-10    	   34197	    175303 ns/op	  207103 B/op	    2125 allocs/op
+BenchmarkFixWithInferTypes/MediumOAS3-10   	    4304	   1424887 ns/op	 1573197 B/op	   17926 allocs/op
+BenchmarkFixWithInferTypes/LargeOAS3-10    	     333	  18325551 ns/op	17647835 B/op	  199744 allocs/op
+BenchmarkFixParsed/SmallOAS3-10            	 1979314	      3039 ns/op	    8373 B/op	      52 allocs/op
+BenchmarkFixParsed/MediumOAS3-10           	  167800	     39124 ns/op	  118365 B/op	     530 allocs/op
+BenchmarkFixParsed/LargeOAS3-10            	   12337	    486321 ns/op	 1191464 B/op	    5021 allocs/op
+BenchmarkFixWithOptions/FilePath/SmallOAS3-10         	   33763	    175003 ns/op	  207258 B/op	    2129 allocs/op
+BenchmarkFixWithOptions/Parsed/SmallOAS3-10           	 1940227	      3105 ns/op	    8637 B/op	      55 allocs/op
+BenchmarkFix-10                                       	 1000000	      5233 ns/op	   12893 B/op	      96 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/fixer	85.887s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/converter
+cpu: Apple M4
+BenchmarkConvertOAS2ToOAS3/Small-10    	   34909	    172896 ns/op	  184563 B/op	    2145 allocs/op
+BenchmarkConvertOAS2ToOAS3/Medium-10   	    4508	   1346159 ns/op	 1351465 B/op	   16717 allocs/op
+BenchmarkConvertOAS3ToOAS2/Small-10    	   33212	    181839 ns/op	  207592 B/op	    2162 allocs/op
+BenchmarkConvertOAS3ToOAS2/Medium-10   	    4111	   1483219 ns/op	 1577414 B/op	   18217 allocs/op
+BenchmarkConvertParsedOAS2ToOAS3/Small-10         	 1474519	      4083 ns/op	   10277 B/op	      83 allocs/op
+BenchmarkConvertParsedOAS2ToOAS3/Medium-10        	  121810	     48739 ns/op	  121463 B/op	     687 allocs/op
+BenchmarkConvertParsedOAS3ToOAS2/Small-10         	 1309573	      4566 ns/op	    8634 B/op	      89 allocs/op
+BenchmarkConvertParsedOAS3ToOAS2/Medium-10        	  102956	     58592 ns/op	  117187 B/op	     821 allocs/op
+BenchmarkConvertNoInfo/Small-10                   	   34149	    174904 ns/op	  184567 B/op	    2145 allocs/op
+BenchmarkConvertNoInfo/Medium-10                  	    4542	   1335255 ns/op	 1351455 B/op	   16717 allocs/op
+BenchmarkConvertWithOptions/FilePath/Small-10     	   34436	    174205 ns/op	  184686 B/op	    2149 allocs/op
+BenchmarkConvertWithOptions/Parsed/Small-10       	 1429155	      4159 ns/op	   10557 B/op	      87 allocs/op
+BenchmarkConvertOAS30ToOAS31/Small-10             	   34860	    173192 ns/op	  205597 B/op	    2145 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/converter	78.709s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/joiner
+cpu: Apple M4
+BenchmarkJoin/TwoDocs-10       	   45704	    131940 ns/op	  135851 B/op	    1495 allocs/op
+BenchmarkJoin/ThreeDocs-10     	   31411	    191468 ns/op	  201533 B/op	    2202 allocs/op
+BenchmarkJoin/FiveDocs-10      	   18244	    328605 ns/op	  337127 B/op	    3713 allocs/op
+BenchmarkJoinParsed/TwoDocs-10 	 5894910	      1492 ns/op	    1896 B/op	      22 allocs/op
+BenchmarkJoinParsed/ThreeDocs-10         	 3545893	      1571 ns/op	    2072 B/op	      23 allocs/op
+BenchmarkJoinStrategy/AcceptLeft-10      	   46032	    127374 ns/op	  135855 B/op	    1495 allocs/op
+BenchmarkJoinStrategy/AcceptRight-10     	   47389	    127981 ns/op	  135856 B/op	    1495 allocs/op
+BenchmarkJoinOptions/MergeArrays-10      	   46785	    128226 ns/op	  135856 B/op	    1495 allocs/op
+BenchmarkJoinOptions/DeduplicateTags-10  	   46891	    129346 ns/op	  135855 B/op	    1495 allocs/op
+BenchmarkJoinWithOptions/FilePaths-10    	   46606	    126856 ns/op	  136142 B/op	    1501 allocs/op
+BenchmarkJoinWithOptions/Parsed-10       	 5052273	      1186 ns/op	    2824 B/op	      28 allocs/op
+BenchmarkJoinWriteResult-10              	   76940	     79112 ns/op	   90266 B/op	     404 allocs/op
+BenchmarkJoinHelpers/DefaultConfig-10    	1000000000	         5.000 ns/op	       0 B/op	       0 allocs/op
+BenchmarkJoinHelpers/IsValidStrategy-10  	924328972	         6.768 ns/op	       0 B/op	       0 allocs/op
+BenchmarkJoinHelpers/ValidStrategies-10  	355980172	        16.74 ns/op	      64 B/op	       1 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/joiner	92.249s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/differ
+cpu: Apple M4
+BenchmarkDiff/FilePath-10      	    9922	    551890 ns/op	  603734 B/op	    7201 allocs/op
+BenchmarkDiff/Parsed-10        	  475170	     12670 ns/op	   15086 B/op	     297 allocs/op
+BenchmarkDiffMode/Simple-10    	  481338	     12714 ns/op	   15086 B/op	     297 allocs/op
+BenchmarkDiffMode/Breaking-10  	  470857	     12675 ns/op	   15086 B/op	     297 allocs/op
+BenchmarkDiffIncludeInfo/WithInfo-10         	  476826	     12770 ns/op	   15086 B/op	     297 allocs/op
+BenchmarkDiffIncludeInfo/WithoutInfo-10      	  462531	     12901 ns/op	   16495 B/op	     298 allocs/op
+BenchmarkDiffIdentical-10                    	  608726	     10275 ns/op	   10707 B/op	     247 allocs/op
+BenchmarkDiffWithOptions/FilePath-10         	   10000	    579319 ns/op	  603971 B/op	    7209 allocs/op
+BenchmarkChangeString-10                     	11943675	       522.1 ns/op	     400 B/op	      15 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/differ	54.904s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/generator
+cpu: Apple M4
+BenchmarkGenerate/Types-10         	  116286	     51189 ns/op	   28448 B/op	     728 allocs/op
+BenchmarkGenerate/Client-10        	   16549	    362266 ns/op	  206143 B/op	    4164 allocs/op
+BenchmarkGenerate/Server-10        	   80917	     74455 ns/op	   48613 B/op	    1052 allocs/op
+BenchmarkGenerate/All-10           	   17952	    337205 ns/op	  199583 B/op	    3959 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/generator	29.004s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/builder
+cpu: Apple M4
+BenchmarkBuilderNew-10             	23397562	       281.8 ns/op	     800 B/op	      14 allocs/op
+BenchmarkBuilderSetInfo-10         	19800879	       311.3 ns/op	     912 B/op	      15 allocs/op
+BenchmarkSchemaFrom/Primitive-10   	13395847	       424.8 ns/op	    1568 B/op	      15 allocs/op
+BenchmarkSchemaFrom/Struct-10      	 1331060	      4494 ns/op	   15368 B/op	      77 allocs/op
+BenchmarkSchemaFrom/NestedStruct-10         	  869217	      6988 ns/op	   23096 B/op	      99 allocs/op
+BenchmarkSchemaFrom/Slice-10                	 1255502	      4768 ns/op	   16136 B/op	      78 allocs/op
+BenchmarkSchemaFrom/Map-10                  	 1255154	      4777 ns/op	   16136 B/op	      78 allocs/op
+BenchmarkBuilderAddOperation/Simple-10      	  984344	      5328 ns/op	   18441 B/op	     100 allocs/op
+BenchmarkBuilderAddOperation/WithParams-10  	  852704	      8094 ns/op	   25957 B/op	     139 allocs/op
+BenchmarkBuilderAddOperation/WithRequestBody-10         	  565819	     10527 ns/op	   30776 B/op	     153 allocs/op
+BenchmarkBuilderBuild-10                                	  482193	     12544 ns/op	   33650 B/op	     208 allocs/op
+BenchmarkBuilderMarshal/YAML-10                         	  130588	     45711 ns/op	   93879 B/op	     482 allocs/op
+BenchmarkBuilderMarshal/JSON-10                         	  237610	     25375 ns/op	    8477 B/op	      38 allocs/op
+BenchmarkOASTag/Apply-10                                	19528102	       356.5 ns/op	    1184 B/op	       6 allocs/op
+BenchmarkOASTag/Parse-10                                	25660435	       234.2 ns/op	     432 B/op	       3 allocs/op
+BenchmarkBuilderFormParams/OAS2-10                      	 2102137	      2938 ns/op	   10374 B/op	      75 allocs/op
+BenchmarkBuilderFormParams/OAS3-10                      	 1834479	      3200 ns/op	   13023 B/op	      81 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/builder	103.980s

--- a/benchmarks/benchmark-v1.22.2.txt
+++ b/benchmarks/benchmark-v1.22.2.txt
@@ -1,0 +1,173 @@
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/parser
+cpu: Apple M4
+BenchmarkMarshalInfo/NoExtra-10    	12175339	       489.4 ns/op	     192 B/op	       2 allocs/op
+BenchmarkMarshalInfo/Extra1-10     	 4424973	      1356 ns/op	    1105 B/op	      20 allocs/op
+BenchmarkMarshalInfo/Extra5-10     	 2396115	      2506 ns/op	    2218 B/op	      31 allocs/op
+BenchmarkMarshalInfo/Extra10-10    	 1405352	      4274 ns/op	    4077 B/op	      43 allocs/op
+BenchmarkMarshalInfo/Extra20-10    	  846424	      7053 ns/op	    5424 B/op	      63 allocs/op
+BenchmarkMarshalContact/NoExtra-10 	11864270	       502.3 ns/op	     192 B/op	       2 allocs/op
+BenchmarkMarshalContact/WithExtra-10         	 3098198	      1952 ns/op	    1377 B/op	      24 allocs/op
+BenchmarkMarshalServer/NoExtra-10            	14052926	       430.7 ns/op	     160 B/op	       2 allocs/op
+BenchmarkMarshalServer/WithExtra-10          	 2037792	      2792 ns/op	    2299 B/op	      30 allocs/op
+BenchmarkMarshalOAS3Document/Small-10        	  280221	     21304 ns/op	    7005 B/op	      66 allocs/op
+BenchmarkMarshalOAS3Document/Medium-10       	   23850	    249034 ns/op	   65910 B/op	     471 allocs/op
+BenchmarkMarshalOAS3Document/Large-10        	    2232	   2889742 ns/op	  849841 B/op	    5337 allocs/op
+BenchmarkMarshalOAS2Document/Small-10        	  309316	     19498 ns/op	    6371 B/op	      58 allocs/op
+BenchmarkMarshalOAS2Document/Medium-10       	   24343	    233917 ns/op	   53639 B/op	     396 allocs/op
+BenchmarkUnmarshalInfo/NoExtra-10            	 2079836	      3082 ns/op	    1224 B/op	      29 allocs/op
+BenchmarkUnmarshalInfo/WithExtra-10          	 1251697	      4636 ns/op	    1736 B/op	      46 allocs/op
+BenchmarkParse/SmallOAS3-10                  	   35574	    178174 ns/op	  197224 B/op	    2070 allocs/op
+BenchmarkParse/MediumOAS3-10                 	    4192	   1443667 ns/op	 1447414 B/op	   17389 allocs/op
+BenchmarkParse/LargeOAS3-10                  	     349	  17249645 ns/op	16424487 B/op	  194712 allocs/op
+BenchmarkParse/SmallOAS2-10                  	   35242	    173128 ns/op	  174215 B/op	    2059 allocs/op
+BenchmarkParse/MediumOAS2-10                 	    4730	   1285699 ns/op	 1230066 B/op	   16027 allocs/op
+BenchmarkParseNoValidation/SmallOAS3-10      	   33939	    176484 ns/op	  196320 B/op	    2047 allocs/op
+BenchmarkParseNoValidation/MediumOAS3-10     	    4086	   1419449 ns/op	 1442432 B/op	   17296 allocs/op
+BenchmarkParseBytes/SmallOAS3-10             	   36577	    167408 ns/op	  195453 B/op	    2065 allocs/op
+BenchmarkParseBytes/MediumOAS3-10            	    4300	   1410184 ns/op	 1433472 B/op	   17384 allocs/op
+BenchmarkParseWithOptions/FilePath/SmallOAS3-10         	   34311	    181175 ns/op	  197481 B/op	    2077 allocs/op
+BenchmarkParseWithOptions/Bytes/SmallOAS3-10            	   35224	    168649 ns/op	  195712 B/op	    2071 allocs/op
+BenchmarkParseWithOptions/ResolveRefs/SmallOAS3-10      	   24194	    247217 ns/op	  365034 B/op	    2455 allocs/op
+BenchmarkParseReader/MediumOAS3-10                      	    3998	   1526768 ns/op	 1496621 B/op	   17397 allocs/op
+BenchmarkParseResultCopy/SmallOAS3-10                   	  820506	      7318 ns/op	   18088 B/op	     113 allocs/op
+BenchmarkParseResolveRefs/MediumOAS3-10                 	    1210	   5042563 ns/op	 6808451 B/op	   42014 allocs/op
+BenchmarkFormatBytes-10                                 	14456084	       408.5 ns/op	      64 B/op	       8 allocs/op
+BenchmarkDeepCopy/SmallOAS3-10                          	 2587230	      2351 ns/op	    7376 B/op	      44 allocs/op
+BenchmarkDeepCopy/MediumOAS3-10                         	  180244	     34822 ns/op	  108561 B/op	     466 allocs/op
+BenchmarkDeepCopy/LargeOAS3-10                          	   12368	    483994 ns/op	 1163520 B/op	    4877 allocs/op
+BenchmarkDeepCopy/SmallOAS2-10                          	 2976178	      2013 ns/op	    6352 B/op	      38 allocs/op
+BenchmarkDeepCopy/MediumOAS2-10                         	  209218	     28214 ns/op	   94769 B/op	     387 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/parser	232.369s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/validator
+cpu: Apple M4
+BenchmarkValidate/SmallOAS3-10     	   33194	    177738 ns/op	  204223 B/op	    2163 allocs/op
+BenchmarkValidate/MediumOAS3-10    	    4246	   1436081 ns/op	 1490598 B/op	   18308 allocs/op
+BenchmarkValidate/LargeOAS3-10     	     338	  17933096 ns/op	16837022 B/op	  205019 allocs/op
+BenchmarkValidate/SmallOAS2-10     	   34694	    259724 ns/op	  180324 B/op	    2136 allocs/op
+BenchmarkValidate/MediumOAS2-10    	    3379	   1576361 ns/op	 1269185 B/op	   16853 allocs/op
+BenchmarkValidateNoWarnings/SmallOAS3-10         	   34141	    201292 ns/op	  204084 B/op	    2163 allocs/op
+BenchmarkValidateNoWarnings/MediumOAS3-10        	    4322	   1397700 ns/op	 1490309 B/op	   18308 allocs/op
+BenchmarkValidateNoWarnings/LargeOAS3-10         	     342	  17565322 ns/op	16838949 B/op	  205020 allocs/op
+BenchmarkValidateParsed/SmallOAS3-10             	 1000000	      5815 ns/op	    5314 B/op	      90 allocs/op
+BenchmarkValidateParsed/MediumOAS3-10            	  123244	     48080 ns/op	   33589 B/op	     914 allocs/op
+BenchmarkValidateParsed/LargeOAS3-10             	   10000	    543361 ns/op	  377492 B/op	   10297 allocs/op
+BenchmarkValidateStrictMode/SmallOAS3-10         	   35432	    170009 ns/op	  203995 B/op	    2163 allocs/op
+BenchmarkValidateStrictMode/MediumOAS3-10        	    4408	   1356364 ns/op	 1490040 B/op	   18308 allocs/op
+BenchmarkValidateStrictMode/LargeOAS3-10         	     352	  17201315 ns/op	16837956 B/op	  205020 allocs/op
+BenchmarkValidateWithOptions/FilePath/SmallOAS3-10         	   35302	    164965 ns/op	  204161 B/op	    2167 allocs/op
+BenchmarkValidateWithOptions/Parsed/SmallOAS3-10           	 1000000	      5443 ns/op	    5551 B/op	      93 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/validator	106.995s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/fixer
+cpu: Apple M4
+BenchmarkFixDocuments/SmallOAS3-10         	   38048	    157985 ns/op	  207555 B/op	    2125 allocs/op
+BenchmarkFixDocuments/MediumOAS3-10        	    4810	   1252405 ns/op	 1577058 B/op	   17924 allocs/op
+BenchmarkFixDocuments/LargeOAS3-10         	     374	  16166395 ns/op	17647963 B/op	  199744 allocs/op
+BenchmarkFixDocuments/SmallOAS2-10         	   39141	    150290 ns/op	  182976 B/op	    2108 allocs/op
+BenchmarkFixDocuments/MediumOAS2-10        	    5305	   1144246 ns/op	 1340955 B/op	   16478 allocs/op
+BenchmarkFixWithInferTypes/SmallOAS3-10    	   36996	    160289 ns/op	  207170 B/op	    2125 allocs/op
+BenchmarkFixWithInferTypes/MediumOAS3-10   	    4681	   1278987 ns/op	 1573875 B/op	   17926 allocs/op
+BenchmarkFixWithInferTypes/LargeOAS3-10    	     350	  17239950 ns/op	17645562 B/op	  199743 allocs/op
+BenchmarkFixParsed/SmallOAS3-10            	 2084854	      2899 ns/op	    8379 B/op	      52 allocs/op
+BenchmarkFixParsed/MediumOAS3-10           	  173662	     34742 ns/op	  118021 B/op	     530 allocs/op
+BenchmarkFixParsed/LargeOAS3-10            	   13358	    450003 ns/op	 1191051 B/op	    5021 allocs/op
+BenchmarkFixWithOptions/FilePath/SmallOAS3-10         	   36944	    160755 ns/op	  207247 B/op	    2129 allocs/op
+BenchmarkFixWithOptions/Parsed/SmallOAS3-10           	 2099911	      2879 ns/op	    8637 B/op	      55 allocs/op
+BenchmarkFix-10                                       	 1222100	      4905 ns/op	   12901 B/op	      96 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/fixer	85.951s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/converter
+cpu: Apple M4
+BenchmarkConvertOAS2ToOAS3/Small-10    	   38791	    155777 ns/op	  184564 B/op	    2145 allocs/op
+BenchmarkConvertOAS2ToOAS3/Medium-10   	    5022	   1197595 ns/op	 1351455 B/op	   16717 allocs/op
+BenchmarkConvertOAS3ToOAS2/Small-10    	   36298	    165702 ns/op	  207623 B/op	    2162 allocs/op
+BenchmarkConvertOAS3ToOAS2/Medium-10   	    4410	   1360389 ns/op	 1577256 B/op	   18217 allocs/op
+BenchmarkConvertParsedOAS2ToOAS3/Small-10         	 1543801	      3879 ns/op	   10277 B/op	      83 allocs/op
+BenchmarkConvertParsedOAS2ToOAS3/Medium-10        	  131739	     45421 ns/op	  121466 B/op	     687 allocs/op
+BenchmarkConvertParsedOAS3ToOAS2/Small-10         	 1452207	      4134 ns/op	    8610 B/op	      89 allocs/op
+BenchmarkConvertParsedOAS3ToOAS2/Medium-10        	  114187	     54962 ns/op	  116855 B/op	     821 allocs/op
+BenchmarkConvertNoInfo/Small-10                   	   34862	    172877 ns/op	  184565 B/op	    2145 allocs/op
+BenchmarkConvertNoInfo/Medium-10                  	    4359	   1342067 ns/op	 1351443 B/op	   16717 allocs/op
+BenchmarkConvertWithOptions/FilePath/Small-10     	   35509	    170393 ns/op	  184686 B/op	    2149 allocs/op
+BenchmarkConvertWithOptions/Parsed/Small-10       	 1430425	      4106 ns/op	   10557 B/op	      87 allocs/op
+BenchmarkConvertOAS30ToOAS31/Small-10             	   35143	    163840 ns/op	  205597 B/op	    2145 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/converter	78.568s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/joiner
+cpu: Apple M4
+BenchmarkJoin/TwoDocs-10       	   51993	    116266 ns/op	  135850 B/op	    1495 allocs/op
+BenchmarkJoin/ThreeDocs-10     	   34558	    176125 ns/op	  201533 B/op	    2202 allocs/op
+BenchmarkJoin/FiveDocs-10      	   20392	    292878 ns/op	  337126 B/op	    3713 allocs/op
+BenchmarkJoinParsed/TwoDocs-10 	 6805932	       888.1 ns/op	    1896 B/op	      22 allocs/op
+BenchmarkJoinParsed/ThreeDocs-10         	 5401530	      1109 ns/op	    2072 B/op	      23 allocs/op
+BenchmarkJoinStrategy/AcceptLeft-10      	   50946	    118740 ns/op	  135855 B/op	    1495 allocs/op
+BenchmarkJoinStrategy/AcceptRight-10     	   50857	    121002 ns/op	  135856 B/op	    1495 allocs/op
+BenchmarkJoinOptions/MergeArrays-10      	   47854	    118467 ns/op	  135856 B/op	    1495 allocs/op
+BenchmarkJoinOptions/DeduplicateTags-10  	   51532	    116629 ns/op	  135854 B/op	    1495 allocs/op
+BenchmarkJoinWithOptions/FilePaths-10    	   50730	    120071 ns/op	  136141 B/op	    1501 allocs/op
+BenchmarkJoinWithOptions/Parsed-10       	 5376675	      1105 ns/op	    2824 B/op	      28 allocs/op
+BenchmarkJoinWriteResult-10              	   82436	     74104 ns/op	   90266 B/op	     404 allocs/op
+BenchmarkJoinHelpers/DefaultConfig-10    	1000000000	         5.000 ns/op	       0 B/op	       0 allocs/op
+BenchmarkJoinHelpers/IsValidStrategy-10  	917412195	         6.439 ns/op	       0 B/op	       0 allocs/op
+BenchmarkJoinHelpers/ValidStrategies-10  	399916994	        15.10 ns/op	      64 B/op	       1 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/joiner	89.753s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/differ
+cpu: Apple M4
+BenchmarkDiff/FilePath-10      	   10000	    523339 ns/op	  603752 B/op	    7201 allocs/op
+BenchmarkDiff/Parsed-10        	  512690	     11731 ns/op	   15086 B/op	     297 allocs/op
+BenchmarkDiffMode/Simple-10    	  505754	     12016 ns/op	   15086 B/op	     297 allocs/op
+BenchmarkDiffMode/Breaking-10  	  489046	     11448 ns/op	   15086 B/op	     297 allocs/op
+BenchmarkDiffIncludeInfo/WithInfo-10         	  527079	     11852 ns/op	   15086 B/op	     297 allocs/op
+BenchmarkDiffIncludeInfo/WithoutInfo-10      	  496468	     12577 ns/op	   16495 B/op	     298 allocs/op
+BenchmarkDiffIdentical-10                    	  643258	      9345 ns/op	   10707 B/op	     247 allocs/op
+BenchmarkDiffWithOptions/FilePath-10         	   10000	    549017 ns/op	  603964 B/op	    7209 allocs/op
+BenchmarkChangeString-10                     	12814122	       464.2 ns/op	     400 B/op	      15 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/differ	53.986s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/generator
+cpu: Apple M4
+BenchmarkGenerate/Types-10         	  127762	     49186 ns/op	   28460 B/op	     728 allocs/op
+BenchmarkGenerate/Client-10        	   16516	    352463 ns/op	  206139 B/op	    4164 allocs/op
+BenchmarkGenerate/Server-10        	   88563	     68110 ns/op	   48624 B/op	    1052 allocs/op
+BenchmarkGenerate/All-10           	   19580	    305245 ns/op	  199606 B/op	    3959 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/generator	29.029s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/builder
+cpu: Apple M4
+BenchmarkBuilderNew-10             	24050883	       256.1 ns/op	     800 B/op	      14 allocs/op
+BenchmarkBuilderSetInfo-10         	21127798	       280.2 ns/op	     912 B/op	      15 allocs/op
+BenchmarkSchemaFrom/Primitive-10   	14974470	       380.5 ns/op	    1568 B/op	      15 allocs/op
+BenchmarkSchemaFrom/Struct-10      	 1591149	      3830 ns/op	   15144 B/op	      67 allocs/op
+BenchmarkSchemaFrom/NestedStruct-10         	  972829	      6005 ns/op	   23032 B/op	      95 allocs/op
+BenchmarkSchemaFrom/Slice-10                	 1495182	      4019 ns/op	   15912 B/op	      68 allocs/op
+BenchmarkSchemaFrom/Map-10                  	 1472325	      4037 ns/op	   15912 B/op	      68 allocs/op
+BenchmarkBuilderAddOperation/Simple-10      	 1230536	      4890 ns/op	   18217 B/op	      90 allocs/op
+BenchmarkBuilderAddOperation/WithParams-10  	  875503	      6807 ns/op	   25733 B/op	     129 allocs/op
+BenchmarkBuilderAddOperation/WithRequestBody-10         	  725058	      8362 ns/op	   30712 B/op	     149 allocs/op
+BenchmarkBuilderBuild-10                                	  623490	      9450 ns/op	   33426 B/op	     198 allocs/op
+BenchmarkBuilderMarshal/YAML-10                         	  153910	     38361 ns/op	   93879 B/op	     482 allocs/op
+BenchmarkBuilderMarshal/JSON-10                         	  276763	     21650 ns/op	    8477 B/op	      38 allocs/op
+BenchmarkOASTag/Apply-10                                	20539926	       300.2 ns/op	    1120 B/op	       5 allocs/op
+BenchmarkOASTag/Parse-10                                	32377470	       184.2 ns/op	     336 B/op	       2 allocs/op
+BenchmarkBuilderFormParams/OAS2-10                      	 2327546	      2561 ns/op	   10373 B/op	      75 allocs/op
+BenchmarkBuilderFormParams/OAS3-10                      	 2049698	      2886 ns/op	   13023 B/op	      81 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/builder	101.812s


### PR DESCRIPTION
## Summary
- Backfill missing benchmark files for versions v1.20.3, v1.21.0, v1.21.1, v1.22.1
- Add benchmark for upcoming release v1.22.2

## Performance Comparison (v1.22.1 → v1.22.2)

| Package | Time Change | Status |
|---------|-------------|--------|
| builder | -14.79% | Improved |
| joiner | -11.57% | Improved |
| fixer | -8.93% | Improved |
| differ | -7.01% | Improved |
| generator | -6.20% | Improved |
| converter | -5.84% | Improved |
| parser | -0.54% | Stable |
| validator | +1.15% | Stable |

## Test plan
- [x] Benchmark files generated using documented process
- [x] All benchmark files contain complete results (ending with PASS)
- [x] Performance comparison shows expected results

🤖 Generated with [Claude Code](https://claude.com/claude-code)