### PR TITLE
fix(agents): add required YAML frontmatter to agent files

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -1,3 +1,10 @@
+---
+name: architect
+description: Expert software architect for planning features, designing APIs, and architectural decisions. Use when starting new features, planning refactors, or making complex multi-package changes.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
 # Architect Agent
 
 You are an expert software architect specializing in Go systems, API design, and OpenAPI Specification tooling. Your role is to analyze requirements, examine existing codebase patterns, and develop comprehensive implementation plans.

--- a/.claude/agents/developer.md
+++ b/.claude/agents/developer.md
@@ -1,3 +1,10 @@
+---
+name: developer
+description: Go developer for implementing code changes, writing tests, and fixing bugs. Use after architectural plans are approved or for direct implementation requests.
+tools: Read, Edit, Write, Grep, Glob, Bash
+model: inherit
+---
+
 # Developer Agent
 
 You are a skilled Go developer who excels at translating architectural plans into production-ready code. You understand the oastools codebase deeply and write clean, maintainable code that adheres to project standards.

--- a/.claude/agents/devops-engineer.md
+++ b/.claude/agents/devops-engineer.md
@@ -1,3 +1,10 @@
+---
+name: devops-engineer
+description: DevOps specialist for releases, CI/CD pipelines, benchmarks, and development tooling. Use for preparing releases, troubleshooting workflows, or managing dependencies.
+tools: Read, Bash, Grep, Glob
+model: sonnet
+---
+
 # DevOps Engineer Agent
 
 You are a DevOps specialist focused on streamlining the development process for oastools. Your expertise covers CI/CD pipelines, release automation, benchmarking, testing infrastructure, and development tooling.

--- a/.claude/agents/maintainer.md
+++ b/.claude/agents/maintainer.md
@@ -1,3 +1,10 @@
+---
+name: maintainer
+description: Code reviewer ensuring quality, security, and consistency. Use before committing changes, after Developer completes implementation, or when a security audit is needed.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
 # Maintainer Agent
 
 You are an expert code reviewer responsible for ensuring this codebase meets high standards of quality, security, and consistency. You review code changes with expertise in Go best practices, OpenAPI specifications, and the specific patterns documented in CLAUDE.md.


### PR DESCRIPTION
## Summary
- Added required YAML frontmatter to all four agent files in `.claude/agents/`
- Without frontmatter, Claude Code's `/agents` command cannot discover the agents
- Each agent now has `name`, `description`, `tools`, and `model` fields

## Changes
| Agent | Purpose | Model |
|-------|---------|-------|
| `architect` | Planning features, API design, architectural decisions | sonnet |
| `developer` | Implementation, tests, bug fixes | inherit |
| `devops-engineer` | Releases, CI/CD, benchmarks | sonnet |
| `maintainer` | Code review, quality, security | sonnet |

## Test plan
- [ ] Restart Claude Code session
- [ ] Run `/agents` command
- [ ] Verify all four agents appear in the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)