### PR TITLE
fix(agents): configure all agents to use opus model

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -2,7 +2,7 @@
 name: architect
 description: Expert software architect for planning features, designing APIs, and architectural decisions. Use when starting new features, planning refactors, or making complex multi-package changes.
 tools: Read, Grep, Glob, Bash
-model: sonnet
+model: opus
 ---
 
 # Architect Agent

--- a/.claude/agents/developer.md
+++ b/.claude/agents/developer.md
@@ -2,7 +2,7 @@
 name: developer
 description: Go developer for implementing code changes, writing tests, and fixing bugs. Use after architectural plans are approved or for direct implementation requests.
 tools: Read, Edit, Write, Grep, Glob, Bash
-model: inherit
+model: opus
 ---
 
 # Developer Agent

--- a/.claude/agents/maintainer.md
+++ b/.claude/agents/maintainer.md
@@ -2,7 +2,7 @@
 name: maintainer
 description: Code reviewer ensuring quality, security, and consistency. Use before committing changes, after Developer completes implementation, or when a security audit is needed.
 tools: Read, Grep, Glob, Bash
-model: sonnet
+model: opus
 ---
 
 # Maintainer Agent


### PR DESCRIPTION
## Summary

- Updates all three specialized development agents to use the `opus` model
- **architect.md**: Changed from `sonnet` → `opus` for enhanced architectural reasoning
- **developer.md**: Changed from `inherit` → `opus` for more capable code implementation  
- **maintainer.md**: Changed from `sonnet` → `opus` for thorough code review

## Rationale

The opus model provides stronger reasoning capabilities which benefits:
- Complex architectural decisions and API design (architect)
- Code implementation quality and test coverage (developer)
- Security audits and consistency reviews (maintainer)

## Test plan

- [x] Verified YAML frontmatter syntax is correct
- [x] Agents load successfully with `/agents` command

🤖 Generated with [Claude Code](https://claude.com/claude-code)