### PR TITLE
feat(builder,joiner): add semantic schema deduplication

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -44,6 +44,15 @@ Invoke this agent when:
 - Highlight performance considerations
 - Note security implications
 
+### 5. Documentation Planning
+Every feature plan MUST include a documentation phase that addresses:
+- **README.md** - Update highlights, package descriptions, and quick start examples
+- **docs/developer-guide.md** - Add library usage examples and API documentation
+- **docs/cli-reference.md** - Add new flags, options, and CLI examples (if CLI-facing)
+- **Package doc.go** - Update package-level documentation
+- **Package example_test.go** - Add runnable godoc examples demonstrating the feature
+- **CLAUDE.md** - Update if new patterns, API features, or important context is added
+
 ## Process
 
 When tasked with architectural work:
@@ -109,6 +118,15 @@ func (d *Doer) Do() (*Result, error)
 - Integration tests: [approach]
 - Benchmark tests: [if performance-sensitive]
 
+### Documentation Phase
+**Files to update:**
+- `README.md` - [what to add: highlights, package table, quick start examples]
+- `docs/developer-guide.md` - [library usage section with code examples]
+- `docs/cli-reference.md` - [new flags, examples, output format] (if CLI-facing)
+- `package/doc.go` - [package documentation updates]
+- `package/example_test.go` - [runnable Example_* functions for godoc]
+- `CLAUDE.md` - [new patterns or API features to document] (if applicable)
+
 ### Considerations
 - [Known gotcha or edge case]
 - [Performance consideration]
@@ -123,10 +141,18 @@ func (d *Doer) Do() (*Result, error)
 
 ### Package Structure
 Each package should have:
-- `doc.go` - Package documentation
-- `example_test.go` - Runnable godoc examples
+- `doc.go` - Package documentation (MUST be updated for new features)
+- `example_test.go` - Runnable godoc examples (MUST add Example_* for new public APIs)
 - `*_test.go` - Comprehensive tests
 - `*_bench_test.go` - Benchmarks (if performance-sensitive)
+
+### Documentation Checklist
+For ANY new feature or significant change, the plan MUST include updates to:
+1. **Package-level:** `doc.go` and `example_test.go` in affected packages
+2. **User-facing:** `README.md` (highlights, package table, quick start)
+3. **Developer-facing:** `docs/developer-guide.md` (library usage with examples)
+4. **CLI-facing:** `docs/cli-reference.md` (if adding CLI flags or commands)
+5. **AI-facing:** `CLAUDE.md` (if adding patterns, APIs, or context future agents need)
 
 ### API Patterns
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A complete, self-contained OpenAPI toolkit for Go with minimal dependencies.
 - **Type-Safe Cloning** - Generated `DeepCopy()` methods preserve types across OAS versions (no JSON marshal hacks)
 - **Enterprise Ready** - Structured errors with `errors.Is()`/`errors.As()`, pluggable logging, configurable resource limits
 - **Well Documented** - Every package has godoc and runnable examples on [pkg.go.dev](https://pkg.go.dev/github.com/erraggy/oastools)
+- **Semantic Deduplication** - Automatically consolidate structurally identical schemas, reducing document size
 
 ## Package Ecosystem
 
@@ -29,11 +30,11 @@ A complete, self-contained OpenAPI toolkit for Go with minimal dependencies.
 | [validator](https://pkg.go.dev/github.com/erraggy/oastools/validator) | Validate specs with structural & semantic checks       |
 | [fixer](https://pkg.go.dev/github.com/erraggy/oastools/fixer)         | Auto-fix common validation errors                      |
 | [converter](https://pkg.go.dev/github.com/erraggy/oastools/converter) | Convert between OAS 2.0 and 3.x                        |
-| [joiner](https://pkg.go.dev/github.com/erraggy/oastools/joiner)       | Merge multiple OAS documents                           |
+| [joiner](https://pkg.go.dev/github.com/erraggy/oastools/joiner)       | Merge multiple OAS documents with schema deduplication |
 | [overlay](https://pkg.go.dev/github.com/erraggy/oastools/overlay)     | Apply OpenAPI Overlay v1.0.0 with JSONPath targeting   |
 | [differ](https://pkg.go.dev/github.com/erraggy/oastools/differ)       | Detect breaking changes between versions               |
 | [generator](https://pkg.go.dev/github.com/erraggy/oastools/generator) | Generate Go client/server code with security support   |
-| [builder](https://pkg.go.dev/github.com/erraggy/oastools/builder)     | Programmatically construct OAS documents               |
+| [builder](https://pkg.go.dev/github.com/erraggy/oastools/builder)     | Programmatically construct OAS documents with deduplication |
 | [oaserrors](https://pkg.go.dev/github.com/erraggy/oastools/oaserrors) | Structured error types for programmatic handling       |
 
 All packages include comprehensive documentation with runnable examples. See individual package pages on [pkg.go.dev](https://pkg.go.dev/github.com/erraggy/oastools) for API details.

--- a/builder/builder_dedupe_test.go
+++ b/builder/builder_dedupe_test.go
@@ -1,0 +1,353 @@
+package builder
+
+import (
+	"testing"
+
+	"github.com/erraggy/oastools/parser"
+)
+
+// addSchema is a test helper to add a schema directly to the builder's internal map
+func (b *Builder) addSchema(name string, schema *parser.Schema) {
+	b.schemas[name] = schema
+}
+
+func TestBuilder_DeduplicateSchemas_Empty(t *testing.T) {
+	b := New(parser.OASVersion320)
+	b.DeduplicateSchemas()
+
+	if len(b.schemaAliases) != 0 {
+		t.Errorf("Expected 0 aliases, got %d", len(b.schemaAliases))
+	}
+}
+
+func TestBuilder_DeduplicateSchemas_Single(t *testing.T) {
+	b := New(parser.OASVersion320)
+	b.addSchema("User", &parser.Schema{Type: "object"})
+	b.DeduplicateSchemas()
+
+	if len(b.schemas) != 1 {
+		t.Errorf("Expected 1 schema, got %d", len(b.schemas))
+	}
+	if len(b.schemaAliases) != 0 {
+		t.Errorf("Expected 0 aliases, got %d", len(b.schemaAliases))
+	}
+}
+
+func TestBuilder_DeduplicateSchemas_Duplicates(t *testing.T) {
+	b := New(parser.OASVersion320)
+
+	// Add identical schemas with different names
+	b.addSchema("Address", &parser.Schema{
+		Type: "object",
+		Properties: map[string]*parser.Schema{
+			"street": {Type: "string"},
+			"city":   {Type: "string"},
+		},
+		Required: []string{"street", "city"},
+	})
+	b.addSchema("Location", &parser.Schema{
+		Type: "object",
+		Properties: map[string]*parser.Schema{
+			"street": {Type: "string"},
+			"city":   {Type: "string"},
+		},
+		Required: []string{"street", "city"},
+	})
+
+	b.DeduplicateSchemas()
+
+	// Should have 1 canonical schema (Address, alphabetically first)
+	if len(b.schemas) != 1 {
+		t.Errorf("Expected 1 schema after dedup, got %d", len(b.schemas))
+	}
+	if _, ok := b.schemas["Address"]; !ok {
+		t.Error("Expected Address to be canonical (alphabetically first)")
+	}
+
+	// Should have 1 alias
+	if len(b.schemaAliases) != 1 {
+		t.Errorf("Expected 1 alias, got %d", len(b.schemaAliases))
+	}
+	if b.schemaAliases["Location"] != "Address" {
+		t.Errorf("Expected Location -> Address, got %s", b.schemaAliases["Location"])
+	}
+}
+
+func TestBuilder_DeduplicateSchemas_NoDuplicates(t *testing.T) {
+	b := New(parser.OASVersion320)
+
+	b.addSchema("User", &parser.Schema{Type: "object"})
+	b.addSchema("Address", &parser.Schema{Type: "string"})
+	b.addSchema("Age", &parser.Schema{Type: "integer"})
+
+	b.DeduplicateSchemas()
+
+	if len(b.schemas) != 3 {
+		t.Errorf("Expected 3 schemas, got %d", len(b.schemas))
+	}
+	if len(b.schemaAliases) != 0 {
+		t.Errorf("Expected 0 aliases, got %d", len(b.schemaAliases))
+	}
+}
+
+func TestBuilder_WithSemanticDeduplication_OAS3(t *testing.T) {
+	b := New(parser.OASVersion320, WithSemanticDeduplication(true))
+
+	// Add identical schemas
+	b.addSchema("Address", &parser.Schema{
+		Type: "object",
+		Properties: map[string]*parser.Schema{
+			"name": {Type: "string"},
+		},
+	})
+	b.addSchema("Location", &parser.Schema{
+		Type: "object",
+		Properties: map[string]*parser.Schema{
+			"name": {Type: "string"},
+		},
+	})
+
+	// Add a reference to Location
+	b.addSchema("Order", &parser.Schema{
+		Type: "object",
+		Properties: map[string]*parser.Schema{
+			"shipTo": {Ref: "#/components/schemas/Location"},
+		},
+	})
+
+	doc, err := b.BuildOAS3()
+	if err != nil {
+		t.Fatalf("BuildOAS3 failed: %v", err)
+	}
+
+	// Should have 2 schemas (Address canonical, Order)
+	if len(doc.Components.Schemas) != 2 {
+		t.Errorf("Expected 2 schemas after dedup, got %d", len(doc.Components.Schemas))
+	}
+
+	// Check that Order's reference was rewritten to Address
+	orderSchema := doc.Components.Schemas["Order"]
+	shipToRef := orderSchema.Properties["shipTo"].Ref
+	expectedRef := "#/components/schemas/Address"
+	if shipToRef != expectedRef {
+		t.Errorf("Expected shipTo.$ref = %s, got %s", expectedRef, shipToRef)
+	}
+}
+
+func TestBuilder_WithSemanticDeduplication_OAS2(t *testing.T) {
+	b := New(parser.OASVersion20, WithSemanticDeduplication(true))
+
+	// Add identical schemas
+	b.addSchema("Address", &parser.Schema{
+		Type: "object",
+		Properties: map[string]*parser.Schema{
+			"name": {Type: "string"},
+		},
+	})
+	b.addSchema("Location", &parser.Schema{
+		Type: "object",
+		Properties: map[string]*parser.Schema{
+			"name": {Type: "string"},
+		},
+	})
+
+	// Add a reference to Location
+	b.addSchema("Order", &parser.Schema{
+		Type: "object",
+		Properties: map[string]*parser.Schema{
+			"shipTo": {Ref: "#/definitions/Location"},
+		},
+	})
+
+	doc, err := b.BuildOAS2()
+	if err != nil {
+		t.Fatalf("BuildOAS2 failed: %v", err)
+	}
+
+	// Should have 2 definitions (Address canonical, Order)
+	if len(doc.Definitions) != 2 {
+		t.Errorf("Expected 2 definitions after dedup, got %d", len(doc.Definitions))
+	}
+
+	// Check that Order's reference was rewritten to Address
+	orderSchema := doc.Definitions["Order"]
+	shipToRef := orderSchema.Properties["shipTo"].Ref
+	expectedRef := "#/definitions/Address"
+	if shipToRef != expectedRef {
+		t.Errorf("Expected shipTo.$ref = %s, got %s", expectedRef, shipToRef)
+	}
+}
+
+func TestBuilder_WithSemanticDeduplication_Disabled(t *testing.T) {
+	// Default behavior: deduplication disabled
+	b := New(parser.OASVersion320)
+
+	b.addSchema("Address", &parser.Schema{Type: "object"})
+	b.addSchema("Location", &parser.Schema{Type: "object"})
+
+	doc, err := b.BuildOAS3()
+	if err != nil {
+		t.Fatalf("BuildOAS3 failed: %v", err)
+	}
+
+	// Should have both schemas (no dedup)
+	if len(doc.Components.Schemas) != 2 {
+		t.Errorf("Expected 2 schemas (no dedup), got %d", len(doc.Components.Schemas))
+	}
+}
+
+func TestBuilder_DeduplicateSchemas_MetadataIgnored(t *testing.T) {
+	b := New(parser.OASVersion320, WithSemanticDeduplication(true))
+
+	// Schemas differ only in metadata - should still be deduplicated
+	b.addSchema("Address", &parser.Schema{
+		Type:        "object",
+		Title:       "An Address",
+		Description: "Represents a physical address",
+		Properties: map[string]*parser.Schema{
+			"street": {Type: "string"},
+		},
+	})
+	b.addSchema("Location", &parser.Schema{
+		Type:        "object",
+		Title:       "A Location",
+		Description: "A place on earth",
+		Properties: map[string]*parser.Schema{
+			"street": {Type: "string"},
+		},
+	})
+
+	doc, err := b.BuildOAS3()
+	if err != nil {
+		t.Fatalf("BuildOAS3 failed: %v", err)
+	}
+
+	// Should deduplicate since structural properties are the same
+	if len(doc.Components.Schemas) != 1 {
+		t.Errorf("Expected 1 schema (metadata ignored), got %d", len(doc.Components.Schemas))
+	}
+}
+
+func TestBuilder_DeduplicateSchemas_MultipleGroups(t *testing.T) {
+	b := New(parser.OASVersion320, WithSemanticDeduplication(true))
+
+	// Group 1: objects with name property
+	b.addSchema("Address", &parser.Schema{
+		Type:       "object",
+		Properties: map[string]*parser.Schema{"name": {Type: "string"}},
+	})
+	b.addSchema("Location", &parser.Schema{
+		Type:       "object",
+		Properties: map[string]*parser.Schema{"name": {Type: "string"}},
+	})
+
+	// Group 2: simple strings
+	b.addSchema("Name", &parser.Schema{Type: "string"})
+	b.addSchema("Title", &parser.Schema{Type: "string"})
+
+	// Unique schema
+	b.addSchema("Age", &parser.Schema{Type: "integer"})
+
+	doc, err := b.BuildOAS3()
+	if err != nil {
+		t.Fatalf("BuildOAS3 failed: %v", err)
+	}
+
+	// Should have 3 schemas: Address (canonical), Age (unique), Name (canonical)
+	if len(doc.Components.Schemas) != 3 {
+		t.Errorf("Expected 3 schemas, got %d", len(doc.Components.Schemas))
+	}
+
+	// Verify canonical names
+	if _, ok := doc.Components.Schemas["Address"]; !ok {
+		t.Error("Expected Address to be canonical")
+	}
+	if _, ok := doc.Components.Schemas["Name"]; !ok {
+		t.Error("Expected Name to be canonical")
+	}
+	if _, ok := doc.Components.Schemas["Age"]; !ok {
+		t.Error("Expected Age to be present")
+	}
+}
+
+func TestBuilder_DeduplicateSchemas_NestedReferences(t *testing.T) {
+	b := New(parser.OASVersion320, WithSemanticDeduplication(true))
+
+	// Add identical schemas
+	b.addSchema("Address", &parser.Schema{
+		Type:       "object",
+		Properties: map[string]*parser.Schema{"street": {Type: "string"}},
+	})
+	b.addSchema("Location", &parser.Schema{
+		Type:       "object",
+		Properties: map[string]*parser.Schema{"street": {Type: "string"}},
+	})
+
+	// Add schema with nested reference to Location
+	b.addSchema("Person", &parser.Schema{
+		Type: "object",
+		Properties: map[string]*parser.Schema{
+			"home": {Ref: "#/components/schemas/Location"},
+			"work": {Ref: "#/components/schemas/Location"},
+		},
+	})
+
+	// Add allOf reference
+	b.addSchema("Employee", &parser.Schema{
+		AllOf: []*parser.Schema{
+			{Ref: "#/components/schemas/Person"},
+			{
+				Type: "object",
+				Properties: map[string]*parser.Schema{
+					"office": {Ref: "#/components/schemas/Location"},
+				},
+			},
+		},
+	})
+
+	doc, err := b.BuildOAS3()
+	if err != nil {
+		t.Fatalf("BuildOAS3 failed: %v", err)
+	}
+
+	// Verify all Location refs are rewritten to Address
+	person := doc.Components.Schemas["Person"]
+	if person.Properties["home"].Ref != "#/components/schemas/Address" {
+		t.Errorf("Expected home.$ref = Address, got %s", person.Properties["home"].Ref)
+	}
+	if person.Properties["work"].Ref != "#/components/schemas/Address" {
+		t.Errorf("Expected work.$ref = Address, got %s", person.Properties["work"].Ref)
+	}
+
+	employee := doc.Components.Schemas["Employee"]
+	officeRef := employee.AllOf[1].Properties["office"].Ref
+	if officeRef != "#/components/schemas/Address" {
+		t.Errorf("Expected office.$ref = Address, got %s", officeRef)
+	}
+}
+
+func TestBuilder_DeduplicateSchemas_ManualCall(t *testing.T) {
+	// Test calling DeduplicateSchemas manually (without option)
+	b := New(parser.OASVersion320)
+
+	b.addSchema("Address", &parser.Schema{Type: "object"})
+	b.addSchema("Location", &parser.Schema{Type: "object"})
+
+	// Manually call deduplication
+	b.DeduplicateSchemas()
+
+	// Verify aliases are set
+	if len(b.schemaAliases) != 1 {
+		t.Errorf("Expected 1 alias, got %d", len(b.schemaAliases))
+	}
+
+	// Build should use the aliases for rewriting
+	doc, err := b.BuildOAS3()
+	if err != nil {
+		t.Fatalf("BuildOAS3 failed: %v", err)
+	}
+
+	if len(doc.Components.Schemas) != 1 {
+		t.Errorf("Expected 1 schema, got %d", len(doc.Components.Schemas))
+	}
+}

--- a/builder/doc.go
+++ b/builder/doc.go
@@ -373,6 +373,37 @@
 //
 // See the examples in example_test.go for more patterns.
 //
+// # Semantic Schema Deduplication
+//
+// The builder can automatically identify and consolidate structurally identical schemas,
+// reducing document size when multiple types converge to the same structure.
+//
+// Enable via option:
+//
+//	spec := builder.New(parser.OASVersion320,
+//	    builder.WithSemanticDeduplication(true),
+//	)
+//
+//	// Add schemas that happen to be structurally identical
+//	spec.AddOperation(http.MethodGet, "/addresses",
+//	    builder.WithResponse(http.StatusOK, []Address{}),
+//	)
+//	spec.AddOperation(http.MethodGet, "/locations",
+//	    builder.WithResponse(http.StatusOK, []Location{}), // Same structure as Address
+//	)
+//
+//	doc, _ := spec.BuildOAS3()
+//	// Only one schema exists; all $refs point to the canonical (alphabetically first) name
+//
+// Or call manually before building:
+//
+//	spec.DeduplicateSchemas()
+//	doc, _ := spec.BuildOAS3()
+//
+// Deduplication compares schemas structurally, ignoring metadata fields (title, description,
+// example, deprecated). When duplicates are found, the alphabetically first name becomes
+// canonical, and all references are automatically rewritten.
+//
 // # Related Packages
 //
 // The builder integrates with other oastools packages:

--- a/builder/options.go
+++ b/builder/options.go
@@ -8,11 +8,12 @@ type BuilderOption func(*builderConfig)
 
 // builderConfig holds builder configuration applied via options.
 type builderConfig struct {
-	namingStrategy SchemaNamingStrategy
-	namingTemplate *template.Template
-	namingFunc     SchemaNameFunc
-	genericConfig  GenericNamingConfig
-	templateError  error // Stores template parse errors for Build() to return
+	namingStrategy        SchemaNamingStrategy
+	namingTemplate        *template.Template
+	namingFunc            SchemaNameFunc
+	genericConfig         GenericNamingConfig
+	templateError         error // Stores template parse errors for Build() to return
+	semanticDeduplication bool  // Enable semantic schema deduplication
 }
 
 // defaultBuilderConfig returns a new builderConfig with default values.
@@ -192,5 +193,27 @@ func WithGenericIncludePackage(include bool) BuilderOption {
 func WithGenericApplyBaseCasing(apply bool) BuilderOption {
 	return func(cfg *builderConfig) {
 		cfg.genericConfig.ApplyBaseCasing = apply
+	}
+}
+
+// WithSemanticDeduplication enables semantic schema deduplication.
+// When enabled, the builder identifies schemas that are structurally identical
+// and consolidates them to a single canonical schema. All references to
+// duplicate schemas are rewritten to point to the canonical schema.
+//
+// The canonical schema name is selected alphabetically (e.g., if "Address"
+// and "Location" are identical, "Address" becomes canonical).
+//
+// This option reduces document size when multiple types converge to the
+// same structure. It is disabled by default.
+//
+// Example:
+//
+//	spec := builder.New(parser.OASVersion320,
+//	    builder.WithSemanticDeduplication(true),
+//	)
+func WithSemanticDeduplication(enabled bool) BuilderOption {
+	return func(cfg *builderConfig) {
+		cfg.semanticDeduplication = enabled
 	}
 }

--- a/cmd/oastools/commands/join.go
+++ b/cmd/oastools/commands/join.go
@@ -58,6 +58,7 @@ type JoinFlags struct {
 	RenameTemplate  string
 	EquivalenceMode string
 	CollisionReport bool
+	SemanticDedup   bool
 	// Namespace prefix configuration
 	NamespacePrefix namespacePrefixFlag
 	AlwaysPrefix    bool
@@ -85,6 +86,7 @@ func SetupJoinFlags() (*flag.FlagSet, *JoinFlags) {
 	fs.StringVar(&flags.RenameTemplate, "rename-template", "{{.Name}}_{{.Source}}", "template for renamed schema names")
 	fs.StringVar(&flags.EquivalenceMode, "equivalence-mode", "none", "schema comparison mode for deduplication (none, shallow, deep)")
 	fs.BoolVar(&flags.CollisionReport, "collision-report", false, "generate detailed collision analysis report")
+	fs.BoolVar(&flags.SemanticDedup, "semantic-dedup", false, "enable semantic deduplication to consolidate identical schemas")
 
 	// Namespace prefix configuration
 	fs.Var(flags.NamespacePrefix, "namespace-prefix", "namespace prefix for source file (format: source=prefix, can be repeated)")
@@ -154,6 +156,7 @@ func HandleJoin(args []string) error {
 	config.RenameTemplate = flags.RenameTemplate
 	config.EquivalenceMode = flags.EquivalenceMode
 	config.CollisionReport = flags.CollisionReport
+	config.SemanticDeduplication = flags.SemanticDedup
 
 	// Apply namespace prefix configuration
 	if len(flags.NamespacePrefix) > 0 {

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -474,6 +474,7 @@ oastools join [flags] <file1> <file2> [file3...]
 | `--path-strategy` | | Collision strategy for paths |
 | `--schema-strategy` | | Collision strategy for schemas/definitions |
 | `--component-strategy` | | Collision strategy for other components |
+| `--semantic-dedup` | | Enable semantic deduplication to consolidate identical schemas |
 | `--no-merge-arrays` | | Don't merge arrays (servers, security, etc.) |
 | `--no-dedup-tags` | | Don't deduplicate tags by name |
 | `-h, --help` | | Display help for join command |
@@ -517,6 +518,9 @@ oastools join --no-merge-arrays -o merged.yaml base.yaml ext.yaml
 
 # Don't deduplicate tags
 oastools join --no-dedup-tags -o merged.yaml base.yaml ext.yaml
+
+# Enable semantic deduplication to consolidate identical schemas
+oastools join --semantic-dedup -o merged.yaml api1.yaml api2.yaml
 ```
 
 ### Output Format
@@ -542,6 +546,16 @@ Warnings (1):
 ✓ Join completed successfully!
 ```
 
+**With Semantic Deduplication:**
+
+When `--semantic-dedup` is enabled, the output includes deduplication information:
+
+```
+Warnings (2):
+  - Schema 'User' collision resolved with accept-left strategy
+  - semantic deduplication: consolidated 3 duplicate definition(s)
+```
+
 ### Exit Codes
 
 | Code | Meaning |
@@ -556,6 +570,7 @@ Warnings (1):
 - Info section is taken from the first document
 - Output file is written with restrictive permissions (0600) for security
 - Warning is displayed if output file already exists (will be overwritten)
+- Semantic deduplication identifies structurally identical schemas and consolidates them, reducing document size
 
 ---
 

--- a/internal/schemautil/dedupe.go
+++ b/internal/schemautil/dedupe.go
@@ -1,0 +1,35 @@
+package schemautil
+
+import "github.com/erraggy/oastools/parser"
+
+// DeduplicationConfig configures semantic schema deduplication behavior.
+type DeduplicationConfig struct {
+	// EquivalenceMode controls comparison depth ("deep" recommended).
+	// Uses joiner.EquivalenceMode values: "none", "shallow", "deep".
+	EquivalenceMode string
+}
+
+// DefaultDeduplicationConfig returns a DeduplicationConfig with sensible defaults.
+func DefaultDeduplicationConfig() DeduplicationConfig {
+	return DeduplicationConfig{
+		EquivalenceMode: "deep",
+	}
+}
+
+// DeduplicationResult contains the outcome of schema deduplication.
+type DeduplicationResult struct {
+	// CanonicalSchemas maps canonical names to their schema definitions.
+	// Only canonical schemas are included; duplicates are removed.
+	CanonicalSchemas map[string]*parser.Schema
+
+	// Aliases maps alias schema names to their canonical name.
+	// All references to alias names should be rewritten to canonical names.
+	Aliases map[string]string
+
+	// RemovedCount is the number of duplicate schemas that were removed.
+	RemovedCount int
+
+	// EquivalenceGroups maps canonical names to all equivalent schema names.
+	// Includes the canonical name itself as the first element.
+	EquivalenceGroups map[string][]string
+}

--- a/internal/schemautil/deduplicator.go
+++ b/internal/schemautil/deduplicator.go
@@ -1,0 +1,180 @@
+package schemautil
+
+import (
+	"sort"
+
+	"github.com/erraggy/oastools/parser"
+)
+
+// CompareFunc compares two schemas for structural equivalence.
+// Returns true if the schemas are semantically identical.
+// This function type allows dependency injection to avoid import cycles.
+type CompareFunc func(left, right *parser.Schema) bool
+
+// SchemaDeduplicator identifies and consolidates semantically identical schemas.
+type SchemaDeduplicator struct {
+	config  DeduplicationConfig
+	hasher  *SchemaHasher
+	compare CompareFunc
+}
+
+// NewSchemaDeduplicator creates a new SchemaDeduplicator.
+// The compare function is used to verify equivalence after hash grouping.
+// If compare is nil, schemas are considered equivalent if they have the same hash
+// (not recommended due to potential hash collisions).
+func NewSchemaDeduplicator(config DeduplicationConfig, compare CompareFunc) *SchemaDeduplicator {
+	return &SchemaDeduplicator{
+		config:  config,
+		hasher:  NewSchemaHasher(),
+		compare: compare,
+	}
+}
+
+// Deduplicate identifies semantically identical schemas and consolidates them.
+// It returns a result containing only canonical schemas and a mapping of aliases.
+//
+// The algorithm:
+//  1. Group schemas by structural hash (O(N))
+//  2. Verify equivalence within each group using deep comparison
+//  3. Select canonical name (alphabetically first) for each equivalence group
+//  4. Build alias mapping and return only canonical schemas
+func (d *SchemaDeduplicator) Deduplicate(schemas map[string]*parser.Schema) (*DeduplicationResult, error) {
+	if len(schemas) < 2 {
+		// Nothing to deduplicate
+		result := &DeduplicationResult{
+			CanonicalSchemas:  make(map[string]*parser.Schema, len(schemas)),
+			Aliases:           make(map[string]string),
+			RemovedCount:      0,
+			EquivalenceGroups: make(map[string][]string),
+		}
+		for name, schema := range schemas {
+			result.CanonicalSchemas[name] = schema
+			result.EquivalenceGroups[name] = []string{name}
+		}
+		return result, nil
+	}
+
+	// Phase 1: Group schemas by hash
+	hashGroups := d.hasher.GroupByHash(schemas)
+
+	// Phase 2: Verify equivalence within each group and build equivalence groups
+	equivalenceGroups := d.buildEquivalenceGroups(schemas, hashGroups)
+
+	// Phase 3: Select canonical names and build result
+	result := d.buildResult(schemas, equivalenceGroups)
+
+	return result, nil
+}
+
+// buildEquivalenceGroups verifies equivalence within hash groups and splits false positives.
+func (d *SchemaDeduplicator) buildEquivalenceGroups(
+	schemas map[string]*parser.Schema,
+	hashGroups map[uint64][]string,
+) [][]string {
+	var equivalenceGroups [][]string
+
+	for _, names := range hashGroups {
+		if len(names) == 1 {
+			// Single schema in group - no duplicates possible
+			equivalenceGroups = append(equivalenceGroups, names)
+			continue
+		}
+
+		// Verify equivalence and split into true equivalence groups
+		subGroups := d.verifyEquivalence(schemas, names)
+		equivalenceGroups = append(equivalenceGroups, subGroups...)
+	}
+
+	return equivalenceGroups
+}
+
+// verifyEquivalence uses deep comparison to split a hash group into true equivalence groups.
+func (d *SchemaDeduplicator) verifyEquivalence(
+	schemas map[string]*parser.Schema,
+	names []string,
+) [][]string {
+	if d.compare == nil {
+		// No comparison function - treat all hash-matching schemas as equivalent
+		return [][]string{names}
+	}
+
+	// Use union-find-like grouping
+	var groups [][]string
+
+	for _, name := range names {
+		schema := schemas[name]
+		foundGroup := -1
+
+		// Check if this schema matches any existing group
+		for groupIdx, group := range groups {
+			representative := schemas[group[0]]
+			if d.compare(schema, representative) {
+				foundGroup = groupIdx
+				break
+			}
+		}
+
+		if foundGroup >= 0 {
+			// Add to existing group
+			groups[foundGroup] = append(groups[foundGroup], name)
+		} else {
+			// Start a new group
+			groups = append(groups, []string{name})
+		}
+	}
+
+	return groups
+}
+
+// buildResult creates the final deduplication result.
+func (d *SchemaDeduplicator) buildResult(
+	schemas map[string]*parser.Schema,
+	equivalenceGroups [][]string,
+) *DeduplicationResult {
+	result := &DeduplicationResult{
+		CanonicalSchemas:  make(map[string]*parser.Schema),
+		Aliases:           make(map[string]string),
+		RemovedCount:      0,
+		EquivalenceGroups: make(map[string][]string),
+	}
+
+	for _, group := range equivalenceGroups {
+		// Sort names alphabetically to select canonical name deterministically
+		sort.Strings(group)
+		canonical := group[0]
+
+		// Store canonical schema
+		result.CanonicalSchemas[canonical] = schemas[canonical]
+		result.EquivalenceGroups[canonical] = group
+
+		// Record aliases (all names except canonical)
+		for i := 1; i < len(group); i++ {
+			alias := group[i]
+			result.Aliases[alias] = canonical
+			result.RemovedCount++
+		}
+	}
+
+	return result
+}
+
+// CanonicalName returns the canonical name for a schema name.
+// If the name is not an alias, it returns the name unchanged.
+func (r *DeduplicationResult) CanonicalName(name string) string {
+	if canonical, ok := r.Aliases[name]; ok {
+		return canonical
+	}
+	return name
+}
+
+// IsAlias returns true if the given name is an alias (not canonical).
+func (r *DeduplicationResult) IsAlias(name string) bool {
+	_, ok := r.Aliases[name]
+	return ok
+}
+
+// IsCanonical returns true if the given name is a canonical schema name.
+func (r *DeduplicationResult) IsCanonical(name string) bool {
+	_, ok := r.CanonicalSchemas[name]
+	return ok
+}

--- a/internal/schemautil/deduplicator_bench_test.go
+++ b/internal/schemautil/deduplicator_bench_test.go
@@ -1,0 +1,139 @@
+package schemautil
+
+import (
+	"testing"
+
+	"github.com/erraggy/oastools/parser"
+)
+
+// BenchmarkSchemaDeduplicator_Deduplicate benchmarks the deduplication algorithm.
+func BenchmarkSchemaDeduplicator_Deduplicate(b *testing.B) {
+	// Simple comparison function for benchmarks
+	compare := func(left, right *parser.Schema) bool {
+		// Simple type comparison for benchmarking
+		return left.Type == right.Type
+	}
+
+	b.Run("10Schemas_NoDupes", func(b *testing.B) {
+		schemas := generateUniqueSchemas(10)
+		config := DefaultDeduplicationConfig()
+		d := NewSchemaDeduplicator(config, compare)
+
+		for b.Loop() {
+			_, _ = d.Deduplicate(schemas)
+		}
+	})
+
+	b.Run("10Schemas_50%Dupes", func(b *testing.B) {
+		schemas := generateSchemasWithDuplicates(10, 0.5)
+		config := DefaultDeduplicationConfig()
+		d := NewSchemaDeduplicator(config, compare)
+
+		for b.Loop() {
+			_, _ = d.Deduplicate(schemas)
+		}
+	})
+
+	b.Run("100Schemas_NoDupes", func(b *testing.B) {
+		schemas := generateUniqueSchemas(100)
+		config := DefaultDeduplicationConfig()
+		d := NewSchemaDeduplicator(config, compare)
+
+		for b.Loop() {
+			_, _ = d.Deduplicate(schemas)
+		}
+	})
+
+	b.Run("100Schemas_50%Dupes", func(b *testing.B) {
+		schemas := generateSchemasWithDuplicates(100, 0.5)
+		config := DefaultDeduplicationConfig()
+		d := NewSchemaDeduplicator(config, compare)
+
+		for b.Loop() {
+			_, _ = d.Deduplicate(schemas)
+		}
+	})
+
+	b.Run("100Schemas_90%Dupes", func(b *testing.B) {
+		schemas := generateSchemasWithDuplicates(100, 0.9)
+		config := DefaultDeduplicationConfig()
+		d := NewSchemaDeduplicator(config, compare)
+
+		for b.Loop() {
+			_, _ = d.Deduplicate(schemas)
+		}
+	})
+
+	b.Run("1000Schemas_NoDupes", func(b *testing.B) {
+		schemas := generateUniqueSchemas(1000)
+		config := DefaultDeduplicationConfig()
+		d := NewSchemaDeduplicator(config, compare)
+
+		for b.Loop() {
+			_, _ = d.Deduplicate(schemas)
+		}
+	})
+
+	b.Run("1000Schemas_50%Dupes", func(b *testing.B) {
+		schemas := generateSchemasWithDuplicates(1000, 0.5)
+		config := DefaultDeduplicationConfig()
+		d := NewSchemaDeduplicator(config, compare)
+
+		for b.Loop() {
+			_, _ = d.Deduplicate(schemas)
+		}
+	})
+}
+
+// generateUniqueSchemas creates n schemas that are all unique.
+func generateUniqueSchemas(n int) map[string]*parser.Schema {
+	schemas := make(map[string]*parser.Schema, n)
+
+	for i := range n {
+		name := schemaName(i)
+		schemas[name] = &parser.Schema{
+			Type: "object",
+			Properties: map[string]*parser.Schema{
+				"unique_field_" + name: {Type: "string"},
+			},
+		}
+	}
+
+	return schemas
+}
+
+// generateSchemasWithDuplicates creates n schemas where duplicateRatio are duplicates.
+func generateSchemasWithDuplicates(n int, duplicateRatio float64) map[string]*parser.Schema {
+	schemas := make(map[string]*parser.Schema, n)
+	uniqueCount := int(float64(n) * (1 - duplicateRatio))
+	if uniqueCount < 1 {
+		uniqueCount = 1
+	}
+
+	for i := range n {
+		name := schemaName(i)
+		// Use modulo to create duplicates
+		templateIdx := i % uniqueCount
+		schemas[name] = &parser.Schema{
+			Type: "object",
+			Properties: map[string]*parser.Schema{
+				"shared_field":                        {Type: "string"},
+				"template_" + schemaName(templateIdx): {Type: "integer"},
+			},
+		}
+	}
+
+	return schemas
+}
+
+// schemaName generates a unique schema name from an index.
+func schemaName(i int) string {
+	result := ""
+	i++ // Start from 1 to avoid empty string
+	for i > 0 {
+		i-- // Adjust for 0-indexed letters
+		result = string(rune('A'+i%26)) + result
+		i /= 26
+	}
+	return result
+}

--- a/internal/schemautil/deduplicator_test.go
+++ b/internal/schemautil/deduplicator_test.go
@@ -1,0 +1,359 @@
+package schemautil
+
+import (
+	"testing"
+
+	"github.com/erraggy/oastools/parser"
+)
+
+// alwaysEqual is a compare function that always returns true
+func alwaysEqual(_, _ *parser.Schema) bool {
+	return true
+}
+
+// neverEqual is a compare function that always returns false
+func neverEqual(_, _ *parser.Schema) bool {
+	return false
+}
+
+// structuralEqual compares two schemas for structural equality (simplified for tests)
+func structuralEqual(a, b *parser.Schema) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	// Simple comparison for tests - just check type and format
+	aType, _ := a.Type.(string)
+	bType, _ := b.Type.(string)
+	return aType == bType && a.Format == b.Format
+}
+
+func TestSchemaDeduplicator_Deduplicate_Empty(t *testing.T) {
+	deduper := NewSchemaDeduplicator(DefaultDeduplicationConfig(), alwaysEqual)
+
+	result, err := deduper.Deduplicate(map[string]*parser.Schema{})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if len(result.CanonicalSchemas) != 0 {
+		t.Errorf("Expected 0 canonical schemas, got %d", len(result.CanonicalSchemas))
+	}
+	if result.RemovedCount != 0 {
+		t.Errorf("Expected 0 removed, got %d", result.RemovedCount)
+	}
+}
+
+func TestSchemaDeduplicator_Deduplicate_Single(t *testing.T) {
+	deduper := NewSchemaDeduplicator(DefaultDeduplicationConfig(), alwaysEqual)
+
+	schemas := map[string]*parser.Schema{
+		"User": {Type: "object"},
+	}
+
+	result, err := deduper.Deduplicate(schemas)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if len(result.CanonicalSchemas) != 1 {
+		t.Errorf("Expected 1 canonical schema, got %d", len(result.CanonicalSchemas))
+	}
+	if _, ok := result.CanonicalSchemas["User"]; !ok {
+		t.Error("Expected User to be canonical")
+	}
+	if result.RemovedCount != 0 {
+		t.Errorf("Expected 0 removed, got %d", result.RemovedCount)
+	}
+}
+
+func TestSchemaDeduplicator_Deduplicate_Duplicates(t *testing.T) {
+	deduper := NewSchemaDeduplicator(DefaultDeduplicationConfig(), structuralEqual)
+
+	schemas := map[string]*parser.Schema{
+		"Address":  {Type: "object"},
+		"Location": {Type: "object"}, // Same as Address
+		"User":     {Type: "object"}, // Same as Address
+	}
+
+	result, err := deduper.Deduplicate(schemas)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Should have 1 canonical schema (alphabetically first: Address)
+	if len(result.CanonicalSchemas) != 1 {
+		t.Errorf("Expected 1 canonical schema, got %d", len(result.CanonicalSchemas))
+	}
+	if _, ok := result.CanonicalSchemas["Address"]; !ok {
+		t.Error("Expected Address to be canonical (alphabetically first)")
+	}
+
+	// Should have 2 aliases
+	if len(result.Aliases) != 2 {
+		t.Errorf("Expected 2 aliases, got %d", len(result.Aliases))
+	}
+	if result.Aliases["Location"] != "Address" {
+		t.Errorf("Expected Location -> Address, got %s", result.Aliases["Location"])
+	}
+	if result.Aliases["User"] != "Address" {
+		t.Errorf("Expected User -> Address, got %s", result.Aliases["User"])
+	}
+
+	if result.RemovedCount != 2 {
+		t.Errorf("Expected 2 removed, got %d", result.RemovedCount)
+	}
+}
+
+func TestSchemaDeduplicator_Deduplicate_NoDuplicates(t *testing.T) {
+	deduper := NewSchemaDeduplicator(DefaultDeduplicationConfig(), structuralEqual)
+
+	schemas := map[string]*parser.Schema{
+		"User":    {Type: "object"},
+		"Address": {Type: "string"},
+		"Age":     {Type: "integer"},
+	}
+
+	result, err := deduper.Deduplicate(schemas)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if len(result.CanonicalSchemas) != 3 {
+		t.Errorf("Expected 3 canonical schemas, got %d", len(result.CanonicalSchemas))
+	}
+	if len(result.Aliases) != 0 {
+		t.Errorf("Expected 0 aliases, got %d", len(result.Aliases))
+	}
+	if result.RemovedCount != 0 {
+		t.Errorf("Expected 0 removed, got %d", result.RemovedCount)
+	}
+}
+
+func TestSchemaDeduplicator_Deduplicate_MultipleGroups(t *testing.T) {
+	deduper := NewSchemaDeduplicator(DefaultDeduplicationConfig(), structuralEqual)
+
+	schemas := map[string]*parser.Schema{
+		// Group 1: objects
+		"Address":  {Type: "object"},
+		"Location": {Type: "object"},
+		// Group 2: strings
+		"Name":  {Type: "string"},
+		"Title": {Type: "string"},
+		// Unique
+		"Age": {Type: "integer"},
+	}
+
+	result, err := deduper.Deduplicate(schemas)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Should have 3 canonical schemas
+	if len(result.CanonicalSchemas) != 3 {
+		t.Errorf("Expected 3 canonical schemas, got %d", len(result.CanonicalSchemas))
+	}
+
+	// Check canonical names (alphabetically first in each group)
+	if _, ok := result.CanonicalSchemas["Address"]; !ok {
+		t.Error("Expected Address to be canonical")
+	}
+	if _, ok := result.CanonicalSchemas["Name"]; !ok {
+		t.Error("Expected Name to be canonical")
+	}
+	if _, ok := result.CanonicalSchemas["Age"]; !ok {
+		t.Error("Expected Age to be canonical")
+	}
+
+	// Check aliases
+	if result.Aliases["Location"] != "Address" {
+		t.Errorf("Expected Location -> Address, got %s", result.Aliases["Location"])
+	}
+	if result.Aliases["Title"] != "Name" {
+		t.Errorf("Expected Title -> Name, got %s", result.Aliases["Title"])
+	}
+
+	if result.RemovedCount != 2 {
+		t.Errorf("Expected 2 removed, got %d", result.RemovedCount)
+	}
+}
+
+func TestSchemaDeduplicator_Deduplicate_AlphabeticCanonical(t *testing.T) {
+	deduper := NewSchemaDeduplicator(DefaultDeduplicationConfig(), alwaysEqual)
+
+	schemas := map[string]*parser.Schema{
+		"Zebra":  {Type: "object"},
+		"Apple":  {Type: "object"},
+		"Mango":  {Type: "object"},
+		"Banana": {Type: "object"},
+	}
+
+	result, err := deduper.Deduplicate(schemas)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Apple should be canonical (alphabetically first)
+	if len(result.CanonicalSchemas) != 1 {
+		t.Errorf("Expected 1 canonical schema, got %d", len(result.CanonicalSchemas))
+	}
+	if _, ok := result.CanonicalSchemas["Apple"]; !ok {
+		t.Error("Expected Apple to be canonical (alphabetically first)")
+	}
+
+	// All others should be aliases to Apple
+	for _, name := range []string{"Banana", "Mango", "Zebra"} {
+		if result.Aliases[name] != "Apple" {
+			t.Errorf("Expected %s -> Apple, got %s", name, result.Aliases[name])
+		}
+	}
+}
+
+func TestSchemaDeduplicator_Deduplicate_NilCompareFunc(t *testing.T) {
+	// When compare func is nil, hash matching is enough
+	deduper := NewSchemaDeduplicator(DefaultDeduplicationConfig(), nil)
+
+	schemas := map[string]*parser.Schema{
+		"User":   {Type: "object"},
+		"Person": {Type: "object"}, // Same hash as User
+	}
+
+	result, err := deduper.Deduplicate(schemas)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Should deduplicate based on hash alone
+	if len(result.CanonicalSchemas) != 1 {
+		t.Errorf("Expected 1 canonical schema, got %d", len(result.CanonicalSchemas))
+	}
+}
+
+func TestSchemaDeduplicator_Deduplicate_HashCollision(t *testing.T) {
+	// Test that compare func correctly splits hash collisions
+	deduper := NewSchemaDeduplicator(DefaultDeduplicationConfig(), neverEqual)
+
+	schemas := map[string]*parser.Schema{
+		"User":   {Type: "object"},
+		"Person": {Type: "object"}, // Same hash, but compare returns false
+	}
+
+	result, err := deduper.Deduplicate(schemas)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Should not deduplicate because compare returns false
+	if len(result.CanonicalSchemas) != 2 {
+		t.Errorf("Expected 2 canonical schemas (no dedup due to compare), got %d", len(result.CanonicalSchemas))
+	}
+	if len(result.Aliases) != 0 {
+		t.Errorf("Expected 0 aliases, got %d", len(result.Aliases))
+	}
+}
+
+func TestDeduplicationResult_CanonicalName(t *testing.T) {
+	result := &DeduplicationResult{
+		CanonicalSchemas: map[string]*parser.Schema{
+			"Address": {Type: "object"},
+		},
+		Aliases: map[string]string{
+			"Location": "Address",
+			"Place":    "Address",
+		},
+	}
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"alias returns canonical", "Location", "Address"},
+		{"alias returns canonical 2", "Place", "Address"},
+		{"canonical returns itself", "Address", "Address"},
+		{"unknown returns itself", "Unknown", "Unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := result.CanonicalName(tt.input)
+			if got != tt.expected {
+				t.Errorf("CanonicalName(%s) = %s, want %s", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDeduplicationResult_IsAlias(t *testing.T) {
+	result := &DeduplicationResult{
+		CanonicalSchemas: map[string]*parser.Schema{
+			"Address": {Type: "object"},
+		},
+		Aliases: map[string]string{
+			"Location": "Address",
+		},
+	}
+
+	if !result.IsAlias("Location") {
+		t.Error("Location should be an alias")
+	}
+	if result.IsAlias("Address") {
+		t.Error("Address should not be an alias")
+	}
+	if result.IsAlias("Unknown") {
+		t.Error("Unknown should not be an alias")
+	}
+}
+
+func TestDeduplicationResult_IsCanonical(t *testing.T) {
+	result := &DeduplicationResult{
+		CanonicalSchemas: map[string]*parser.Schema{
+			"Address": {Type: "object"},
+		},
+		Aliases: map[string]string{
+			"Location": "Address",
+		},
+	}
+
+	if !result.IsCanonical("Address") {
+		t.Error("Address should be canonical")
+	}
+	if result.IsCanonical("Location") {
+		t.Error("Location should not be canonical")
+	}
+	if result.IsCanonical("Unknown") {
+		t.Error("Unknown should not be canonical")
+	}
+}
+
+func TestDeduplicationResult_EquivalenceGroups(t *testing.T) {
+	deduper := NewSchemaDeduplicator(DefaultDeduplicationConfig(), alwaysEqual)
+
+	schemas := map[string]*parser.Schema{
+		"Address":  {Type: "object"},
+		"Location": {Type: "object"},
+		"Place":    {Type: "object"},
+	}
+
+	result, err := deduper.Deduplicate(schemas)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Check equivalence groups
+	group, ok := result.EquivalenceGroups["Address"]
+	if !ok {
+		t.Fatal("Expected Address in equivalence groups")
+	}
+
+	if len(group) != 3 {
+		t.Errorf("Expected 3 members in group, got %d", len(group))
+	}
+
+	// First should be canonical (Address, alphabetically first)
+	if group[0] != "Address" {
+		t.Errorf("Expected Address as first (canonical), got %s", group[0])
+	}
+}

--- a/internal/schemautil/hash.go
+++ b/internal/schemautil/hash.go
@@ -1,0 +1,410 @@
+package schemautil
+
+import (
+	"fmt"
+	"hash"
+	"hash/fnv"
+	"reflect"
+	"sort"
+
+	"github.com/erraggy/oastools/parser"
+)
+
+// SchemaHasher computes structural hashes for schemas.
+// Structural hashes ignore metadata fields (title, description, example, deprecated)
+// and focus on fields that affect the schema's semantic meaning.
+type SchemaHasher struct {
+	visited map[uintptr]bool
+}
+
+// NewSchemaHasher creates a new SchemaHasher.
+func NewSchemaHasher() *SchemaHasher {
+	return &SchemaHasher{
+		visited: make(map[uintptr]bool),
+	}
+}
+
+// Hash computes a structural hash for a schema.
+// Schemas with identical structural properties will have the same hash.
+// Note: Hash collisions are possible; use deep comparison to verify equivalence.
+func (h *SchemaHasher) Hash(schema *parser.Schema) uint64 {
+	h.visited = make(map[uintptr]bool) // Reset visited map
+	hasher := fnv.New64a()
+	h.hashSchema(hasher, schema)
+	return hasher.Sum64()
+}
+
+// GroupByHash groups schemas by their structural hash.
+// Returns a map from hash value to list of schema names with that hash.
+func (h *SchemaHasher) GroupByHash(schemas map[string]*parser.Schema) map[uint64][]string {
+	groups := make(map[uint64][]string)
+	for name, schema := range schemas {
+		hashVal := h.Hash(schema)
+		groups[hashVal] = append(groups[hashVal], name)
+	}
+	return groups
+}
+
+// hashSchema recursively hashes a schema's structural properties.
+func (h *SchemaHasher) hashSchema(hasher hash.Hash64, schema *parser.Schema) {
+	if schema == nil {
+		h.writeString(hasher, "nil")
+		return
+	}
+
+	// Check for circular reference
+	ptr := reflect.ValueOf(schema).Pointer()
+	if h.visited[ptr] {
+		h.writeString(hasher, "circular")
+		return
+	}
+	h.visited[ptr] = true
+	defer func() { h.visited[ptr] = false }()
+
+	// Hash $ref if present (schema is just a reference)
+	if schema.Ref != "" {
+		h.writeString(hasher, "$ref:")
+		h.writeString(hasher, schema.Ref)
+		return
+	}
+
+	// Type (handle both string and []any for OAS 3.1+)
+	h.hashType(hasher, schema.Type)
+
+	// Format
+	h.writeString(hasher, "format:")
+	h.writeString(hasher, schema.Format)
+
+	// Pattern
+	h.writeString(hasher, "pattern:")
+	h.writeString(hasher, schema.Pattern)
+
+	// Enum (order matters)
+	if len(schema.Enum) > 0 {
+		h.writeString(hasher, "enum:")
+		for _, v := range schema.Enum {
+			h.writeString(hasher, fmt.Sprintf("%v", v))
+		}
+	}
+
+	// Const
+	if schema.Const != nil {
+		h.writeString(hasher, "const:")
+		h.writeString(hasher, fmt.Sprintf("%v", schema.Const))
+	}
+
+	// Required (sort for order-independent comparison)
+	if len(schema.Required) > 0 {
+		h.writeString(hasher, "required:")
+		sorted := make([]string, len(schema.Required))
+		copy(sorted, schema.Required)
+		sort.Strings(sorted)
+		for _, r := range sorted {
+			h.writeString(hasher, r)
+		}
+	}
+
+	// Properties (sorted by key for deterministic hashing)
+	if len(schema.Properties) > 0 {
+		h.writeString(hasher, "properties:")
+		keys := make([]string, 0, len(schema.Properties))
+		for k := range schema.Properties {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			h.writeString(hasher, k)
+			h.hashSchema(hasher, schema.Properties[k])
+		}
+	}
+
+	// PatternProperties (sorted by key)
+	if len(schema.PatternProperties) > 0 {
+		h.writeString(hasher, "patternProperties:")
+		keys := make([]string, 0, len(schema.PatternProperties))
+		for k := range schema.PatternProperties {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			h.writeString(hasher, k)
+			h.hashSchema(hasher, schema.PatternProperties[k])
+		}
+	}
+
+	// AdditionalProperties (can be *Schema or bool)
+	if schema.AdditionalProperties != nil {
+		h.writeString(hasher, "additionalProperties:")
+		h.hashSchemaOrBool(hasher, schema.AdditionalProperties)
+	}
+
+	// Items (can be *Schema or bool in OAS 3.1+)
+	if schema.Items != nil {
+		h.writeString(hasher, "items:")
+		h.hashSchemaOrBool(hasher, schema.Items)
+	}
+
+	// PrefixItems
+	if len(schema.PrefixItems) > 0 {
+		h.writeString(hasher, "prefixItems:")
+		for _, item := range schema.PrefixItems {
+			h.hashSchema(hasher, item)
+		}
+	}
+
+	// AdditionalItems
+	if schema.AdditionalItems != nil {
+		h.writeString(hasher, "additionalItems:")
+		h.hashSchemaOrBool(hasher, schema.AdditionalItems)
+	}
+
+	// Numeric constraints
+	h.hashNumericConstraints(hasher, schema)
+
+	// String constraints
+	h.hashStringConstraints(hasher, schema)
+
+	// Array constraints
+	h.hashArrayConstraints(hasher, schema)
+
+	// Object constraints
+	h.hashObjectConstraints(hasher, schema)
+
+	// Composition (allOf, anyOf, oneOf, not)
+	h.hashComposition(hasher, schema)
+
+	// Conditionals (if/then/else)
+	if schema.If != nil {
+		h.writeString(hasher, "if:")
+		h.hashSchema(hasher, schema.If)
+	}
+	if schema.Then != nil {
+		h.writeString(hasher, "then:")
+		h.hashSchema(hasher, schema.Then)
+	}
+	if schema.Else != nil {
+		h.writeString(hasher, "else:")
+		h.hashSchema(hasher, schema.Else)
+	}
+
+	// Nullable (OAS 3.0)
+	if schema.Nullable {
+		h.writeString(hasher, "nullable:true")
+	}
+
+	// ReadOnly/WriteOnly
+	if schema.ReadOnly {
+		h.writeString(hasher, "readOnly:true")
+	}
+	if schema.WriteOnly {
+		h.writeString(hasher, "writeOnly:true")
+	}
+
+	// Discriminator
+	if schema.Discriminator != nil {
+		h.writeString(hasher, "discriminator:")
+		h.writeString(hasher, schema.Discriminator.PropertyName)
+		if len(schema.Discriminator.Mapping) > 0 {
+			keys := make([]string, 0, len(schema.Discriminator.Mapping))
+			for k := range schema.Discriminator.Mapping {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			for _, k := range keys {
+				h.writeString(hasher, k)
+				h.writeString(hasher, schema.Discriminator.Mapping[k])
+			}
+		}
+	}
+
+	// Contains
+	if schema.Contains != nil {
+		h.writeString(hasher, "contains:")
+		h.hashSchema(hasher, schema.Contains)
+	}
+
+	// PropertyNames
+	if schema.PropertyNames != nil {
+		h.writeString(hasher, "propertyNames:")
+		h.hashSchema(hasher, schema.PropertyNames)
+	}
+
+	// DependentRequired
+	if len(schema.DependentRequired) > 0 {
+		h.writeString(hasher, "dependentRequired:")
+		keys := make([]string, 0, len(schema.DependentRequired))
+		for k := range schema.DependentRequired {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			h.writeString(hasher, k)
+			deps := make([]string, len(schema.DependentRequired[k]))
+			copy(deps, schema.DependentRequired[k])
+			sort.Strings(deps)
+			for _, d := range deps {
+				h.writeString(hasher, d)
+			}
+		}
+	}
+
+	// DependentSchemas
+	if len(schema.DependentSchemas) > 0 {
+		h.writeString(hasher, "dependentSchemas:")
+		keys := make([]string, 0, len(schema.DependentSchemas))
+		for k := range schema.DependentSchemas {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			h.writeString(hasher, k)
+			h.hashSchema(hasher, schema.DependentSchemas[k])
+		}
+	}
+
+	// Defs
+	if len(schema.Defs) > 0 {
+		h.writeString(hasher, "$defs:")
+		keys := make([]string, 0, len(schema.Defs))
+		for k := range schema.Defs {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			h.writeString(hasher, k)
+			h.hashSchema(hasher, schema.Defs[k])
+		}
+	}
+}
+
+// hashType handles both string and []any type values.
+func (h *SchemaHasher) hashType(hasher hash.Hash64, t any) {
+	h.writeString(hasher, "type:")
+	switch v := t.(type) {
+	case string:
+		h.writeString(hasher, v)
+	case []any:
+		// Sort for consistent hashing
+		types := make([]string, 0, len(v))
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				types = append(types, s)
+			}
+		}
+		sort.Strings(types)
+		for _, s := range types {
+			h.writeString(hasher, s)
+		}
+	case []string:
+		// Sort for consistent hashing
+		sorted := make([]string, len(v))
+		copy(sorted, v)
+		sort.Strings(sorted)
+		for _, s := range sorted {
+			h.writeString(hasher, s)
+		}
+	}
+}
+
+// hashSchemaOrBool handles fields that can be *Schema or bool.
+func (h *SchemaHasher) hashSchemaOrBool(hasher hash.Hash64, v any) {
+	switch val := v.(type) {
+	case *parser.Schema:
+		h.hashSchema(hasher, val)
+	case bool:
+		if val {
+			h.writeString(hasher, "true")
+		} else {
+			h.writeString(hasher, "false")
+		}
+	}
+}
+
+// hashNumericConstraints hashes numeric validation fields.
+func (h *SchemaHasher) hashNumericConstraints(hasher hash.Hash64, schema *parser.Schema) {
+	if schema.Minimum != nil {
+		h.writeString(hasher, fmt.Sprintf("minimum:%v", *schema.Minimum))
+	}
+	if schema.Maximum != nil {
+		h.writeString(hasher, fmt.Sprintf("maximum:%v", *schema.Maximum))
+	}
+	if schema.ExclusiveMinimum != nil {
+		h.writeString(hasher, fmt.Sprintf("exclusiveMinimum:%v", schema.ExclusiveMinimum))
+	}
+	if schema.ExclusiveMaximum != nil {
+		h.writeString(hasher, fmt.Sprintf("exclusiveMaximum:%v", schema.ExclusiveMaximum))
+	}
+	if schema.MultipleOf != nil {
+		h.writeString(hasher, fmt.Sprintf("multipleOf:%v", *schema.MultipleOf))
+	}
+}
+
+// hashStringConstraints hashes string validation fields.
+func (h *SchemaHasher) hashStringConstraints(hasher hash.Hash64, schema *parser.Schema) {
+	if schema.MinLength != nil {
+		h.writeString(hasher, fmt.Sprintf("minLength:%d", *schema.MinLength))
+	}
+	if schema.MaxLength != nil {
+		h.writeString(hasher, fmt.Sprintf("maxLength:%d", *schema.MaxLength))
+	}
+}
+
+// hashArrayConstraints hashes array validation fields.
+func (h *SchemaHasher) hashArrayConstraints(hasher hash.Hash64, schema *parser.Schema) {
+	if schema.MinItems != nil {
+		h.writeString(hasher, fmt.Sprintf("minItems:%d", *schema.MinItems))
+	}
+	if schema.MaxItems != nil {
+		h.writeString(hasher, fmt.Sprintf("maxItems:%d", *schema.MaxItems))
+	}
+	if schema.UniqueItems {
+		h.writeString(hasher, "uniqueItems:true")
+	}
+	if schema.MinContains != nil {
+		h.writeString(hasher, fmt.Sprintf("minContains:%d", *schema.MinContains))
+	}
+	if schema.MaxContains != nil {
+		h.writeString(hasher, fmt.Sprintf("maxContains:%d", *schema.MaxContains))
+	}
+}
+
+// hashObjectConstraints hashes object validation fields.
+func (h *SchemaHasher) hashObjectConstraints(hasher hash.Hash64, schema *parser.Schema) {
+	if schema.MinProperties != nil {
+		h.writeString(hasher, fmt.Sprintf("minProperties:%d", *schema.MinProperties))
+	}
+	if schema.MaxProperties != nil {
+		h.writeString(hasher, fmt.Sprintf("maxProperties:%d", *schema.MaxProperties))
+	}
+}
+
+// hashComposition hashes schema composition fields.
+func (h *SchemaHasher) hashComposition(hasher hash.Hash64, schema *parser.Schema) {
+	if len(schema.AllOf) > 0 {
+		h.writeString(hasher, "allOf:")
+		for _, s := range schema.AllOf {
+			h.hashSchema(hasher, s)
+		}
+	}
+	if len(schema.AnyOf) > 0 {
+		h.writeString(hasher, "anyOf:")
+		for _, s := range schema.AnyOf {
+			h.hashSchema(hasher, s)
+		}
+	}
+	if len(schema.OneOf) > 0 {
+		h.writeString(hasher, "oneOf:")
+		for _, s := range schema.OneOf {
+			h.hashSchema(hasher, s)
+		}
+	}
+	if schema.Not != nil {
+		h.writeString(hasher, "not:")
+		h.hashSchema(hasher, schema.Not)
+	}
+}
+
+// writeString writes a string to the hash.
+func (h *SchemaHasher) writeString(hasher hash.Hash64, s string) {
+	_, _ = hasher.Write([]byte(s))
+}

--- a/internal/schemautil/hash_bench_test.go
+++ b/internal/schemautil/hash_bench_test.go
@@ -1,0 +1,166 @@
+package schemautil
+
+import (
+	"testing"
+
+	"github.com/erraggy/oastools/parser"
+)
+
+// BenchmarkSchemaHasher_Hash benchmarks the hashing of various schema types.
+func BenchmarkSchemaHasher_Hash(b *testing.B) {
+	b.Run("Simple", func(b *testing.B) {
+		schema := &parser.Schema{
+			Type: "string",
+		}
+		h := NewSchemaHasher()
+
+		for b.Loop() {
+			_ = h.Hash(schema)
+		}
+	})
+
+	b.Run("Object", func(b *testing.B) {
+		schema := &parser.Schema{
+			Type: "object",
+			Properties: map[string]*parser.Schema{
+				"id":   {Type: "integer"},
+				"name": {Type: "string"},
+			},
+			Required: []string{"id", "name"},
+		}
+		h := NewSchemaHasher()
+
+		for b.Loop() {
+			_ = h.Hash(schema)
+		}
+	})
+
+	b.Run("ComplexObject", func(b *testing.B) {
+		schema := &parser.Schema{
+			Type: "object",
+			Properties: map[string]*parser.Schema{
+				"id":       {Type: "integer", Format: "int64"},
+				"name":     {Type: "string", MinLength: intPtr(1), MaxLength: intPtr(100)},
+				"email":    {Type: "string", Format: "email", Pattern: "^[a-z]+@[a-z]+\\.[a-z]+$"},
+				"age":      {Type: "integer", Minimum: floatPtr(0), Maximum: floatPtr(150)},
+				"active":   {Type: "boolean"},
+				"tags":     {Type: "array", Items: &parser.Schema{Type: "string"}},
+				"metadata": {Type: "object", AdditionalProperties: &parser.Schema{Type: "string"}},
+			},
+			Required: []string{"id", "name", "email"},
+		}
+		h := NewSchemaHasher()
+
+		for b.Loop() {
+			_ = h.Hash(schema)
+		}
+	})
+
+	b.Run("NestedObject", func(b *testing.B) {
+		schema := &parser.Schema{
+			Type: "object",
+			Properties: map[string]*parser.Schema{
+				"user": {
+					Type: "object",
+					Properties: map[string]*parser.Schema{
+						"profile": {
+							Type: "object",
+							Properties: map[string]*parser.Schema{
+								"name":    {Type: "string"},
+								"avatar":  {Type: "string", Format: "uri"},
+								"bio":     {Type: "string"},
+								"website": {Type: "string", Format: "uri"},
+							},
+						},
+						"settings": {
+							Type: "object",
+							Properties: map[string]*parser.Schema{
+								"theme":         {Type: "string", Enum: []any{"light", "dark"}},
+								"notifications": {Type: "boolean"},
+								"language":      {Type: "string"},
+							},
+						},
+					},
+				},
+			},
+		}
+		h := NewSchemaHasher()
+
+		for b.Loop() {
+			_ = h.Hash(schema)
+		}
+	})
+
+	b.Run("Composition", func(b *testing.B) {
+		schema := &parser.Schema{
+			AllOf: []*parser.Schema{
+				{Ref: "#/components/schemas/Base"},
+				{
+					Type: "object",
+					Properties: map[string]*parser.Schema{
+						"extended": {Type: "string"},
+					},
+				},
+			},
+		}
+		h := NewSchemaHasher()
+
+		for b.Loop() {
+			_ = h.Hash(schema)
+		}
+	})
+}
+
+// BenchmarkSchemaHasher_GroupByHash benchmarks grouping schemas by hash.
+func BenchmarkSchemaHasher_GroupByHash(b *testing.B) {
+	b.Run("10Schemas", func(b *testing.B) {
+		schemas := generateSchemas(10)
+		h := NewSchemaHasher()
+
+		for b.Loop() {
+			_ = h.GroupByHash(schemas)
+		}
+	})
+
+	b.Run("100Schemas", func(b *testing.B) {
+		schemas := generateSchemas(100)
+		h := NewSchemaHasher()
+
+		for b.Loop() {
+			_ = h.GroupByHash(schemas)
+		}
+	})
+
+	b.Run("1000Schemas", func(b *testing.B) {
+		schemas := generateSchemas(1000)
+		h := NewSchemaHasher()
+
+		for b.Loop() {
+			_ = h.GroupByHash(schemas)
+		}
+	})
+}
+
+// Helper functions for creating pointer values.
+func intPtr(i int) *int           { return &i }
+func floatPtr(f float64) *float64 { return &f }
+
+// generateSchemas creates n schemas with varying types for benchmarking.
+func generateSchemas(n int) map[string]*parser.Schema {
+	types := []string{"string", "integer", "boolean", "number"}
+	schemas := make(map[string]*parser.Schema, n)
+
+	for i := range n {
+		schemaType := types[i%len(types)]
+		name := string(rune('A'+i%26)) + string(rune('0'+i/26))
+
+		schemas[name] = &parser.Schema{
+			Type: schemaType,
+			Properties: map[string]*parser.Schema{
+				"field": {Type: "string"},
+			},
+		}
+	}
+
+	return schemas
+}

--- a/internal/schemautil/hash_test.go
+++ b/internal/schemautil/hash_test.go
@@ -1,0 +1,429 @@
+package schemautil
+
+import (
+	"testing"
+
+	"github.com/erraggy/oastools/parser"
+)
+
+func TestSchemaHasher_Hash_Consistency(t *testing.T) {
+	hasher := NewSchemaHasher()
+
+	schema := &parser.Schema{
+		Type:   "object",
+		Format: "",
+		Properties: map[string]*parser.Schema{
+			"name": {Type: "string"},
+			"age":  {Type: "integer", Format: "int32"},
+		},
+		Required: []string{"name"},
+	}
+
+	hash1 := hasher.Hash(schema)
+	hash2 := hasher.Hash(schema)
+
+	if hash1 != hash2 {
+		t.Errorf("Hash is not consistent: %d != %d", hash1, hash2)
+	}
+}
+
+func TestSchemaHasher_Hash_IdenticalSchemas(t *testing.T) {
+	hasher := NewSchemaHasher()
+
+	schema1 := &parser.Schema{
+		Type:   "object",
+		Format: "",
+		Properties: map[string]*parser.Schema{
+			"name": {Type: "string"},
+			"age":  {Type: "integer", Format: "int32"},
+		},
+		Required: []string{"name"},
+	}
+
+	schema2 := &parser.Schema{
+		Type:   "object",
+		Format: "",
+		Properties: map[string]*parser.Schema{
+			"name": {Type: "string"},
+			"age":  {Type: "integer", Format: "int32"},
+		},
+		Required: []string{"name"},
+	}
+
+	hash1 := hasher.Hash(schema1)
+	hash2 := hasher.Hash(schema2)
+
+	if hash1 != hash2 {
+		t.Errorf("Identical schemas should have same hash: %d != %d", hash1, hash2)
+	}
+}
+
+func TestSchemaHasher_Hash_DifferentSchemas(t *testing.T) {
+	hasher := NewSchemaHasher()
+
+	tests := []struct {
+		name    string
+		schema1 *parser.Schema
+		schema2 *parser.Schema
+	}{
+		{
+			name:    "different types",
+			schema1: &parser.Schema{Type: "string"},
+			schema2: &parser.Schema{Type: "integer"},
+		},
+		{
+			name:    "different formats",
+			schema1: &parser.Schema{Type: "string", Format: "email"},
+			schema2: &parser.Schema{Type: "string", Format: "uri"},
+		},
+		{
+			name: "different properties",
+			schema1: &parser.Schema{
+				Type:       "object",
+				Properties: map[string]*parser.Schema{"foo": {Type: "string"}},
+			},
+			schema2: &parser.Schema{
+				Type:       "object",
+				Properties: map[string]*parser.Schema{"bar": {Type: "string"}},
+			},
+		},
+		{
+			name: "different required",
+			schema1: &parser.Schema{
+				Type:     "object",
+				Required: []string{"foo"},
+			},
+			schema2: &parser.Schema{
+				Type:     "object",
+				Required: []string{"bar"},
+			},
+		},
+		{
+			name:    "different enum",
+			schema1: &parser.Schema{Type: "string", Enum: []any{"a", "b"}},
+			schema2: &parser.Schema{Type: "string", Enum: []any{"x", "y"}},
+		},
+		{
+			name:    "different pattern",
+			schema1: &parser.Schema{Type: "string", Pattern: "^[a-z]+$"},
+			schema2: &parser.Schema{Type: "string", Pattern: "^[0-9]+$"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hash1 := hasher.Hash(tt.schema1)
+			hash2 := hasher.Hash(tt.schema2)
+			if hash1 == hash2 {
+				t.Errorf("Different schemas should have different hashes (hash collision)")
+			}
+		})
+	}
+}
+
+func TestSchemaHasher_Hash_RequiredOrderIndependent(t *testing.T) {
+	hasher := NewSchemaHasher()
+
+	schema1 := &parser.Schema{
+		Type:     "object",
+		Required: []string{"a", "b", "c"},
+	}
+
+	schema2 := &parser.Schema{
+		Type:     "object",
+		Required: []string{"c", "a", "b"},
+	}
+
+	hash1 := hasher.Hash(schema1)
+	hash2 := hasher.Hash(schema2)
+
+	if hash1 != hash2 {
+		t.Errorf("Required order should not affect hash: %d != %d", hash1, hash2)
+	}
+}
+
+func TestSchemaHasher_Hash_PropertyOrderIndependent(t *testing.T) {
+	hasher := NewSchemaHasher()
+
+	// Create schemas with properties in different insertion order
+	schema1 := &parser.Schema{
+		Type: "object",
+		Properties: map[string]*parser.Schema{
+			"alpha": {Type: "string"},
+			"beta":  {Type: "integer"},
+			"gamma": {Type: "boolean"},
+		},
+	}
+
+	schema2 := &parser.Schema{
+		Type: "object",
+		Properties: map[string]*parser.Schema{
+			"gamma": {Type: "boolean"},
+			"alpha": {Type: "string"},
+			"beta":  {Type: "integer"},
+		},
+	}
+
+	hash1 := hasher.Hash(schema1)
+	hash2 := hasher.Hash(schema2)
+
+	if hash1 != hash2 {
+		t.Errorf("Property order should not affect hash: %d != %d", hash1, hash2)
+	}
+}
+
+func TestSchemaHasher_Hash_CircularReference(t *testing.T) {
+	hasher := NewSchemaHasher()
+
+	// Create a circular reference: schema -> property -> back to schema
+	schema := &parser.Schema{
+		Type:       "object",
+		Properties: map[string]*parser.Schema{},
+	}
+	schema.Properties["self"] = schema
+
+	// Should not panic or infinite loop
+	hash := hasher.Hash(schema)
+	if hash == 0 {
+		t.Error("Hash should be non-zero for circular schema")
+	}
+
+	// Verify consistency even with circular reference
+	hash2 := hasher.Hash(schema)
+	if hash != hash2 {
+		t.Errorf("Hash should be consistent for circular schema: %d != %d", hash, hash2)
+	}
+}
+
+func TestSchemaHasher_Hash_NilSchema(t *testing.T) {
+	hasher := NewSchemaHasher()
+	hash := hasher.Hash(nil)
+	// Should not panic
+	if hash == 0 {
+		t.Error("Nil schema should still produce a hash")
+	}
+}
+
+func TestSchemaHasher_Hash_RefSchema(t *testing.T) {
+	hasher := NewSchemaHasher()
+
+	schema1 := &parser.Schema{Ref: "#/components/schemas/User"}
+	schema2 := &parser.Schema{Ref: "#/components/schemas/User"}
+	schema3 := &parser.Schema{Ref: "#/components/schemas/Address"}
+
+	hash1 := hasher.Hash(schema1)
+	hash2 := hasher.Hash(schema2)
+	hash3 := hasher.Hash(schema3)
+
+	if hash1 != hash2 {
+		t.Errorf("Same $ref should have same hash: %d != %d", hash1, hash2)
+	}
+	if hash1 == hash3 {
+		t.Error("Different $ref should have different hash")
+	}
+}
+
+func TestSchemaHasher_Hash_OAS31TypeArray(t *testing.T) {
+	hasher := NewSchemaHasher()
+
+	// OAS 3.1 can have type as array
+	schema1 := &parser.Schema{Type: []any{"string", "null"}}
+	schema2 := &parser.Schema{Type: []any{"null", "string"}} // Different order
+	schema3 := &parser.Schema{Type: []any{"integer", "null"}}
+
+	hash1 := hasher.Hash(schema1)
+	hash2 := hasher.Hash(schema2)
+	hash3 := hasher.Hash(schema3)
+
+	if hash1 != hash2 {
+		t.Errorf("Type array order should not affect hash: %d != %d", hash1, hash2)
+	}
+	if hash1 == hash3 {
+		t.Error("Different type arrays should have different hash")
+	}
+}
+
+func TestSchemaHasher_Hash_Composition(t *testing.T) {
+	hasher := NewSchemaHasher()
+
+	schema1 := &parser.Schema{
+		AllOf: []*parser.Schema{
+			{Type: "object"},
+			{Type: "string"},
+		},
+	}
+
+	schema2 := &parser.Schema{
+		AllOf: []*parser.Schema{
+			{Type: "object"},
+			{Type: "string"},
+		},
+	}
+
+	schema3 := &parser.Schema{
+		AnyOf: []*parser.Schema{
+			{Type: "object"},
+			{Type: "string"},
+		},
+	}
+
+	hash1 := hasher.Hash(schema1)
+	hash2 := hasher.Hash(schema2)
+	hash3 := hasher.Hash(schema3)
+
+	if hash1 != hash2 {
+		t.Errorf("Identical allOf should have same hash: %d != %d", hash1, hash2)
+	}
+	if hash1 == hash3 {
+		t.Error("allOf and anyOf should have different hash")
+	}
+}
+
+func TestSchemaHasher_Hash_NumericConstraints(t *testing.T) {
+	hasher := NewSchemaHasher()
+
+	min1, min2 := 0.0, 1.0
+	max1, max2 := 100.0, 200.0
+
+	schema1 := &parser.Schema{Type: "integer", Minimum: &min1, Maximum: &max1}
+	schema2 := &parser.Schema{Type: "integer", Minimum: &min1, Maximum: &max1}
+	schema3 := &parser.Schema{Type: "integer", Minimum: &min2, Maximum: &max2}
+
+	hash1 := hasher.Hash(schema1)
+	hash2 := hasher.Hash(schema2)
+	hash3 := hasher.Hash(schema3)
+
+	if hash1 != hash2 {
+		t.Errorf("Same constraints should have same hash: %d != %d", hash1, hash2)
+	}
+	if hash1 == hash3 {
+		t.Error("Different constraints should have different hash")
+	}
+}
+
+func TestSchemaHasher_Hash_ArrayItems(t *testing.T) {
+	hasher := NewSchemaHasher()
+
+	schema1 := &parser.Schema{
+		Type:  "array",
+		Items: &parser.Schema{Type: "string"},
+	}
+	schema2 := &parser.Schema{
+		Type:  "array",
+		Items: &parser.Schema{Type: "string"},
+	}
+	schema3 := &parser.Schema{
+		Type:  "array",
+		Items: &parser.Schema{Type: "integer"},
+	}
+
+	hash1 := hasher.Hash(schema1)
+	hash2 := hasher.Hash(schema2)
+	hash3 := hasher.Hash(schema3)
+
+	if hash1 != hash2 {
+		t.Errorf("Same items should have same hash: %d != %d", hash1, hash2)
+	}
+	if hash1 == hash3 {
+		t.Error("Different items should have different hash")
+	}
+}
+
+func TestSchemaHasher_Hash_AdditionalPropertiesBool(t *testing.T) {
+	hasher := NewSchemaHasher()
+
+	schema1 := &parser.Schema{Type: "object", AdditionalProperties: true}
+	schema2 := &parser.Schema{Type: "object", AdditionalProperties: true}
+	schema3 := &parser.Schema{Type: "object", AdditionalProperties: false}
+
+	hash1 := hasher.Hash(schema1)
+	hash2 := hasher.Hash(schema2)
+	hash3 := hasher.Hash(schema3)
+
+	if hash1 != hash2 {
+		t.Errorf("Same additionalProperties should have same hash: %d != %d", hash1, hash2)
+	}
+	if hash1 == hash3 {
+		t.Error("Different additionalProperties should have different hash")
+	}
+}
+
+func TestSchemaHasher_GroupByHash(t *testing.T) {
+	hasher := NewSchemaHasher()
+
+	schemas := map[string]*parser.Schema{
+		"User": {
+			Type: "object",
+			Properties: map[string]*parser.Schema{
+				"name": {Type: "string"},
+			},
+		},
+		"Person": { // Identical to User
+			Type: "object",
+			Properties: map[string]*parser.Schema{
+				"name": {Type: "string"},
+			},
+		},
+		"Address": { // Different
+			Type: "object",
+			Properties: map[string]*parser.Schema{
+				"street": {Type: "string"},
+			},
+		},
+	}
+
+	groups := hasher.GroupByHash(schemas)
+
+	// Should have 2 groups: one with User+Person, one with Address
+	if len(groups) != 2 {
+		t.Errorf("Expected 2 groups, got %d", len(groups))
+	}
+
+	// Find the group with multiple schemas
+	foundDuplicateGroup := false
+	for _, names := range groups {
+		if len(names) == 2 {
+			foundDuplicateGroup = true
+			// Should contain User and Person
+			hasUser, hasPerson := false, false
+			for _, name := range names {
+				if name == "User" {
+					hasUser = true
+				}
+				if name == "Person" {
+					hasPerson = true
+				}
+			}
+			if !hasUser || !hasPerson {
+				t.Error("Duplicate group should contain User and Person")
+			}
+		}
+	}
+	if !foundDuplicateGroup {
+		t.Error("Should find a group with 2 identical schemas")
+	}
+}
+
+func TestSchemaHasher_Hash_MetadataIgnored(t *testing.T) {
+	hasher := NewSchemaHasher()
+
+	// Schemas that differ only in metadata should have the same hash
+	schema1 := &parser.Schema{
+		Type:        "string",
+		Title:       "User Name",
+		Description: "The name of the user",
+	}
+
+	schema2 := &parser.Schema{
+		Type:        "string",
+		Title:       "Different Title",
+		Description: "Completely different description",
+	}
+
+	hash1 := hasher.Hash(schema1)
+	hash2 := hasher.Hash(schema2)
+
+	if hash1 != hash2 {
+		t.Errorf("Metadata-only differences should not affect hash: %d != %d", hash1, hash2)
+	}
+}

--- a/joiner/doc.go
+++ b/joiner/doc.go
@@ -90,6 +90,34 @@
 // Pre-join overlays are applied to each input document before merging.
 // Post-join overlays are applied to the final merged result.
 //
+// # Semantic Schema Deduplication
+//
+// After merging, the joiner can automatically identify and consolidate structurally
+// identical schemas across all input documents. This reduces document size when multiple
+// APIs happen to define equivalent types with different names.
+//
+// Enable via option:
+//
+//	result, err := joiner.JoinWithOptions(
+//	    joiner.WithFilePaths([]string{"users-api.yaml", "orders-api.yaml"}),
+//	    joiner.WithSemanticDeduplication(true),
+//	)
+//
+// Or via config:
+//
+//	config := joiner.DefaultConfig()
+//	config.SemanticDeduplication = true
+//	j := joiner.New(config)
+//	result, _ := j.Join([]string{"api1.yaml", "api2.yaml"})
+//
+// When schemas from different documents are structurally equivalent (same type, properties,
+// constraints), they are consolidated into a single canonical schema (alphabetically first
+// name). All $ref references throughout the merged document are automatically rewritten.
+//
+// This differs from the StrategyDeduplicateEquivalent collision strategy which only
+// handles same-named collisions. Semantic deduplication works across all schemas
+// regardless of their original names.
+//
 // # Features and Limitations
 //
 // The joiner validates all input documents, prevents output file overwrites with

--- a/joiner/joiner_dedupe_test.go
+++ b/joiner/joiner_dedupe_test.go
@@ -1,0 +1,727 @@
+package joiner
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/erraggy/oastools/parser"
+)
+
+func TestJoiner_SemanticDeduplication_OAS3(t *testing.T) {
+	// Create two documents with identical schemas under different names
+	doc1 := &parser.OAS3Document{
+		OpenAPI: "3.0.3",
+		Info:    &parser.Info{Title: "API 1", Version: "1.0.0"},
+		Paths:   make(parser.Paths),
+		Components: &parser.Components{
+			Schemas: map[string]*parser.Schema{
+				"Address": {
+					Type: "object",
+					Properties: map[string]*parser.Schema{
+						"street": {Type: "string"},
+						"city":   {Type: "string"},
+					},
+					Required: []string{"street", "city"},
+				},
+			},
+		},
+		OASVersion: parser.OASVersion303,
+	}
+
+	doc2 := &parser.OAS3Document{
+		OpenAPI: "3.0.3",
+		Info:    &parser.Info{Title: "API 2", Version: "1.0.0"},
+		Paths:   make(parser.Paths),
+		Components: &parser.Components{
+			Schemas: map[string]*parser.Schema{
+				// Identical schema with different name
+				"Location": {
+					Type: "object",
+					Properties: map[string]*parser.Schema{
+						"street": {Type: "string"},
+						"city":   {Type: "string"},
+					},
+					Required: []string{"street", "city"},
+				},
+			},
+		},
+		OASVersion: parser.OASVersion303,
+	}
+
+	// Create parse results
+	results := []parser.ParseResult{
+		{
+			Document:     doc1,
+			Version:      "3.0.3",
+			OASVersion:   parser.OASVersion303,
+			SourcePath:   "api1.yaml",
+			SourceFormat: "yaml",
+		},
+		{
+			Document:     doc2,
+			Version:      "3.0.3",
+			OASVersion:   parser.OASVersion303,
+			SourcePath:   "api2.yaml",
+			SourceFormat: "yaml",
+		},
+	}
+
+	// Join with semantic deduplication enabled
+	config := DefaultConfig()
+	config.SemanticDeduplication = true
+	j := New(config)
+
+	joinResult, err := j.JoinParsed(results)
+	if err != nil {
+		t.Fatalf("JoinParsed failed: %v", err)
+	}
+
+	oas3Doc, ok := joinResult.Document.(*parser.OAS3Document)
+	if !ok {
+		t.Fatal("Expected OAS3Document")
+	}
+
+	// Should have 1 schema (Address is canonical, alphabetically first)
+	if len(oas3Doc.Components.Schemas) != 1 {
+		t.Errorf("Expected 1 schema after dedup, got %d", len(oas3Doc.Components.Schemas))
+	}
+
+	if _, ok := oas3Doc.Components.Schemas["Address"]; !ok {
+		t.Error("Expected Address to be canonical (alphabetically first)")
+	}
+
+	if _, ok := oas3Doc.Components.Schemas["Location"]; ok {
+		t.Error("Expected Location to be removed (duplicate of Address)")
+	}
+}
+
+func TestJoiner_SemanticDeduplication_OAS2(t *testing.T) {
+	// Create two documents with identical schemas under different names
+	doc1 := &parser.OAS2Document{
+		Swagger: "2.0",
+		Info:    &parser.Info{Title: "API 1", Version: "1.0.0"},
+		Paths:   make(parser.Paths),
+		Definitions: map[string]*parser.Schema{
+			"Address": {
+				Type: "object",
+				Properties: map[string]*parser.Schema{
+					"street": {Type: "string"},
+					"city":   {Type: "string"},
+				},
+				Required: []string{"street", "city"},
+			},
+		},
+		OASVersion: parser.OASVersion20,
+	}
+
+	doc2 := &parser.OAS2Document{
+		Swagger: "2.0",
+		Info:    &parser.Info{Title: "API 2", Version: "1.0.0"},
+		Paths:   make(parser.Paths),
+		Definitions: map[string]*parser.Schema{
+			// Identical schema with different name
+			"Location": {
+				Type: "object",
+				Properties: map[string]*parser.Schema{
+					"street": {Type: "string"},
+					"city":   {Type: "string"},
+				},
+				Required: []string{"street", "city"},
+			},
+		},
+		OASVersion: parser.OASVersion20,
+	}
+
+	// Create parse results
+	results := []parser.ParseResult{
+		{
+			Document:     doc1,
+			Version:      "2.0",
+			OASVersion:   parser.OASVersion20,
+			SourcePath:   "api1.yaml",
+			SourceFormat: "yaml",
+		},
+		{
+			Document:     doc2,
+			Version:      "2.0",
+			OASVersion:   parser.OASVersion20,
+			SourcePath:   "api2.yaml",
+			SourceFormat: "yaml",
+		},
+	}
+
+	// Join with semantic deduplication enabled
+	config := DefaultConfig()
+	config.SemanticDeduplication = true
+	j := New(config)
+
+	joinResult, err := j.JoinParsed(results)
+	if err != nil {
+		t.Fatalf("JoinParsed failed: %v", err)
+	}
+
+	oas2Doc, ok := joinResult.Document.(*parser.OAS2Document)
+	if !ok {
+		t.Fatal("Expected OAS2Document")
+	}
+
+	// Should have 1 definition (Address is canonical, alphabetically first)
+	if len(oas2Doc.Definitions) != 1 {
+		t.Errorf("Expected 1 definition after dedup, got %d", len(oas2Doc.Definitions))
+	}
+
+	if _, ok := oas2Doc.Definitions["Address"]; !ok {
+		t.Error("Expected Address to be canonical (alphabetically first)")
+	}
+
+	if _, ok := oas2Doc.Definitions["Location"]; ok {
+		t.Error("Expected Location to be removed (duplicate of Address)")
+	}
+}
+
+func TestJoiner_SemanticDeduplication_ReferenceRewriting_OAS3(t *testing.T) {
+	// Create documents where one references a schema that will be deduplicated
+	doc1 := &parser.OAS3Document{
+		OpenAPI: "3.0.3",
+		Info:    &parser.Info{Title: "API 1", Version: "1.0.0"},
+		Paths:   make(parser.Paths),
+		Components: &parser.Components{
+			Schemas: map[string]*parser.Schema{
+				"Address": {
+					Type: "object",
+					Properties: map[string]*parser.Schema{
+						"street": {Type: "string"},
+					},
+				},
+			},
+		},
+		OASVersion: parser.OASVersion303,
+	}
+
+	doc2 := &parser.OAS3Document{
+		OpenAPI: "3.0.3",
+		Info:    &parser.Info{Title: "API 2", Version: "1.0.0"},
+		Paths:   make(parser.Paths),
+		Components: &parser.Components{
+			Schemas: map[string]*parser.Schema{
+				// Identical to Address
+				"Location": {
+					Type: "object",
+					Properties: map[string]*parser.Schema{
+						"street": {Type: "string"},
+					},
+				},
+				// References Location (which will be deduplicated to Address)
+				"Order": {
+					Type: "object",
+					Properties: map[string]*parser.Schema{
+						"shipTo": {Ref: "#/components/schemas/Location"},
+					},
+				},
+			},
+		},
+		OASVersion: parser.OASVersion303,
+	}
+
+	results := []parser.ParseResult{
+		{
+			Document:     doc1,
+			Version:      "3.0.3",
+			OASVersion:   parser.OASVersion303,
+			SourcePath:   "api1.yaml",
+			SourceFormat: "yaml",
+		},
+		{
+			Document:     doc2,
+			Version:      "3.0.3",
+			OASVersion:   parser.OASVersion303,
+			SourcePath:   "api2.yaml",
+			SourceFormat: "yaml",
+		},
+	}
+
+	config := DefaultConfig()
+	config.SemanticDeduplication = true
+	j := New(config)
+
+	joinResult, err := j.JoinParsed(results)
+	if err != nil {
+		t.Fatalf("JoinParsed failed: %v", err)
+	}
+
+	oas3Doc, ok := joinResult.Document.(*parser.OAS3Document)
+	if !ok {
+		t.Fatal("Expected OAS3Document")
+	}
+
+	// Should have 2 schemas: Address (canonical) and Order
+	if len(oas3Doc.Components.Schemas) != 2 {
+		t.Errorf("Expected 2 schemas after dedup, got %d", len(oas3Doc.Components.Schemas))
+	}
+
+	// Order's reference to Location should be rewritten to Address
+	orderSchema := oas3Doc.Components.Schemas["Order"]
+	if orderSchema == nil {
+		t.Fatal("Expected Order schema to exist")
+	}
+
+	shipToRef := orderSchema.Properties["shipTo"].Ref
+	expectedRef := "#/components/schemas/Address"
+	if shipToRef != expectedRef {
+		t.Errorf("Expected shipTo.$ref = %s, got %s", expectedRef, shipToRef)
+	}
+}
+
+func TestJoiner_SemanticDeduplication_ReferenceRewriting_OAS2(t *testing.T) {
+	// Create documents where one references a schema that will be deduplicated
+	doc1 := &parser.OAS2Document{
+		Swagger: "2.0",
+		Info:    &parser.Info{Title: "API 1", Version: "1.0.0"},
+		Paths:   make(parser.Paths),
+		Definitions: map[string]*parser.Schema{
+			"Address": {
+				Type: "object",
+				Properties: map[string]*parser.Schema{
+					"street": {Type: "string"},
+				},
+			},
+		},
+		OASVersion: parser.OASVersion20,
+	}
+
+	doc2 := &parser.OAS2Document{
+		Swagger: "2.0",
+		Info:    &parser.Info{Title: "API 2", Version: "1.0.0"},
+		Paths:   make(parser.Paths),
+		Definitions: map[string]*parser.Schema{
+			// Identical to Address
+			"Location": {
+				Type: "object",
+				Properties: map[string]*parser.Schema{
+					"street": {Type: "string"},
+				},
+			},
+			// References Location (which will be deduplicated to Address)
+			"Order": {
+				Type: "object",
+				Properties: map[string]*parser.Schema{
+					"shipTo": {Ref: "#/definitions/Location"},
+				},
+			},
+		},
+		OASVersion: parser.OASVersion20,
+	}
+
+	results := []parser.ParseResult{
+		{
+			Document:     doc1,
+			Version:      "2.0",
+			OASVersion:   parser.OASVersion20,
+			SourcePath:   "api1.yaml",
+			SourceFormat: "yaml",
+		},
+		{
+			Document:     doc2,
+			Version:      "2.0",
+			OASVersion:   parser.OASVersion20,
+			SourcePath:   "api2.yaml",
+			SourceFormat: "yaml",
+		},
+	}
+
+	config := DefaultConfig()
+	config.SemanticDeduplication = true
+	j := New(config)
+
+	joinResult, err := j.JoinParsed(results)
+	if err != nil {
+		t.Fatalf("JoinParsed failed: %v", err)
+	}
+
+	oas2Doc, ok := joinResult.Document.(*parser.OAS2Document)
+	if !ok {
+		t.Fatal("Expected OAS2Document")
+	}
+
+	// Should have 2 definitions: Address (canonical) and Order
+	if len(oas2Doc.Definitions) != 2 {
+		t.Errorf("Expected 2 definitions after dedup, got %d", len(oas2Doc.Definitions))
+	}
+
+	// Order's reference to Location should be rewritten to Address
+	orderSchema := oas2Doc.Definitions["Order"]
+	if orderSchema == nil {
+		t.Fatal("Expected Order definition to exist")
+	}
+
+	shipToRef := orderSchema.Properties["shipTo"].Ref
+	expectedRef := "#/definitions/Address"
+	if shipToRef != expectedRef {
+		t.Errorf("Expected shipTo.$ref = %s, got %s", expectedRef, shipToRef)
+	}
+}
+
+func TestJoiner_SemanticDeduplication_Disabled(t *testing.T) {
+	// Create two documents with identical schemas
+	doc1 := &parser.OAS3Document{
+		OpenAPI: "3.0.3",
+		Info:    &parser.Info{Title: "API 1", Version: "1.0.0"},
+		Paths:   make(parser.Paths),
+		Components: &parser.Components{
+			Schemas: map[string]*parser.Schema{
+				"Address": {Type: "object"},
+			},
+		},
+		OASVersion: parser.OASVersion303,
+	}
+
+	doc2 := &parser.OAS3Document{
+		OpenAPI: "3.0.3",
+		Info:    &parser.Info{Title: "API 2", Version: "1.0.0"},
+		Paths:   make(parser.Paths),
+		Components: &parser.Components{
+			Schemas: map[string]*parser.Schema{
+				"Location": {Type: "object"},
+			},
+		},
+		OASVersion: parser.OASVersion303,
+	}
+
+	results := []parser.ParseResult{
+		{
+			Document:     doc1,
+			Version:      "3.0.3",
+			OASVersion:   parser.OASVersion303,
+			SourcePath:   "api1.yaml",
+			SourceFormat: "yaml",
+		},
+		{
+			Document:     doc2,
+			Version:      "3.0.3",
+			OASVersion:   parser.OASVersion303,
+			SourcePath:   "api2.yaml",
+			SourceFormat: "yaml",
+		},
+	}
+
+	// Default config - deduplication disabled
+	config := DefaultConfig()
+	j := New(config)
+
+	joinResult, err := j.JoinParsed(results)
+	if err != nil {
+		t.Fatalf("JoinParsed failed: %v", err)
+	}
+
+	oas3Doc, ok := joinResult.Document.(*parser.OAS3Document)
+	if !ok {
+		t.Fatal("Expected OAS3Document")
+	}
+
+	// Should have both schemas (no deduplication)
+	if len(oas3Doc.Components.Schemas) != 2 {
+		t.Errorf("Expected 2 schemas (no dedup), got %d", len(oas3Doc.Components.Schemas))
+	}
+}
+
+func TestJoiner_SemanticDeduplication_MultipleGroups(t *testing.T) {
+	// Create documents with multiple equivalence groups
+	doc1 := &parser.OAS3Document{
+		OpenAPI: "3.0.3",
+		Info:    &parser.Info{Title: "API 1", Version: "1.0.0"},
+		Paths:   make(parser.Paths),
+		Components: &parser.Components{
+			Schemas: map[string]*parser.Schema{
+				// Group 1: objects with name property
+				"Address": {
+					Type:       "object",
+					Properties: map[string]*parser.Schema{"name": {Type: "string"}},
+				},
+				// Group 2: simple strings
+				"Name": {Type: "string"},
+				// Unique
+				"Age": {Type: "integer"},
+			},
+		},
+		OASVersion: parser.OASVersion303,
+	}
+
+	doc2 := &parser.OAS3Document{
+		OpenAPI: "3.0.3",
+		Info:    &parser.Info{Title: "API 2", Version: "1.0.0"},
+		Paths:   make(parser.Paths),
+		Components: &parser.Components{
+			Schemas: map[string]*parser.Schema{
+				// Group 1: identical to Address
+				"Location": {
+					Type:       "object",
+					Properties: map[string]*parser.Schema{"name": {Type: "string"}},
+				},
+				// Group 2: identical to Name
+				"Title": {Type: "string"},
+			},
+		},
+		OASVersion: parser.OASVersion303,
+	}
+
+	results := []parser.ParseResult{
+		{
+			Document:     doc1,
+			Version:      "3.0.3",
+			OASVersion:   parser.OASVersion303,
+			SourcePath:   "api1.yaml",
+			SourceFormat: "yaml",
+		},
+		{
+			Document:     doc2,
+			Version:      "3.0.3",
+			OASVersion:   parser.OASVersion303,
+			SourcePath:   "api2.yaml",
+			SourceFormat: "yaml",
+		},
+	}
+
+	config := DefaultConfig()
+	config.SemanticDeduplication = true
+	j := New(config)
+
+	joinResult, err := j.JoinParsed(results)
+	if err != nil {
+		t.Fatalf("JoinParsed failed: %v", err)
+	}
+
+	oas3Doc, ok := joinResult.Document.(*parser.OAS3Document)
+	if !ok {
+		t.Fatal("Expected OAS3Document")
+	}
+
+	// Should have 3 schemas: Address (canonical), Name (canonical), Age (unique)
+	if len(oas3Doc.Components.Schemas) != 3 {
+		t.Errorf("Expected 3 schemas, got %d", len(oas3Doc.Components.Schemas))
+	}
+
+	// Verify canonical names
+	if _, ok := oas3Doc.Components.Schemas["Address"]; !ok {
+		t.Error("Expected Address to be canonical")
+	}
+	if _, ok := oas3Doc.Components.Schemas["Name"]; !ok {
+		t.Error("Expected Name to be canonical")
+	}
+	if _, ok := oas3Doc.Components.Schemas["Age"]; !ok {
+		t.Error("Expected Age to be present")
+	}
+
+	// Verify duplicates removed
+	if _, ok := oas3Doc.Components.Schemas["Location"]; ok {
+		t.Error("Expected Location to be removed (duplicate of Address)")
+	}
+	if _, ok := oas3Doc.Components.Schemas["Title"]; ok {
+		t.Error("Expected Title to be removed (duplicate of Name)")
+	}
+}
+
+func TestJoiner_SemanticDeduplication_WarningsGenerated(t *testing.T) {
+	// Create two documents with identical schemas
+	doc1 := &parser.OAS3Document{
+		OpenAPI: "3.0.3",
+		Info:    &parser.Info{Title: "API 1", Version: "1.0.0"},
+		Paths:   make(parser.Paths),
+		Components: &parser.Components{
+			Schemas: map[string]*parser.Schema{
+				"Address": {Type: "object"},
+			},
+		},
+		OASVersion: parser.OASVersion303,
+	}
+
+	doc2 := &parser.OAS3Document{
+		OpenAPI: "3.0.3",
+		Info:    &parser.Info{Title: "API 2", Version: "1.0.0"},
+		Paths:   make(parser.Paths),
+		Components: &parser.Components{
+			Schemas: map[string]*parser.Schema{
+				"Location": {Type: "object"},
+			},
+		},
+		OASVersion: parser.OASVersion303,
+	}
+
+	results := []parser.ParseResult{
+		{
+			Document:     doc1,
+			Version:      "3.0.3",
+			OASVersion:   parser.OASVersion303,
+			SourcePath:   "api1.yaml",
+			SourceFormat: "yaml",
+		},
+		{
+			Document:     doc2,
+			Version:      "3.0.3",
+			OASVersion:   parser.OASVersion303,
+			SourcePath:   "api2.yaml",
+			SourceFormat: "yaml",
+		},
+	}
+
+	config := DefaultConfig()
+	config.SemanticDeduplication = true
+	j := New(config)
+
+	joinResult, err := j.JoinParsed(results)
+	if err != nil {
+		t.Fatalf("JoinParsed failed: %v", err)
+	}
+
+	// Check that a warning was generated about deduplication
+	found := false
+	for _, w := range joinResult.Warnings {
+		if strings.Contains(w, "semantic deduplication") && strings.Contains(w, "consolidated") {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Error("Expected warning about semantic deduplication consolidation")
+	}
+}
+
+func TestJoiner_WithSemanticDeduplication_Option(t *testing.T) {
+	// Create two documents with identical schemas
+	doc1 := &parser.OAS3Document{
+		OpenAPI: "3.0.3",
+		Info:    &parser.Info{Title: "API 1", Version: "1.0.0"},
+		Paths:   make(parser.Paths),
+		Components: &parser.Components{
+			Schemas: map[string]*parser.Schema{
+				"Address": {Type: "object"},
+			},
+		},
+		OASVersion: parser.OASVersion303,
+	}
+
+	doc2 := &parser.OAS3Document{
+		OpenAPI: "3.0.3",
+		Info:    &parser.Info{Title: "API 2", Version: "1.0.0"},
+		Paths:   make(parser.Paths),
+		Components: &parser.Components{
+			Schemas: map[string]*parser.Schema{
+				"Location": {Type: "object"},
+			},
+		},
+		OASVersion: parser.OASVersion303,
+	}
+
+	results := []parser.ParseResult{
+		{
+			Document:     doc1,
+			Version:      "3.0.3",
+			OASVersion:   parser.OASVersion303,
+			SourcePath:   "api1.yaml",
+			SourceFormat: "yaml",
+		},
+		{
+			Document:     doc2,
+			Version:      "3.0.3",
+			OASVersion:   parser.OASVersion303,
+			SourcePath:   "api2.yaml",
+			SourceFormat: "yaml",
+		},
+	}
+
+	// Use functional option
+	joinResult, err := JoinWithOptions(
+		WithParsed(results...),
+		WithSemanticDeduplication(true),
+	)
+	if err != nil {
+		t.Fatalf("JoinWithOptions failed: %v", err)
+	}
+
+	oas3Doc, ok := joinResult.Document.(*parser.OAS3Document)
+	if !ok {
+		t.Fatal("Expected OAS3Document")
+	}
+
+	// Should have 1 schema after deduplication
+	if len(oas3Doc.Components.Schemas) != 1 {
+		t.Errorf("Expected 1 schema after dedup, got %d", len(oas3Doc.Components.Schemas))
+	}
+}
+
+func TestJoiner_SemanticDeduplication_MetadataIgnored(t *testing.T) {
+	// Create two documents with schemas that differ only in metadata
+	doc1 := &parser.OAS3Document{
+		OpenAPI: "3.0.3",
+		Info:    &parser.Info{Title: "API 1", Version: "1.0.0"},
+		Paths:   make(parser.Paths),
+		Components: &parser.Components{
+			Schemas: map[string]*parser.Schema{
+				"Address": {
+					Type:        "object",
+					Title:       "An Address",
+					Description: "Represents a physical address",
+					Properties: map[string]*parser.Schema{
+						"street": {Type: "string"},
+					},
+				},
+			},
+		},
+		OASVersion: parser.OASVersion303,
+	}
+
+	doc2 := &parser.OAS3Document{
+		OpenAPI: "3.0.3",
+		Info:    &parser.Info{Title: "API 2", Version: "1.0.0"},
+		Paths:   make(parser.Paths),
+		Components: &parser.Components{
+			Schemas: map[string]*parser.Schema{
+				"Location": {
+					Type:        "object",
+					Title:       "A Location",
+					Description: "A place on earth",
+					Properties: map[string]*parser.Schema{
+						"street": {Type: "string"},
+					},
+				},
+			},
+		},
+		OASVersion: parser.OASVersion303,
+	}
+
+	results := []parser.ParseResult{
+		{
+			Document:     doc1,
+			Version:      "3.0.3",
+			OASVersion:   parser.OASVersion303,
+			SourcePath:   "api1.yaml",
+			SourceFormat: "yaml",
+		},
+		{
+			Document:     doc2,
+			Version:      "3.0.3",
+			OASVersion:   parser.OASVersion303,
+			SourcePath:   "api2.yaml",
+			SourceFormat: "yaml",
+		},
+	}
+
+	config := DefaultConfig()
+	config.SemanticDeduplication = true
+	j := New(config)
+
+	joinResult, err := j.JoinParsed(results)
+	if err != nil {
+		t.Fatalf("JoinParsed failed: %v", err)
+	}
+
+	oas3Doc, ok := joinResult.Document.(*parser.OAS3Document)
+	if !ok {
+		t.Fatal("Expected OAS3Document")
+	}
+
+	// Should deduplicate since structural properties are the same
+	if len(oas3Doc.Components.Schemas) != 1 {
+		t.Errorf("Expected 1 schema (metadata ignored), got %d", len(oas3Doc.Components.Schemas))
+	}
+}


### PR DESCRIPTION
## Summary

- Add semantic deduplication to identify and consolidate structurally identical schemas
- Reduces document size by eliminating duplicate schema definitions
- Uses FNV-1a structural hashing for O(N) candidate grouping + deep equivalence verification
- Alphabetically-first name becomes the canonical schema, all `$ref`s are automatically rewritten

## Changes

### New: `internal/schemautil/` Infrastructure
- `hash.go` - FNV-1a structural hashing with cycle detection
- `deduplicator.go` - Hash-based grouping + deep equivalence verification  
- `dedupe.go` - Types and configuration
- Comprehensive tests and benchmarks

### Builder Integration
- `WithSemanticDeduplication(bool)` option to enable during build
- `DeduplicateSchemas()` method for explicit deduplication
- Automatic `$ref` rewriting to canonical schemas

### Joiner Integration  
- `SemanticDeduplication` config option
- Post-merge deduplication consolidates identical schemas across documents
- Works with both OAS 2.0 and OAS 3.x documents
- CLI: `--semantic-dedup` flag

### Documentation
- README.md: Added semantic deduplication to highlights
- `docs/cli-reference.md`: Added `--semantic-dedup` flag documentation
- `docs/developer-guide.md`: Added usage examples for both packages
- `builder/example_test.go`: Added `Example_semanticDeduplication()`
- `joiner/example_test.go`: Added `Example_semanticDeduplication()`
- Updated `doc.go` files for both packages
- Updated Architect agent to always include documentation planning

## Test plan

- [x] All existing tests pass (`make check`)
- [x] New unit tests for `internal/schemautil/` (hash, deduplicator)
- [x] Integration tests for builder deduplication
- [x] Integration tests for joiner deduplication
- [x] Benchmark tests for hash and deduplicator performance
- [x] Example tests run successfully in godoc

🤖 Generated with [Claude Code](https://claude.com/claude-code)