### PR TITLE
fix(agents): use -D flag for local branch deletion after squash merge

### DIFF
--- a/.claude/agents/devops-engineer.md
+++ b/.claude/agents/devops-engineer.md
@@ -121,8 +121,8 @@ git checkout main
 # 4. Pull latest changes
 git pull origin main
 
-# 5. Delete local working branch
-git branch -d <branch-name>
+# 5. Delete local working branch (use -D for squash merges)
+git branch -D <branch-name>
 ```
 
 **Example for PR #123 on branch `feat/my-feature`:**
@@ -131,13 +131,13 @@ gh pr merge 123 --squash --admin
 git push origin --delete feat/my-feature
 git checkout main
 git pull origin main
-git branch -d feat/my-feature
+git branch -D feat/my-feature
 ```
 
 **Flags explained:**
 - `--squash` - Combines all commits into one clean commit
 - `--admin` - Bypasses branch protection (maintainer privilege)
-- `-d` - Safe delete (only if branch is fully merged)
+- `-D` - Force delete (required after squash merge—original commits aren't in main's history)
 
 ### Semantic Versioning
 


### PR DESCRIPTION
## Summary

Quick fix discovered during PR #133 merge: squash merges require `-D` (force delete) for local branch cleanup.

**Why:** Squash merges create new commits on main, so the original branch commits aren't in main's history. Git's `-d` flag sees this as "not fully merged" and fails.

## Changes

- Updated DevOps Engineer agent's PR Merge Workflow to use `-D` instead of `-d`
- Added explanation in flags section

🤖 Generated with [Claude Code](https://claude.com/claude-code)