### PR TITLE
chore: add v1.28.4 benchmarks

### DIFF
--- a/benchmarks/benchmark-v1.28.4.txt
+++ b/benchmarks/benchmark-v1.28.4.txt
@@ -1,0 +1,6483 @@
+PASS
+ok  	github.com/erraggy/oastools	0.198s
+PASS
+ok  	github.com/erraggy/oastools/builder	0.240s
+?   	github.com/erraggy/oastools/cmd/oastools	[no test files]
+Usage: oastools convert [flags] <file|url|->
+
+Convert an OpenAPI specification from one version to another.
+
+Flags:
+  -no-warnings
+    	suppress warning and info messages
+  -o string
+    	output file path (default: stdout)
+  -output string
+    	output file path (default: stdout)
+  -q	quiet mode: only output the document, no diagnostic messages
+  -quiet
+    	quiet mode: only output the document, no diagnostic messages
+  -s	include line numbers in conversion issues (IDE-friendly format)
+  -source-map
+    	include line numbers in conversion issues (IDE-friendly format)
+  -strict
+    	fail on any conversion issues (even warnings)
+  -t string
+    	target OAS version (e.g., "3.0.3", "2.0", "3.1.0") (required)
+  -target string
+    	target OAS version (e.g., "3.0.3", "2.0", "3.1.0") (required)
+
+Supported Conversions:
+  - OAS 2.0 → OAS 3.x (3.0.0 through 3.2.0)
+  - OAS 3.x → OAS 2.0
+  - OAS 3.x → OAS 3.y (version updates)
+
+Examples:
+  oastools convert -t 3.0.3 swagger.yaml -o openapi.yaml
+  oastools convert -t 3.0.3 https://example.com/swagger.yaml -o openapi.yaml
+  oastools convert -t 2.0 openapi-v3.yaml
+  oastools convert --strict -t 3.1.0 swagger.yaml -o openapi-v3.yaml
+  cat swagger.yaml | oastools convert -q -t 3.0.3 - > openapi.yaml
+  oastools convert -s -t 3.0.3 swagger.yaml  # Include line numbers in issues
+
+Pipelining:
+  - Use '-' as the file path to read from stdin
+  - Use --quiet/-q to suppress diagnostic output for pipelining
+
+Notes:
+  - Critical issues indicate features that cannot be converted (data loss)
+  - Warnings indicate lossy conversions or best-effort transformations
+  - Info messages provide context about conversion choices
+  - Always validate converted documents before deployment
+
+Exit Codes:
+  0    Conversion successful
+  1    Conversion failed or critical issues found (in --strict mode)
+Usage: oastools convert [flags] <file|url|->
+
+Convert an OpenAPI specification from one version to another.
+
+Flags:
+  -no-warnings
+    	suppress warning and info messages
+  -o string
+    	output file path (default: stdout)
+  -output string
+    	output file path (default: stdout)
+  -q	quiet mode: only output the document, no diagnostic messages
+  -quiet
+    	quiet mode: only output the document, no diagnostic messages
+  -s	include line numbers in conversion issues (IDE-friendly format)
+  -source-map
+    	include line numbers in conversion issues (IDE-friendly format)
+  -strict
+    	fail on any conversion issues (even warnings)
+  -t string
+    	target OAS version (e.g., "3.0.3", "2.0", "3.1.0") (required)
+  -target string
+    	target OAS version (e.g., "3.0.3", "2.0", "3.1.0") (required)
+
+Supported Conversions:
+  - OAS 2.0 → OAS 3.x (3.0.0 through 3.2.0)
+  - OAS 3.x → OAS 2.0
+  - OAS 3.x → OAS 3.y (version updates)
+
+Examples:
+  oastools convert -t 3.0.3 swagger.yaml -o openapi.yaml
+  oastools convert -t 3.0.3 https://example.com/swagger.yaml -o openapi.yaml
+  oastools convert -t 2.0 openapi-v3.yaml
+  oastools convert --strict -t 3.1.0 swagger.yaml -o openapi-v3.yaml
+  cat swagger.yaml | oastools convert -q -t 3.0.3 - > openapi.yaml
+  oastools convert -s -t 3.0.3 swagger.yaml  # Include line numbers in issues
+
+Pipelining:
+  - Use '-' as the file path to read from stdin
+  - Use --quiet/-q to suppress diagnostic output for pipelining
+
+Notes:
+  - Critical issues indicate features that cannot be converted (data loss)
+  - Warnings indicate lossy conversions or best-effort transformations
+  - Info messages provide context about conversion choices
+  - Always validate converted documents before deployment
+
+Exit Codes:
+  0    Conversion successful
+  1    Conversion failed or critical issues found (in --strict mode)
+Usage: oastools convert [flags] <file|url|->
+
+Convert an OpenAPI specification from one version to another.
+
+Flags:
+  -no-warnings
+    	suppress warning and info messages
+  -o string
+    	output file path (default: stdout)
+  -output string
+    	output file path (default: stdout)
+  -q	quiet mode: only output the document, no diagnostic messages
+  -quiet
+    	quiet mode: only output the document, no diagnostic messages
+  -s	include line numbers in conversion issues (IDE-friendly format)
+  -source-map
+    	include line numbers in conversion issues (IDE-friendly format)
+  -strict
+    	fail on any conversion issues (even warnings)
+  -t string
+    	target OAS version (e.g., "3.0.3", "2.0", "3.1.0") (required)
+  -target string
+    	target OAS version (e.g., "3.0.3", "2.0", "3.1.0") (required)
+
+Supported Conversions:
+  - OAS 2.0 → OAS 3.x (3.0.0 through 3.2.0)
+  - OAS 3.x → OAS 2.0
+  - OAS 3.x → OAS 3.y (version updates)
+
+Examples:
+  oastools convert -t 3.0.3 swagger.yaml -o openapi.yaml
+  oastools convert -t 3.0.3 https://example.com/swagger.yaml -o openapi.yaml
+  oastools convert -t 2.0 openapi-v3.yaml
+  oastools convert --strict -t 3.1.0 swagger.yaml -o openapi-v3.yaml
+  cat swagger.yaml | oastools convert -q -t 3.0.3 - > openapi.yaml
+  oastools convert -s -t 3.0.3 swagger.yaml  # Include line numbers in issues
+
+Pipelining:
+  - Use '-' as the file path to read from stdin
+  - Use --quiet/-q to suppress diagnostic output for pipelining
+
+Notes:
+  - Critical issues indicate features that cannot be converted (data loss)
+  - Warnings indicate lossy conversions or best-effort transformations
+  - Info messages provide context about conversion choices
+  - Always validate converted documents before deployment
+
+Exit Codes:
+  0    Conversion successful
+  1    Conversion failed or critical issues found (in --strict mode)
+Usage: oastools diff [flags] <source> <target>
+
+Compare two OpenAPI specification files or URLs and report differences.
+
+Flags:
+  -breaking
+    	enable breaking change detection and categorization
+  -format string
+    	output format: text, json, or yaml (default "text")
+  -no-info
+    	exclude informational changes from output
+  -s	include line numbers in diff output (IDE-friendly format)
+  -source-map
+    	include line numbers in diff output (IDE-friendly format)
+
+Output Formats:
+  text (default)  Human-readable text output
+  json            JSON format for programmatic processing
+  yaml            YAML format for programmatic processing
+
+Modes:
+  Default (Simple):
+    Reports all semantic differences between specifications without
+    categorizing them by severity or breaking change impact.
+
+  --breaking (Breaking Change Detection):
+    Categorizes changes by severity and identifies breaking API changes:
+    - Critical: Removed endpoints or operations
+    - Error:    Removed required parameters, incompatible type changes
+    - Warning:  Deprecated operations, added required fields
+    - Info:     Additions, relaxed constraints, documentation updates
+
+Examples:
+  oastools diff api-v1.yaml api-v2.yaml
+  oastools diff --breaking api-v1.yaml api-v2.yaml
+  oastools diff --breaking --no-info old.yaml new.yaml
+  oastools diff --format json --breaking api-v1.yaml api-v2.yaml | jq '.HasBreakingChanges'
+  oastools diff https://example.com/api/v1.yaml https://example.com/api/v2.yaml
+  oastools diff -s api-v1.yaml api-v2.yaml  # Include line numbers in changes
+
+Exit Status:
+  0    No differences found (or no breaking changes in --breaking mode)
+  1    Differences found (or breaking changes found in --breaking mode)
+
+Notes:
+  - Both specifications must be valid OpenAPI documents
+  - Cross-version comparison (2.0 vs 3.x) is supported with limitations
+  - Breaking change detection helps identify backward compatibility issues
+Usage: oastools diff [flags] <source> <target>
+
+Compare two OpenAPI specification files or URLs and report differences.
+
+Flags:
+  -breaking
+    	enable breaking change detection and categorization
+  -format string
+    	output format: text, json, or yaml (default "text")
+  -no-info
+    	exclude informational changes from output
+  -s	include line numbers in diff output (IDE-friendly format)
+  -source-map
+    	include line numbers in diff output (IDE-friendly format)
+
+Output Formats:
+  text (default)  Human-readable text output
+  json            JSON format for programmatic processing
+  yaml            YAML format for programmatic processing
+
+Modes:
+  Default (Simple):
+    Reports all semantic differences between specifications without
+    categorizing them by severity or breaking change impact.
+
+  --breaking (Breaking Change Detection):
+    Categorizes changes by severity and identifies breaking API changes:
+    - Critical: Removed endpoints or operations
+    - Error:    Removed required parameters, incompatible type changes
+    - Warning:  Deprecated operations, added required fields
+    - Info:     Additions, relaxed constraints, documentation updates
+
+Examples:
+  oastools diff api-v1.yaml api-v2.yaml
+  oastools diff --breaking api-v1.yaml api-v2.yaml
+  oastools diff --breaking --no-info old.yaml new.yaml
+  oastools diff --format json --breaking api-v1.yaml api-v2.yaml | jq '.HasBreakingChanges'
+  oastools diff https://example.com/api/v1.yaml https://example.com/api/v2.yaml
+  oastools diff -s api-v1.yaml api-v2.yaml  # Include line numbers in changes
+
+Exit Status:
+  0    No differences found (or no breaking changes in --breaking mode)
+  1    Differences found (or breaking changes found in --breaking mode)
+
+Notes:
+  - Both specifications must be valid OpenAPI documents
+  - Cross-version comparison (2.0 vs 3.x) is supported with limitations
+  - Breaking change detection helps identify backward compatibility issues
+Usage: oastools diff [flags] <source> <target>
+
+Compare two OpenAPI specification files or URLs and report differences.
+
+Flags:
+  -breaking
+    	enable breaking change detection and categorization
+  -format string
+    	output format: text, json, or yaml (default "text")
+  -no-info
+    	exclude informational changes from output
+  -s	include line numbers in diff output (IDE-friendly format)
+  -source-map
+    	include line numbers in diff output (IDE-friendly format)
+
+Output Formats:
+  text (default)  Human-readable text output
+  json            JSON format for programmatic processing
+  yaml            YAML format for programmatic processing
+
+Modes:
+  Default (Simple):
+    Reports all semantic differences between specifications without
+    categorizing them by severity or breaking change impact.
+
+  --breaking (Breaking Change Detection):
+    Categorizes changes by severity and identifies breaking API changes:
+    - Critical: Removed endpoints or operations
+    - Error:    Removed required parameters, incompatible type changes
+    - Warning:  Deprecated operations, added required fields
+    - Info:     Additions, relaxed constraints, documentation updates
+
+Examples:
+  oastools diff api-v1.yaml api-v2.yaml
+  oastools diff --breaking api-v1.yaml api-v2.yaml
+  oastools diff --breaking --no-info old.yaml new.yaml
+  oastools diff --format json --breaking api-v1.yaml api-v2.yaml | jq '.HasBreakingChanges'
+  oastools diff https://example.com/api/v1.yaml https://example.com/api/v2.yaml
+  oastools diff -s api-v1.yaml api-v2.yaml  # Include line numbers in changes
+
+Exit Status:
+  0    No differences found (or no breaking changes in --breaking mode)
+  1    Differences found (or breaking changes found in --breaking mode)
+
+Notes:
+  - Both specifications must be valid OpenAPI documents
+  - Cross-version comparison (2.0 vs 3.x) is supported with limitations
+  - Breaking change detection helps identify backward compatibility issues
+Usage: oastools fix [flags] <file|url|->
+
+Apply automatic fixes to common OpenAPI specification issues.
+
+Flags:
+  -dry-run
+    	preview changes without modifying the document
+  -fix-schema-names
+    	fix invalid schema names (brackets, special characters)
+  -generic-naming string
+    	strategy for renaming generic types: underscore, of, for, flat, dot (default "underscore")
+  -generic-param-separator string
+    	separator between multiple type parameters (default "_")
+  -generic-separator string
+    	separator for underscore strategy (default "_")
+  -infer
+    	infer parameter types from naming conventions
+  -o string
+    	output file path (default: stdout)
+  -output string
+    	output file path (default: stdout)
+  -preserve-casing
+    	preserve original casing of type parameters
+  -prune
+    	apply all pruning fixes (alias for --prune-all)
+  -prune-all
+    	apply all pruning fixes (schemas, paths)
+  -prune-paths
+    	remove paths with no operations
+  -prune-schemas
+    	remove unreferenced schema definitions
+  -q	quiet mode: only output the document, no diagnostic messages
+  -quiet
+    	quiet mode: only output the document, no diagnostic messages
+  -s	include line numbers in fix output (IDE-friendly format)
+  -source-map
+    	include line numbers in fix output (IDE-friendly format)
+
+Supported Fixes:
+  - Missing path parameters: Adds Parameter objects for path template
+    variables that are not declared in the operation's parameters list.
+    Default type is 'string'. Use --infer for smart type inference.
+  - Invalid schema names (--fix-schema-names): Renames schemas with
+    invalid characters (brackets, etc.) using configurable strategies.
+  - Prune schemas (--prune-schemas): Removes unreferenced schemas.
+  - Prune paths (--prune-paths): Removes paths with no operations.
+
+Type Inference (--infer):
+  - Names ending in 'id', 'Id', 'ID' -> integer
+  - Names containing 'uuid', 'guid' -> string with format uuid
+  - All other names -> string
+
+Generic Naming Strategies (--generic-naming):
+  underscore: Response[User] → Response_User_
+  of:         Response[User] → ResponseOfUser
+  for:        Response[User] → ResponseForUser
+  flat:       Response[User] → ResponseUser
+  dot:        Response[User] → Response.User
+
+Examples:
+  oastools fix openapi.yaml
+  oastools fix -o fixed.yaml openapi.yaml
+  oastools fix --infer openapi.yaml
+  oastools fix --fix-schema-names --generic-naming of api.yaml
+  oastools fix --prune-all api.yaml
+  oastools fix --dry-run --prune-schemas api.yaml
+  cat openapi.yaml | oastools fix -q - > fixed.yaml
+  oastools fix -s openapi.yaml  # Include line numbers in fixes
+
+Pipelining:
+  oastools fix -q api.yaml | oastools validate -q -
+  oastools fix -q --infer api.yaml | oastools convert -q -t 3.1.0 -
+
+Notes:
+  - Use 'oastools validate' to see validation errors before fixing
+  - Pruning fixes only run when explicitly requested via flags
+  - Use --dry-run to preview what would be changed
+  - Output preserves the original format (JSON or YAML)
+
+Exit Codes:
+  0    Fixes applied successfully (or no fixes needed)
+  1    Failed to parse or fix the specification
+Usage: oastools fix [flags] <file|url|->
+
+Apply automatic fixes to common OpenAPI specification issues.
+
+Flags:
+  -dry-run
+    	preview changes without modifying the document
+  -fix-schema-names
+    	fix invalid schema names (brackets, special characters)
+  -generic-naming string
+    	strategy for renaming generic types: underscore, of, for, flat, dot (default "underscore")
+  -generic-param-separator string
+    	separator between multiple type parameters (default "_")
+  -generic-separator string
+    	separator for underscore strategy (default "_")
+  -infer
+    	infer parameter types from naming conventions
+  -o string
+    	output file path (default: stdout)
+  -output string
+    	output file path (default: stdout)
+  -preserve-casing
+    	preserve original casing of type parameters
+  -prune
+    	apply all pruning fixes (alias for --prune-all)
+  -prune-all
+    	apply all pruning fixes (schemas, paths)
+  -prune-paths
+    	remove paths with no operations
+  -prune-schemas
+    	remove unreferenced schema definitions
+  -q	quiet mode: only output the document, no diagnostic messages
+  -quiet
+    	quiet mode: only output the document, no diagnostic messages
+  -s	include line numbers in fix output (IDE-friendly format)
+  -source-map
+    	include line numbers in fix output (IDE-friendly format)
+
+Supported Fixes:
+  - Missing path parameters: Adds Parameter objects for path template
+    variables that are not declared in the operation's parameters list.
+    Default type is 'string'. Use --infer for smart type inference.
+  - Invalid schema names (--fix-schema-names): Renames schemas with
+    invalid characters (brackets, etc.) using configurable strategies.
+  - Prune schemas (--prune-schemas): Removes unreferenced schemas.
+  - Prune paths (--prune-paths): Removes paths with no operations.
+
+Type Inference (--infer):
+  - Names ending in 'id', 'Id', 'ID' -> integer
+  - Names containing 'uuid', 'guid' -> string with format uuid
+  - All other names -> string
+
+Generic Naming Strategies (--generic-naming):
+  underscore: Response[User] → Response_User_
+  of:         Response[User] → ResponseOfUser
+  for:        Response[User] → ResponseForUser
+  flat:       Response[User] → ResponseUser
+  dot:        Response[User] → Response.User
+
+Examples:
+  oastools fix openapi.yaml
+  oastools fix -o fixed.yaml openapi.yaml
+  oastools fix --infer openapi.yaml
+  oastools fix --fix-schema-names --generic-naming of api.yaml
+  oastools fix --prune-all api.yaml
+  oastools fix --dry-run --prune-schemas api.yaml
+  cat openapi.yaml | oastools fix -q - > fixed.yaml
+  oastools fix -s openapi.yaml  # Include line numbers in fixes
+
+Pipelining:
+  oastools fix -q api.yaml | oastools validate -q -
+  oastools fix -q --infer api.yaml | oastools convert -q -t 3.1.0 -
+
+Notes:
+  - Use 'oastools validate' to see validation errors before fixing
+  - Pruning fixes only run when explicitly requested via flags
+  - Use --dry-run to preview what would be changed
+  - Output preserves the original format (JSON or YAML)
+
+Exit Codes:
+  0    Fixes applied successfully (or no fixes needed)
+  1    Failed to parse or fix the specification
+Usage: oastools generate [flags] <file|url|->
+
+Generate Go code from an OpenAPI specification.
+
+Flags:
+  -client
+    	generate HTTP client code
+  -credential-mgmt
+    	generate credential management interfaces
+  -max-lines-per-file int
+    	maximum lines per generated file (0 = no limit) (default 2000)
+  -max-ops-per-file int
+    	maximum operations per generated file (0 = no limit) (default 100)
+  -max-types-per-file int
+    	maximum types per generated file (0 = no limit) (default 200)
+  -no-pointers
+    	don't use pointer types for optional fields
+  -no-readme
+    	don't generate README.md file
+  -no-security
+    	don't generate security helper functions
+  -no-split-by-path
+    	don't split files by path prefix
+  -no-split-by-tag
+    	don't split files by operation tag
+  -no-validation
+    	don't include validation tags
+  -no-warnings
+    	suppress warning and info messages
+  -o string
+    	output directory for generated files (required)
+  -oauth2-flows
+    	generate OAuth2 token flow helpers
+  -oidc-discovery
+    	generate OpenID Connect discovery client
+  -output string
+    	output directory for generated files (required)
+  -p string
+    	Go package name for generated code (default "api")
+  -package string
+    	Go package name for generated code (default "api")
+  -s	include line numbers in generation issues (IDE-friendly format)
+  -security-enforce
+    	generate security enforcement middleware
+  -server
+    	generate server interface code
+  -source-map
+    	include line numbers in generation issues (IDE-friendly format)
+  -strict
+    	fail on any generation issues (even warnings)
+  -types
+    	generate type definitions from schemas (default true)
+
+Examples:
+  oastools generate --client -o ./client openapi.yaml
+  oastools generate --server -o ./server -p myapi openapi.yaml
+  oastools generate --client --server -o ./api petstore.yaml
+  oastools generate --types -o ./models https://example.com/api/openapi.yaml
+  oastools generate --client --oauth2-flows -o ./client openapi.yaml
+  oastools generate --client --credential-mgmt --security-enforce -o ./api openapi.yaml
+  oastools generate --client --max-lines-per-file 1500 -o ./client large-api.yaml
+  cat openapi.yaml | oastools generate --client -o ./client -
+  oastools generate -s --client -o ./client openapi.yaml  # Include line numbers in issues
+
+Pipelining:
+  Use '-' as the file path to read the OpenAPI specification from stdin.
+  Example: oastools convert -t 3.0.3 swagger.yaml | oastools generate --client -o ./client -
+
+Notes:
+  - At least one of --client, --server, or --types must be enabled
+  - Types are always generated when --client or --server is enabled
+  - Security helpers are generated by default when --client is enabled
+  - Generated code uses Go idioms and best practices
+  - Server interface is framework-agnostic
+Usage: oastools generate [flags] <file|url|->
+
+Generate Go code from an OpenAPI specification.
+
+Flags:
+  -client
+    	generate HTTP client code
+  -credential-mgmt
+    	generate credential management interfaces
+  -max-lines-per-file int
+    	maximum lines per generated file (0 = no limit) (default 2000)
+  -max-ops-per-file int
+    	maximum operations per generated file (0 = no limit) (default 100)
+  -max-types-per-file int
+    	maximum types per generated file (0 = no limit) (default 200)
+  -no-pointers
+    	don't use pointer types for optional fields
+  -no-readme
+    	don't generate README.md file
+  -no-security
+    	don't generate security helper functions
+  -no-split-by-path
+    	don't split files by path prefix
+  -no-split-by-tag
+    	don't split files by operation tag
+  -no-validation
+    	don't include validation tags
+  -no-warnings
+    	suppress warning and info messages
+  -o string
+    	output directory for generated files (required)
+  -oauth2-flows
+    	generate OAuth2 token flow helpers
+  -oidc-discovery
+    	generate OpenID Connect discovery client
+  -output string
+    	output directory for generated files (required)
+  -p string
+    	Go package name for generated code (default "api")
+  -package string
+    	Go package name for generated code (default "api")
+  -s	include line numbers in generation issues (IDE-friendly format)
+  -security-enforce
+    	generate security enforcement middleware
+  -server
+    	generate server interface code
+  -source-map
+    	include line numbers in generation issues (IDE-friendly format)
+  -strict
+    	fail on any generation issues (even warnings)
+  -types
+    	generate type definitions from schemas (default true)
+
+Examples:
+  oastools generate --client -o ./client openapi.yaml
+  oastools generate --server -o ./server -p myapi openapi.yaml
+  oastools generate --client --server -o ./api petstore.yaml
+  oastools generate --types -o ./models https://example.com/api/openapi.yaml
+  oastools generate --client --oauth2-flows -o ./client openapi.yaml
+  oastools generate --client --credential-mgmt --security-enforce -o ./api openapi.yaml
+  oastools generate --client --max-lines-per-file 1500 -o ./client large-api.yaml
+  cat openapi.yaml | oastools generate --client -o ./client -
+  oastools generate -s --client -o ./client openapi.yaml  # Include line numbers in issues
+
+Pipelining:
+  Use '-' as the file path to read the OpenAPI specification from stdin.
+  Example: oastools convert -t 3.0.3 swagger.yaml | oastools generate --client -o ./client -
+
+Notes:
+  - At least one of --client, --server, or --types must be enabled
+  - Types are always generated when --client or --server is enabled
+  - Security helpers are generated by default when --client is enabled
+  - Generated code uses Go idioms and best practices
+  - Server interface is framework-agnostic
+Usage: oastools generate [flags] <file|url|->
+
+Generate Go code from an OpenAPI specification.
+
+Flags:
+  -client
+    	generate HTTP client code
+  -credential-mgmt
+    	generate credential management interfaces
+  -max-lines-per-file int
+    	maximum lines per generated file (0 = no limit) (default 2000)
+  -max-ops-per-file int
+    	maximum operations per generated file (0 = no limit) (default 100)
+  -max-types-per-file int
+    	maximum types per generated file (0 = no limit) (default 200)
+  -no-pointers
+    	don't use pointer types for optional fields
+  -no-readme
+    	don't generate README.md file
+  -no-security
+    	don't generate security helper functions
+  -no-split-by-path
+    	don't split files by path prefix
+  -no-split-by-tag
+    	don't split files by operation tag
+  -no-validation
+    	don't include validation tags
+  -no-warnings
+    	suppress warning and info messages
+  -o string
+    	output directory for generated files (required)
+  -oauth2-flows
+    	generate OAuth2 token flow helpers
+  -oidc-discovery
+    	generate OpenID Connect discovery client
+  -output string
+    	output directory for generated files (required)
+  -p string
+    	Go package name for generated code (default "api")
+  -package string
+    	Go package name for generated code (default "api")
+  -s	include line numbers in generation issues (IDE-friendly format)
+  -security-enforce
+    	generate security enforcement middleware
+  -server
+    	generate server interface code
+  -source-map
+    	include line numbers in generation issues (IDE-friendly format)
+  -strict
+    	fail on any generation issues (even warnings)
+  -types
+    	generate type definitions from schemas (default true)
+
+Examples:
+  oastools generate --client -o ./client openapi.yaml
+  oastools generate --server -o ./server -p myapi openapi.yaml
+  oastools generate --client --server -o ./api petstore.yaml
+  oastools generate --types -o ./models https://example.com/api/openapi.yaml
+  oastools generate --client --oauth2-flows -o ./client openapi.yaml
+  oastools generate --client --credential-mgmt --security-enforce -o ./api openapi.yaml
+  oastools generate --client --max-lines-per-file 1500 -o ./client large-api.yaml
+  cat openapi.yaml | oastools generate --client -o ./client -
+  oastools generate -s --client -o ./client openapi.yaml  # Include line numbers in issues
+
+Pipelining:
+  Use '-' as the file path to read the OpenAPI specification from stdin.
+  Example: oastools convert -t 3.0.3 swagger.yaml | oastools generate --client -o ./client -
+
+Notes:
+  - At least one of --client, --server, or --types must be enabled
+  - Types are always generated when --client or --server is enabled
+  - Security helpers are generated by default when --client is enabled
+  - Generated code uses Go idioms and best practices
+  - Server interface is framework-agnostic
+Usage: oastools generate [flags] <file|url|->
+
+Generate Go code from an OpenAPI specification.
+
+Flags:
+  -client
+    	generate HTTP client code
+  -credential-mgmt
+    	generate credential management interfaces
+  -max-lines-per-file int
+    	maximum lines per generated file (0 = no limit) (default 2000)
+  -max-ops-per-file int
+    	maximum operations per generated file (0 = no limit) (default 100)
+  -max-types-per-file int
+    	maximum types per generated file (0 = no limit) (default 200)
+  -no-pointers
+    	don't use pointer types for optional fields
+  -no-readme
+    	don't generate README.md file
+  -no-security
+    	don't generate security helper functions
+  -no-split-by-path
+    	don't split files by path prefix
+  -no-split-by-tag
+    	don't split files by operation tag
+  -no-validation
+    	don't include validation tags
+  -no-warnings
+    	suppress warning and info messages
+  -o string
+    	output directory for generated files (required)
+  -oauth2-flows
+    	generate OAuth2 token flow helpers
+  -oidc-discovery
+    	generate OpenID Connect discovery client
+  -output string
+    	output directory for generated files (required)
+  -p string
+    	Go package name for generated code (default "api")
+  -package string
+    	Go package name for generated code (default "api")
+  -s	include line numbers in generation issues (IDE-friendly format)
+  -security-enforce
+    	generate security enforcement middleware
+  -server
+    	generate server interface code
+  -source-map
+    	include line numbers in generation issues (IDE-friendly format)
+  -strict
+    	fail on any generation issues (even warnings)
+  -types
+    	generate type definitions from schemas (default true)
+
+Examples:
+  oastools generate --client -o ./client openapi.yaml
+  oastools generate --server -o ./server -p myapi openapi.yaml
+  oastools generate --client --server -o ./api petstore.yaml
+  oastools generate --types -o ./models https://example.com/api/openapi.yaml
+  oastools generate --client --oauth2-flows -o ./client openapi.yaml
+  oastools generate --client --credential-mgmt --security-enforce -o ./api openapi.yaml
+  oastools generate --client --max-lines-per-file 1500 -o ./client large-api.yaml
+  cat openapi.yaml | oastools generate --client -o ./client -
+  oastools generate -s --client -o ./client openapi.yaml  # Include line numbers in issues
+
+Pipelining:
+  Use '-' as the file path to read the OpenAPI specification from stdin.
+  Example: oastools convert -t 3.0.3 swagger.yaml | oastools generate --client -o ./client -
+
+Notes:
+  - At least one of --client, --server, or --types must be enabled
+  - Types are always generated when --client or --server is enabled
+  - Security helpers are generated by default when --client is enabled
+  - Generated code uses Go idioms and best practices
+  - Server interface is framework-agnostic
+Usage: oastools join [flags] <file1> <file2> [file3...]
+
+Join multiple OpenAPI specification files into a single document.
+
+Flags:
+  -always-prefix
+    	apply namespace prefix to all schemas, not just on collision
+  -collision-report
+    	generate detailed collision analysis report
+  -component-strategy string
+    	collision strategy for other components
+  -equivalence-mode string
+    	schema comparison mode for deduplication (none, shallow, deep) (default "none")
+  -namespace-prefix value
+    	namespace prefix for source file (format: source=prefix, can be repeated)
+  -no-dedup-tags
+    	don't deduplicate tags by name
+  -no-merge-arrays
+    	don't merge arrays (servers, security, etc.)
+  -o string
+    	output file path (default: stdout)
+  -output string
+    	output file path (default: stdout)
+  -path-strategy string
+    	collision strategy for paths (accept-left, accept-right, fail, fail-on-paths)
+  -q	quiet mode: suppress diagnostic messages (for pipelining)
+  -quiet
+    	quiet mode: suppress diagnostic messages (for pipelining)
+  -rename-template string
+    	template for renamed schema names (default "{{.Name}}_{{.Source}}")
+  -s	include line numbers in collision warnings (IDE-friendly format)
+  -schema-strategy string
+    	collision strategy for schemas (accept-left, accept-right, rename-left, rename-right, deduplicate, fail)
+  -semantic-dedup
+    	enable semantic deduplication to consolidate identical schemas
+  -source-map
+    	include line numbers in collision warnings (IDE-friendly format)
+
+Collision Strategies:
+  accept-left      Keep the first value when collisions occur
+  accept-right     Keep the last value when collisions occur (overwrite)
+  rename-left      Rename left schema, keep right under original name
+  rename-right     Rename right schema, keep left under original name
+  deduplicate      Merge structurally identical schemas (requires equivalence-mode)
+  fail             Fail with an error on any collision
+  fail-on-paths    Fail only on path collisions, allow schema collisions
+
+Namespace Prefixes:
+  Use --namespace-prefix to add source-based prefixes to schema names.
+  Format: source=prefix (can be specified multiple times)
+  By default, prefix is only applied on collision. Use --always-prefix to
+  apply namespace prefixes to all schemas from the configured sources.
+
+Examples:
+  oastools join -o merged.yaml base.yaml extensions.yaml
+  oastools join --path-strategy accept-left -o api.yaml spec1.yaml spec2.yaml
+  oastools join --schema-strategy accept-right -o output.yaml api1.yaml api2.yaml api3.yaml
+  oastools join --namespace-prefix users.yaml=Users --namespace-prefix billing.yaml=Billing -o merged.yaml users.yaml billing.yaml
+  oastools join --namespace-prefix api2.yaml=V2 --always-prefix -o merged.yaml api1.yaml api2.yaml
+  oastools join -s -o merged.yaml api1.yaml api2.yaml  # Include line numbers in warnings
+
+Pipelining:
+  oastools join -q base.yaml ext.yaml | oastools validate -q -
+  oastools join -q spec1.yaml spec2.yaml | oastools convert -q -t 3.1.0 -
+
+Notes:
+  - All input files must be the same major OAS version (2.0 or 3.x)
+  - The output will use the version of the first input file
+  - Info section is taken from the first document by default
+  - When -o is specified, file is written with restrictive permissions (0600)
+Usage: oastools join [flags] <file1> <file2> [file3...]
+
+Join multiple OpenAPI specification files into a single document.
+
+Flags:
+  -always-prefix
+    	apply namespace prefix to all schemas, not just on collision
+  -collision-report
+    	generate detailed collision analysis report
+  -component-strategy string
+    	collision strategy for other components
+  -equivalence-mode string
+    	schema comparison mode for deduplication (none, shallow, deep) (default "none")
+  -namespace-prefix value
+    	namespace prefix for source file (format: source=prefix, can be repeated)
+  -no-dedup-tags
+    	don't deduplicate tags by name
+  -no-merge-arrays
+    	don't merge arrays (servers, security, etc.)
+  -o string
+    	output file path (default: stdout)
+  -output string
+    	output file path (default: stdout)
+  -path-strategy string
+    	collision strategy for paths (accept-left, accept-right, fail, fail-on-paths)
+  -q	quiet mode: suppress diagnostic messages (for pipelining)
+  -quiet
+    	quiet mode: suppress diagnostic messages (for pipelining)
+  -rename-template string
+    	template for renamed schema names (default "{{.Name}}_{{.Source}}")
+  -s	include line numbers in collision warnings (IDE-friendly format)
+  -schema-strategy string
+    	collision strategy for schemas (accept-left, accept-right, rename-left, rename-right, deduplicate, fail)
+  -semantic-dedup
+    	enable semantic deduplication to consolidate identical schemas
+  -source-map
+    	include line numbers in collision warnings (IDE-friendly format)
+
+Collision Strategies:
+  accept-left      Keep the first value when collisions occur
+  accept-right     Keep the last value when collisions occur (overwrite)
+  rename-left      Rename left schema, keep right under original name
+  rename-right     Rename right schema, keep left under original name
+  deduplicate      Merge structurally identical schemas (requires equivalence-mode)
+  fail             Fail with an error on any collision
+  fail-on-paths    Fail only on path collisions, allow schema collisions
+
+Namespace Prefixes:
+  Use --namespace-prefix to add source-based prefixes to schema names.
+  Format: source=prefix (can be specified multiple times)
+  By default, prefix is only applied on collision. Use --always-prefix to
+  apply namespace prefixes to all schemas from the configured sources.
+
+Examples:
+  oastools join -o merged.yaml base.yaml extensions.yaml
+  oastools join --path-strategy accept-left -o api.yaml spec1.yaml spec2.yaml
+  oastools join --schema-strategy accept-right -o output.yaml api1.yaml api2.yaml api3.yaml
+  oastools join --namespace-prefix users.yaml=Users --namespace-prefix billing.yaml=Billing -o merged.yaml users.yaml billing.yaml
+  oastools join --namespace-prefix api2.yaml=V2 --always-prefix -o merged.yaml api1.yaml api2.yaml
+  oastools join -s -o merged.yaml api1.yaml api2.yaml  # Include line numbers in warnings
+
+Pipelining:
+  oastools join -q base.yaml ext.yaml | oastools validate -q -
+  oastools join -q spec1.yaml spec2.yaml | oastools convert -q -t 3.1.0 -
+
+Notes:
+  - All input files must be the same major OAS version (2.0 or 3.x)
+  - The output will use the version of the first input file
+  - Info section is taken from the first document by default
+  - When -o is specified, file is written with restrictive permissions (0600)
+invalid value "invalid" for flag -namespace-prefix: invalid namespace prefix format: "invalid" (expected source=prefix)
+Usage: oastools join [flags] <file1> <file2> [file3...]
+
+Join multiple OpenAPI specification files into a single document.
+
+Flags:
+  -always-prefix
+    	apply namespace prefix to all schemas, not just on collision
+  -collision-report
+    	generate detailed collision analysis report
+  -component-strategy string
+    	collision strategy for other components
+  -equivalence-mode string
+    	schema comparison mode for deduplication (none, shallow, deep) (default "none")
+  -namespace-prefix value
+    	namespace prefix for source file (format: source=prefix, can be repeated)
+  -no-dedup-tags
+    	don't deduplicate tags by name
+  -no-merge-arrays
+    	don't merge arrays (servers, security, etc.)
+  -o string
+    	output file path (default: stdout)
+  -output string
+    	output file path (default: stdout)
+  -path-strategy string
+    	collision strategy for paths (accept-left, accept-right, fail, fail-on-paths)
+  -q	quiet mode: suppress diagnostic messages (for pipelining)
+  -quiet
+    	quiet mode: suppress diagnostic messages (for pipelining)
+  -rename-template string
+    	template for renamed schema names (default "{{.Name}}_{{.Source}}")
+  -s	include line numbers in collision warnings (IDE-friendly format)
+  -schema-strategy string
+    	collision strategy for schemas (accept-left, accept-right, rename-left, rename-right, deduplicate, fail)
+  -semantic-dedup
+    	enable semantic deduplication to consolidate identical schemas
+  -source-map
+    	include line numbers in collision warnings (IDE-friendly format)
+
+Collision Strategies:
+  accept-left      Keep the first value when collisions occur
+  accept-right     Keep the last value when collisions occur (overwrite)
+  rename-left      Rename left schema, keep right under original name
+  rename-right     Rename right schema, keep left under original name
+  deduplicate      Merge structurally identical schemas (requires equivalence-mode)
+  fail             Fail with an error on any collision
+  fail-on-paths    Fail only on path collisions, allow schema collisions
+
+Namespace Prefixes:
+  Use --namespace-prefix to add source-based prefixes to schema names.
+  Format: source=prefix (can be specified multiple times)
+  By default, prefix is only applied on collision. Use --always-prefix to
+  apply namespace prefixes to all schemas from the configured sources.
+
+Examples:
+  oastools join -o merged.yaml base.yaml extensions.yaml
+  oastools join --path-strategy accept-left -o api.yaml spec1.yaml spec2.yaml
+  oastools join --schema-strategy accept-right -o output.yaml api1.yaml api2.yaml api3.yaml
+  oastools join --namespace-prefix users.yaml=Users --namespace-prefix billing.yaml=Billing -o merged.yaml users.yaml billing.yaml
+  oastools join --namespace-prefix api2.yaml=V2 --always-prefix -o merged.yaml api1.yaml api2.yaml
+  oastools join -s -o merged.yaml api1.yaml api2.yaml  # Include line numbers in warnings
+
+Pipelining:
+  oastools join -q base.yaml ext.yaml | oastools validate -q -
+  oastools join -q spec1.yaml spec2.yaml | oastools convert -q -t 3.1.0 -
+
+Notes:
+  - All input files must be the same major OAS version (2.0 or 3.x)
+  - The output will use the version of the first input file
+  - Info section is taken from the first document by default
+  - When -o is specified, file is written with restrictive permissions (0600)
+invalid value "=Prefix" for flag -namespace-prefix: namespace prefix requires non-empty source and prefix: "=Prefix"
+Usage: oastools join [flags] <file1> <file2> [file3...]
+
+Join multiple OpenAPI specification files into a single document.
+
+Flags:
+  -always-prefix
+    	apply namespace prefix to all schemas, not just on collision
+  -collision-report
+    	generate detailed collision analysis report
+  -component-strategy string
+    	collision strategy for other components
+  -equivalence-mode string
+    	schema comparison mode for deduplication (none, shallow, deep) (default "none")
+  -namespace-prefix value
+    	namespace prefix for source file (format: source=prefix, can be repeated)
+  -no-dedup-tags
+    	don't deduplicate tags by name
+  -no-merge-arrays
+    	don't merge arrays (servers, security, etc.)
+  -o string
+    	output file path (default: stdout)
+  -output string
+    	output file path (default: stdout)
+  -path-strategy string
+    	collision strategy for paths (accept-left, accept-right, fail, fail-on-paths)
+  -q	quiet mode: suppress diagnostic messages (for pipelining)
+  -quiet
+    	quiet mode: suppress diagnostic messages (for pipelining)
+  -rename-template string
+    	template for renamed schema names (default "{{.Name}}_{{.Source}}")
+  -s	include line numbers in collision warnings (IDE-friendly format)
+  -schema-strategy string
+    	collision strategy for schemas (accept-left, accept-right, rename-left, rename-right, deduplicate, fail)
+  -semantic-dedup
+    	enable semantic deduplication to consolidate identical schemas
+  -source-map
+    	include line numbers in collision warnings (IDE-friendly format)
+
+Collision Strategies:
+  accept-left      Keep the first value when collisions occur
+  accept-right     Keep the last value when collisions occur (overwrite)
+  rename-left      Rename left schema, keep right under original name
+  rename-right     Rename right schema, keep left under original name
+  deduplicate      Merge structurally identical schemas (requires equivalence-mode)
+  fail             Fail with an error on any collision
+  fail-on-paths    Fail only on path collisions, allow schema collisions
+
+Namespace Prefixes:
+  Use --namespace-prefix to add source-based prefixes to schema names.
+  Format: source=prefix (can be specified multiple times)
+  By default, prefix is only applied on collision. Use --always-prefix to
+  apply namespace prefixes to all schemas from the configured sources.
+
+Examples:
+  oastools join -o merged.yaml base.yaml extensions.yaml
+  oastools join --path-strategy accept-left -o api.yaml spec1.yaml spec2.yaml
+  oastools join --schema-strategy accept-right -o output.yaml api1.yaml api2.yaml api3.yaml
+  oastools join --namespace-prefix users.yaml=Users --namespace-prefix billing.yaml=Billing -o merged.yaml users.yaml billing.yaml
+  oastools join --namespace-prefix api2.yaml=V2 --always-prefix -o merged.yaml api1.yaml api2.yaml
+  oastools join -s -o merged.yaml api1.yaml api2.yaml  # Include line numbers in warnings
+
+Pipelining:
+  oastools join -q base.yaml ext.yaml | oastools validate -q -
+  oastools join -q spec1.yaml spec2.yaml | oastools convert -q -t 3.1.0 -
+
+Notes:
+  - All input files must be the same major OAS version (2.0 or 3.x)
+  - The output will use the version of the first input file
+  - Info section is taken from the first document by default
+  - When -o is specified, file is written with restrictive permissions (0600)
+invalid value "api.yaml=" for flag -namespace-prefix: namespace prefix requires non-empty source and prefix: "api.yaml="
+Usage: oastools join [flags] <file1> <file2> [file3...]
+
+Join multiple OpenAPI specification files into a single document.
+
+Flags:
+  -always-prefix
+    	apply namespace prefix to all schemas, not just on collision
+  -collision-report
+    	generate detailed collision analysis report
+  -component-strategy string
+    	collision strategy for other components
+  -equivalence-mode string
+    	schema comparison mode for deduplication (none, shallow, deep) (default "none")
+  -namespace-prefix value
+    	namespace prefix for source file (format: source=prefix, can be repeated)
+  -no-dedup-tags
+    	don't deduplicate tags by name
+  -no-merge-arrays
+    	don't merge arrays (servers, security, etc.)
+  -o string
+    	output file path (default: stdout)
+  -output string
+    	output file path (default: stdout)
+  -path-strategy string
+    	collision strategy for paths (accept-left, accept-right, fail, fail-on-paths)
+  -q	quiet mode: suppress diagnostic messages (for pipelining)
+  -quiet
+    	quiet mode: suppress diagnostic messages (for pipelining)
+  -rename-template string
+    	template for renamed schema names (default "{{.Name}}_{{.Source}}")
+  -s	include line numbers in collision warnings (IDE-friendly format)
+  -schema-strategy string
+    	collision strategy for schemas (accept-left, accept-right, rename-left, rename-right, deduplicate, fail)
+  -semantic-dedup
+    	enable semantic deduplication to consolidate identical schemas
+  -source-map
+    	include line numbers in collision warnings (IDE-friendly format)
+
+Collision Strategies:
+  accept-left      Keep the first value when collisions occur
+  accept-right     Keep the last value when collisions occur (overwrite)
+  rename-left      Rename left schema, keep right under original name
+  rename-right     Rename right schema, keep left under original name
+  deduplicate      Merge structurally identical schemas (requires equivalence-mode)
+  fail             Fail with an error on any collision
+  fail-on-paths    Fail only on path collisions, allow schema collisions
+
+Namespace Prefixes:
+  Use --namespace-prefix to add source-based prefixes to schema names.
+  Format: source=prefix (can be specified multiple times)
+  By default, prefix is only applied on collision. Use --always-prefix to
+  apply namespace prefixes to all schemas from the configured sources.
+
+Examples:
+  oastools join -o merged.yaml base.yaml extensions.yaml
+  oastools join --path-strategy accept-left -o api.yaml spec1.yaml spec2.yaml
+  oastools join --schema-strategy accept-right -o output.yaml api1.yaml api2.yaml api3.yaml
+  oastools join --namespace-prefix users.yaml=Users --namespace-prefix billing.yaml=Billing -o merged.yaml users.yaml billing.yaml
+  oastools join --namespace-prefix api2.yaml=V2 --always-prefix -o merged.yaml api1.yaml api2.yaml
+  oastools join -s -o merged.yaml api1.yaml api2.yaml  # Include line numbers in warnings
+
+Pipelining:
+  oastools join -q base.yaml ext.yaml | oastools validate -q -
+  oastools join -q spec1.yaml spec2.yaml | oastools convert -q -t 3.1.0 -
+
+Notes:
+  - All input files must be the same major OAS version (2.0 or 3.x)
+  - The output will use the version of the first input file
+  - Info section is taken from the first document by default
+  - When -o is specified, file is written with restrictive permissions (0600)
+Usage: oastools parse [flags] <file|url|->
+
+Parse and output OpenAPI document structure.
+
+Flags:
+  -insecure
+    	disable TLS certificate verification for HTTPS refs
+  -q	quiet mode: only output the document, no diagnostic messages
+  -quiet
+    	quiet mode: only output the document, no diagnostic messages
+  -resolve-http-refs
+    	resolve HTTP/HTTPS $ref URLs (requires --resolve-refs)
+  -resolve-refs
+    	resolve external $ref references
+  -validate-structure
+    	validate document structure during parsing
+
+Examples:
+  oastools parse openapi.yaml
+  oastools parse --resolve-refs openapi.yaml
+  oastools parse --resolve-refs --resolve-http-refs https://example.com/api/openapi.yaml
+  oastools parse --resolve-refs --resolve-http-refs --insecure https://internal-server/api.yaml
+  oastools parse --validate-structure https://example.com/api/openapi.yaml
+  cat openapi.yaml | oastools parse -q -
+
+HTTP Reference Resolution:
+  --resolve-http-refs enables fetching and resolving $refs that point to HTTP/HTTPS URLs.
+  This is disabled by default for security (SSRF protection).
+  Use --insecure to skip TLS certificate verification for self-signed certs.
+
+Pipelining:
+  - Use '-' as the file path to read from stdin
+  - Use --quiet/-q to suppress diagnostic output for pipelining
+
+Exit Codes:
+  0    Parsing successful
+  1    Parsing failed or validation errors found (with --validate-structure)
+Usage: oastools parse [flags] <file|url|->
+
+Parse and output OpenAPI document structure.
+
+Flags:
+  -insecure
+    	disable TLS certificate verification for HTTPS refs
+  -q	quiet mode: only output the document, no diagnostic messages
+  -quiet
+    	quiet mode: only output the document, no diagnostic messages
+  -resolve-http-refs
+    	resolve HTTP/HTTPS $ref URLs (requires --resolve-refs)
+  -resolve-refs
+    	resolve external $ref references
+  -validate-structure
+    	validate document structure during parsing
+
+Examples:
+  oastools parse openapi.yaml
+  oastools parse --resolve-refs openapi.yaml
+  oastools parse --resolve-refs --resolve-http-refs https://example.com/api/openapi.yaml
+  oastools parse --resolve-refs --resolve-http-refs --insecure https://internal-server/api.yaml
+  oastools parse --validate-structure https://example.com/api/openapi.yaml
+  cat openapi.yaml | oastools parse -q -
+
+HTTP Reference Resolution:
+  --resolve-http-refs enables fetching and resolving $refs that point to HTTP/HTTPS URLs.
+  This is disabled by default for security (SSRF protection).
+  Use --insecure to skip TLS certificate verification for self-signed certs.
+
+Pipelining:
+  - Use '-' as the file path to read from stdin
+  - Use --quiet/-q to suppress diagnostic output for pipelining
+
+Exit Codes:
+  0    Parsing successful
+  1    Parsing failed or validation errors found (with --validate-structure)
+Usage: oastools validate [flags] <file|url|->
+
+Validate an OpenAPI specification file, URL, or stdin against the specification version it declares.
+
+Flags:
+  -format string
+    	output format: text, json, or yaml (default "text")
+  -no-warnings
+    	suppress warning messages (only show errors)
+  -q	quiet mode: only output validation result, no diagnostic messages
+  -quiet
+    	quiet mode: only output validation result, no diagnostic messages
+  -s	include line numbers in validation errors (IDE-friendly format)
+  -source-map
+    	include line numbers in validation errors (IDE-friendly format)
+  -strict
+    	enable stricter validation beyond spec requirements
+
+Output Formats:
+  text (default)  Human-readable text output
+  json            JSON format for programmatic processing
+  yaml            YAML format for programmatic processing
+
+Examples:
+  oastools validate openapi.yaml
+  oastools validate https://example.com/api/openapi.yaml
+  oastools validate --strict api-spec.yaml
+  oastools validate --no-warnings openapi.json
+  cat openapi.yaml | oastools validate -q -
+  oastools validate --format json openapi.yaml | jq '.valid'
+  oastools validate -s openapi.yaml  # Include line numbers in errors
+
+Pipelining:
+  - Use '-' as the file path to read from stdin
+  - Use --quiet/-q to suppress diagnostic output for pipelining
+  - Use --format json/yaml for structured output that can be parsed
+
+Exit Codes:
+  0    Validation successful
+  1    Validation failed with errors
+Usage: oastools validate [flags] <file|url|->
+
+Validate an OpenAPI specification file, URL, or stdin against the specification version it declares.
+
+Flags:
+  -format string
+    	output format: text, json, or yaml (default "text")
+  -no-warnings
+    	suppress warning messages (only show errors)
+  -q	quiet mode: only output validation result, no diagnostic messages
+  -quiet
+    	quiet mode: only output validation result, no diagnostic messages
+  -s	include line numbers in validation errors (IDE-friendly format)
+  -source-map
+    	include line numbers in validation errors (IDE-friendly format)
+  -strict
+    	enable stricter validation beyond spec requirements
+
+Output Formats:
+  text (default)  Human-readable text output
+  json            JSON format for programmatic processing
+  yaml            YAML format for programmatic processing
+
+Examples:
+  oastools validate openapi.yaml
+  oastools validate https://example.com/api/openapi.yaml
+  oastools validate --strict api-spec.yaml
+  oastools validate --no-warnings openapi.json
+  cat openapi.yaml | oastools validate -q -
+  oastools validate --format json openapi.yaml | jq '.valid'
+  oastools validate -s openapi.yaml  # Include line numbers in errors
+
+Pipelining:
+  - Use '-' as the file path to read from stdin
+  - Use --quiet/-q to suppress diagnostic output for pipelining
+  - Use --format json/yaml for structured output that can be parsed
+
+Exit Codes:
+  0    Validation successful
+  1    Validation failed with errors
+Usage: oastools convert [flags] <file|url|->
+
+Convert an OpenAPI specification from one version to another.
+
+Flags:
+  -no-warnings
+    	suppress warning and info messages
+  -o string
+    	output file path (default: stdout)
+  -output string
+    	output file path (default: stdout)
+  -q	quiet mode: only output the document, no diagnostic messages
+  -quiet
+    	quiet mode: only output the document, no diagnostic messages
+  -s	include line numbers in conversion issues (IDE-friendly format)
+  -source-map
+    	include line numbers in conversion issues (IDE-friendly format)
+  -strict
+    	fail on any conversion issues (even warnings)
+  -t string
+    	target OAS version (e.g., "3.0.3", "2.0", "3.1.0") (required)
+  -target string
+    	target OAS version (e.g., "3.0.3", "2.0", "3.1.0") (required)
+
+Supported Conversions:
+  - OAS 2.0 → OAS 3.x (3.0.0 through 3.2.0)
+  - OAS 3.x → OAS 2.0
+  - OAS 3.x → OAS 3.y (version updates)
+
+Examples:
+  oastools convert -t 3.0.3 swagger.yaml -o openapi.yaml
+  oastools convert -t 3.0.3 https://example.com/swagger.yaml -o openapi.yaml
+  oastools convert -t 2.0 openapi-v3.yaml
+  oastools convert --strict -t 3.1.0 swagger.yaml -o openapi-v3.yaml
+  cat swagger.yaml | oastools convert -q -t 3.0.3 - > openapi.yaml
+  oastools convert -s -t 3.0.3 swagger.yaml  # Include line numbers in issues
+
+Pipelining:
+  - Use '-' as the file path to read from stdin
+  - Use --quiet/-q to suppress diagnostic output for pipelining
+
+Notes:
+  - Critical issues indicate features that cannot be converted (data loss)
+  - Warnings indicate lossy conversions or best-effort transformations
+  - Info messages provide context about conversion choices
+  - Always validate converted documents before deployment
+
+Exit Codes:
+  0    Conversion successful
+  1    Conversion failed or critical issues found (in --strict mode)
+Usage: oastools convert [flags] <file|url|->
+
+Convert an OpenAPI specification from one version to another.
+
+Flags:
+  -no-warnings
+    	suppress warning and info messages
+  -o string
+    	output file path (default: stdout)
+  -output string
+    	output file path (default: stdout)
+  -q	quiet mode: only output the document, no diagnostic messages
+  -quiet
+    	quiet mode: only output the document, no diagnostic messages
+  -s	include line numbers in conversion issues (IDE-friendly format)
+  -source-map
+    	include line numbers in conversion issues (IDE-friendly format)
+  -strict
+    	fail on any conversion issues (even warnings)
+  -t string
+    	target OAS version (e.g., "3.0.3", "2.0", "3.1.0") (required)
+  -target string
+    	target OAS version (e.g., "3.0.3", "2.0", "3.1.0") (required)
+
+Supported Conversions:
+  - OAS 2.0 → OAS 3.x (3.0.0 through 3.2.0)
+  - OAS 3.x → OAS 2.0
+  - OAS 3.x → OAS 3.y (version updates)
+
+Examples:
+  oastools convert -t 3.0.3 swagger.yaml -o openapi.yaml
+  oastools convert -t 3.0.3 https://example.com/swagger.yaml -o openapi.yaml
+  oastools convert -t 2.0 openapi-v3.yaml
+  oastools convert --strict -t 3.1.0 swagger.yaml -o openapi-v3.yaml
+  cat swagger.yaml | oastools convert -q -t 3.0.3 - > openapi.yaml
+  oastools convert -s -t 3.0.3 swagger.yaml  # Include line numbers in issues
+
+Pipelining:
+  - Use '-' as the file path to read from stdin
+  - Use --quiet/-q to suppress diagnostic output for pipelining
+
+Notes:
+  - Critical issues indicate features that cannot be converted (data loss)
+  - Warnings indicate lossy conversions or best-effort transformations
+  - Info messages provide context about conversion choices
+  - Always validate converted documents before deployment
+
+Exit Codes:
+  0    Conversion successful
+  1    Conversion failed or critical issues found (in --strict mode)
+Usage: oastools convert [flags] <file|url|->
+
+Convert an OpenAPI specification from one version to another.
+
+Flags:
+  -no-warnings
+    	suppress warning and info messages
+  -o string
+    	output file path (default: stdout)
+  -output string
+    	output file path (default: stdout)
+  -q	quiet mode: only output the document, no diagnostic messages
+  -quiet
+    	quiet mode: only output the document, no diagnostic messages
+  -s	include line numbers in conversion issues (IDE-friendly format)
+  -source-map
+    	include line numbers in conversion issues (IDE-friendly format)
+  -strict
+    	fail on any conversion issues (even warnings)
+  -t string
+    	target OAS version (e.g., "3.0.3", "2.0", "3.1.0") (required)
+  -target string
+    	target OAS version (e.g., "3.0.3", "2.0", "3.1.0") (required)
+
+Supported Conversions:
+  - OAS 2.0 → OAS 3.x (3.0.0 through 3.2.0)
+  - OAS 3.x → OAS 2.0
+  - OAS 3.x → OAS 3.y (version updates)
+
+Examples:
+  oastools convert -t 3.0.3 swagger.yaml -o openapi.yaml
+  oastools convert -t 3.0.3 https://example.com/swagger.yaml -o openapi.yaml
+  oastools convert -t 2.0 openapi-v3.yaml
+  oastools convert --strict -t 3.1.0 swagger.yaml -o openapi-v3.yaml
+  cat swagger.yaml | oastools convert -q -t 3.0.3 - > openapi.yaml
+  oastools convert -s -t 3.0.3 swagger.yaml  # Include line numbers in issues
+
+Pipelining:
+  - Use '-' as the file path to read from stdin
+  - Use --quiet/-q to suppress diagnostic output for pipelining
+
+Notes:
+  - Critical issues indicate features that cannot be converted (data loss)
+  - Warnings indicate lossy conversions or best-effort transformations
+  - Info messages provide context about conversion choices
+  - Always validate converted documents before deployment
+
+Exit Codes:
+  0    Conversion successful
+  1    Conversion failed or critical issues found (in --strict mode)
+Usage: oastools diff [flags] <source> <target>
+
+Compare two OpenAPI specification files or URLs and report differences.
+
+Flags:
+  -breaking
+    	enable breaking change detection and categorization
+  -format string
+    	output format: text, json, or yaml (default "text")
+  -no-info
+    	exclude informational changes from output
+  -s	include line numbers in diff output (IDE-friendly format)
+  -source-map
+    	include line numbers in diff output (IDE-friendly format)
+
+Output Formats:
+  text (default)  Human-readable text output
+  json            JSON format for programmatic processing
+  yaml            YAML format for programmatic processing
+
+Modes:
+  Default (Simple):
+    Reports all semantic differences between specifications without
+    categorizing them by severity or breaking change impact.
+
+  --breaking (Breaking Change Detection):
+    Categorizes changes by severity and identifies breaking API changes:
+    - Critical: Removed endpoints or operations
+    - Error:    Removed required parameters, incompatible type changes
+    - Warning:  Deprecated operations, added required fields
+    - Info:     Additions, relaxed constraints, documentation updates
+
+Examples:
+  oastools diff api-v1.yaml api-v2.yaml
+  oastools diff --breaking api-v1.yaml api-v2.yaml
+  oastools diff --breaking --no-info old.yaml new.yaml
+  oastools diff --format json --breaking api-v1.yaml api-v2.yaml | jq '.HasBreakingChanges'
+  oastools diff https://example.com/api/v1.yaml https://example.com/api/v2.yaml
+  oastools diff -s api-v1.yaml api-v2.yaml  # Include line numbers in changes
+
+Exit Status:
+  0    No differences found (or no breaking changes in --breaking mode)
+  1    Differences found (or breaking changes found in --breaking mode)
+
+Notes:
+  - Both specifications must be valid OpenAPI documents
+  - Cross-version comparison (2.0 vs 3.x) is supported with limitations
+  - Breaking change detection helps identify backward compatibility issues
+Usage: oastools diff [flags] <source> <target>
+
+Compare two OpenAPI specification files or URLs and report differences.
+
+Flags:
+  -breaking
+    	enable breaking change detection and categorization
+  -format string
+    	output format: text, json, or yaml (default "text")
+  -no-info
+    	exclude informational changes from output
+  -s	include line numbers in diff output (IDE-friendly format)
+  -source-map
+    	include line numbers in diff output (IDE-friendly format)
+
+Output Formats:
+  text (default)  Human-readable text output
+  json            JSON format for programmatic processing
+  yaml            YAML format for programmatic processing
+
+Modes:
+  Default (Simple):
+    Reports all semantic differences between specifications without
+    categorizing them by severity or breaking change impact.
+
+  --breaking (Breaking Change Detection):
+    Categorizes changes by severity and identifies breaking API changes:
+    - Critical: Removed endpoints or operations
+    - Error:    Removed required parameters, incompatible type changes
+    - Warning:  Deprecated operations, added required fields
+    - Info:     Additions, relaxed constraints, documentation updates
+
+Examples:
+  oastools diff api-v1.yaml api-v2.yaml
+  oastools diff --breaking api-v1.yaml api-v2.yaml
+  oastools diff --breaking --no-info old.yaml new.yaml
+  oastools diff --format json --breaking api-v1.yaml api-v2.yaml | jq '.HasBreakingChanges'
+  oastools diff https://example.com/api/v1.yaml https://example.com/api/v2.yaml
+  oastools diff -s api-v1.yaml api-v2.yaml  # Include line numbers in changes
+
+Exit Status:
+  0    No differences found (or no breaking changes in --breaking mode)
+  1    Differences found (or breaking changes found in --breaking mode)
+
+Notes:
+  - Both specifications must be valid OpenAPI documents
+  - Cross-version comparison (2.0 vs 3.x) is supported with limitations
+  - Breaking change detection helps identify backward compatibility issues
+Usage: oastools diff [flags] <source> <target>
+
+Compare two OpenAPI specification files or URLs and report differences.
+
+Flags:
+  -breaking
+    	enable breaking change detection and categorization
+  -format string
+    	output format: text, json, or yaml (default "text")
+  -no-info
+    	exclude informational changes from output
+  -s	include line numbers in diff output (IDE-friendly format)
+  -source-map
+    	include line numbers in diff output (IDE-friendly format)
+
+Output Formats:
+  text (default)  Human-readable text output
+  json            JSON format for programmatic processing
+  yaml            YAML format for programmatic processing
+
+Modes:
+  Default (Simple):
+    Reports all semantic differences between specifications without
+    categorizing them by severity or breaking change impact.
+
+  --breaking (Breaking Change Detection):
+    Categorizes changes by severity and identifies breaking API changes:
+    - Critical: Removed endpoints or operations
+    - Error:    Removed required parameters, incompatible type changes
+    - Warning:  Deprecated operations, added required fields
+    - Info:     Additions, relaxed constraints, documentation updates
+
+Examples:
+  oastools diff api-v1.yaml api-v2.yaml
+  oastools diff --breaking api-v1.yaml api-v2.yaml
+  oastools diff --breaking --no-info old.yaml new.yaml
+  oastools diff --format json --breaking api-v1.yaml api-v2.yaml | jq '.HasBreakingChanges'
+  oastools diff https://example.com/api/v1.yaml https://example.com/api/v2.yaml
+  oastools diff -s api-v1.yaml api-v2.yaml  # Include line numbers in changes
+
+Exit Status:
+  0    No differences found (or no breaking changes in --breaking mode)
+  1    Differences found (or breaking changes found in --breaking mode)
+
+Notes:
+  - Both specifications must be valid OpenAPI documents
+  - Cross-version comparison (2.0 vs 3.x) is supported with limitations
+  - Breaking change detection helps identify backward compatibility issues
+Usage: oastools fix [flags] <file|url|->
+
+Apply automatic fixes to common OpenAPI specification issues.
+
+Flags:
+  -dry-run
+    	preview changes without modifying the document
+  -fix-schema-names
+    	fix invalid schema names (brackets, special characters)
+  -generic-naming string
+    	strategy for renaming generic types: underscore, of, for, flat, dot (default "underscore")
+  -generic-param-separator string
+    	separator between multiple type parameters (default "_")
+  -generic-separator string
+    	separator for underscore strategy (default "_")
+  -infer
+    	infer parameter types from naming conventions
+  -o string
+    	output file path (default: stdout)
+  -output string
+    	output file path (default: stdout)
+  -preserve-casing
+    	preserve original casing of type parameters
+  -prune
+    	apply all pruning fixes (alias for --prune-all)
+  -prune-all
+    	apply all pruning fixes (schemas, paths)
+  -prune-paths
+    	remove paths with no operations
+  -prune-schemas
+    	remove unreferenced schema definitions
+  -q	quiet mode: only output the document, no diagnostic messages
+  -quiet
+    	quiet mode: only output the document, no diagnostic messages
+  -s	include line numbers in fix output (IDE-friendly format)
+  -source-map
+    	include line numbers in fix output (IDE-friendly format)
+
+Supported Fixes:
+  - Missing path parameters: Adds Parameter objects for path template
+    variables that are not declared in the operation's parameters list.
+    Default type is 'string'. Use --infer for smart type inference.
+  - Invalid schema names (--fix-schema-names): Renames schemas with
+    invalid characters (brackets, etc.) using configurable strategies.
+  - Prune schemas (--prune-schemas): Removes unreferenced schemas.
+  - Prune paths (--prune-paths): Removes paths with no operations.
+
+Type Inference (--infer):
+  - Names ending in 'id', 'Id', 'ID' -> integer
+  - Names containing 'uuid', 'guid' -> string with format uuid
+  - All other names -> string
+
+Generic Naming Strategies (--generic-naming):
+  underscore: Response[User] → Response_User_
+  of:         Response[User] → ResponseOfUser
+  for:        Response[User] → ResponseForUser
+  flat:       Response[User] → ResponseUser
+  dot:        Response[User] → Response.User
+
+Examples:
+  oastools fix openapi.yaml
+  oastools fix -o fixed.yaml openapi.yaml
+  oastools fix --infer openapi.yaml
+  oastools fix --fix-schema-names --generic-naming of api.yaml
+  oastools fix --prune-all api.yaml
+  oastools fix --dry-run --prune-schemas api.yaml
+  cat openapi.yaml | oastools fix -q - > fixed.yaml
+  oastools fix -s openapi.yaml  # Include line numbers in fixes
+
+Pipelining:
+  oastools fix -q api.yaml | oastools validate -q -
+  oastools fix -q --infer api.yaml | oastools convert -q -t 3.1.0 -
+
+Notes:
+  - Use 'oastools validate' to see validation errors before fixing
+  - Pruning fixes only run when explicitly requested via flags
+  - Use --dry-run to preview what would be changed
+  - Output preserves the original format (JSON or YAML)
+
+Exit Codes:
+  0    Fixes applied successfully (or no fixes needed)
+  1    Failed to parse or fix the specification
+Usage: oastools fix [flags] <file|url|->
+
+Apply automatic fixes to common OpenAPI specification issues.
+
+Flags:
+  -dry-run
+    	preview changes without modifying the document
+  -fix-schema-names
+    	fix invalid schema names (brackets, special characters)
+  -generic-naming string
+    	strategy for renaming generic types: underscore, of, for, flat, dot (default "underscore")
+  -generic-param-separator string
+    	separator between multiple type parameters (default "_")
+  -generic-separator string
+    	separator for underscore strategy (default "_")
+  -infer
+    	infer parameter types from naming conventions
+  -o string
+    	output file path (default: stdout)
+  -output string
+    	output file path (default: stdout)
+  -preserve-casing
+    	preserve original casing of type parameters
+  -prune
+    	apply all pruning fixes (alias for --prune-all)
+  -prune-all
+    	apply all pruning fixes (schemas, paths)
+  -prune-paths
+    	remove paths with no operations
+  -prune-schemas
+    	remove unreferenced schema definitions
+  -q	quiet mode: only output the document, no diagnostic messages
+  -quiet
+    	quiet mode: only output the document, no diagnostic messages
+  -s	include line numbers in fix output (IDE-friendly format)
+  -source-map
+    	include line numbers in fix output (IDE-friendly format)
+
+Supported Fixes:
+  - Missing path parameters: Adds Parameter objects for path template
+    variables that are not declared in the operation's parameters list.
+    Default type is 'string'. Use --infer for smart type inference.
+  - Invalid schema names (--fix-schema-names): Renames schemas with
+    invalid characters (brackets, etc.) using configurable strategies.
+  - Prune schemas (--prune-schemas): Removes unreferenced schemas.
+  - Prune paths (--prune-paths): Removes paths with no operations.
+
+Type Inference (--infer):
+  - Names ending in 'id', 'Id', 'ID' -> integer
+  - Names containing 'uuid', 'guid' -> string with format uuid
+  - All other names -> string
+
+Generic Naming Strategies (--generic-naming):
+  underscore: Response[User] → Response_User_
+  of:         Response[User] → ResponseOfUser
+  for:        Response[User] → ResponseForUser
+  flat:       Response[User] → ResponseUser
+  dot:        Response[User] → Response.User
+
+Examples:
+  oastools fix openapi.yaml
+  oastools fix -o fixed.yaml openapi.yaml
+  oastools fix --infer openapi.yaml
+  oastools fix --fix-schema-names --generic-naming of api.yaml
+  oastools fix --prune-all api.yaml
+  oastools fix --dry-run --prune-schemas api.yaml
+  cat openapi.yaml | oastools fix -q - > fixed.yaml
+  oastools fix -s openapi.yaml  # Include line numbers in fixes
+
+Pipelining:
+  oastools fix -q api.yaml | oastools validate -q -
+  oastools fix -q --infer api.yaml | oastools convert -q -t 3.1.0 -
+
+Notes:
+  - Use 'oastools validate' to see validation errors before fixing
+  - Pruning fixes only run when explicitly requested via flags
+  - Use --dry-run to preview what would be changed
+  - Output preserves the original format (JSON or YAML)
+
+Exit Codes:
+  0    Fixes applied successfully (or no fixes needed)
+  1    Failed to parse or fix the specification
+Usage: oastools generate [flags] <file|url|->
+
+Generate Go code from an OpenAPI specification.
+
+Flags:
+  -client
+    	generate HTTP client code
+  -credential-mgmt
+    	generate credential management interfaces
+  -max-lines-per-file int
+    	maximum lines per generated file (0 = no limit) (default 2000)
+  -max-ops-per-file int
+    	maximum operations per generated file (0 = no limit) (default 100)
+  -max-types-per-file int
+    	maximum types per generated file (0 = no limit) (default 200)
+  -no-pointers
+    	don't use pointer types for optional fields
+  -no-readme
+    	don't generate README.md file
+  -no-security
+    	don't generate security helper functions
+  -no-split-by-path
+    	don't split files by path prefix
+  -no-split-by-tag
+    	don't split files by operation tag
+  -no-validation
+    	don't include validation tags
+  -no-warnings
+    	suppress warning and info messages
+  -o string
+    	output directory for generated files (required)
+  -oauth2-flows
+    	generate OAuth2 token flow helpers
+  -oidc-discovery
+    	generate OpenID Connect discovery client
+  -output string
+    	output directory for generated files (required)
+  -p string
+    	Go package name for generated code (default "api")
+  -package string
+    	Go package name for generated code (default "api")
+  -s	include line numbers in generation issues (IDE-friendly format)
+  -security-enforce
+    	generate security enforcement middleware
+  -server
+    	generate server interface code
+  -source-map
+    	include line numbers in generation issues (IDE-friendly format)
+  -strict
+    	fail on any generation issues (even warnings)
+  -types
+    	generate type definitions from schemas (default true)
+
+Examples:
+  oastools generate --client -o ./client openapi.yaml
+  oastools generate --server -o ./server -p myapi openapi.yaml
+  oastools generate --client --server -o ./api petstore.yaml
+  oastools generate --types -o ./models https://example.com/api/openapi.yaml
+  oastools generate --client --oauth2-flows -o ./client openapi.yaml
+  oastools generate --client --credential-mgmt --security-enforce -o ./api openapi.yaml
+  oastools generate --client --max-lines-per-file 1500 -o ./client large-api.yaml
+  cat openapi.yaml | oastools generate --client -o ./client -
+  oastools generate -s --client -o ./client openapi.yaml  # Include line numbers in issues
+
+Pipelining:
+  Use '-' as the file path to read the OpenAPI specification from stdin.
+  Example: oastools convert -t 3.0.3 swagger.yaml | oastools generate --client -o ./client -
+
+Notes:
+  - At least one of --client, --server, or --types must be enabled
+  - Types are always generated when --client or --server is enabled
+  - Security helpers are generated by default when --client is enabled
+  - Generated code uses Go idioms and best practices
+  - Server interface is framework-agnostic
+Usage: oastools generate [flags] <file|url|->
+
+Generate Go code from an OpenAPI specification.
+
+Flags:
+  -client
+    	generate HTTP client code
+  -credential-mgmt
+    	generate credential management interfaces
+  -max-lines-per-file int
+    	maximum lines per generated file (0 = no limit) (default 2000)
+  -max-ops-per-file int
+    	maximum operations per generated file (0 = no limit) (default 100)
+  -max-types-per-file int
+    	maximum types per generated file (0 = no limit) (default 200)
+  -no-pointers
+    	don't use pointer types for optional fields
+  -no-readme
+    	don't generate README.md file
+  -no-security
+    	don't generate security helper functions
+  -no-split-by-path
+    	don't split files by path prefix
+  -no-split-by-tag
+    	don't split files by operation tag
+  -no-validation
+    	don't include validation tags
+  -no-warnings
+    	suppress warning and info messages
+  -o string
+    	output directory for generated files (required)
+  -oauth2-flows
+    	generate OAuth2 token flow helpers
+  -oidc-discovery
+    	generate OpenID Connect discovery client
+  -output string
+    	output directory for generated files (required)
+  -p string
+    	Go package name for generated code (default "api")
+  -package string
+    	Go package name for generated code (default "api")
+  -s	include line numbers in generation issues (IDE-friendly format)
+  -security-enforce
+    	generate security enforcement middleware
+  -server
+    	generate server interface code
+  -source-map
+    	include line numbers in generation issues (IDE-friendly format)
+  -strict
+    	fail on any generation issues (even warnings)
+  -types
+    	generate type definitions from schemas (default true)
+
+Examples:
+  oastools generate --client -o ./client openapi.yaml
+  oastools generate --server -o ./server -p myapi openapi.yaml
+  oastools generate --client --server -o ./api petstore.yaml
+  oastools generate --types -o ./models https://example.com/api/openapi.yaml
+  oastools generate --client --oauth2-flows -o ./client openapi.yaml
+  oastools generate --client --credential-mgmt --security-enforce -o ./api openapi.yaml
+  oastools generate --client --max-lines-per-file 1500 -o ./client large-api.yaml
+  cat openapi.yaml | oastools generate --client -o ./client -
+  oastools generate -s --client -o ./client openapi.yaml  # Include line numbers in issues
+
+Pipelining:
+  Use '-' as the file path to read the OpenAPI specification from stdin.
+  Example: oastools convert -t 3.0.3 swagger.yaml | oastools generate --client -o ./client -
+
+Notes:
+  - At least one of --client, --server, or --types must be enabled
+  - Types are always generated when --client or --server is enabled
+  - Security helpers are generated by default when --client is enabled
+  - Generated code uses Go idioms and best practices
+  - Server interface is framework-agnostic
+Usage: oastools generate [flags] <file|url|->
+
+Generate Go code from an OpenAPI specification.
+
+Flags:
+  -client
+    	generate HTTP client code
+  -credential-mgmt
+    	generate credential management interfaces
+  -max-lines-per-file int
+    	maximum lines per generated file (0 = no limit) (default 2000)
+  -max-ops-per-file int
+    	maximum operations per generated file (0 = no limit) (default 100)
+  -max-types-per-file int
+    	maximum types per generated file (0 = no limit) (default 200)
+  -no-pointers
+    	don't use pointer types for optional fields
+  -no-readme
+    	don't generate README.md file
+  -no-security
+    	don't generate security helper functions
+  -no-split-by-path
+    	don't split files by path prefix
+  -no-split-by-tag
+    	don't split files by operation tag
+  -no-validation
+    	don't include validation tags
+  -no-warnings
+    	suppress warning and info messages
+  -o string
+    	output directory for generated files (required)
+  -oauth2-flows
+    	generate OAuth2 token flow helpers
+  -oidc-discovery
+    	generate OpenID Connect discovery client
+  -output string
+    	output directory for generated files (required)
+  -p string
+    	Go package name for generated code (default "api")
+  -package string
+    	Go package name for generated code (default "api")
+  -s	include line numbers in generation issues (IDE-friendly format)
+  -security-enforce
+    	generate security enforcement middleware
+  -server
+    	generate server interface code
+  -source-map
+    	include line numbers in generation issues (IDE-friendly format)
+  -strict
+    	fail on any generation issues (even warnings)
+  -types
+    	generate type definitions from schemas (default true)
+
+Examples:
+  oastools generate --client -o ./client openapi.yaml
+  oastools generate --server -o ./server -p myapi openapi.yaml
+  oastools generate --client --server -o ./api petstore.yaml
+  oastools generate --types -o ./models https://example.com/api/openapi.yaml
+  oastools generate --client --oauth2-flows -o ./client openapi.yaml
+  oastools generate --client --credential-mgmt --security-enforce -o ./api openapi.yaml
+  oastools generate --client --max-lines-per-file 1500 -o ./client large-api.yaml
+  cat openapi.yaml | oastools generate --client -o ./client -
+  oastools generate -s --client -o ./client openapi.yaml  # Include line numbers in issues
+
+Pipelining:
+  Use '-' as the file path to read the OpenAPI specification from stdin.
+  Example: oastools convert -t 3.0.3 swagger.yaml | oastools generate --client -o ./client -
+
+Notes:
+  - At least one of --client, --server, or --types must be enabled
+  - Types are always generated when --client or --server is enabled
+  - Security helpers are generated by default when --client is enabled
+  - Generated code uses Go idioms and best practices
+  - Server interface is framework-agnostic
+Usage: oastools generate [flags] <file|url|->
+
+Generate Go code from an OpenAPI specification.
+
+Flags:
+  -client
+    	generate HTTP client code
+  -credential-mgmt
+    	generate credential management interfaces
+  -max-lines-per-file int
+    	maximum lines per generated file (0 = no limit) (default 2000)
+  -max-ops-per-file int
+    	maximum operations per generated file (0 = no limit) (default 100)
+  -max-types-per-file int
+    	maximum types per generated file (0 = no limit) (default 200)
+  -no-pointers
+    	don't use pointer types for optional fields
+  -no-readme
+    	don't generate README.md file
+  -no-security
+    	don't generate security helper functions
+  -no-split-by-path
+    	don't split files by path prefix
+  -no-split-by-tag
+    	don't split files by operation tag
+  -no-validation
+    	don't include validation tags
+  -no-warnings
+    	suppress warning and info messages
+  -o string
+    	output directory for generated files (required)
+  -oauth2-flows
+    	generate OAuth2 token flow helpers
+  -oidc-discovery
+    	generate OpenID Connect discovery client
+  -output string
+    	output directory for generated files (required)
+  -p string
+    	Go package name for generated code (default "api")
+  -package string
+    	Go package name for generated code (default "api")
+  -s	include line numbers in generation issues (IDE-friendly format)
+  -security-enforce
+    	generate security enforcement middleware
+  -server
+    	generate server interface code
+  -source-map
+    	include line numbers in generation issues (IDE-friendly format)
+  -strict
+    	fail on any generation issues (even warnings)
+  -types
+    	generate type definitions from schemas (default true)
+
+Examples:
+  oastools generate --client -o ./client openapi.yaml
+  oastools generate --server -o ./server -p myapi openapi.yaml
+  oastools generate --client --server -o ./api petstore.yaml
+  oastools generate --types -o ./models https://example.com/api/openapi.yaml
+  oastools generate --client --oauth2-flows -o ./client openapi.yaml
+  oastools generate --client --credential-mgmt --security-enforce -o ./api openapi.yaml
+  oastools generate --client --max-lines-per-file 1500 -o ./client large-api.yaml
+  cat openapi.yaml | oastools generate --client -o ./client -
+  oastools generate -s --client -o ./client openapi.yaml  # Include line numbers in issues
+
+Pipelining:
+  Use '-' as the file path to read the OpenAPI specification from stdin.
+  Example: oastools convert -t 3.0.3 swagger.yaml | oastools generate --client -o ./client -
+
+Notes:
+  - At least one of --client, --server, or --types must be enabled
+  - Types are always generated when --client or --server is enabled
+  - Security helpers are generated by default when --client is enabled
+  - Generated code uses Go idioms and best practices
+  - Server interface is framework-agnostic
+Usage: oastools join [flags] <file1> <file2> [file3...]
+
+Join multiple OpenAPI specification files into a single document.
+
+Flags:
+  -always-prefix
+    	apply namespace prefix to all schemas, not just on collision
+  -collision-report
+    	generate detailed collision analysis report
+  -component-strategy string
+    	collision strategy for other components
+  -equivalence-mode string
+    	schema comparison mode for deduplication (none, shallow, deep) (default "none")
+  -namespace-prefix value
+    	namespace prefix for source file (format: source=prefix, can be repeated)
+  -no-dedup-tags
+    	don't deduplicate tags by name
+  -no-merge-arrays
+    	don't merge arrays (servers, security, etc.)
+  -o string
+    	output file path (default: stdout)
+  -output string
+    	output file path (default: stdout)
+  -path-strategy string
+    	collision strategy for paths (accept-left, accept-right, fail, fail-on-paths)
+  -q	quiet mode: suppress diagnostic messages (for pipelining)
+  -quiet
+    	quiet mode: suppress diagnostic messages (for pipelining)
+  -rename-template string
+    	template for renamed schema names (default "{{.Name}}_{{.Source}}")
+  -s	include line numbers in collision warnings (IDE-friendly format)
+  -schema-strategy string
+    	collision strategy for schemas (accept-left, accept-right, rename-left, rename-right, deduplicate, fail)
+  -semantic-dedup
+    	enable semantic deduplication to consolidate identical schemas
+  -source-map
+    	include line numbers in collision warnings (IDE-friendly format)
+
+Collision Strategies:
+  accept-left      Keep the first value when collisions occur
+  accept-right     Keep the last value when collisions occur (overwrite)
+  rename-left      Rename left schema, keep right under original name
+  rename-right     Rename right schema, keep left under original name
+  deduplicate      Merge structurally identical schemas (requires equivalence-mode)
+  fail             Fail with an error on any collision
+  fail-on-paths    Fail only on path collisions, allow schema collisions
+
+Namespace Prefixes:
+  Use --namespace-prefix to add source-based prefixes to schema names.
+  Format: source=prefix (can be specified multiple times)
+  By default, prefix is only applied on collision. Use --always-prefix to
+  apply namespace prefixes to all schemas from the configured sources.
+
+Examples:
+  oastools join -o merged.yaml base.yaml extensions.yaml
+  oastools join --path-strategy accept-left -o api.yaml spec1.yaml spec2.yaml
+  oastools join --schema-strategy accept-right -o output.yaml api1.yaml api2.yaml api3.yaml
+  oastools join --namespace-prefix users.yaml=Users --namespace-prefix billing.yaml=Billing -o merged.yaml users.yaml billing.yaml
+  oastools join --namespace-prefix api2.yaml=V2 --always-prefix -o merged.yaml api1.yaml api2.yaml
+  oastools join -s -o merged.yaml api1.yaml api2.yaml  # Include line numbers in warnings
+
+Pipelining:
+  oastools join -q base.yaml ext.yaml | oastools validate -q -
+  oastools join -q spec1.yaml spec2.yaml | oastools convert -q -t 3.1.0 -
+
+Notes:
+  - All input files must be the same major OAS version (2.0 or 3.x)
+  - The output will use the version of the first input file
+  - Info section is taken from the first document by default
+  - When -o is specified, file is written with restrictive permissions (0600)
+Usage: oastools join [flags] <file1> <file2> [file3...]
+
+Join multiple OpenAPI specification files into a single document.
+
+Flags:
+  -always-prefix
+    	apply namespace prefix to all schemas, not just on collision
+  -collision-report
+    	generate detailed collision analysis report
+  -component-strategy string
+    	collision strategy for other components
+  -equivalence-mode string
+    	schema comparison mode for deduplication (none, shallow, deep) (default "none")
+  -namespace-prefix value
+    	namespace prefix for source file (format: source=prefix, can be repeated)
+  -no-dedup-tags
+    	don't deduplicate tags by name
+  -no-merge-arrays
+    	don't merge arrays (servers, security, etc.)
+  -o string
+    	output file path (default: stdout)
+  -output string
+    	output file path (default: stdout)
+  -path-strategy string
+    	collision strategy for paths (accept-left, accept-right, fail, fail-on-paths)
+  -q	quiet mode: suppress diagnostic messages (for pipelining)
+  -quiet
+    	quiet mode: suppress diagnostic messages (for pipelining)
+  -rename-template string
+    	template for renamed schema names (default "{{.Name}}_{{.Source}}")
+  -s	include line numbers in collision warnings (IDE-friendly format)
+  -schema-strategy string
+    	collision strategy for schemas (accept-left, accept-right, rename-left, rename-right, deduplicate, fail)
+  -semantic-dedup
+    	enable semantic deduplication to consolidate identical schemas
+  -source-map
+    	include line numbers in collision warnings (IDE-friendly format)
+
+Collision Strategies:
+  accept-left      Keep the first value when collisions occur
+  accept-right     Keep the last value when collisions occur (overwrite)
+  rename-left      Rename left schema, keep right under original name
+  rename-right     Rename right schema, keep left under original name
+  deduplicate      Merge structurally identical schemas (requires equivalence-mode)
+  fail             Fail with an error on any collision
+  fail-on-paths    Fail only on path collisions, allow schema collisions
+
+Namespace Prefixes:
+  Use --namespace-prefix to add source-based prefixes to schema names.
+  Format: source=prefix (can be specified multiple times)
+  By default, prefix is only applied on collision. Use --always-prefix to
+  apply namespace prefixes to all schemas from the configured sources.
+
+Examples:
+  oastools join -o merged.yaml base.yaml extensions.yaml
+  oastools join --path-strategy accept-left -o api.yaml spec1.yaml spec2.yaml
+  oastools join --schema-strategy accept-right -o output.yaml api1.yaml api2.yaml api3.yaml
+  oastools join --namespace-prefix users.yaml=Users --namespace-prefix billing.yaml=Billing -o merged.yaml users.yaml billing.yaml
+  oastools join --namespace-prefix api2.yaml=V2 --always-prefix -o merged.yaml api1.yaml api2.yaml
+  oastools join -s -o merged.yaml api1.yaml api2.yaml  # Include line numbers in warnings
+
+Pipelining:
+  oastools join -q base.yaml ext.yaml | oastools validate -q -
+  oastools join -q spec1.yaml spec2.yaml | oastools convert -q -t 3.1.0 -
+
+Notes:
+  - All input files must be the same major OAS version (2.0 or 3.x)
+  - The output will use the version of the first input file
+  - Info section is taken from the first document by default
+  - When -o is specified, file is written with restrictive permissions (0600)
+invalid value "invalid" for flag -namespace-prefix: invalid namespace prefix format: "invalid" (expected source=prefix)
+Usage: oastools join [flags] <file1> <file2> [file3...]
+
+Join multiple OpenAPI specification files into a single document.
+
+Flags:
+  -always-prefix
+    	apply namespace prefix to all schemas, not just on collision
+  -collision-report
+    	generate detailed collision analysis report
+  -component-strategy string
+    	collision strategy for other components
+  -equivalence-mode string
+    	schema comparison mode for deduplication (none, shallow, deep) (default "none")
+  -namespace-prefix value
+    	namespace prefix for source file (format: source=prefix, can be repeated)
+  -no-dedup-tags
+    	don't deduplicate tags by name
+  -no-merge-arrays
+    	don't merge arrays (servers, security, etc.)
+  -o string
+    	output file path (default: stdout)
+  -output string
+    	output file path (default: stdout)
+  -path-strategy string
+    	collision strategy for paths (accept-left, accept-right, fail, fail-on-paths)
+  -q	quiet mode: suppress diagnostic messages (for pipelining)
+  -quiet
+    	quiet mode: suppress diagnostic messages (for pipelining)
+  -rename-template string
+    	template for renamed schema names (default "{{.Name}}_{{.Source}}")
+  -s	include line numbers in collision warnings (IDE-friendly format)
+  -schema-strategy string
+    	collision strategy for schemas (accept-left, accept-right, rename-left, rename-right, deduplicate, fail)
+  -semantic-dedup
+    	enable semantic deduplication to consolidate identical schemas
+  -source-map
+    	include line numbers in collision warnings (IDE-friendly format)
+
+Collision Strategies:
+  accept-left      Keep the first value when collisions occur
+  accept-right     Keep the last value when collisions occur (overwrite)
+  rename-left      Rename left schema, keep right under original name
+  rename-right     Rename right schema, keep left under original name
+  deduplicate      Merge structurally identical schemas (requires equivalence-mode)
+  fail             Fail with an error on any collision
+  fail-on-paths    Fail only on path collisions, allow schema collisions
+
+Namespace Prefixes:
+  Use --namespace-prefix to add source-based prefixes to schema names.
+  Format: source=prefix (can be specified multiple times)
+  By default, prefix is only applied on collision. Use --always-prefix to
+  apply namespace prefixes to all schemas from the configured sources.
+
+Examples:
+  oastools join -o merged.yaml base.yaml extensions.yaml
+  oastools join --path-strategy accept-left -o api.yaml spec1.yaml spec2.yaml
+  oastools join --schema-strategy accept-right -o output.yaml api1.yaml api2.yaml api3.yaml
+  oastools join --namespace-prefix users.yaml=Users --namespace-prefix billing.yaml=Billing -o merged.yaml users.yaml billing.yaml
+  oastools join --namespace-prefix api2.yaml=V2 --always-prefix -o merged.yaml api1.yaml api2.yaml
+  oastools join -s -o merged.yaml api1.yaml api2.yaml  # Include line numbers in warnings
+
+Pipelining:
+  oastools join -q base.yaml ext.yaml | oastools validate -q -
+  oastools join -q spec1.yaml spec2.yaml | oastools convert -q -t 3.1.0 -
+
+Notes:
+  - All input files must be the same major OAS version (2.0 or 3.x)
+  - The output will use the version of the first input file
+  - Info section is taken from the first document by default
+  - When -o is specified, file is written with restrictive permissions (0600)
+invalid value "=Prefix" for flag -namespace-prefix: namespace prefix requires non-empty source and prefix: "=Prefix"
+Usage: oastools join [flags] <file1> <file2> [file3...]
+
+Join multiple OpenAPI specification files into a single document.
+
+Flags:
+  -always-prefix
+    	apply namespace prefix to all schemas, not just on collision
+  -collision-report
+    	generate detailed collision analysis report
+  -component-strategy string
+    	collision strategy for other components
+  -equivalence-mode string
+    	schema comparison mode for deduplication (none, shallow, deep) (default "none")
+  -namespace-prefix value
+    	namespace prefix for source file (format: source=prefix, can be repeated)
+  -no-dedup-tags
+    	don't deduplicate tags by name
+  -no-merge-arrays
+    	don't merge arrays (servers, security, etc.)
+  -o string
+    	output file path (default: stdout)
+  -output string
+    	output file path (default: stdout)
+  -path-strategy string
+    	collision strategy for paths (accept-left, accept-right, fail, fail-on-paths)
+  -q	quiet mode: suppress diagnostic messages (for pipelining)
+  -quiet
+    	quiet mode: suppress diagnostic messages (for pipelining)
+  -rename-template string
+    	template for renamed schema names (default "{{.Name}}_{{.Source}}")
+  -s	include line numbers in collision warnings (IDE-friendly format)
+  -schema-strategy string
+    	collision strategy for schemas (accept-left, accept-right, rename-left, rename-right, deduplicate, fail)
+  -semantic-dedup
+    	enable semantic deduplication to consolidate identical schemas
+  -source-map
+    	include line numbers in collision warnings (IDE-friendly format)
+
+Collision Strategies:
+  accept-left      Keep the first value when collisions occur
+  accept-right     Keep the last value when collisions occur (overwrite)
+  rename-left      Rename left schema, keep right under original name
+  rename-right     Rename right schema, keep left under original name
+  deduplicate      Merge structurally identical schemas (requires equivalence-mode)
+  fail             Fail with an error on any collision
+  fail-on-paths    Fail only on path collisions, allow schema collisions
+
+Namespace Prefixes:
+  Use --namespace-prefix to add source-based prefixes to schema names.
+  Format: source=prefix (can be specified multiple times)
+  By default, prefix is only applied on collision. Use --always-prefix to
+  apply namespace prefixes to all schemas from the configured sources.
+
+Examples:
+  oastools join -o merged.yaml base.yaml extensions.yaml
+  oastools join --path-strategy accept-left -o api.yaml spec1.yaml spec2.yaml
+  oastools join --schema-strategy accept-right -o output.yaml api1.yaml api2.yaml api3.yaml
+  oastools join --namespace-prefix users.yaml=Users --namespace-prefix billing.yaml=Billing -o merged.yaml users.yaml billing.yaml
+  oastools join --namespace-prefix api2.yaml=V2 --always-prefix -o merged.yaml api1.yaml api2.yaml
+  oastools join -s -o merged.yaml api1.yaml api2.yaml  # Include line numbers in warnings
+
+Pipelining:
+  oastools join -q base.yaml ext.yaml | oastools validate -q -
+  oastools join -q spec1.yaml spec2.yaml | oastools convert -q -t 3.1.0 -
+
+Notes:
+  - All input files must be the same major OAS version (2.0 or 3.x)
+  - The output will use the version of the first input file
+  - Info section is taken from the first document by default
+  - When -o is specified, file is written with restrictive permissions (0600)
+invalid value "api.yaml=" for flag -namespace-prefix: namespace prefix requires non-empty source and prefix: "api.yaml="
+Usage: oastools join [flags] <file1> <file2> [file3...]
+
+Join multiple OpenAPI specification files into a single document.
+
+Flags:
+  -always-prefix
+    	apply namespace prefix to all schemas, not just on collision
+  -collision-report
+    	generate detailed collision analysis report
+  -component-strategy string
+    	collision strategy for other components
+  -equivalence-mode string
+    	schema comparison mode for deduplication (none, shallow, deep) (default "none")
+  -namespace-prefix value
+    	namespace prefix for source file (format: source=prefix, can be repeated)
+  -no-dedup-tags
+    	don't deduplicate tags by name
+  -no-merge-arrays
+    	don't merge arrays (servers, security, etc.)
+  -o string
+    	output file path (default: stdout)
+  -output string
+    	output file path (default: stdout)
+  -path-strategy string
+    	collision strategy for paths (accept-left, accept-right, fail, fail-on-paths)
+  -q	quiet mode: suppress diagnostic messages (for pipelining)
+  -quiet
+    	quiet mode: suppress diagnostic messages (for pipelining)
+  -rename-template string
+    	template for renamed schema names (default "{{.Name}}_{{.Source}}")
+  -s	include line numbers in collision warnings (IDE-friendly format)
+  -schema-strategy string
+    	collision strategy for schemas (accept-left, accept-right, rename-left, rename-right, deduplicate, fail)
+  -semantic-dedup
+    	enable semantic deduplication to consolidate identical schemas
+  -source-map
+    	include line numbers in collision warnings (IDE-friendly format)
+
+Collision Strategies:
+  accept-left      Keep the first value when collisions occur
+  accept-right     Keep the last value when collisions occur (overwrite)
+  rename-left      Rename left schema, keep right under original name
+  rename-right     Rename right schema, keep left under original name
+  deduplicate      Merge structurally identical schemas (requires equivalence-mode)
+  fail             Fail with an error on any collision
+  fail-on-paths    Fail only on path collisions, allow schema collisions
+
+Namespace Prefixes:
+  Use --namespace-prefix to add source-based prefixes to schema names.
+  Format: source=prefix (can be specified multiple times)
+  By default, prefix is only applied on collision. Use --always-prefix to
+  apply namespace prefixes to all schemas from the configured sources.
+
+Examples:
+  oastools join -o merged.yaml base.yaml extensions.yaml
+  oastools join --path-strategy accept-left -o api.yaml spec1.yaml spec2.yaml
+  oastools join --schema-strategy accept-right -o output.yaml api1.yaml api2.yaml api3.yaml
+  oastools join --namespace-prefix users.yaml=Users --namespace-prefix billing.yaml=Billing -o merged.yaml users.yaml billing.yaml
+  oastools join --namespace-prefix api2.yaml=V2 --always-prefix -o merged.yaml api1.yaml api2.yaml
+  oastools join -s -o merged.yaml api1.yaml api2.yaml  # Include line numbers in warnings
+
+Pipelining:
+  oastools join -q base.yaml ext.yaml | oastools validate -q -
+  oastools join -q spec1.yaml spec2.yaml | oastools convert -q -t 3.1.0 -
+
+Notes:
+  - All input files must be the same major OAS version (2.0 or 3.x)
+  - The output will use the version of the first input file
+  - Info section is taken from the first document by default
+  - When -o is specified, file is written with restrictive permissions (0600)
+Usage: oastools parse [flags] <file|url|->
+
+Parse and output OpenAPI document structure.
+
+Flags:
+  -insecure
+    	disable TLS certificate verification for HTTPS refs
+  -q	quiet mode: only output the document, no diagnostic messages
+  -quiet
+    	quiet mode: only output the document, no diagnostic messages
+  -resolve-http-refs
+    	resolve HTTP/HTTPS $ref URLs (requires --resolve-refs)
+  -resolve-refs
+    	resolve external $ref references
+  -validate-structure
+    	validate document structure during parsing
+
+Examples:
+  oastools parse openapi.yaml
+  oastools parse --resolve-refs openapi.yaml
+  oastools parse --resolve-refs --resolve-http-refs https://example.com/api/openapi.yaml
+  oastools parse --resolve-refs --resolve-http-refs --insecure https://internal-server/api.yaml
+  oastools parse --validate-structure https://example.com/api/openapi.yaml
+  cat openapi.yaml | oastools parse -q -
+
+HTTP Reference Resolution:
+  --resolve-http-refs enables fetching and resolving $refs that point to HTTP/HTTPS URLs.
+  This is disabled by default for security (SSRF protection).
+  Use --insecure to skip TLS certificate verification for self-signed certs.
+
+Pipelining:
+  - Use '-' as the file path to read from stdin
+  - Use --quiet/-q to suppress diagnostic output for pipelining
+
+Exit Codes:
+  0    Parsing successful
+  1    Parsing failed or validation errors found (with --validate-structure)
+Usage: oastools parse [flags] <file|url|->
+
+Parse and output OpenAPI document structure.
+
+Flags:
+  -insecure
+    	disable TLS certificate verification for HTTPS refs
+  -q	quiet mode: only output the document, no diagnostic messages
+  -quiet
+    	quiet mode: only output the document, no diagnostic messages
+  -resolve-http-refs
+    	resolve HTTP/HTTPS $ref URLs (requires --resolve-refs)
+  -resolve-refs
+    	resolve external $ref references
+  -validate-structure
+    	validate document structure during parsing
+
+Examples:
+  oastools parse openapi.yaml
+  oastools parse --resolve-refs openapi.yaml
+  oastools parse --resolve-refs --resolve-http-refs https://example.com/api/openapi.yaml
+  oastools parse --resolve-refs --resolve-http-refs --insecure https://internal-server/api.yaml
+  oastools parse --validate-structure https://example.com/api/openapi.yaml
+  cat openapi.yaml | oastools parse -q -
+
+HTTP Reference Resolution:
+  --resolve-http-refs enables fetching and resolving $refs that point to HTTP/HTTPS URLs.
+  This is disabled by default for security (SSRF protection).
+  Use --insecure to skip TLS certificate verification for self-signed certs.
+
+Pipelining:
+  - Use '-' as the file path to read from stdin
+  - Use --quiet/-q to suppress diagnostic output for pipelining
+
+Exit Codes:
+  0    Parsing successful
+  1    Parsing failed or validation errors found (with --validate-structure)
+Usage: oastools validate [flags] <file|url|->
+
+Validate an OpenAPI specification file, URL, or stdin against the specification version it declares.
+
+Flags:
+  -format string
+    	output format: text, json, or yaml (default "text")
+  -no-warnings
+    	suppress warning messages (only show errors)
+  -q	quiet mode: only output validation result, no diagnostic messages
+  -quiet
+    	quiet mode: only output validation result, no diagnostic messages
+  -s	include line numbers in validation errors (IDE-friendly format)
+  -source-map
+    	include line numbers in validation errors (IDE-friendly format)
+  -strict
+    	enable stricter validation beyond spec requirements
+
+Output Formats:
+  text (default)  Human-readable text output
+  json            JSON format for programmatic processing
+  yaml            YAML format for programmatic processing
+
+Examples:
+  oastools validate openapi.yaml
+  oastools validate https://example.com/api/openapi.yaml
+  oastools validate --strict api-spec.yaml
+  oastools validate --no-warnings openapi.json
+  cat openapi.yaml | oastools validate -q -
+  oastools validate --format json openapi.yaml | jq '.valid'
+  oastools validate -s openapi.yaml  # Include line numbers in errors
+
+Pipelining:
+  - Use '-' as the file path to read from stdin
+  - Use --quiet/-q to suppress diagnostic output for pipelining
+  - Use --format json/yaml for structured output that can be parsed
+
+Exit Codes:
+  0    Validation successful
+  1    Validation failed with errors
+Usage: oastools validate [flags] <file|url|->
+
+Validate an OpenAPI specification file, URL, or stdin against the specification version it declares.
+
+Flags:
+  -format string
+    	output format: text, json, or yaml (default "text")
+  -no-warnings
+    	suppress warning messages (only show errors)
+  -q	quiet mode: only output validation result, no diagnostic messages
+  -quiet
+    	quiet mode: only output validation result, no diagnostic messages
+  -s	include line numbers in validation errors (IDE-friendly format)
+  -source-map
+    	include line numbers in validation errors (IDE-friendly format)
+  -strict
+    	enable stricter validation beyond spec requirements
+
+Output Formats:
+  text (default)  Human-readable text output
+  json            JSON format for programmatic processing
+  yaml            YAML format for programmatic processing
+
+Examples:
+  oastools validate openapi.yaml
+  oastools validate https://example.com/api/openapi.yaml
+  oastools validate --strict api-spec.yaml
+  oastools validate --no-warnings openapi.json
+  cat openapi.yaml | oastools validate -q -
+  oastools validate --format json openapi.yaml | jq '.valid'
+  oastools validate -s openapi.yaml  # Include line numbers in errors
+
+Pipelining:
+  - Use '-' as the file path to read from stdin
+  - Use --quiet/-q to suppress diagnostic output for pipelining
+  - Use --format json/yaml for structured output that can be parsed
+
+Exit Codes:
+  0    Validation successful
+  1    Validation failed with errors
+Usage: oastools convert [flags] <file|url|->
+
+Convert an OpenAPI specification from one version to another.
+
+Flags:
+  -no-warnings
+    	suppress warning and info messages
+  -o string
+    	output file path (default: stdout)
+  -output string
+    	output file path (default: stdout)
+  -q	quiet mode: only output the document, no diagnostic messages
+  -quiet
+    	quiet mode: only output the document, no diagnostic messages
+  -s	include line numbers in conversion issues (IDE-friendly format)
+  -source-map
+    	include line numbers in conversion issues (IDE-friendly format)
+  -strict
+    	fail on any conversion issues (even warnings)
+  -t string
+    	target OAS version (e.g., "3.0.3", "2.0", "3.1.0") (required)
+  -target string
+    	target OAS version (e.g., "3.0.3", "2.0", "3.1.0") (required)
+
+Supported Conversions:
+  - OAS 2.0 → OAS 3.x (3.0.0 through 3.2.0)
+  - OAS 3.x → OAS 2.0
+  - OAS 3.x → OAS 3.y (version updates)
+
+Examples:
+  oastools convert -t 3.0.3 swagger.yaml -o openapi.yaml
+  oastools convert -t 3.0.3 https://example.com/swagger.yaml -o openapi.yaml
+  oastools convert -t 2.0 openapi-v3.yaml
+  oastools convert --strict -t 3.1.0 swagger.yaml -o openapi-v3.yaml
+  cat swagger.yaml | oastools convert -q -t 3.0.3 - > openapi.yaml
+  oastools convert -s -t 3.0.3 swagger.yaml  # Include line numbers in issues
+
+Pipelining:
+  - Use '-' as the file path to read from stdin
+  - Use --quiet/-q to suppress diagnostic output for pipelining
+
+Notes:
+  - Critical issues indicate features that cannot be converted (data loss)
+  - Warnings indicate lossy conversions or best-effort transformations
+  - Info messages provide context about conversion choices
+  - Always validate converted documents before deployment
+
+Exit Codes:
+  0    Conversion successful
+  1    Conversion failed or critical issues found (in --strict mode)
+Usage: oastools convert [flags] <file|url|->
+
+Convert an OpenAPI specification from one version to another.
+
+Flags:
+  -no-warnings
+    	suppress warning and info messages
+  -o string
+    	output file path (default: stdout)
+  -output string
+    	output file path (default: stdout)
+  -q	quiet mode: only output the document, no diagnostic messages
+  -quiet
+    	quiet mode: only output the document, no diagnostic messages
+  -s	include line numbers in conversion issues (IDE-friendly format)
+  -source-map
+    	include line numbers in conversion issues (IDE-friendly format)
+  -strict
+    	fail on any conversion issues (even warnings)
+  -t string
+    	target OAS version (e.g., "3.0.3", "2.0", "3.1.0") (required)
+  -target string
+    	target OAS version (e.g., "3.0.3", "2.0", "3.1.0") (required)
+
+Supported Conversions:
+  - OAS 2.0 → OAS 3.x (3.0.0 through 3.2.0)
+  - OAS 3.x → OAS 2.0
+  - OAS 3.x → OAS 3.y (version updates)
+
+Examples:
+  oastools convert -t 3.0.3 swagger.yaml -o openapi.yaml
+  oastools convert -t 3.0.3 https://example.com/swagger.yaml -o openapi.yaml
+  oastools convert -t 2.0 openapi-v3.yaml
+  oastools convert --strict -t 3.1.0 swagger.yaml -o openapi-v3.yaml
+  cat swagger.yaml | oastools convert -q -t 3.0.3 - > openapi.yaml
+  oastools convert -s -t 3.0.3 swagger.yaml  # Include line numbers in issues
+
+Pipelining:
+  - Use '-' as the file path to read from stdin
+  - Use --quiet/-q to suppress diagnostic output for pipelining
+
+Notes:
+  - Critical issues indicate features that cannot be converted (data loss)
+  - Warnings indicate lossy conversions or best-effort transformations
+  - Info messages provide context about conversion choices
+  - Always validate converted documents before deployment
+
+Exit Codes:
+  0    Conversion successful
+  1    Conversion failed or critical issues found (in --strict mode)
+Usage: oastools convert [flags] <file|url|->
+
+Convert an OpenAPI specification from one version to another.
+
+Flags:
+  -no-warnings
+    	suppress warning and info messages
+  -o string
+    	output file path (default: stdout)
+  -output string
+    	output file path (default: stdout)
+  -q	quiet mode: only output the document, no diagnostic messages
+  -quiet
+    	quiet mode: only output the document, no diagnostic messages
+  -s	include line numbers in conversion issues (IDE-friendly format)
+  -source-map
+    	include line numbers in conversion issues (IDE-friendly format)
+  -strict
+    	fail on any conversion issues (even warnings)
+  -t string
+    	target OAS version (e.g., "3.0.3", "2.0", "3.1.0") (required)
+  -target string
+    	target OAS version (e.g., "3.0.3", "2.0", "3.1.0") (required)
+
+Supported Conversions:
+  - OAS 2.0 → OAS 3.x (3.0.0 through 3.2.0)
+  - OAS 3.x → OAS 2.0
+  - OAS 3.x → OAS 3.y (version updates)
+
+Examples:
+  oastools convert -t 3.0.3 swagger.yaml -o openapi.yaml
+  oastools convert -t 3.0.3 https://example.com/swagger.yaml -o openapi.yaml
+  oastools convert -t 2.0 openapi-v3.yaml
+  oastools convert --strict -t 3.1.0 swagger.yaml -o openapi-v3.yaml
+  cat swagger.yaml | oastools convert -q -t 3.0.3 - > openapi.yaml
+  oastools convert -s -t 3.0.3 swagger.yaml  # Include line numbers in issues
+
+Pipelining:
+  - Use '-' as the file path to read from stdin
+  - Use --quiet/-q to suppress diagnostic output for pipelining
+
+Notes:
+  - Critical issues indicate features that cannot be converted (data loss)
+  - Warnings indicate lossy conversions or best-effort transformations
+  - Info messages provide context about conversion choices
+  - Always validate converted documents before deployment
+
+Exit Codes:
+  0    Conversion successful
+  1    Conversion failed or critical issues found (in --strict mode)
+Usage: oastools diff [flags] <source> <target>
+
+Compare two OpenAPI specification files or URLs and report differences.
+
+Flags:
+  -breaking
+    	enable breaking change detection and categorization
+  -format string
+    	output format: text, json, or yaml (default "text")
+  -no-info
+    	exclude informational changes from output
+  -s	include line numbers in diff output (IDE-friendly format)
+  -source-map
+    	include line numbers in diff output (IDE-friendly format)
+
+Output Formats:
+  text (default)  Human-readable text output
+  json            JSON format for programmatic processing
+  yaml            YAML format for programmatic processing
+
+Modes:
+  Default (Simple):
+    Reports all semantic differences between specifications without
+    categorizing them by severity or breaking change impact.
+
+  --breaking (Breaking Change Detection):
+    Categorizes changes by severity and identifies breaking API changes:
+    - Critical: Removed endpoints or operations
+    - Error:    Removed required parameters, incompatible type changes
+    - Warning:  Deprecated operations, added required fields
+    - Info:     Additions, relaxed constraints, documentation updates
+
+Examples:
+  oastools diff api-v1.yaml api-v2.yaml
+  oastools diff --breaking api-v1.yaml api-v2.yaml
+  oastools diff --breaking --no-info old.yaml new.yaml
+  oastools diff --format json --breaking api-v1.yaml api-v2.yaml | jq '.HasBreakingChanges'
+  oastools diff https://example.com/api/v1.yaml https://example.com/api/v2.yaml
+  oastools diff -s api-v1.yaml api-v2.yaml  # Include line numbers in changes
+
+Exit Status:
+  0    No differences found (or no breaking changes in --breaking mode)
+  1    Differences found (or breaking changes found in --breaking mode)
+
+Notes:
+  - Both specifications must be valid OpenAPI documents
+  - Cross-version comparison (2.0 vs 3.x) is supported with limitations
+  - Breaking change detection helps identify backward compatibility issues
+Usage: oastools diff [flags] <source> <target>
+
+Compare two OpenAPI specification files or URLs and report differences.
+
+Flags:
+  -breaking
+    	enable breaking change detection and categorization
+  -format string
+    	output format: text, json, or yaml (default "text")
+  -no-info
+    	exclude informational changes from output
+  -s	include line numbers in diff output (IDE-friendly format)
+  -source-map
+    	include line numbers in diff output (IDE-friendly format)
+
+Output Formats:
+  text (default)  Human-readable text output
+  json            JSON format for programmatic processing
+  yaml            YAML format for programmatic processing
+
+Modes:
+  Default (Simple):
+    Reports all semantic differences between specifications without
+    categorizing them by severity or breaking change impact.
+
+  --breaking (Breaking Change Detection):
+    Categorizes changes by severity and identifies breaking API changes:
+    - Critical: Removed endpoints or operations
+    - Error:    Removed required parameters, incompatible type changes
+    - Warning:  Deprecated operations, added required fields
+    - Info:     Additions, relaxed constraints, documentation updates
+
+Examples:
+  oastools diff api-v1.yaml api-v2.yaml
+  oastools diff --breaking api-v1.yaml api-v2.yaml
+  oastools diff --breaking --no-info old.yaml new.yaml
+  oastools diff --format json --breaking api-v1.yaml api-v2.yaml | jq '.HasBreakingChanges'
+  oastools diff https://example.com/api/v1.yaml https://example.com/api/v2.yaml
+  oastools diff -s api-v1.yaml api-v2.yaml  # Include line numbers in changes
+
+Exit Status:
+  0    No differences found (or no breaking changes in --breaking mode)
+  1    Differences found (or breaking changes found in --breaking mode)
+
+Notes:
+  - Both specifications must be valid OpenAPI documents
+  - Cross-version comparison (2.0 vs 3.x) is supported with limitations
+  - Breaking change detection helps identify backward compatibility issues
+Usage: oastools diff [flags] <source> <target>
+
+Compare two OpenAPI specification files or URLs and report differences.
+
+Flags:
+  -breaking
+    	enable breaking change detection and categorization
+  -format string
+    	output format: text, json, or yaml (default "text")
+  -no-info
+    	exclude informational changes from output
+  -s	include line numbers in diff output (IDE-friendly format)
+  -source-map
+    	include line numbers in diff output (IDE-friendly format)
+
+Output Formats:
+  text (default)  Human-readable text output
+  json            JSON format for programmatic processing
+  yaml            YAML format for programmatic processing
+
+Modes:
+  Default (Simple):
+    Reports all semantic differences between specifications without
+    categorizing them by severity or breaking change impact.
+
+  --breaking (Breaking Change Detection):
+    Categorizes changes by severity and identifies breaking API changes:
+    - Critical: Removed endpoints or operations
+    - Error:    Removed required parameters, incompatible type changes
+    - Warning:  Deprecated operations, added required fields
+    - Info:     Additions, relaxed constraints, documentation updates
+
+Examples:
+  oastools diff api-v1.yaml api-v2.yaml
+  oastools diff --breaking api-v1.yaml api-v2.yaml
+  oastools diff --breaking --no-info old.yaml new.yaml
+  oastools diff --format json --breaking api-v1.yaml api-v2.yaml | jq '.HasBreakingChanges'
+  oastools diff https://example.com/api/v1.yaml https://example.com/api/v2.yaml
+  oastools diff -s api-v1.yaml api-v2.yaml  # Include line numbers in changes
+
+Exit Status:
+  0    No differences found (or no breaking changes in --breaking mode)
+  1    Differences found (or breaking changes found in --breaking mode)
+
+Notes:
+  - Both specifications must be valid OpenAPI documents
+  - Cross-version comparison (2.0 vs 3.x) is supported with limitations
+  - Breaking change detection helps identify backward compatibility issues
+Usage: oastools fix [flags] <file|url|->
+
+Apply automatic fixes to common OpenAPI specification issues.
+
+Flags:
+  -dry-run
+    	preview changes without modifying the document
+  -fix-schema-names
+    	fix invalid schema names (brackets, special characters)
+  -generic-naming string
+    	strategy for renaming generic types: underscore, of, for, flat, dot (default "underscore")
+  -generic-param-separator string
+    	separator between multiple type parameters (default "_")
+  -generic-separator string
+    	separator for underscore strategy (default "_")
+  -infer
+    	infer parameter types from naming conventions
+  -o string
+    	output file path (default: stdout)
+  -output string
+    	output file path (default: stdout)
+  -preserve-casing
+    	preserve original casing of type parameters
+  -prune
+    	apply all pruning fixes (alias for --prune-all)
+  -prune-all
+    	apply all pruning fixes (schemas, paths)
+  -prune-paths
+    	remove paths with no operations
+  -prune-schemas
+    	remove unreferenced schema definitions
+  -q	quiet mode: only output the document, no diagnostic messages
+  -quiet
+    	quiet mode: only output the document, no diagnostic messages
+  -s	include line numbers in fix output (IDE-friendly format)
+  -source-map
+    	include line numbers in fix output (IDE-friendly format)
+
+Supported Fixes:
+  - Missing path parameters: Adds Parameter objects for path template
+    variables that are not declared in the operation's parameters list.
+    Default type is 'string'. Use --infer for smart type inference.
+  - Invalid schema names (--fix-schema-names): Renames schemas with
+    invalid characters (brackets, etc.) using configurable strategies.
+  - Prune schemas (--prune-schemas): Removes unreferenced schemas.
+  - Prune paths (--prune-paths): Removes paths with no operations.
+
+Type Inference (--infer):
+  - Names ending in 'id', 'Id', 'ID' -> integer
+  - Names containing 'uuid', 'guid' -> string with format uuid
+  - All other names -> string
+
+Generic Naming Strategies (--generic-naming):
+  underscore: Response[User] → Response_User_
+  of:         Response[User] → ResponseOfUser
+  for:        Response[User] → ResponseForUser
+  flat:       Response[User] → ResponseUser
+  dot:        Response[User] → Response.User
+
+Examples:
+  oastools fix openapi.yaml
+  oastools fix -o fixed.yaml openapi.yaml
+  oastools fix --infer openapi.yaml
+  oastools fix --fix-schema-names --generic-naming of api.yaml
+  oastools fix --prune-all api.yaml
+  oastools fix --dry-run --prune-schemas api.yaml
+  cat openapi.yaml | oastools fix -q - > fixed.yaml
+  oastools fix -s openapi.yaml  # Include line numbers in fixes
+
+Pipelining:
+  oastools fix -q api.yaml | oastools validate -q -
+  oastools fix -q --infer api.yaml | oastools convert -q -t 3.1.0 -
+
+Notes:
+  - Use 'oastools validate' to see validation errors before fixing
+  - Pruning fixes only run when explicitly requested via flags
+  - Use --dry-run to preview what would be changed
+  - Output preserves the original format (JSON or YAML)
+
+Exit Codes:
+  0    Fixes applied successfully (or no fixes needed)
+  1    Failed to parse or fix the specification
+Usage: oastools fix [flags] <file|url|->
+
+Apply automatic fixes to common OpenAPI specification issues.
+
+Flags:
+  -dry-run
+    	preview changes without modifying the document
+  -fix-schema-names
+    	fix invalid schema names (brackets, special characters)
+  -generic-naming string
+    	strategy for renaming generic types: underscore, of, for, flat, dot (default "underscore")
+  -generic-param-separator string
+    	separator between multiple type parameters (default "_")
+  -generic-separator string
+    	separator for underscore strategy (default "_")
+  -infer
+    	infer parameter types from naming conventions
+  -o string
+    	output file path (default: stdout)
+  -output string
+    	output file path (default: stdout)
+  -preserve-casing
+    	preserve original casing of type parameters
+  -prune
+    	apply all pruning fixes (alias for --prune-all)
+  -prune-all
+    	apply all pruning fixes (schemas, paths)
+  -prune-paths
+    	remove paths with no operations
+  -prune-schemas
+    	remove unreferenced schema definitions
+  -q	quiet mode: only output the document, no diagnostic messages
+  -quiet
+    	quiet mode: only output the document, no diagnostic messages
+  -s	include line numbers in fix output (IDE-friendly format)
+  -source-map
+    	include line numbers in fix output (IDE-friendly format)
+
+Supported Fixes:
+  - Missing path parameters: Adds Parameter objects for path template
+    variables that are not declared in the operation's parameters list.
+    Default type is 'string'. Use --infer for smart type inference.
+  - Invalid schema names (--fix-schema-names): Renames schemas with
+    invalid characters (brackets, etc.) using configurable strategies.
+  - Prune schemas (--prune-schemas): Removes unreferenced schemas.
+  - Prune paths (--prune-paths): Removes paths with no operations.
+
+Type Inference (--infer):
+  - Names ending in 'id', 'Id', 'ID' -> integer
+  - Names containing 'uuid', 'guid' -> string with format uuid
+  - All other names -> string
+
+Generic Naming Strategies (--generic-naming):
+  underscore: Response[User] → Response_User_
+  of:         Response[User] → ResponseOfUser
+  for:        Response[User] → ResponseForUser
+  flat:       Response[User] → ResponseUser
+  dot:        Response[User] → Response.User
+
+Examples:
+  oastools fix openapi.yaml
+  oastools fix -o fixed.yaml openapi.yaml
+  oastools fix --infer openapi.yaml
+  oastools fix --fix-schema-names --generic-naming of api.yaml
+  oastools fix --prune-all api.yaml
+  oastools fix --dry-run --prune-schemas api.yaml
+  cat openapi.yaml | oastools fix -q - > fixed.yaml
+  oastools fix -s openapi.yaml  # Include line numbers in fixes
+
+Pipelining:
+  oastools fix -q api.yaml | oastools validate -q -
+  oastools fix -q --infer api.yaml | oastools convert -q -t 3.1.0 -
+
+Notes:
+  - Use 'oastools validate' to see validation errors before fixing
+  - Pruning fixes only run when explicitly requested via flags
+  - Use --dry-run to preview what would be changed
+  - Output preserves the original format (JSON or YAML)
+
+Exit Codes:
+  0    Fixes applied successfully (or no fixes needed)
+  1    Failed to parse or fix the specification
+Usage: oastools generate [flags] <file|url|->
+
+Generate Go code from an OpenAPI specification.
+
+Flags:
+  -client
+    	generate HTTP client code
+  -credential-mgmt
+    	generate credential management interfaces
+  -max-lines-per-file int
+    	maximum lines per generated file (0 = no limit) (default 2000)
+  -max-ops-per-file int
+    	maximum operations per generated file (0 = no limit) (default 100)
+  -max-types-per-file int
+    	maximum types per generated file (0 = no limit) (default 200)
+  -no-pointers
+    	don't use pointer types for optional fields
+  -no-readme
+    	don't generate README.md file
+  -no-security
+    	don't generate security helper functions
+  -no-split-by-path
+    	don't split files by path prefix
+  -no-split-by-tag
+    	don't split files by operation tag
+  -no-validation
+    	don't include validation tags
+  -no-warnings
+    	suppress warning and info messages
+  -o string
+    	output directory for generated files (required)
+  -oauth2-flows
+    	generate OAuth2 token flow helpers
+  -oidc-discovery
+    	generate OpenID Connect discovery client
+  -output string
+    	output directory for generated files (required)
+  -p string
+    	Go package name for generated code (default "api")
+  -package string
+    	Go package name for generated code (default "api")
+  -s	include line numbers in generation issues (IDE-friendly format)
+  -security-enforce
+    	generate security enforcement middleware
+  -server
+    	generate server interface code
+  -source-map
+    	include line numbers in generation issues (IDE-friendly format)
+  -strict
+    	fail on any generation issues (even warnings)
+  -types
+    	generate type definitions from schemas (default true)
+
+Examples:
+  oastools generate --client -o ./client openapi.yaml
+  oastools generate --server -o ./server -p myapi openapi.yaml
+  oastools generate --client --server -o ./api petstore.yaml
+  oastools generate --types -o ./models https://example.com/api/openapi.yaml
+  oastools generate --client --oauth2-flows -o ./client openapi.yaml
+  oastools generate --client --credential-mgmt --security-enforce -o ./api openapi.yaml
+  oastools generate --client --max-lines-per-file 1500 -o ./client large-api.yaml
+  cat openapi.yaml | oastools generate --client -o ./client -
+  oastools generate -s --client -o ./client openapi.yaml  # Include line numbers in issues
+
+Pipelining:
+  Use '-' as the file path to read the OpenAPI specification from stdin.
+  Example: oastools convert -t 3.0.3 swagger.yaml | oastools generate --client -o ./client -
+
+Notes:
+  - At least one of --client, --server, or --types must be enabled
+  - Types are always generated when --client or --server is enabled
+  - Security helpers are generated by default when --client is enabled
+  - Generated code uses Go idioms and best practices
+  - Server interface is framework-agnostic
+Usage: oastools generate [flags] <file|url|->
+
+Generate Go code from an OpenAPI specification.
+
+Flags:
+  -client
+    	generate HTTP client code
+  -credential-mgmt
+    	generate credential management interfaces
+  -max-lines-per-file int
+    	maximum lines per generated file (0 = no limit) (default 2000)
+  -max-ops-per-file int
+    	maximum operations per generated file (0 = no limit) (default 100)
+  -max-types-per-file int
+    	maximum types per generated file (0 = no limit) (default 200)
+  -no-pointers
+    	don't use pointer types for optional fields
+  -no-readme
+    	don't generate README.md file
+  -no-security
+    	don't generate security helper functions
+  -no-split-by-path
+    	don't split files by path prefix
+  -no-split-by-tag
+    	don't split files by operation tag
+  -no-validation
+    	don't include validation tags
+  -no-warnings
+    	suppress warning and info messages
+  -o string
+    	output directory for generated files (required)
+  -oauth2-flows
+    	generate OAuth2 token flow helpers
+  -oidc-discovery
+    	generate OpenID Connect discovery client
+  -output string
+    	output directory for generated files (required)
+  -p string
+    	Go package name for generated code (default "api")
+  -package string
+    	Go package name for generated code (default "api")
+  -s	include line numbers in generation issues (IDE-friendly format)
+  -security-enforce
+    	generate security enforcement middleware
+  -server
+    	generate server interface code
+  -source-map
+    	include line numbers in generation issues (IDE-friendly format)
+  -strict
+    	fail on any generation issues (even warnings)
+  -types
+    	generate type definitions from schemas (default true)
+
+Examples:
+  oastools generate --client -o ./client openapi.yaml
+  oastools generate --server -o ./server -p myapi openapi.yaml
+  oastools generate --client --server -o ./api petstore.yaml
+  oastools generate --types -o ./models https://example.com/api/openapi.yaml
+  oastools generate --client --oauth2-flows -o ./client openapi.yaml
+  oastools generate --client --credential-mgmt --security-enforce -o ./api openapi.yaml
+  oastools generate --client --max-lines-per-file 1500 -o ./client large-api.yaml
+  cat openapi.yaml | oastools generate --client -o ./client -
+  oastools generate -s --client -o ./client openapi.yaml  # Include line numbers in issues
+
+Pipelining:
+  Use '-' as the file path to read the OpenAPI specification from stdin.
+  Example: oastools convert -t 3.0.3 swagger.yaml | oastools generate --client -o ./client -
+
+Notes:
+  - At least one of --client, --server, or --types must be enabled
+  - Types are always generated when --client or --server is enabled
+  - Security helpers are generated by default when --client is enabled
+  - Generated code uses Go idioms and best practices
+  - Server interface is framework-agnostic
+Usage: oastools generate [flags] <file|url|->
+
+Generate Go code from an OpenAPI specification.
+
+Flags:
+  -client
+    	generate HTTP client code
+  -credential-mgmt
+    	generate credential management interfaces
+  -max-lines-per-file int
+    	maximum lines per generated file (0 = no limit) (default 2000)
+  -max-ops-per-file int
+    	maximum operations per generated file (0 = no limit) (default 100)
+  -max-types-per-file int
+    	maximum types per generated file (0 = no limit) (default 200)
+  -no-pointers
+    	don't use pointer types for optional fields
+  -no-readme
+    	don't generate README.md file
+  -no-security
+    	don't generate security helper functions
+  -no-split-by-path
+    	don't split files by path prefix
+  -no-split-by-tag
+    	don't split files by operation tag
+  -no-validation
+    	don't include validation tags
+  -no-warnings
+    	suppress warning and info messages
+  -o string
+    	output directory for generated files (required)
+  -oauth2-flows
+    	generate OAuth2 token flow helpers
+  -oidc-discovery
+    	generate OpenID Connect discovery client
+  -output string
+    	output directory for generated files (required)
+  -p string
+    	Go package name for generated code (default "api")
+  -package string
+    	Go package name for generated code (default "api")
+  -s	include line numbers in generation issues (IDE-friendly format)
+  -security-enforce
+    	generate security enforcement middleware
+  -server
+    	generate server interface code
+  -source-map
+    	include line numbers in generation issues (IDE-friendly format)
+  -strict
+    	fail on any generation issues (even warnings)
+  -types
+    	generate type definitions from schemas (default true)
+
+Examples:
+  oastools generate --client -o ./client openapi.yaml
+  oastools generate --server -o ./server -p myapi openapi.yaml
+  oastools generate --client --server -o ./api petstore.yaml
+  oastools generate --types -o ./models https://example.com/api/openapi.yaml
+  oastools generate --client --oauth2-flows -o ./client openapi.yaml
+  oastools generate --client --credential-mgmt --security-enforce -o ./api openapi.yaml
+  oastools generate --client --max-lines-per-file 1500 -o ./client large-api.yaml
+  cat openapi.yaml | oastools generate --client -o ./client -
+  oastools generate -s --client -o ./client openapi.yaml  # Include line numbers in issues
+
+Pipelining:
+  Use '-' as the file path to read the OpenAPI specification from stdin.
+  Example: oastools convert -t 3.0.3 swagger.yaml | oastools generate --client -o ./client -
+
+Notes:
+  - At least one of --client, --server, or --types must be enabled
+  - Types are always generated when --client or --server is enabled
+  - Security helpers are generated by default when --client is enabled
+  - Generated code uses Go idioms and best practices
+  - Server interface is framework-agnostic
+Usage: oastools generate [flags] <file|url|->
+
+Generate Go code from an OpenAPI specification.
+
+Flags:
+  -client
+    	generate HTTP client code
+  -credential-mgmt
+    	generate credential management interfaces
+  -max-lines-per-file int
+    	maximum lines per generated file (0 = no limit) (default 2000)
+  -max-ops-per-file int
+    	maximum operations per generated file (0 = no limit) (default 100)
+  -max-types-per-file int
+    	maximum types per generated file (0 = no limit) (default 200)
+  -no-pointers
+    	don't use pointer types for optional fields
+  -no-readme
+    	don't generate README.md file
+  -no-security
+    	don't generate security helper functions
+  -no-split-by-path
+    	don't split files by path prefix
+  -no-split-by-tag
+    	don't split files by operation tag
+  -no-validation
+    	don't include validation tags
+  -no-warnings
+    	suppress warning and info messages
+  -o string
+    	output directory for generated files (required)
+  -oauth2-flows
+    	generate OAuth2 token flow helpers
+  -oidc-discovery
+    	generate OpenID Connect discovery client
+  -output string
+    	output directory for generated files (required)
+  -p string
+    	Go package name for generated code (default "api")
+  -package string
+    	Go package name for generated code (default "api")
+  -s	include line numbers in generation issues (IDE-friendly format)
+  -security-enforce
+    	generate security enforcement middleware
+  -server
+    	generate server interface code
+  -source-map
+    	include line numbers in generation issues (IDE-friendly format)
+  -strict
+    	fail on any generation issues (even warnings)
+  -types
+    	generate type definitions from schemas (default true)
+
+Examples:
+  oastools generate --client -o ./client openapi.yaml
+  oastools generate --server -o ./server -p myapi openapi.yaml
+  oastools generate --client --server -o ./api petstore.yaml
+  oastools generate --types -o ./models https://example.com/api/openapi.yaml
+  oastools generate --client --oauth2-flows -o ./client openapi.yaml
+  oastools generate --client --credential-mgmt --security-enforce -o ./api openapi.yaml
+  oastools generate --client --max-lines-per-file 1500 -o ./client large-api.yaml
+  cat openapi.yaml | oastools generate --client -o ./client -
+  oastools generate -s --client -o ./client openapi.yaml  # Include line numbers in issues
+
+Pipelining:
+  Use '-' as the file path to read the OpenAPI specification from stdin.
+  Example: oastools convert -t 3.0.3 swagger.yaml | oastools generate --client -o ./client -
+
+Notes:
+  - At least one of --client, --server, or --types must be enabled
+  - Types are always generated when --client or --server is enabled
+  - Security helpers are generated by default when --client is enabled
+  - Generated code uses Go idioms and best practices
+  - Server interface is framework-agnostic
+Usage: oastools join [flags] <file1> <file2> [file3...]
+
+Join multiple OpenAPI specification files into a single document.
+
+Flags:
+  -always-prefix
+    	apply namespace prefix to all schemas, not just on collision
+  -collision-report
+    	generate detailed collision analysis report
+  -component-strategy string
+    	collision strategy for other components
+  -equivalence-mode string
+    	schema comparison mode for deduplication (none, shallow, deep) (default "none")
+  -namespace-prefix value
+    	namespace prefix for source file (format: source=prefix, can be repeated)
+  -no-dedup-tags
+    	don't deduplicate tags by name
+  -no-merge-arrays
+    	don't merge arrays (servers, security, etc.)
+  -o string
+    	output file path (default: stdout)
+  -output string
+    	output file path (default: stdout)
+  -path-strategy string
+    	collision strategy for paths (accept-left, accept-right, fail, fail-on-paths)
+  -q	quiet mode: suppress diagnostic messages (for pipelining)
+  -quiet
+    	quiet mode: suppress diagnostic messages (for pipelining)
+  -rename-template string
+    	template for renamed schema names (default "{{.Name}}_{{.Source}}")
+  -s	include line numbers in collision warnings (IDE-friendly format)
+  -schema-strategy string
+    	collision strategy for schemas (accept-left, accept-right, rename-left, rename-right, deduplicate, fail)
+  -semantic-dedup
+    	enable semantic deduplication to consolidate identical schemas
+  -source-map
+    	include line numbers in collision warnings (IDE-friendly format)
+
+Collision Strategies:
+  accept-left      Keep the first value when collisions occur
+  accept-right     Keep the last value when collisions occur (overwrite)
+  rename-left      Rename left schema, keep right under original name
+  rename-right     Rename right schema, keep left under original name
+  deduplicate      Merge structurally identical schemas (requires equivalence-mode)
+  fail             Fail with an error on any collision
+  fail-on-paths    Fail only on path collisions, allow schema collisions
+
+Namespace Prefixes:
+  Use --namespace-prefix to add source-based prefixes to schema names.
+  Format: source=prefix (can be specified multiple times)
+  By default, prefix is only applied on collision. Use --always-prefix to
+  apply namespace prefixes to all schemas from the configured sources.
+
+Examples:
+  oastools join -o merged.yaml base.yaml extensions.yaml
+  oastools join --path-strategy accept-left -o api.yaml spec1.yaml spec2.yaml
+  oastools join --schema-strategy accept-right -o output.yaml api1.yaml api2.yaml api3.yaml
+  oastools join --namespace-prefix users.yaml=Users --namespace-prefix billing.yaml=Billing -o merged.yaml users.yaml billing.yaml
+  oastools join --namespace-prefix api2.yaml=V2 --always-prefix -o merged.yaml api1.yaml api2.yaml
+  oastools join -s -o merged.yaml api1.yaml api2.yaml  # Include line numbers in warnings
+
+Pipelining:
+  oastools join -q base.yaml ext.yaml | oastools validate -q -
+  oastools join -q spec1.yaml spec2.yaml | oastools convert -q -t 3.1.0 -
+
+Notes:
+  - All input files must be the same major OAS version (2.0 or 3.x)
+  - The output will use the version of the first input file
+  - Info section is taken from the first document by default
+  - When -o is specified, file is written with restrictive permissions (0600)
+Usage: oastools join [flags] <file1> <file2> [file3...]
+
+Join multiple OpenAPI specification files into a single document.
+
+Flags:
+  -always-prefix
+    	apply namespace prefix to all schemas, not just on collision
+  -collision-report
+    	generate detailed collision analysis report
+  -component-strategy string
+    	collision strategy for other components
+  -equivalence-mode string
+    	schema comparison mode for deduplication (none, shallow, deep) (default "none")
+  -namespace-prefix value
+    	namespace prefix for source file (format: source=prefix, can be repeated)
+  -no-dedup-tags
+    	don't deduplicate tags by name
+  -no-merge-arrays
+    	don't merge arrays (servers, security, etc.)
+  -o string
+    	output file path (default: stdout)
+  -output string
+    	output file path (default: stdout)
+  -path-strategy string
+    	collision strategy for paths (accept-left, accept-right, fail, fail-on-paths)
+  -q	quiet mode: suppress diagnostic messages (for pipelining)
+  -quiet
+    	quiet mode: suppress diagnostic messages (for pipelining)
+  -rename-template string
+    	template for renamed schema names (default "{{.Name}}_{{.Source}}")
+  -s	include line numbers in collision warnings (IDE-friendly format)
+  -schema-strategy string
+    	collision strategy for schemas (accept-left, accept-right, rename-left, rename-right, deduplicate, fail)
+  -semantic-dedup
+    	enable semantic deduplication to consolidate identical schemas
+  -source-map
+    	include line numbers in collision warnings (IDE-friendly format)
+
+Collision Strategies:
+  accept-left      Keep the first value when collisions occur
+  accept-right     Keep the last value when collisions occur (overwrite)
+  rename-left      Rename left schema, keep right under original name
+  rename-right     Rename right schema, keep left under original name
+  deduplicate      Merge structurally identical schemas (requires equivalence-mode)
+  fail             Fail with an error on any collision
+  fail-on-paths    Fail only on path collisions, allow schema collisions
+
+Namespace Prefixes:
+  Use --namespace-prefix to add source-based prefixes to schema names.
+  Format: source=prefix (can be specified multiple times)
+  By default, prefix is only applied on collision. Use --always-prefix to
+  apply namespace prefixes to all schemas from the configured sources.
+
+Examples:
+  oastools join -o merged.yaml base.yaml extensions.yaml
+  oastools join --path-strategy accept-left -o api.yaml spec1.yaml spec2.yaml
+  oastools join --schema-strategy accept-right -o output.yaml api1.yaml api2.yaml api3.yaml
+  oastools join --namespace-prefix users.yaml=Users --namespace-prefix billing.yaml=Billing -o merged.yaml users.yaml billing.yaml
+  oastools join --namespace-prefix api2.yaml=V2 --always-prefix -o merged.yaml api1.yaml api2.yaml
+  oastools join -s -o merged.yaml api1.yaml api2.yaml  # Include line numbers in warnings
+
+Pipelining:
+  oastools join -q base.yaml ext.yaml | oastools validate -q -
+  oastools join -q spec1.yaml spec2.yaml | oastools convert -q -t 3.1.0 -
+
+Notes:
+  - All input files must be the same major OAS version (2.0 or 3.x)
+  - The output will use the version of the first input file
+  - Info section is taken from the first document by default
+  - When -o is specified, file is written with restrictive permissions (0600)
+invalid value "invalid" for flag -namespace-prefix: invalid namespace prefix format: "invalid" (expected source=prefix)
+Usage: oastools join [flags] <file1> <file2> [file3...]
+
+Join multiple OpenAPI specification files into a single document.
+
+Flags:
+  -always-prefix
+    	apply namespace prefix to all schemas, not just on collision
+  -collision-report
+    	generate detailed collision analysis report
+  -component-strategy string
+    	collision strategy for other components
+  -equivalence-mode string
+    	schema comparison mode for deduplication (none, shallow, deep) (default "none")
+  -namespace-prefix value
+    	namespace prefix for source file (format: source=prefix, can be repeated)
+  -no-dedup-tags
+    	don't deduplicate tags by name
+  -no-merge-arrays
+    	don't merge arrays (servers, security, etc.)
+  -o string
+    	output file path (default: stdout)
+  -output string
+    	output file path (default: stdout)
+  -path-strategy string
+    	collision strategy for paths (accept-left, accept-right, fail, fail-on-paths)
+  -q	quiet mode: suppress diagnostic messages (for pipelining)
+  -quiet
+    	quiet mode: suppress diagnostic messages (for pipelining)
+  -rename-template string
+    	template for renamed schema names (default "{{.Name}}_{{.Source}}")
+  -s	include line numbers in collision warnings (IDE-friendly format)
+  -schema-strategy string
+    	collision strategy for schemas (accept-left, accept-right, rename-left, rename-right, deduplicate, fail)
+  -semantic-dedup
+    	enable semantic deduplication to consolidate identical schemas
+  -source-map
+    	include line numbers in collision warnings (IDE-friendly format)
+
+Collision Strategies:
+  accept-left      Keep the first value when collisions occur
+  accept-right     Keep the last value when collisions occur (overwrite)
+  rename-left      Rename left schema, keep right under original name
+  rename-right     Rename right schema, keep left under original name
+  deduplicate      Merge structurally identical schemas (requires equivalence-mode)
+  fail             Fail with an error on any collision
+  fail-on-paths    Fail only on path collisions, allow schema collisions
+
+Namespace Prefixes:
+  Use --namespace-prefix to add source-based prefixes to schema names.
+  Format: source=prefix (can be specified multiple times)
+  By default, prefix is only applied on collision. Use --always-prefix to
+  apply namespace prefixes to all schemas from the configured sources.
+
+Examples:
+  oastools join -o merged.yaml base.yaml extensions.yaml
+  oastools join --path-strategy accept-left -o api.yaml spec1.yaml spec2.yaml
+  oastools join --schema-strategy accept-right -o output.yaml api1.yaml api2.yaml api3.yaml
+  oastools join --namespace-prefix users.yaml=Users --namespace-prefix billing.yaml=Billing -o merged.yaml users.yaml billing.yaml
+  oastools join --namespace-prefix api2.yaml=V2 --always-prefix -o merged.yaml api1.yaml api2.yaml
+  oastools join -s -o merged.yaml api1.yaml api2.yaml  # Include line numbers in warnings
+
+Pipelining:
+  oastools join -q base.yaml ext.yaml | oastools validate -q -
+  oastools join -q spec1.yaml spec2.yaml | oastools convert -q -t 3.1.0 -
+
+Notes:
+  - All input files must be the same major OAS version (2.0 or 3.x)
+  - The output will use the version of the first input file
+  - Info section is taken from the first document by default
+  - When -o is specified, file is written with restrictive permissions (0600)
+invalid value "=Prefix" for flag -namespace-prefix: namespace prefix requires non-empty source and prefix: "=Prefix"
+Usage: oastools join [flags] <file1> <file2> [file3...]
+
+Join multiple OpenAPI specification files into a single document.
+
+Flags:
+  -always-prefix
+    	apply namespace prefix to all schemas, not just on collision
+  -collision-report
+    	generate detailed collision analysis report
+  -component-strategy string
+    	collision strategy for other components
+  -equivalence-mode string
+    	schema comparison mode for deduplication (none, shallow, deep) (default "none")
+  -namespace-prefix value
+    	namespace prefix for source file (format: source=prefix, can be repeated)
+  -no-dedup-tags
+    	don't deduplicate tags by name
+  -no-merge-arrays
+    	don't merge arrays (servers, security, etc.)
+  -o string
+    	output file path (default: stdout)
+  -output string
+    	output file path (default: stdout)
+  -path-strategy string
+    	collision strategy for paths (accept-left, accept-right, fail, fail-on-paths)
+  -q	quiet mode: suppress diagnostic messages (for pipelining)
+  -quiet
+    	quiet mode: suppress diagnostic messages (for pipelining)
+  -rename-template string
+    	template for renamed schema names (default "{{.Name}}_{{.Source}}")
+  -s	include line numbers in collision warnings (IDE-friendly format)
+  -schema-strategy string
+    	collision strategy for schemas (accept-left, accept-right, rename-left, rename-right, deduplicate, fail)
+  -semantic-dedup
+    	enable semantic deduplication to consolidate identical schemas
+  -source-map
+    	include line numbers in collision warnings (IDE-friendly format)
+
+Collision Strategies:
+  accept-left      Keep the first value when collisions occur
+  accept-right     Keep the last value when collisions occur (overwrite)
+  rename-left      Rename left schema, keep right under original name
+  rename-right     Rename right schema, keep left under original name
+  deduplicate      Merge structurally identical schemas (requires equivalence-mode)
+  fail             Fail with an error on any collision
+  fail-on-paths    Fail only on path collisions, allow schema collisions
+
+Namespace Prefixes:
+  Use --namespace-prefix to add source-based prefixes to schema names.
+  Format: source=prefix (can be specified multiple times)
+  By default, prefix is only applied on collision. Use --always-prefix to
+  apply namespace prefixes to all schemas from the configured sources.
+
+Examples:
+  oastools join -o merged.yaml base.yaml extensions.yaml
+  oastools join --path-strategy accept-left -o api.yaml spec1.yaml spec2.yaml
+  oastools join --schema-strategy accept-right -o output.yaml api1.yaml api2.yaml api3.yaml
+  oastools join --namespace-prefix users.yaml=Users --namespace-prefix billing.yaml=Billing -o merged.yaml users.yaml billing.yaml
+  oastools join --namespace-prefix api2.yaml=V2 --always-prefix -o merged.yaml api1.yaml api2.yaml
+  oastools join -s -o merged.yaml api1.yaml api2.yaml  # Include line numbers in warnings
+
+Pipelining:
+  oastools join -q base.yaml ext.yaml | oastools validate -q -
+  oastools join -q spec1.yaml spec2.yaml | oastools convert -q -t 3.1.0 -
+
+Notes:
+  - All input files must be the same major OAS version (2.0 or 3.x)
+  - The output will use the version of the first input file
+  - Info section is taken from the first document by default
+  - When -o is specified, file is written with restrictive permissions (0600)
+invalid value "api.yaml=" for flag -namespace-prefix: namespace prefix requires non-empty source and prefix: "api.yaml="
+Usage: oastools join [flags] <file1> <file2> [file3...]
+
+Join multiple OpenAPI specification files into a single document.
+
+Flags:
+  -always-prefix
+    	apply namespace prefix to all schemas, not just on collision
+  -collision-report
+    	generate detailed collision analysis report
+  -component-strategy string
+    	collision strategy for other components
+  -equivalence-mode string
+    	schema comparison mode for deduplication (none, shallow, deep) (default "none")
+  -namespace-prefix value
+    	namespace prefix for source file (format: source=prefix, can be repeated)
+  -no-dedup-tags
+    	don't deduplicate tags by name
+  -no-merge-arrays
+    	don't merge arrays (servers, security, etc.)
+  -o string
+    	output file path (default: stdout)
+  -output string
+    	output file path (default: stdout)
+  -path-strategy string
+    	collision strategy for paths (accept-left, accept-right, fail, fail-on-paths)
+  -q	quiet mode: suppress diagnostic messages (for pipelining)
+  -quiet
+    	quiet mode: suppress diagnostic messages (for pipelining)
+  -rename-template string
+    	template for renamed schema names (default "{{.Name}}_{{.Source}}")
+  -s	include line numbers in collision warnings (IDE-friendly format)
+  -schema-strategy string
+    	collision strategy for schemas (accept-left, accept-right, rename-left, rename-right, deduplicate, fail)
+  -semantic-dedup
+    	enable semantic deduplication to consolidate identical schemas
+  -source-map
+    	include line numbers in collision warnings (IDE-friendly format)
+
+Collision Strategies:
+  accept-left      Keep the first value when collisions occur
+  accept-right     Keep the last value when collisions occur (overwrite)
+  rename-left      Rename left schema, keep right under original name
+  rename-right     Rename right schema, keep left under original name
+  deduplicate      Merge structurally identical schemas (requires equivalence-mode)
+  fail             Fail with an error on any collision
+  fail-on-paths    Fail only on path collisions, allow schema collisions
+
+Namespace Prefixes:
+  Use --namespace-prefix to add source-based prefixes to schema names.
+  Format: source=prefix (can be specified multiple times)
+  By default, prefix is only applied on collision. Use --always-prefix to
+  apply namespace prefixes to all schemas from the configured sources.
+
+Examples:
+  oastools join -o merged.yaml base.yaml extensions.yaml
+  oastools join --path-strategy accept-left -o api.yaml spec1.yaml spec2.yaml
+  oastools join --schema-strategy accept-right -o output.yaml api1.yaml api2.yaml api3.yaml
+  oastools join --namespace-prefix users.yaml=Users --namespace-prefix billing.yaml=Billing -o merged.yaml users.yaml billing.yaml
+  oastools join --namespace-prefix api2.yaml=V2 --always-prefix -o merged.yaml api1.yaml api2.yaml
+  oastools join -s -o merged.yaml api1.yaml api2.yaml  # Include line numbers in warnings
+
+Pipelining:
+  oastools join -q base.yaml ext.yaml | oastools validate -q -
+  oastools join -q spec1.yaml spec2.yaml | oastools convert -q -t 3.1.0 -
+
+Notes:
+  - All input files must be the same major OAS version (2.0 or 3.x)
+  - The output will use the version of the first input file
+  - Info section is taken from the first document by default
+  - When -o is specified, file is written with restrictive permissions (0600)
+Usage: oastools parse [flags] <file|url|->
+
+Parse and output OpenAPI document structure.
+
+Flags:
+  -insecure
+    	disable TLS certificate verification for HTTPS refs
+  -q	quiet mode: only output the document, no diagnostic messages
+  -quiet
+    	quiet mode: only output the document, no diagnostic messages
+  -resolve-http-refs
+    	resolve HTTP/HTTPS $ref URLs (requires --resolve-refs)
+  -resolve-refs
+    	resolve external $ref references
+  -validate-structure
+    	validate document structure during parsing
+
+Examples:
+  oastools parse openapi.yaml
+  oastools parse --resolve-refs openapi.yaml
+  oastools parse --resolve-refs --resolve-http-refs https://example.com/api/openapi.yaml
+  oastools parse --resolve-refs --resolve-http-refs --insecure https://internal-server/api.yaml
+  oastools parse --validate-structure https://example.com/api/openapi.yaml
+  cat openapi.yaml | oastools parse -q -
+
+HTTP Reference Resolution:
+  --resolve-http-refs enables fetching and resolving $refs that point to HTTP/HTTPS URLs.
+  This is disabled by default for security (SSRF protection).
+  Use --insecure to skip TLS certificate verification for self-signed certs.
+
+Pipelining:
+  - Use '-' as the file path to read from stdin
+  - Use --quiet/-q to suppress diagnostic output for pipelining
+
+Exit Codes:
+  0    Parsing successful
+  1    Parsing failed or validation errors found (with --validate-structure)
+Usage: oastools parse [flags] <file|url|->
+
+Parse and output OpenAPI document structure.
+
+Flags:
+  -insecure
+    	disable TLS certificate verification for HTTPS refs
+  -q	quiet mode: only output the document, no diagnostic messages
+  -quiet
+    	quiet mode: only output the document, no diagnostic messages
+  -resolve-http-refs
+    	resolve HTTP/HTTPS $ref URLs (requires --resolve-refs)
+  -resolve-refs
+    	resolve external $ref references
+  -validate-structure
+    	validate document structure during parsing
+
+Examples:
+  oastools parse openapi.yaml
+  oastools parse --resolve-refs openapi.yaml
+  oastools parse --resolve-refs --resolve-http-refs https://example.com/api/openapi.yaml
+  oastools parse --resolve-refs --resolve-http-refs --insecure https://internal-server/api.yaml
+  oastools parse --validate-structure https://example.com/api/openapi.yaml
+  cat openapi.yaml | oastools parse -q -
+
+HTTP Reference Resolution:
+  --resolve-http-refs enables fetching and resolving $refs that point to HTTP/HTTPS URLs.
+  This is disabled by default for security (SSRF protection).
+  Use --insecure to skip TLS certificate verification for self-signed certs.
+
+Pipelining:
+  - Use '-' as the file path to read from stdin
+  - Use --quiet/-q to suppress diagnostic output for pipelining
+
+Exit Codes:
+  0    Parsing successful
+  1    Parsing failed or validation errors found (with --validate-structure)
+Usage: oastools validate [flags] <file|url|->
+
+Validate an OpenAPI specification file, URL, or stdin against the specification version it declares.
+
+Flags:
+  -format string
+    	output format: text, json, or yaml (default "text")
+  -no-warnings
+    	suppress warning messages (only show errors)
+  -q	quiet mode: only output validation result, no diagnostic messages
+  -quiet
+    	quiet mode: only output validation result, no diagnostic messages
+  -s	include line numbers in validation errors (IDE-friendly format)
+  -source-map
+    	include line numbers in validation errors (IDE-friendly format)
+  -strict
+    	enable stricter validation beyond spec requirements
+
+Output Formats:
+  text (default)  Human-readable text output
+  json            JSON format for programmatic processing
+  yaml            YAML format for programmatic processing
+
+Examples:
+  oastools validate openapi.yaml
+  oastools validate https://example.com/api/openapi.yaml
+  oastools validate --strict api-spec.yaml
+  oastools validate --no-warnings openapi.json
+  cat openapi.yaml | oastools validate -q -
+  oastools validate --format json openapi.yaml | jq '.valid'
+  oastools validate -s openapi.yaml  # Include line numbers in errors
+
+Pipelining:
+  - Use '-' as the file path to read from stdin
+  - Use --quiet/-q to suppress diagnostic output for pipelining
+  - Use --format json/yaml for structured output that can be parsed
+
+Exit Codes:
+  0    Validation successful
+  1    Validation failed with errors
+Usage: oastools validate [flags] <file|url|->
+
+Validate an OpenAPI specification file, URL, or stdin against the specification version it declares.
+
+Flags:
+  -format string
+    	output format: text, json, or yaml (default "text")
+  -no-warnings
+    	suppress warning messages (only show errors)
+  -q	quiet mode: only output validation result, no diagnostic messages
+  -quiet
+    	quiet mode: only output validation result, no diagnostic messages
+  -s	include line numbers in validation errors (IDE-friendly format)
+  -source-map
+    	include line numbers in validation errors (IDE-friendly format)
+  -strict
+    	enable stricter validation beyond spec requirements
+
+Output Formats:
+  text (default)  Human-readable text output
+  json            JSON format for programmatic processing
+  yaml            YAML format for programmatic processing
+
+Examples:
+  oastools validate openapi.yaml
+  oastools validate https://example.com/api/openapi.yaml
+  oastools validate --strict api-spec.yaml
+  oastools validate --no-warnings openapi.json
+  cat openapi.yaml | oastools validate -q -
+  oastools validate --format json openapi.yaml | jq '.valid'
+  oastools validate -s openapi.yaml  # Include line numbers in errors
+
+Pipelining:
+  - Use '-' as the file path to read from stdin
+  - Use --quiet/-q to suppress diagnostic output for pipelining
+  - Use --format json/yaml for structured output that can be parsed
+
+Exit Codes:
+  0    Validation successful
+  1    Validation failed with errors
+Usage: oastools convert [flags] <file|url|->
+
+Convert an OpenAPI specification from one version to another.
+
+Flags:
+  -no-warnings
+    	suppress warning and info messages
+  -o string
+    	output file path (default: stdout)
+  -output string
+    	output file path (default: stdout)
+  -q	quiet mode: only output the document, no diagnostic messages
+  -quiet
+    	quiet mode: only output the document, no diagnostic messages
+  -s	include line numbers in conversion issues (IDE-friendly format)
+  -source-map
+    	include line numbers in conversion issues (IDE-friendly format)
+  -strict
+    	fail on any conversion issues (even warnings)
+  -t string
+    	target OAS version (e.g., "3.0.3", "2.0", "3.1.0") (required)
+  -target string
+    	target OAS version (e.g., "3.0.3", "2.0", "3.1.0") (required)
+
+Supported Conversions:
+  - OAS 2.0 → OAS 3.x (3.0.0 through 3.2.0)
+  - OAS 3.x → OAS 2.0
+  - OAS 3.x → OAS 3.y (version updates)
+
+Examples:
+  oastools convert -t 3.0.3 swagger.yaml -o openapi.yaml
+  oastools convert -t 3.0.3 https://example.com/swagger.yaml -o openapi.yaml
+  oastools convert -t 2.0 openapi-v3.yaml
+  oastools convert --strict -t 3.1.0 swagger.yaml -o openapi-v3.yaml
+  cat swagger.yaml | oastools convert -q -t 3.0.3 - > openapi.yaml
+  oastools convert -s -t 3.0.3 swagger.yaml  # Include line numbers in issues
+
+Pipelining:
+  - Use '-' as the file path to read from stdin
+  - Use --quiet/-q to suppress diagnostic output for pipelining
+
+Notes:
+  - Critical issues indicate features that cannot be converted (data loss)
+  - Warnings indicate lossy conversions or best-effort transformations
+  - Info messages provide context about conversion choices
+  - Always validate converted documents before deployment
+
+Exit Codes:
+  0    Conversion successful
+  1    Conversion failed or critical issues found (in --strict mode)
+Usage: oastools convert [flags] <file|url|->
+
+Convert an OpenAPI specification from one version to another.
+
+Flags:
+  -no-warnings
+    	suppress warning and info messages
+  -o string
+    	output file path (default: stdout)
+  -output string
+    	output file path (default: stdout)
+  -q	quiet mode: only output the document, no diagnostic messages
+  -quiet
+    	quiet mode: only output the document, no diagnostic messages
+  -s	include line numbers in conversion issues (IDE-friendly format)
+  -source-map
+    	include line numbers in conversion issues (IDE-friendly format)
+  -strict
+    	fail on any conversion issues (even warnings)
+  -t string
+    	target OAS version (e.g., "3.0.3", "2.0", "3.1.0") (required)
+  -target string
+    	target OAS version (e.g., "3.0.3", "2.0", "3.1.0") (required)
+
+Supported Conversions:
+  - OAS 2.0 → OAS 3.x (3.0.0 through 3.2.0)
+  - OAS 3.x → OAS 2.0
+  - OAS 3.x → OAS 3.y (version updates)
+
+Examples:
+  oastools convert -t 3.0.3 swagger.yaml -o openapi.yaml
+  oastools convert -t 3.0.3 https://example.com/swagger.yaml -o openapi.yaml
+  oastools convert -t 2.0 openapi-v3.yaml
+  oastools convert --strict -t 3.1.0 swagger.yaml -o openapi-v3.yaml
+  cat swagger.yaml | oastools convert -q -t 3.0.3 - > openapi.yaml
+  oastools convert -s -t 3.0.3 swagger.yaml  # Include line numbers in issues
+
+Pipelining:
+  - Use '-' as the file path to read from stdin
+  - Use --quiet/-q to suppress diagnostic output for pipelining
+
+Notes:
+  - Critical issues indicate features that cannot be converted (data loss)
+  - Warnings indicate lossy conversions or best-effort transformations
+  - Info messages provide context about conversion choices
+  - Always validate converted documents before deployment
+
+Exit Codes:
+  0    Conversion successful
+  1    Conversion failed or critical issues found (in --strict mode)
+Usage: oastools convert [flags] <file|url|->
+
+Convert an OpenAPI specification from one version to another.
+
+Flags:
+  -no-warnings
+    	suppress warning and info messages
+  -o string
+    	output file path (default: stdout)
+  -output string
+    	output file path (default: stdout)
+  -q	quiet mode: only output the document, no diagnostic messages
+  -quiet
+    	quiet mode: only output the document, no diagnostic messages
+  -s	include line numbers in conversion issues (IDE-friendly format)
+  -source-map
+    	include line numbers in conversion issues (IDE-friendly format)
+  -strict
+    	fail on any conversion issues (even warnings)
+  -t string
+    	target OAS version (e.g., "3.0.3", "2.0", "3.1.0") (required)
+  -target string
+    	target OAS version (e.g., "3.0.3", "2.0", "3.1.0") (required)
+
+Supported Conversions:
+  - OAS 2.0 → OAS 3.x (3.0.0 through 3.2.0)
+  - OAS 3.x → OAS 2.0
+  - OAS 3.x → OAS 3.y (version updates)
+
+Examples:
+  oastools convert -t 3.0.3 swagger.yaml -o openapi.yaml
+  oastools convert -t 3.0.3 https://example.com/swagger.yaml -o openapi.yaml
+  oastools convert -t 2.0 openapi-v3.yaml
+  oastools convert --strict -t 3.1.0 swagger.yaml -o openapi-v3.yaml
+  cat swagger.yaml | oastools convert -q -t 3.0.3 - > openapi.yaml
+  oastools convert -s -t 3.0.3 swagger.yaml  # Include line numbers in issues
+
+Pipelining:
+  - Use '-' as the file path to read from stdin
+  - Use --quiet/-q to suppress diagnostic output for pipelining
+
+Notes:
+  - Critical issues indicate features that cannot be converted (data loss)
+  - Warnings indicate lossy conversions or best-effort transformations
+  - Info messages provide context about conversion choices
+  - Always validate converted documents before deployment
+
+Exit Codes:
+  0    Conversion successful
+  1    Conversion failed or critical issues found (in --strict mode)
+Usage: oastools diff [flags] <source> <target>
+
+Compare two OpenAPI specification files or URLs and report differences.
+
+Flags:
+  -breaking
+    	enable breaking change detection and categorization
+  -format string
+    	output format: text, json, or yaml (default "text")
+  -no-info
+    	exclude informational changes from output
+  -s	include line numbers in diff output (IDE-friendly format)
+  -source-map
+    	include line numbers in diff output (IDE-friendly format)
+
+Output Formats:
+  text (default)  Human-readable text output
+  json            JSON format for programmatic processing
+  yaml            YAML format for programmatic processing
+
+Modes:
+  Default (Simple):
+    Reports all semantic differences between specifications without
+    categorizing them by severity or breaking change impact.
+
+  --breaking (Breaking Change Detection):
+    Categorizes changes by severity and identifies breaking API changes:
+    - Critical: Removed endpoints or operations
+    - Error:    Removed required parameters, incompatible type changes
+    - Warning:  Deprecated operations, added required fields
+    - Info:     Additions, relaxed constraints, documentation updates
+
+Examples:
+  oastools diff api-v1.yaml api-v2.yaml
+  oastools diff --breaking api-v1.yaml api-v2.yaml
+  oastools diff --breaking --no-info old.yaml new.yaml
+  oastools diff --format json --breaking api-v1.yaml api-v2.yaml | jq '.HasBreakingChanges'
+  oastools diff https://example.com/api/v1.yaml https://example.com/api/v2.yaml
+  oastools diff -s api-v1.yaml api-v2.yaml  # Include line numbers in changes
+
+Exit Status:
+  0    No differences found (or no breaking changes in --breaking mode)
+  1    Differences found (or breaking changes found in --breaking mode)
+
+Notes:
+  - Both specifications must be valid OpenAPI documents
+  - Cross-version comparison (2.0 vs 3.x) is supported with limitations
+  - Breaking change detection helps identify backward compatibility issues
+Usage: oastools diff [flags] <source> <target>
+
+Compare two OpenAPI specification files or URLs and report differences.
+
+Flags:
+  -breaking
+    	enable breaking change detection and categorization
+  -format string
+    	output format: text, json, or yaml (default "text")
+  -no-info
+    	exclude informational changes from output
+  -s	include line numbers in diff output (IDE-friendly format)
+  -source-map
+    	include line numbers in diff output (IDE-friendly format)
+
+Output Formats:
+  text (default)  Human-readable text output
+  json            JSON format for programmatic processing
+  yaml            YAML format for programmatic processing
+
+Modes:
+  Default (Simple):
+    Reports all semantic differences between specifications without
+    categorizing them by severity or breaking change impact.
+
+  --breaking (Breaking Change Detection):
+    Categorizes changes by severity and identifies breaking API changes:
+    - Critical: Removed endpoints or operations
+    - Error:    Removed required parameters, incompatible type changes
+    - Warning:  Deprecated operations, added required fields
+    - Info:     Additions, relaxed constraints, documentation updates
+
+Examples:
+  oastools diff api-v1.yaml api-v2.yaml
+  oastools diff --breaking api-v1.yaml api-v2.yaml
+  oastools diff --breaking --no-info old.yaml new.yaml
+  oastools diff --format json --breaking api-v1.yaml api-v2.yaml | jq '.HasBreakingChanges'
+  oastools diff https://example.com/api/v1.yaml https://example.com/api/v2.yaml
+  oastools diff -s api-v1.yaml api-v2.yaml  # Include line numbers in changes
+
+Exit Status:
+  0    No differences found (or no breaking changes in --breaking mode)
+  1    Differences found (or breaking changes found in --breaking mode)
+
+Notes:
+  - Both specifications must be valid OpenAPI documents
+  - Cross-version comparison (2.0 vs 3.x) is supported with limitations
+  - Breaking change detection helps identify backward compatibility issues
+Usage: oastools diff [flags] <source> <target>
+
+Compare two OpenAPI specification files or URLs and report differences.
+
+Flags:
+  -breaking
+    	enable breaking change detection and categorization
+  -format string
+    	output format: text, json, or yaml (default "text")
+  -no-info
+    	exclude informational changes from output
+  -s	include line numbers in diff output (IDE-friendly format)
+  -source-map
+    	include line numbers in diff output (IDE-friendly format)
+
+Output Formats:
+  text (default)  Human-readable text output
+  json            JSON format for programmatic processing
+  yaml            YAML format for programmatic processing
+
+Modes:
+  Default (Simple):
+    Reports all semantic differences between specifications without
+    categorizing them by severity or breaking change impact.
+
+  --breaking (Breaking Change Detection):
+    Categorizes changes by severity and identifies breaking API changes:
+    - Critical: Removed endpoints or operations
+    - Error:    Removed required parameters, incompatible type changes
+    - Warning:  Deprecated operations, added required fields
+    - Info:     Additions, relaxed constraints, documentation updates
+
+Examples:
+  oastools diff api-v1.yaml api-v2.yaml
+  oastools diff --breaking api-v1.yaml api-v2.yaml
+  oastools diff --breaking --no-info old.yaml new.yaml
+  oastools diff --format json --breaking api-v1.yaml api-v2.yaml | jq '.HasBreakingChanges'
+  oastools diff https://example.com/api/v1.yaml https://example.com/api/v2.yaml
+  oastools diff -s api-v1.yaml api-v2.yaml  # Include line numbers in changes
+
+Exit Status:
+  0    No differences found (or no breaking changes in --breaking mode)
+  1    Differences found (or breaking changes found in --breaking mode)
+
+Notes:
+  - Both specifications must be valid OpenAPI documents
+  - Cross-version comparison (2.0 vs 3.x) is supported with limitations
+  - Breaking change detection helps identify backward compatibility issues
+Usage: oastools fix [flags] <file|url|->
+
+Apply automatic fixes to common OpenAPI specification issues.
+
+Flags:
+  -dry-run
+    	preview changes without modifying the document
+  -fix-schema-names
+    	fix invalid schema names (brackets, special characters)
+  -generic-naming string
+    	strategy for renaming generic types: underscore, of, for, flat, dot (default "underscore")
+  -generic-param-separator string
+    	separator between multiple type parameters (default "_")
+  -generic-separator string
+    	separator for underscore strategy (default "_")
+  -infer
+    	infer parameter types from naming conventions
+  -o string
+    	output file path (default: stdout)
+  -output string
+    	output file path (default: stdout)
+  -preserve-casing
+    	preserve original casing of type parameters
+  -prune
+    	apply all pruning fixes (alias for --prune-all)
+  -prune-all
+    	apply all pruning fixes (schemas, paths)
+  -prune-paths
+    	remove paths with no operations
+  -prune-schemas
+    	remove unreferenced schema definitions
+  -q	quiet mode: only output the document, no diagnostic messages
+  -quiet
+    	quiet mode: only output the document, no diagnostic messages
+  -s	include line numbers in fix output (IDE-friendly format)
+  -source-map
+    	include line numbers in fix output (IDE-friendly format)
+
+Supported Fixes:
+  - Missing path parameters: Adds Parameter objects for path template
+    variables that are not declared in the operation's parameters list.
+    Default type is 'string'. Use --infer for smart type inference.
+  - Invalid schema names (--fix-schema-names): Renames schemas with
+    invalid characters (brackets, etc.) using configurable strategies.
+  - Prune schemas (--prune-schemas): Removes unreferenced schemas.
+  - Prune paths (--prune-paths): Removes paths with no operations.
+
+Type Inference (--infer):
+  - Names ending in 'id', 'Id', 'ID' -> integer
+  - Names containing 'uuid', 'guid' -> string with format uuid
+  - All other names -> string
+
+Generic Naming Strategies (--generic-naming):
+  underscore: Response[User] → Response_User_
+  of:         Response[User] → ResponseOfUser
+  for:        Response[User] → ResponseForUser
+  flat:       Response[User] → ResponseUser
+  dot:        Response[User] → Response.User
+
+Examples:
+  oastools fix openapi.yaml
+  oastools fix -o fixed.yaml openapi.yaml
+  oastools fix --infer openapi.yaml
+  oastools fix --fix-schema-names --generic-naming of api.yaml
+  oastools fix --prune-all api.yaml
+  oastools fix --dry-run --prune-schemas api.yaml
+  cat openapi.yaml | oastools fix -q - > fixed.yaml
+  oastools fix -s openapi.yaml  # Include line numbers in fixes
+
+Pipelining:
+  oastools fix -q api.yaml | oastools validate -q -
+  oastools fix -q --infer api.yaml | oastools convert -q -t 3.1.0 -
+
+Notes:
+  - Use 'oastools validate' to see validation errors before fixing
+  - Pruning fixes only run when explicitly requested via flags
+  - Use --dry-run to preview what would be changed
+  - Output preserves the original format (JSON or YAML)
+
+Exit Codes:
+  0    Fixes applied successfully (or no fixes needed)
+  1    Failed to parse or fix the specification
+Usage: oastools fix [flags] <file|url|->
+
+Apply automatic fixes to common OpenAPI specification issues.
+
+Flags:
+  -dry-run
+    	preview changes without modifying the document
+  -fix-schema-names
+    	fix invalid schema names (brackets, special characters)
+  -generic-naming string
+    	strategy for renaming generic types: underscore, of, for, flat, dot (default "underscore")
+  -generic-param-separator string
+    	separator between multiple type parameters (default "_")
+  -generic-separator string
+    	separator for underscore strategy (default "_")
+  -infer
+    	infer parameter types from naming conventions
+  -o string
+    	output file path (default: stdout)
+  -output string
+    	output file path (default: stdout)
+  -preserve-casing
+    	preserve original casing of type parameters
+  -prune
+    	apply all pruning fixes (alias for --prune-all)
+  -prune-all
+    	apply all pruning fixes (schemas, paths)
+  -prune-paths
+    	remove paths with no operations
+  -prune-schemas
+    	remove unreferenced schema definitions
+  -q	quiet mode: only output the document, no diagnostic messages
+  -quiet
+    	quiet mode: only output the document, no diagnostic messages
+  -s	include line numbers in fix output (IDE-friendly format)
+  -source-map
+    	include line numbers in fix output (IDE-friendly format)
+
+Supported Fixes:
+  - Missing path parameters: Adds Parameter objects for path template
+    variables that are not declared in the operation's parameters list.
+    Default type is 'string'. Use --infer for smart type inference.
+  - Invalid schema names (--fix-schema-names): Renames schemas with
+    invalid characters (brackets, etc.) using configurable strategies.
+  - Prune schemas (--prune-schemas): Removes unreferenced schemas.
+  - Prune paths (--prune-paths): Removes paths with no operations.
+
+Type Inference (--infer):
+  - Names ending in 'id', 'Id', 'ID' -> integer
+  - Names containing 'uuid', 'guid' -> string with format uuid
+  - All other names -> string
+
+Generic Naming Strategies (--generic-naming):
+  underscore: Response[User] → Response_User_
+  of:         Response[User] → ResponseOfUser
+  for:        Response[User] → ResponseForUser
+  flat:       Response[User] → ResponseUser
+  dot:        Response[User] → Response.User
+
+Examples:
+  oastools fix openapi.yaml
+  oastools fix -o fixed.yaml openapi.yaml
+  oastools fix --infer openapi.yaml
+  oastools fix --fix-schema-names --generic-naming of api.yaml
+  oastools fix --prune-all api.yaml
+  oastools fix --dry-run --prune-schemas api.yaml
+  cat openapi.yaml | oastools fix -q - > fixed.yaml
+  oastools fix -s openapi.yaml  # Include line numbers in fixes
+
+Pipelining:
+  oastools fix -q api.yaml | oastools validate -q -
+  oastools fix -q --infer api.yaml | oastools convert -q -t 3.1.0 -
+
+Notes:
+  - Use 'oastools validate' to see validation errors before fixing
+  - Pruning fixes only run when explicitly requested via flags
+  - Use --dry-run to preview what would be changed
+  - Output preserves the original format (JSON or YAML)
+
+Exit Codes:
+  0    Fixes applied successfully (or no fixes needed)
+  1    Failed to parse or fix the specification
+Usage: oastools generate [flags] <file|url|->
+
+Generate Go code from an OpenAPI specification.
+
+Flags:
+  -client
+    	generate HTTP client code
+  -credential-mgmt
+    	generate credential management interfaces
+  -max-lines-per-file int
+    	maximum lines per generated file (0 = no limit) (default 2000)
+  -max-ops-per-file int
+    	maximum operations per generated file (0 = no limit) (default 100)
+  -max-types-per-file int
+    	maximum types per generated file (0 = no limit) (default 200)
+  -no-pointers
+    	don't use pointer types for optional fields
+  -no-readme
+    	don't generate README.md file
+  -no-security
+    	don't generate security helper functions
+  -no-split-by-path
+    	don't split files by path prefix
+  -no-split-by-tag
+    	don't split files by operation tag
+  -no-validation
+    	don't include validation tags
+  -no-warnings
+    	suppress warning and info messages
+  -o string
+    	output directory for generated files (required)
+  -oauth2-flows
+    	generate OAuth2 token flow helpers
+  -oidc-discovery
+    	generate OpenID Connect discovery client
+  -output string
+    	output directory for generated files (required)
+  -p string
+    	Go package name for generated code (default "api")
+  -package string
+    	Go package name for generated code (default "api")
+  -s	include line numbers in generation issues (IDE-friendly format)
+  -security-enforce
+    	generate security enforcement middleware
+  -server
+    	generate server interface code
+  -source-map
+    	include line numbers in generation issues (IDE-friendly format)
+  -strict
+    	fail on any generation issues (even warnings)
+  -types
+    	generate type definitions from schemas (default true)
+
+Examples:
+  oastools generate --client -o ./client openapi.yaml
+  oastools generate --server -o ./server -p myapi openapi.yaml
+  oastools generate --client --server -o ./api petstore.yaml
+  oastools generate --types -o ./models https://example.com/api/openapi.yaml
+  oastools generate --client --oauth2-flows -o ./client openapi.yaml
+  oastools generate --client --credential-mgmt --security-enforce -o ./api openapi.yaml
+  oastools generate --client --max-lines-per-file 1500 -o ./client large-api.yaml
+  cat openapi.yaml | oastools generate --client -o ./client -
+  oastools generate -s --client -o ./client openapi.yaml  # Include line numbers in issues
+
+Pipelining:
+  Use '-' as the file path to read the OpenAPI specification from stdin.
+  Example: oastools convert -t 3.0.3 swagger.yaml | oastools generate --client -o ./client -
+
+Notes:
+  - At least one of --client, --server, or --types must be enabled
+  - Types are always generated when --client or --server is enabled
+  - Security helpers are generated by default when --client is enabled
+  - Generated code uses Go idioms and best practices
+  - Server interface is framework-agnostic
+Usage: oastools generate [flags] <file|url|->
+
+Generate Go code from an OpenAPI specification.
+
+Flags:
+  -client
+    	generate HTTP client code
+  -credential-mgmt
+    	generate credential management interfaces
+  -max-lines-per-file int
+    	maximum lines per generated file (0 = no limit) (default 2000)
+  -max-ops-per-file int
+    	maximum operations per generated file (0 = no limit) (default 100)
+  -max-types-per-file int
+    	maximum types per generated file (0 = no limit) (default 200)
+  -no-pointers
+    	don't use pointer types for optional fields
+  -no-readme
+    	don't generate README.md file
+  -no-security
+    	don't generate security helper functions
+  -no-split-by-path
+    	don't split files by path prefix
+  -no-split-by-tag
+    	don't split files by operation tag
+  -no-validation
+    	don't include validation tags
+  -no-warnings
+    	suppress warning and info messages
+  -o string
+    	output directory for generated files (required)
+  -oauth2-flows
+    	generate OAuth2 token flow helpers
+  -oidc-discovery
+    	generate OpenID Connect discovery client
+  -output string
+    	output directory for generated files (required)
+  -p string
+    	Go package name for generated code (default "api")
+  -package string
+    	Go package name for generated code (default "api")
+  -s	include line numbers in generation issues (IDE-friendly format)
+  -security-enforce
+    	generate security enforcement middleware
+  -server
+    	generate server interface code
+  -source-map
+    	include line numbers in generation issues (IDE-friendly format)
+  -strict
+    	fail on any generation issues (even warnings)
+  -types
+    	generate type definitions from schemas (default true)
+
+Examples:
+  oastools generate --client -o ./client openapi.yaml
+  oastools generate --server -o ./server -p myapi openapi.yaml
+  oastools generate --client --server -o ./api petstore.yaml
+  oastools generate --types -o ./models https://example.com/api/openapi.yaml
+  oastools generate --client --oauth2-flows -o ./client openapi.yaml
+  oastools generate --client --credential-mgmt --security-enforce -o ./api openapi.yaml
+  oastools generate --client --max-lines-per-file 1500 -o ./client large-api.yaml
+  cat openapi.yaml | oastools generate --client -o ./client -
+  oastools generate -s --client -o ./client openapi.yaml  # Include line numbers in issues
+
+Pipelining:
+  Use '-' as the file path to read the OpenAPI specification from stdin.
+  Example: oastools convert -t 3.0.3 swagger.yaml | oastools generate --client -o ./client -
+
+Notes:
+  - At least one of --client, --server, or --types must be enabled
+  - Types are always generated when --client or --server is enabled
+  - Security helpers are generated by default when --client is enabled
+  - Generated code uses Go idioms and best practices
+  - Server interface is framework-agnostic
+Usage: oastools generate [flags] <file|url|->
+
+Generate Go code from an OpenAPI specification.
+
+Flags:
+  -client
+    	generate HTTP client code
+  -credential-mgmt
+    	generate credential management interfaces
+  -max-lines-per-file int
+    	maximum lines per generated file (0 = no limit) (default 2000)
+  -max-ops-per-file int
+    	maximum operations per generated file (0 = no limit) (default 100)
+  -max-types-per-file int
+    	maximum types per generated file (0 = no limit) (default 200)
+  -no-pointers
+    	don't use pointer types for optional fields
+  -no-readme
+    	don't generate README.md file
+  -no-security
+    	don't generate security helper functions
+  -no-split-by-path
+    	don't split files by path prefix
+  -no-split-by-tag
+    	don't split files by operation tag
+  -no-validation
+    	don't include validation tags
+  -no-warnings
+    	suppress warning and info messages
+  -o string
+    	output directory for generated files (required)
+  -oauth2-flows
+    	generate OAuth2 token flow helpers
+  -oidc-discovery
+    	generate OpenID Connect discovery client
+  -output string
+    	output directory for generated files (required)
+  -p string
+    	Go package name for generated code (default "api")
+  -package string
+    	Go package name for generated code (default "api")
+  -s	include line numbers in generation issues (IDE-friendly format)
+  -security-enforce
+    	generate security enforcement middleware
+  -server
+    	generate server interface code
+  -source-map
+    	include line numbers in generation issues (IDE-friendly format)
+  -strict
+    	fail on any generation issues (even warnings)
+  -types
+    	generate type definitions from schemas (default true)
+
+Examples:
+  oastools generate --client -o ./client openapi.yaml
+  oastools generate --server -o ./server -p myapi openapi.yaml
+  oastools generate --client --server -o ./api petstore.yaml
+  oastools generate --types -o ./models https://example.com/api/openapi.yaml
+  oastools generate --client --oauth2-flows -o ./client openapi.yaml
+  oastools generate --client --credential-mgmt --security-enforce -o ./api openapi.yaml
+  oastools generate --client --max-lines-per-file 1500 -o ./client large-api.yaml
+  cat openapi.yaml | oastools generate --client -o ./client -
+  oastools generate -s --client -o ./client openapi.yaml  # Include line numbers in issues
+
+Pipelining:
+  Use '-' as the file path to read the OpenAPI specification from stdin.
+  Example: oastools convert -t 3.0.3 swagger.yaml | oastools generate --client -o ./client -
+
+Notes:
+  - At least one of --client, --server, or --types must be enabled
+  - Types are always generated when --client or --server is enabled
+  - Security helpers are generated by default when --client is enabled
+  - Generated code uses Go idioms and best practices
+  - Server interface is framework-agnostic
+Usage: oastools generate [flags] <file|url|->
+
+Generate Go code from an OpenAPI specification.
+
+Flags:
+  -client
+    	generate HTTP client code
+  -credential-mgmt
+    	generate credential management interfaces
+  -max-lines-per-file int
+    	maximum lines per generated file (0 = no limit) (default 2000)
+  -max-ops-per-file int
+    	maximum operations per generated file (0 = no limit) (default 100)
+  -max-types-per-file int
+    	maximum types per generated file (0 = no limit) (default 200)
+  -no-pointers
+    	don't use pointer types for optional fields
+  -no-readme
+    	don't generate README.md file
+  -no-security
+    	don't generate security helper functions
+  -no-split-by-path
+    	don't split files by path prefix
+  -no-split-by-tag
+    	don't split files by operation tag
+  -no-validation
+    	don't include validation tags
+  -no-warnings
+    	suppress warning and info messages
+  -o string
+    	output directory for generated files (required)
+  -oauth2-flows
+    	generate OAuth2 token flow helpers
+  -oidc-discovery
+    	generate OpenID Connect discovery client
+  -output string
+    	output directory for generated files (required)
+  -p string
+    	Go package name for generated code (default "api")
+  -package string
+    	Go package name for generated code (default "api")
+  -s	include line numbers in generation issues (IDE-friendly format)
+  -security-enforce
+    	generate security enforcement middleware
+  -server
+    	generate server interface code
+  -source-map
+    	include line numbers in generation issues (IDE-friendly format)
+  -strict
+    	fail on any generation issues (even warnings)
+  -types
+    	generate type definitions from schemas (default true)
+
+Examples:
+  oastools generate --client -o ./client openapi.yaml
+  oastools generate --server -o ./server -p myapi openapi.yaml
+  oastools generate --client --server -o ./api petstore.yaml
+  oastools generate --types -o ./models https://example.com/api/openapi.yaml
+  oastools generate --client --oauth2-flows -o ./client openapi.yaml
+  oastools generate --client --credential-mgmt --security-enforce -o ./api openapi.yaml
+  oastools generate --client --max-lines-per-file 1500 -o ./client large-api.yaml
+  cat openapi.yaml | oastools generate --client -o ./client -
+  oastools generate -s --client -o ./client openapi.yaml  # Include line numbers in issues
+
+Pipelining:
+  Use '-' as the file path to read the OpenAPI specification from stdin.
+  Example: oastools convert -t 3.0.3 swagger.yaml | oastools generate --client -o ./client -
+
+Notes:
+  - At least one of --client, --server, or --types must be enabled
+  - Types are always generated when --client or --server is enabled
+  - Security helpers are generated by default when --client is enabled
+  - Generated code uses Go idioms and best practices
+  - Server interface is framework-agnostic
+Usage: oastools join [flags] <file1> <file2> [file3...]
+
+Join multiple OpenAPI specification files into a single document.
+
+Flags:
+  -always-prefix
+    	apply namespace prefix to all schemas, not just on collision
+  -collision-report
+    	generate detailed collision analysis report
+  -component-strategy string
+    	collision strategy for other components
+  -equivalence-mode string
+    	schema comparison mode for deduplication (none, shallow, deep) (default "none")
+  -namespace-prefix value
+    	namespace prefix for source file (format: source=prefix, can be repeated)
+  -no-dedup-tags
+    	don't deduplicate tags by name
+  -no-merge-arrays
+    	don't merge arrays (servers, security, etc.)
+  -o string
+    	output file path (default: stdout)
+  -output string
+    	output file path (default: stdout)
+  -path-strategy string
+    	collision strategy for paths (accept-left, accept-right, fail, fail-on-paths)
+  -q	quiet mode: suppress diagnostic messages (for pipelining)
+  -quiet
+    	quiet mode: suppress diagnostic messages (for pipelining)
+  -rename-template string
+    	template for renamed schema names (default "{{.Name}}_{{.Source}}")
+  -s	include line numbers in collision warnings (IDE-friendly format)
+  -schema-strategy string
+    	collision strategy for schemas (accept-left, accept-right, rename-left, rename-right, deduplicate, fail)
+  -semantic-dedup
+    	enable semantic deduplication to consolidate identical schemas
+  -source-map
+    	include line numbers in collision warnings (IDE-friendly format)
+
+Collision Strategies:
+  accept-left      Keep the first value when collisions occur
+  accept-right     Keep the last value when collisions occur (overwrite)
+  rename-left      Rename left schema, keep right under original name
+  rename-right     Rename right schema, keep left under original name
+  deduplicate      Merge structurally identical schemas (requires equivalence-mode)
+  fail             Fail with an error on any collision
+  fail-on-paths    Fail only on path collisions, allow schema collisions
+
+Namespace Prefixes:
+  Use --namespace-prefix to add source-based prefixes to schema names.
+  Format: source=prefix (can be specified multiple times)
+  By default, prefix is only applied on collision. Use --always-prefix to
+  apply namespace prefixes to all schemas from the configured sources.
+
+Examples:
+  oastools join -o merged.yaml base.yaml extensions.yaml
+  oastools join --path-strategy accept-left -o api.yaml spec1.yaml spec2.yaml
+  oastools join --schema-strategy accept-right -o output.yaml api1.yaml api2.yaml api3.yaml
+  oastools join --namespace-prefix users.yaml=Users --namespace-prefix billing.yaml=Billing -o merged.yaml users.yaml billing.yaml
+  oastools join --namespace-prefix api2.yaml=V2 --always-prefix -o merged.yaml api1.yaml api2.yaml
+  oastools join -s -o merged.yaml api1.yaml api2.yaml  # Include line numbers in warnings
+
+Pipelining:
+  oastools join -q base.yaml ext.yaml | oastools validate -q -
+  oastools join -q spec1.yaml spec2.yaml | oastools convert -q -t 3.1.0 -
+
+Notes:
+  - All input files must be the same major OAS version (2.0 or 3.x)
+  - The output will use the version of the first input file
+  - Info section is taken from the first document by default
+  - When -o is specified, file is written with restrictive permissions (0600)
+Usage: oastools join [flags] <file1> <file2> [file3...]
+
+Join multiple OpenAPI specification files into a single document.
+
+Flags:
+  -always-prefix
+    	apply namespace prefix to all schemas, not just on collision
+  -collision-report
+    	generate detailed collision analysis report
+  -component-strategy string
+    	collision strategy for other components
+  -equivalence-mode string
+    	schema comparison mode for deduplication (none, shallow, deep) (default "none")
+  -namespace-prefix value
+    	namespace prefix for source file (format: source=prefix, can be repeated)
+  -no-dedup-tags
+    	don't deduplicate tags by name
+  -no-merge-arrays
+    	don't merge arrays (servers, security, etc.)
+  -o string
+    	output file path (default: stdout)
+  -output string
+    	output file path (default: stdout)
+  -path-strategy string
+    	collision strategy for paths (accept-left, accept-right, fail, fail-on-paths)
+  -q	quiet mode: suppress diagnostic messages (for pipelining)
+  -quiet
+    	quiet mode: suppress diagnostic messages (for pipelining)
+  -rename-template string
+    	template for renamed schema names (default "{{.Name}}_{{.Source}}")
+  -s	include line numbers in collision warnings (IDE-friendly format)
+  -schema-strategy string
+    	collision strategy for schemas (accept-left, accept-right, rename-left, rename-right, deduplicate, fail)
+  -semantic-dedup
+    	enable semantic deduplication to consolidate identical schemas
+  -source-map
+    	include line numbers in collision warnings (IDE-friendly format)
+
+Collision Strategies:
+  accept-left      Keep the first value when collisions occur
+  accept-right     Keep the last value when collisions occur (overwrite)
+  rename-left      Rename left schema, keep right under original name
+  rename-right     Rename right schema, keep left under original name
+  deduplicate      Merge structurally identical schemas (requires equivalence-mode)
+  fail             Fail with an error on any collision
+  fail-on-paths    Fail only on path collisions, allow schema collisions
+
+Namespace Prefixes:
+  Use --namespace-prefix to add source-based prefixes to schema names.
+  Format: source=prefix (can be specified multiple times)
+  By default, prefix is only applied on collision. Use --always-prefix to
+  apply namespace prefixes to all schemas from the configured sources.
+
+Examples:
+  oastools join -o merged.yaml base.yaml extensions.yaml
+  oastools join --path-strategy accept-left -o api.yaml spec1.yaml spec2.yaml
+  oastools join --schema-strategy accept-right -o output.yaml api1.yaml api2.yaml api3.yaml
+  oastools join --namespace-prefix users.yaml=Users --namespace-prefix billing.yaml=Billing -o merged.yaml users.yaml billing.yaml
+  oastools join --namespace-prefix api2.yaml=V2 --always-prefix -o merged.yaml api1.yaml api2.yaml
+  oastools join -s -o merged.yaml api1.yaml api2.yaml  # Include line numbers in warnings
+
+Pipelining:
+  oastools join -q base.yaml ext.yaml | oastools validate -q -
+  oastools join -q spec1.yaml spec2.yaml | oastools convert -q -t 3.1.0 -
+
+Notes:
+  - All input files must be the same major OAS version (2.0 or 3.x)
+  - The output will use the version of the first input file
+  - Info section is taken from the first document by default
+  - When -o is specified, file is written with restrictive permissions (0600)
+invalid value "invalid" for flag -namespace-prefix: invalid namespace prefix format: "invalid" (expected source=prefix)
+Usage: oastools join [flags] <file1> <file2> [file3...]
+
+Join multiple OpenAPI specification files into a single document.
+
+Flags:
+  -always-prefix
+    	apply namespace prefix to all schemas, not just on collision
+  -collision-report
+    	generate detailed collision analysis report
+  -component-strategy string
+    	collision strategy for other components
+  -equivalence-mode string
+    	schema comparison mode for deduplication (none, shallow, deep) (default "none")
+  -namespace-prefix value
+    	namespace prefix for source file (format: source=prefix, can be repeated)
+  -no-dedup-tags
+    	don't deduplicate tags by name
+  -no-merge-arrays
+    	don't merge arrays (servers, security, etc.)
+  -o string
+    	output file path (default: stdout)
+  -output string
+    	output file path (default: stdout)
+  -path-strategy string
+    	collision strategy for paths (accept-left, accept-right, fail, fail-on-paths)
+  -q	quiet mode: suppress diagnostic messages (for pipelining)
+  -quiet
+    	quiet mode: suppress diagnostic messages (for pipelining)
+  -rename-template string
+    	template for renamed schema names (default "{{.Name}}_{{.Source}}")
+  -s	include line numbers in collision warnings (IDE-friendly format)
+  -schema-strategy string
+    	collision strategy for schemas (accept-left, accept-right, rename-left, rename-right, deduplicate, fail)
+  -semantic-dedup
+    	enable semantic deduplication to consolidate identical schemas
+  -source-map
+    	include line numbers in collision warnings (IDE-friendly format)
+
+Collision Strategies:
+  accept-left      Keep the first value when collisions occur
+  accept-right     Keep the last value when collisions occur (overwrite)
+  rename-left      Rename left schema, keep right under original name
+  rename-right     Rename right schema, keep left under original name
+  deduplicate      Merge structurally identical schemas (requires equivalence-mode)
+  fail             Fail with an error on any collision
+  fail-on-paths    Fail only on path collisions, allow schema collisions
+
+Namespace Prefixes:
+  Use --namespace-prefix to add source-based prefixes to schema names.
+  Format: source=prefix (can be specified multiple times)
+  By default, prefix is only applied on collision. Use --always-prefix to
+  apply namespace prefixes to all schemas from the configured sources.
+
+Examples:
+  oastools join -o merged.yaml base.yaml extensions.yaml
+  oastools join --path-strategy accept-left -o api.yaml spec1.yaml spec2.yaml
+  oastools join --schema-strategy accept-right -o output.yaml api1.yaml api2.yaml api3.yaml
+  oastools join --namespace-prefix users.yaml=Users --namespace-prefix billing.yaml=Billing -o merged.yaml users.yaml billing.yaml
+  oastools join --namespace-prefix api2.yaml=V2 --always-prefix -o merged.yaml api1.yaml api2.yaml
+  oastools join -s -o merged.yaml api1.yaml api2.yaml  # Include line numbers in warnings
+
+Pipelining:
+  oastools join -q base.yaml ext.yaml | oastools validate -q -
+  oastools join -q spec1.yaml spec2.yaml | oastools convert -q -t 3.1.0 -
+
+Notes:
+  - All input files must be the same major OAS version (2.0 or 3.x)
+  - The output will use the version of the first input file
+  - Info section is taken from the first document by default
+  - When -o is specified, file is written with restrictive permissions (0600)
+invalid value "=Prefix" for flag -namespace-prefix: namespace prefix requires non-empty source and prefix: "=Prefix"
+Usage: oastools join [flags] <file1> <file2> [file3...]
+
+Join multiple OpenAPI specification files into a single document.
+
+Flags:
+  -always-prefix
+    	apply namespace prefix to all schemas, not just on collision
+  -collision-report
+    	generate detailed collision analysis report
+  -component-strategy string
+    	collision strategy for other components
+  -equivalence-mode string
+    	schema comparison mode for deduplication (none, shallow, deep) (default "none")
+  -namespace-prefix value
+    	namespace prefix for source file (format: source=prefix, can be repeated)
+  -no-dedup-tags
+    	don't deduplicate tags by name
+  -no-merge-arrays
+    	don't merge arrays (servers, security, etc.)
+  -o string
+    	output file path (default: stdout)
+  -output string
+    	output file path (default: stdout)
+  -path-strategy string
+    	collision strategy for paths (accept-left, accept-right, fail, fail-on-paths)
+  -q	quiet mode: suppress diagnostic messages (for pipelining)
+  -quiet
+    	quiet mode: suppress diagnostic messages (for pipelining)
+  -rename-template string
+    	template for renamed schema names (default "{{.Name}}_{{.Source}}")
+  -s	include line numbers in collision warnings (IDE-friendly format)
+  -schema-strategy string
+    	collision strategy for schemas (accept-left, accept-right, rename-left, rename-right, deduplicate, fail)
+  -semantic-dedup
+    	enable semantic deduplication to consolidate identical schemas
+  -source-map
+    	include line numbers in collision warnings (IDE-friendly format)
+
+Collision Strategies:
+  accept-left      Keep the first value when collisions occur
+  accept-right     Keep the last value when collisions occur (overwrite)
+  rename-left      Rename left schema, keep right under original name
+  rename-right     Rename right schema, keep left under original name
+  deduplicate      Merge structurally identical schemas (requires equivalence-mode)
+  fail             Fail with an error on any collision
+  fail-on-paths    Fail only on path collisions, allow schema collisions
+
+Namespace Prefixes:
+  Use --namespace-prefix to add source-based prefixes to schema names.
+  Format: source=prefix (can be specified multiple times)
+  By default, prefix is only applied on collision. Use --always-prefix to
+  apply namespace prefixes to all schemas from the configured sources.
+
+Examples:
+  oastools join -o merged.yaml base.yaml extensions.yaml
+  oastools join --path-strategy accept-left -o api.yaml spec1.yaml spec2.yaml
+  oastools join --schema-strategy accept-right -o output.yaml api1.yaml api2.yaml api3.yaml
+  oastools join --namespace-prefix users.yaml=Users --namespace-prefix billing.yaml=Billing -o merged.yaml users.yaml billing.yaml
+  oastools join --namespace-prefix api2.yaml=V2 --always-prefix -o merged.yaml api1.yaml api2.yaml
+  oastools join -s -o merged.yaml api1.yaml api2.yaml  # Include line numbers in warnings
+
+Pipelining:
+  oastools join -q base.yaml ext.yaml | oastools validate -q -
+  oastools join -q spec1.yaml spec2.yaml | oastools convert -q -t 3.1.0 -
+
+Notes:
+  - All input files must be the same major OAS version (2.0 or 3.x)
+  - The output will use the version of the first input file
+  - Info section is taken from the first document by default
+  - When -o is specified, file is written with restrictive permissions (0600)
+invalid value "api.yaml=" for flag -namespace-prefix: namespace prefix requires non-empty source and prefix: "api.yaml="
+Usage: oastools join [flags] <file1> <file2> [file3...]
+
+Join multiple OpenAPI specification files into a single document.
+
+Flags:
+  -always-prefix
+    	apply namespace prefix to all schemas, not just on collision
+  -collision-report
+    	generate detailed collision analysis report
+  -component-strategy string
+    	collision strategy for other components
+  -equivalence-mode string
+    	schema comparison mode for deduplication (none, shallow, deep) (default "none")
+  -namespace-prefix value
+    	namespace prefix for source file (format: source=prefix, can be repeated)
+  -no-dedup-tags
+    	don't deduplicate tags by name
+  -no-merge-arrays
+    	don't merge arrays (servers, security, etc.)
+  -o string
+    	output file path (default: stdout)
+  -output string
+    	output file path (default: stdout)
+  -path-strategy string
+    	collision strategy for paths (accept-left, accept-right, fail, fail-on-paths)
+  -q	quiet mode: suppress diagnostic messages (for pipelining)
+  -quiet
+    	quiet mode: suppress diagnostic messages (for pipelining)
+  -rename-template string
+    	template for renamed schema names (default "{{.Name}}_{{.Source}}")
+  -s	include line numbers in collision warnings (IDE-friendly format)
+  -schema-strategy string
+    	collision strategy for schemas (accept-left, accept-right, rename-left, rename-right, deduplicate, fail)
+  -semantic-dedup
+    	enable semantic deduplication to consolidate identical schemas
+  -source-map
+    	include line numbers in collision warnings (IDE-friendly format)
+
+Collision Strategies:
+  accept-left      Keep the first value when collisions occur
+  accept-right     Keep the last value when collisions occur (overwrite)
+  rename-left      Rename left schema, keep right under original name
+  rename-right     Rename right schema, keep left under original name
+  deduplicate      Merge structurally identical schemas (requires equivalence-mode)
+  fail             Fail with an error on any collision
+  fail-on-paths    Fail only on path collisions, allow schema collisions
+
+Namespace Prefixes:
+  Use --namespace-prefix to add source-based prefixes to schema names.
+  Format: source=prefix (can be specified multiple times)
+  By default, prefix is only applied on collision. Use --always-prefix to
+  apply namespace prefixes to all schemas from the configured sources.
+
+Examples:
+  oastools join -o merged.yaml base.yaml extensions.yaml
+  oastools join --path-strategy accept-left -o api.yaml spec1.yaml spec2.yaml
+  oastools join --schema-strategy accept-right -o output.yaml api1.yaml api2.yaml api3.yaml
+  oastools join --namespace-prefix users.yaml=Users --namespace-prefix billing.yaml=Billing -o merged.yaml users.yaml billing.yaml
+  oastools join --namespace-prefix api2.yaml=V2 --always-prefix -o merged.yaml api1.yaml api2.yaml
+  oastools join -s -o merged.yaml api1.yaml api2.yaml  # Include line numbers in warnings
+
+Pipelining:
+  oastools join -q base.yaml ext.yaml | oastools validate -q -
+  oastools join -q spec1.yaml spec2.yaml | oastools convert -q -t 3.1.0 -
+
+Notes:
+  - All input files must be the same major OAS version (2.0 or 3.x)
+  - The output will use the version of the first input file
+  - Info section is taken from the first document by default
+  - When -o is specified, file is written with restrictive permissions (0600)
+Usage: oastools parse [flags] <file|url|->
+
+Parse and output OpenAPI document structure.
+
+Flags:
+  -insecure
+    	disable TLS certificate verification for HTTPS refs
+  -q	quiet mode: only output the document, no diagnostic messages
+  -quiet
+    	quiet mode: only output the document, no diagnostic messages
+  -resolve-http-refs
+    	resolve HTTP/HTTPS $ref URLs (requires --resolve-refs)
+  -resolve-refs
+    	resolve external $ref references
+  -validate-structure
+    	validate document structure during parsing
+
+Examples:
+  oastools parse openapi.yaml
+  oastools parse --resolve-refs openapi.yaml
+  oastools parse --resolve-refs --resolve-http-refs https://example.com/api/openapi.yaml
+  oastools parse --resolve-refs --resolve-http-refs --insecure https://internal-server/api.yaml
+  oastools parse --validate-structure https://example.com/api/openapi.yaml
+  cat openapi.yaml | oastools parse -q -
+
+HTTP Reference Resolution:
+  --resolve-http-refs enables fetching and resolving $refs that point to HTTP/HTTPS URLs.
+  This is disabled by default for security (SSRF protection).
+  Use --insecure to skip TLS certificate verification for self-signed certs.
+
+Pipelining:
+  - Use '-' as the file path to read from stdin
+  - Use --quiet/-q to suppress diagnostic output for pipelining
+
+Exit Codes:
+  0    Parsing successful
+  1    Parsing failed or validation errors found (with --validate-structure)
+Usage: oastools parse [flags] <file|url|->
+
+Parse and output OpenAPI document structure.
+
+Flags:
+  -insecure
+    	disable TLS certificate verification for HTTPS refs
+  -q	quiet mode: only output the document, no diagnostic messages
+  -quiet
+    	quiet mode: only output the document, no diagnostic messages
+  -resolve-http-refs
+    	resolve HTTP/HTTPS $ref URLs (requires --resolve-refs)
+  -resolve-refs
+    	resolve external $ref references
+  -validate-structure
+    	validate document structure during parsing
+
+Examples:
+  oastools parse openapi.yaml
+  oastools parse --resolve-refs openapi.yaml
+  oastools parse --resolve-refs --resolve-http-refs https://example.com/api/openapi.yaml
+  oastools parse --resolve-refs --resolve-http-refs --insecure https://internal-server/api.yaml
+  oastools parse --validate-structure https://example.com/api/openapi.yaml
+  cat openapi.yaml | oastools parse -q -
+
+HTTP Reference Resolution:
+  --resolve-http-refs enables fetching and resolving $refs that point to HTTP/HTTPS URLs.
+  This is disabled by default for security (SSRF protection).
+  Use --insecure to skip TLS certificate verification for self-signed certs.
+
+Pipelining:
+  - Use '-' as the file path to read from stdin
+  - Use --quiet/-q to suppress diagnostic output for pipelining
+
+Exit Codes:
+  0    Parsing successful
+  1    Parsing failed or validation errors found (with --validate-structure)
+Usage: oastools validate [flags] <file|url|->
+
+Validate an OpenAPI specification file, URL, or stdin against the specification version it declares.
+
+Flags:
+  -format string
+    	output format: text, json, or yaml (default "text")
+  -no-warnings
+    	suppress warning messages (only show errors)
+  -q	quiet mode: only output validation result, no diagnostic messages
+  -quiet
+    	quiet mode: only output validation result, no diagnostic messages
+  -s	include line numbers in validation errors (IDE-friendly format)
+  -source-map
+    	include line numbers in validation errors (IDE-friendly format)
+  -strict
+    	enable stricter validation beyond spec requirements
+
+Output Formats:
+  text (default)  Human-readable text output
+  json            JSON format for programmatic processing
+  yaml            YAML format for programmatic processing
+
+Examples:
+  oastools validate openapi.yaml
+  oastools validate https://example.com/api/openapi.yaml
+  oastools validate --strict api-spec.yaml
+  oastools validate --no-warnings openapi.json
+  cat openapi.yaml | oastools validate -q -
+  oastools validate --format json openapi.yaml | jq '.valid'
+  oastools validate -s openapi.yaml  # Include line numbers in errors
+
+Pipelining:
+  - Use '-' as the file path to read from stdin
+  - Use --quiet/-q to suppress diagnostic output for pipelining
+  - Use --format json/yaml for structured output that can be parsed
+
+Exit Codes:
+  0    Validation successful
+  1    Validation failed with errors
+Usage: oastools validate [flags] <file|url|->
+
+Validate an OpenAPI specification file, URL, or stdin against the specification version it declares.
+
+Flags:
+  -format string
+    	output format: text, json, or yaml (default "text")
+  -no-warnings
+    	suppress warning messages (only show errors)
+  -q	quiet mode: only output validation result, no diagnostic messages
+  -quiet
+    	quiet mode: only output validation result, no diagnostic messages
+  -s	include line numbers in validation errors (IDE-friendly format)
+  -source-map
+    	include line numbers in validation errors (IDE-friendly format)
+  -strict
+    	enable stricter validation beyond spec requirements
+
+Output Formats:
+  text (default)  Human-readable text output
+  json            JSON format for programmatic processing
+  yaml            YAML format for programmatic processing
+
+Examples:
+  oastools validate openapi.yaml
+  oastools validate https://example.com/api/openapi.yaml
+  oastools validate --strict api-spec.yaml
+  oastools validate --no-warnings openapi.json
+  cat openapi.yaml | oastools validate -q -
+  oastools validate --format json openapi.yaml | jq '.valid'
+  oastools validate -s openapi.yaml  # Include line numbers in errors
+
+Pipelining:
+  - Use '-' as the file path to read from stdin
+  - Use --quiet/-q to suppress diagnostic output for pipelining
+  - Use --format json/yaml for structured output that can be parsed
+
+Exit Codes:
+  0    Validation successful
+  1    Validation failed with errors
+Usage: oastools convert [flags] <file|url|->
+
+Convert an OpenAPI specification from one version to another.
+
+Flags:
+  -no-warnings
+    	suppress warning and info messages
+  -o string
+    	output file path (default: stdout)
+  -output string
+    	output file path (default: stdout)
+  -q	quiet mode: only output the document, no diagnostic messages
+  -quiet
+    	quiet mode: only output the document, no diagnostic messages
+  -s	include line numbers in conversion issues (IDE-friendly format)
+  -source-map
+    	include line numbers in conversion issues (IDE-friendly format)
+  -strict
+    	fail on any conversion issues (even warnings)
+  -t string
+    	target OAS version (e.g., "3.0.3", "2.0", "3.1.0") (required)
+  -target string
+    	target OAS version (e.g., "3.0.3", "2.0", "3.1.0") (required)
+
+Supported Conversions:
+  - OAS 2.0 → OAS 3.x (3.0.0 through 3.2.0)
+  - OAS 3.x → OAS 2.0
+  - OAS 3.x → OAS 3.y (version updates)
+
+Examples:
+  oastools convert -t 3.0.3 swagger.yaml -o openapi.yaml
+  oastools convert -t 3.0.3 https://example.com/swagger.yaml -o openapi.yaml
+  oastools convert -t 2.0 openapi-v3.yaml
+  oastools convert --strict -t 3.1.0 swagger.yaml -o openapi-v3.yaml
+  cat swagger.yaml | oastools convert -q -t 3.0.3 - > openapi.yaml
+  oastools convert -s -t 3.0.3 swagger.yaml  # Include line numbers in issues
+
+Pipelining:
+  - Use '-' as the file path to read from stdin
+  - Use --quiet/-q to suppress diagnostic output for pipelining
+
+Notes:
+  - Critical issues indicate features that cannot be converted (data loss)
+  - Warnings indicate lossy conversions or best-effort transformations
+  - Info messages provide context about conversion choices
+  - Always validate converted documents before deployment
+
+Exit Codes:
+  0    Conversion successful
+  1    Conversion failed or critical issues found (in --strict mode)
+Usage: oastools convert [flags] <file|url|->
+
+Convert an OpenAPI specification from one version to another.
+
+Flags:
+  -no-warnings
+    	suppress warning and info messages
+  -o string
+    	output file path (default: stdout)
+  -output string
+    	output file path (default: stdout)
+  -q	quiet mode: only output the document, no diagnostic messages
+  -quiet
+    	quiet mode: only output the document, no diagnostic messages
+  -s	include line numbers in conversion issues (IDE-friendly format)
+  -source-map
+    	include line numbers in conversion issues (IDE-friendly format)
+  -strict
+    	fail on any conversion issues (even warnings)
+  -t string
+    	target OAS version (e.g., "3.0.3", "2.0", "3.1.0") (required)
+  -target string
+    	target OAS version (e.g., "3.0.3", "2.0", "3.1.0") (required)
+
+Supported Conversions:
+  - OAS 2.0 → OAS 3.x (3.0.0 through 3.2.0)
+  - OAS 3.x → OAS 2.0
+  - OAS 3.x → OAS 3.y (version updates)
+
+Examples:
+  oastools convert -t 3.0.3 swagger.yaml -o openapi.yaml
+  oastools convert -t 3.0.3 https://example.com/swagger.yaml -o openapi.yaml
+  oastools convert -t 2.0 openapi-v3.yaml
+  oastools convert --strict -t 3.1.0 swagger.yaml -o openapi-v3.yaml
+  cat swagger.yaml | oastools convert -q -t 3.0.3 - > openapi.yaml
+  oastools convert -s -t 3.0.3 swagger.yaml  # Include line numbers in issues
+
+Pipelining:
+  - Use '-' as the file path to read from stdin
+  - Use --quiet/-q to suppress diagnostic output for pipelining
+
+Notes:
+  - Critical issues indicate features that cannot be converted (data loss)
+  - Warnings indicate lossy conversions or best-effort transformations
+  - Info messages provide context about conversion choices
+  - Always validate converted documents before deployment
+
+Exit Codes:
+  0    Conversion successful
+  1    Conversion failed or critical issues found (in --strict mode)
+Usage: oastools convert [flags] <file|url|->
+
+Convert an OpenAPI specification from one version to another.
+
+Flags:
+  -no-warnings
+    	suppress warning and info messages
+  -o string
+    	output file path (default: stdout)
+  -output string
+    	output file path (default: stdout)
+  -q	quiet mode: only output the document, no diagnostic messages
+  -quiet
+    	quiet mode: only output the document, no diagnostic messages
+  -s	include line numbers in conversion issues (IDE-friendly format)
+  -source-map
+    	include line numbers in conversion issues (IDE-friendly format)
+  -strict
+    	fail on any conversion issues (even warnings)
+  -t string
+    	target OAS version (e.g., "3.0.3", "2.0", "3.1.0") (required)
+  -target string
+    	target OAS version (e.g., "3.0.3", "2.0", "3.1.0") (required)
+
+Supported Conversions:
+  - OAS 2.0 → OAS 3.x (3.0.0 through 3.2.0)
+  - OAS 3.x → OAS 2.0
+  - OAS 3.x → OAS 3.y (version updates)
+
+Examples:
+  oastools convert -t 3.0.3 swagger.yaml -o openapi.yaml
+  oastools convert -t 3.0.3 https://example.com/swagger.yaml -o openapi.yaml
+  oastools convert -t 2.0 openapi-v3.yaml
+  oastools convert --strict -t 3.1.0 swagger.yaml -o openapi-v3.yaml
+  cat swagger.yaml | oastools convert -q -t 3.0.3 - > openapi.yaml
+  oastools convert -s -t 3.0.3 swagger.yaml  # Include line numbers in issues
+
+Pipelining:
+  - Use '-' as the file path to read from stdin
+  - Use --quiet/-q to suppress diagnostic output for pipelining
+
+Notes:
+  - Critical issues indicate features that cannot be converted (data loss)
+  - Warnings indicate lossy conversions or best-effort transformations
+  - Info messages provide context about conversion choices
+  - Always validate converted documents before deployment
+
+Exit Codes:
+  0    Conversion successful
+  1    Conversion failed or critical issues found (in --strict mode)
+Usage: oastools diff [flags] <source> <target>
+
+Compare two OpenAPI specification files or URLs and report differences.
+
+Flags:
+  -breaking
+    	enable breaking change detection and categorization
+  -format string
+    	output format: text, json, or yaml (default "text")
+  -no-info
+    	exclude informational changes from output
+  -s	include line numbers in diff output (IDE-friendly format)
+  -source-map
+    	include line numbers in diff output (IDE-friendly format)
+
+Output Formats:
+  text (default)  Human-readable text output
+  json            JSON format for programmatic processing
+  yaml            YAML format for programmatic processing
+
+Modes:
+  Default (Simple):
+    Reports all semantic differences between specifications without
+    categorizing them by severity or breaking change impact.
+
+  --breaking (Breaking Change Detection):
+    Categorizes changes by severity and identifies breaking API changes:
+    - Critical: Removed endpoints or operations
+    - Error:    Removed required parameters, incompatible type changes
+    - Warning:  Deprecated operations, added required fields
+    - Info:     Additions, relaxed constraints, documentation updates
+
+Examples:
+  oastools diff api-v1.yaml api-v2.yaml
+  oastools diff --breaking api-v1.yaml api-v2.yaml
+  oastools diff --breaking --no-info old.yaml new.yaml
+  oastools diff --format json --breaking api-v1.yaml api-v2.yaml | jq '.HasBreakingChanges'
+  oastools diff https://example.com/api/v1.yaml https://example.com/api/v2.yaml
+  oastools diff -s api-v1.yaml api-v2.yaml  # Include line numbers in changes
+
+Exit Status:
+  0    No differences found (or no breaking changes in --breaking mode)
+  1    Differences found (or breaking changes found in --breaking mode)
+
+Notes:
+  - Both specifications must be valid OpenAPI documents
+  - Cross-version comparison (2.0 vs 3.x) is supported with limitations
+  - Breaking change detection helps identify backward compatibility issues
+Usage: oastools diff [flags] <source> <target>
+
+Compare two OpenAPI specification files or URLs and report differences.
+
+Flags:
+  -breaking
+    	enable breaking change detection and categorization
+  -format string
+    	output format: text, json, or yaml (default "text")
+  -no-info
+    	exclude informational changes from output
+  -s	include line numbers in diff output (IDE-friendly format)
+  -source-map
+    	include line numbers in diff output (IDE-friendly format)
+
+Output Formats:
+  text (default)  Human-readable text output
+  json            JSON format for programmatic processing
+  yaml            YAML format for programmatic processing
+
+Modes:
+  Default (Simple):
+    Reports all semantic differences between specifications without
+    categorizing them by severity or breaking change impact.
+
+  --breaking (Breaking Change Detection):
+    Categorizes changes by severity and identifies breaking API changes:
+    - Critical: Removed endpoints or operations
+    - Error:    Removed required parameters, incompatible type changes
+    - Warning:  Deprecated operations, added required fields
+    - Info:     Additions, relaxed constraints, documentation updates
+
+Examples:
+  oastools diff api-v1.yaml api-v2.yaml
+  oastools diff --breaking api-v1.yaml api-v2.yaml
+  oastools diff --breaking --no-info old.yaml new.yaml
+  oastools diff --format json --breaking api-v1.yaml api-v2.yaml | jq '.HasBreakingChanges'
+  oastools diff https://example.com/api/v1.yaml https://example.com/api/v2.yaml
+  oastools diff -s api-v1.yaml api-v2.yaml  # Include line numbers in changes
+
+Exit Status:
+  0    No differences found (or no breaking changes in --breaking mode)
+  1    Differences found (or breaking changes found in --breaking mode)
+
+Notes:
+  - Both specifications must be valid OpenAPI documents
+  - Cross-version comparison (2.0 vs 3.x) is supported with limitations
+  - Breaking change detection helps identify backward compatibility issues
+Usage: oastools diff [flags] <source> <target>
+
+Compare two OpenAPI specification files or URLs and report differences.
+
+Flags:
+  -breaking
+    	enable breaking change detection and categorization
+  -format string
+    	output format: text, json, or yaml (default "text")
+  -no-info
+    	exclude informational changes from output
+  -s	include line numbers in diff output (IDE-friendly format)
+  -source-map
+    	include line numbers in diff output (IDE-friendly format)
+
+Output Formats:
+  text (default)  Human-readable text output
+  json            JSON format for programmatic processing
+  yaml            YAML format for programmatic processing
+
+Modes:
+  Default (Simple):
+    Reports all semantic differences between specifications without
+    categorizing them by severity or breaking change impact.
+
+  --breaking (Breaking Change Detection):
+    Categorizes changes by severity and identifies breaking API changes:
+    - Critical: Removed endpoints or operations
+    - Error:    Removed required parameters, incompatible type changes
+    - Warning:  Deprecated operations, added required fields
+    - Info:     Additions, relaxed constraints, documentation updates
+
+Examples:
+  oastools diff api-v1.yaml api-v2.yaml
+  oastools diff --breaking api-v1.yaml api-v2.yaml
+  oastools diff --breaking --no-info old.yaml new.yaml
+  oastools diff --format json --breaking api-v1.yaml api-v2.yaml | jq '.HasBreakingChanges'
+  oastools diff https://example.com/api/v1.yaml https://example.com/api/v2.yaml
+  oastools diff -s api-v1.yaml api-v2.yaml  # Include line numbers in changes
+
+Exit Status:
+  0    No differences found (or no breaking changes in --breaking mode)
+  1    Differences found (or breaking changes found in --breaking mode)
+
+Notes:
+  - Both specifications must be valid OpenAPI documents
+  - Cross-version comparison (2.0 vs 3.x) is supported with limitations
+  - Breaking change detection helps identify backward compatibility issues
+Usage: oastools fix [flags] <file|url|->
+
+Apply automatic fixes to common OpenAPI specification issues.
+
+Flags:
+  -dry-run
+    	preview changes without modifying the document
+  -fix-schema-names
+    	fix invalid schema names (brackets, special characters)
+  -generic-naming string
+    	strategy for renaming generic types: underscore, of, for, flat, dot (default "underscore")
+  -generic-param-separator string
+    	separator between multiple type parameters (default "_")
+  -generic-separator string
+    	separator for underscore strategy (default "_")
+  -infer
+    	infer parameter types from naming conventions
+  -o string
+    	output file path (default: stdout)
+  -output string
+    	output file path (default: stdout)
+  -preserve-casing
+    	preserve original casing of type parameters
+  -prune
+    	apply all pruning fixes (alias for --prune-all)
+  -prune-all
+    	apply all pruning fixes (schemas, paths)
+  -prune-paths
+    	remove paths with no operations
+  -prune-schemas
+    	remove unreferenced schema definitions
+  -q	quiet mode: only output the document, no diagnostic messages
+  -quiet
+    	quiet mode: only output the document, no diagnostic messages
+  -s	include line numbers in fix output (IDE-friendly format)
+  -source-map
+    	include line numbers in fix output (IDE-friendly format)
+
+Supported Fixes:
+  - Missing path parameters: Adds Parameter objects for path template
+    variables that are not declared in the operation's parameters list.
+    Default type is 'string'. Use --infer for smart type inference.
+  - Invalid schema names (--fix-schema-names): Renames schemas with
+    invalid characters (brackets, etc.) using configurable strategies.
+  - Prune schemas (--prune-schemas): Removes unreferenced schemas.
+  - Prune paths (--prune-paths): Removes paths with no operations.
+
+Type Inference (--infer):
+  - Names ending in 'id', 'Id', 'ID' -> integer
+  - Names containing 'uuid', 'guid' -> string with format uuid
+  - All other names -> string
+
+Generic Naming Strategies (--generic-naming):
+  underscore: Response[User] → Response_User_
+  of:         Response[User] → ResponseOfUser
+  for:        Response[User] → ResponseForUser
+  flat:       Response[User] → ResponseUser
+  dot:        Response[User] → Response.User
+
+Examples:
+  oastools fix openapi.yaml
+  oastools fix -o fixed.yaml openapi.yaml
+  oastools fix --infer openapi.yaml
+  oastools fix --fix-schema-names --generic-naming of api.yaml
+  oastools fix --prune-all api.yaml
+  oastools fix --dry-run --prune-schemas api.yaml
+  cat openapi.yaml | oastools fix -q - > fixed.yaml
+  oastools fix -s openapi.yaml  # Include line numbers in fixes
+
+Pipelining:
+  oastools fix -q api.yaml | oastools validate -q -
+  oastools fix -q --infer api.yaml | oastools convert -q -t 3.1.0 -
+
+Notes:
+  - Use 'oastools validate' to see validation errors before fixing
+  - Pruning fixes only run when explicitly requested via flags
+  - Use --dry-run to preview what would be changed
+  - Output preserves the original format (JSON or YAML)
+
+Exit Codes:
+  0    Fixes applied successfully (or no fixes needed)
+  1    Failed to parse or fix the specification
+Usage: oastools fix [flags] <file|url|->
+
+Apply automatic fixes to common OpenAPI specification issues.
+
+Flags:
+  -dry-run
+    	preview changes without modifying the document
+  -fix-schema-names
+    	fix invalid schema names (brackets, special characters)
+  -generic-naming string
+    	strategy for renaming generic types: underscore, of, for, flat, dot (default "underscore")
+  -generic-param-separator string
+    	separator between multiple type parameters (default "_")
+  -generic-separator string
+    	separator for underscore strategy (default "_")
+  -infer
+    	infer parameter types from naming conventions
+  -o string
+    	output file path (default: stdout)
+  -output string
+    	output file path (default: stdout)
+  -preserve-casing
+    	preserve original casing of type parameters
+  -prune
+    	apply all pruning fixes (alias for --prune-all)
+  -prune-all
+    	apply all pruning fixes (schemas, paths)
+  -prune-paths
+    	remove paths with no operations
+  -prune-schemas
+    	remove unreferenced schema definitions
+  -q	quiet mode: only output the document, no diagnostic messages
+  -quiet
+    	quiet mode: only output the document, no diagnostic messages
+  -s	include line numbers in fix output (IDE-friendly format)
+  -source-map
+    	include line numbers in fix output (IDE-friendly format)
+
+Supported Fixes:
+  - Missing path parameters: Adds Parameter objects for path template
+    variables that are not declared in the operation's parameters list.
+    Default type is 'string'. Use --infer for smart type inference.
+  - Invalid schema names (--fix-schema-names): Renames schemas with
+    invalid characters (brackets, etc.) using configurable strategies.
+  - Prune schemas (--prune-schemas): Removes unreferenced schemas.
+  - Prune paths (--prune-paths): Removes paths with no operations.
+
+Type Inference (--infer):
+  - Names ending in 'id', 'Id', 'ID' -> integer
+  - Names containing 'uuid', 'guid' -> string with format uuid
+  - All other names -> string
+
+Generic Naming Strategies (--generic-naming):
+  underscore: Response[User] → Response_User_
+  of:         Response[User] → ResponseOfUser
+  for:        Response[User] → ResponseForUser
+  flat:       Response[User] → ResponseUser
+  dot:        Response[User] → Response.User
+
+Examples:
+  oastools fix openapi.yaml
+  oastools fix -o fixed.yaml openapi.yaml
+  oastools fix --infer openapi.yaml
+  oastools fix --fix-schema-names --generic-naming of api.yaml
+  oastools fix --prune-all api.yaml
+  oastools fix --dry-run --prune-schemas api.yaml
+  cat openapi.yaml | oastools fix -q - > fixed.yaml
+  oastools fix -s openapi.yaml  # Include line numbers in fixes
+
+Pipelining:
+  oastools fix -q api.yaml | oastools validate -q -
+  oastools fix -q --infer api.yaml | oastools convert -q -t 3.1.0 -
+
+Notes:
+  - Use 'oastools validate' to see validation errors before fixing
+  - Pruning fixes only run when explicitly requested via flags
+  - Use --dry-run to preview what would be changed
+  - Output preserves the original format (JSON or YAML)
+
+Exit Codes:
+  0    Fixes applied successfully (or no fixes needed)
+  1    Failed to parse or fix the specification
+Usage: oastools generate [flags] <file|url|->
+
+Generate Go code from an OpenAPI specification.
+
+Flags:
+  -client
+    	generate HTTP client code
+  -credential-mgmt
+    	generate credential management interfaces
+  -max-lines-per-file int
+    	maximum lines per generated file (0 = no limit) (default 2000)
+  -max-ops-per-file int
+    	maximum operations per generated file (0 = no limit) (default 100)
+  -max-types-per-file int
+    	maximum types per generated file (0 = no limit) (default 200)
+  -no-pointers
+    	don't use pointer types for optional fields
+  -no-readme
+    	don't generate README.md file
+  -no-security
+    	don't generate security helper functions
+  -no-split-by-path
+    	don't split files by path prefix
+  -no-split-by-tag
+    	don't split files by operation tag
+  -no-validation
+    	don't include validation tags
+  -no-warnings
+    	suppress warning and info messages
+  -o string
+    	output directory for generated files (required)
+  -oauth2-flows
+    	generate OAuth2 token flow helpers
+  -oidc-discovery
+    	generate OpenID Connect discovery client
+  -output string
+    	output directory for generated files (required)
+  -p string
+    	Go package name for generated code (default "api")
+  -package string
+    	Go package name for generated code (default "api")
+  -s	include line numbers in generation issues (IDE-friendly format)
+  -security-enforce
+    	generate security enforcement middleware
+  -server
+    	generate server interface code
+  -source-map
+    	include line numbers in generation issues (IDE-friendly format)
+  -strict
+    	fail on any generation issues (even warnings)
+  -types
+    	generate type definitions from schemas (default true)
+
+Examples:
+  oastools generate --client -o ./client openapi.yaml
+  oastools generate --server -o ./server -p myapi openapi.yaml
+  oastools generate --client --server -o ./api petstore.yaml
+  oastools generate --types -o ./models https://example.com/api/openapi.yaml
+  oastools generate --client --oauth2-flows -o ./client openapi.yaml
+  oastools generate --client --credential-mgmt --security-enforce -o ./api openapi.yaml
+  oastools generate --client --max-lines-per-file 1500 -o ./client large-api.yaml
+  cat openapi.yaml | oastools generate --client -o ./client -
+  oastools generate -s --client -o ./client openapi.yaml  # Include line numbers in issues
+
+Pipelining:
+  Use '-' as the file path to read the OpenAPI specification from stdin.
+  Example: oastools convert -t 3.0.3 swagger.yaml | oastools generate --client -o ./client -
+
+Notes:
+  - At least one of --client, --server, or --types must be enabled
+  - Types are always generated when --client or --server is enabled
+  - Security helpers are generated by default when --client is enabled
+  - Generated code uses Go idioms and best practices
+  - Server interface is framework-agnostic
+Usage: oastools generate [flags] <file|url|->
+
+Generate Go code from an OpenAPI specification.
+
+Flags:
+  -client
+    	generate HTTP client code
+  -credential-mgmt
+    	generate credential management interfaces
+  -max-lines-per-file int
+    	maximum lines per generated file (0 = no limit) (default 2000)
+  -max-ops-per-file int
+    	maximum operations per generated file (0 = no limit) (default 100)
+  -max-types-per-file int
+    	maximum types per generated file (0 = no limit) (default 200)
+  -no-pointers
+    	don't use pointer types for optional fields
+  -no-readme
+    	don't generate README.md file
+  -no-security
+    	don't generate security helper functions
+  -no-split-by-path
+    	don't split files by path prefix
+  -no-split-by-tag
+    	don't split files by operation tag
+  -no-validation
+    	don't include validation tags
+  -no-warnings
+    	suppress warning and info messages
+  -o string
+    	output directory for generated files (required)
+  -oauth2-flows
+    	generate OAuth2 token flow helpers
+  -oidc-discovery
+    	generate OpenID Connect discovery client
+  -output string
+    	output directory for generated files (required)
+  -p string
+    	Go package name for generated code (default "api")
+  -package string
+    	Go package name for generated code (default "api")
+  -s	include line numbers in generation issues (IDE-friendly format)
+  -security-enforce
+    	generate security enforcement middleware
+  -server
+    	generate server interface code
+  -source-map
+    	include line numbers in generation issues (IDE-friendly format)
+  -strict
+    	fail on any generation issues (even warnings)
+  -types
+    	generate type definitions from schemas (default true)
+
+Examples:
+  oastools generate --client -o ./client openapi.yaml
+  oastools generate --server -o ./server -p myapi openapi.yaml
+  oastools generate --client --server -o ./api petstore.yaml
+  oastools generate --types -o ./models https://example.com/api/openapi.yaml
+  oastools generate --client --oauth2-flows -o ./client openapi.yaml
+  oastools generate --client --credential-mgmt --security-enforce -o ./api openapi.yaml
+  oastools generate --client --max-lines-per-file 1500 -o ./client large-api.yaml
+  cat openapi.yaml | oastools generate --client -o ./client -
+  oastools generate -s --client -o ./client openapi.yaml  # Include line numbers in issues
+
+Pipelining:
+  Use '-' as the file path to read the OpenAPI specification from stdin.
+  Example: oastools convert -t 3.0.3 swagger.yaml | oastools generate --client -o ./client -
+
+Notes:
+  - At least one of --client, --server, or --types must be enabled
+  - Types are always generated when --client or --server is enabled
+  - Security helpers are generated by default when --client is enabled
+  - Generated code uses Go idioms and best practices
+  - Server interface is framework-agnostic
+Usage: oastools generate [flags] <file|url|->
+
+Generate Go code from an OpenAPI specification.
+
+Flags:
+  -client
+    	generate HTTP client code
+  -credential-mgmt
+    	generate credential management interfaces
+  -max-lines-per-file int
+    	maximum lines per generated file (0 = no limit) (default 2000)
+  -max-ops-per-file int
+    	maximum operations per generated file (0 = no limit) (default 100)
+  -max-types-per-file int
+    	maximum types per generated file (0 = no limit) (default 200)
+  -no-pointers
+    	don't use pointer types for optional fields
+  -no-readme
+    	don't generate README.md file
+  -no-security
+    	don't generate security helper functions
+  -no-split-by-path
+    	don't split files by path prefix
+  -no-split-by-tag
+    	don't split files by operation tag
+  -no-validation
+    	don't include validation tags
+  -no-warnings
+    	suppress warning and info messages
+  -o string
+    	output directory for generated files (required)
+  -oauth2-flows
+    	generate OAuth2 token flow helpers
+  -oidc-discovery
+    	generate OpenID Connect discovery client
+  -output string
+    	output directory for generated files (required)
+  -p string
+    	Go package name for generated code (default "api")
+  -package string
+    	Go package name for generated code (default "api")
+  -s	include line numbers in generation issues (IDE-friendly format)
+  -security-enforce
+    	generate security enforcement middleware
+  -server
+    	generate server interface code
+  -source-map
+    	include line numbers in generation issues (IDE-friendly format)
+  -strict
+    	fail on any generation issues (even warnings)
+  -types
+    	generate type definitions from schemas (default true)
+
+Examples:
+  oastools generate --client -o ./client openapi.yaml
+  oastools generate --server -o ./server -p myapi openapi.yaml
+  oastools generate --client --server -o ./api petstore.yaml
+  oastools generate --types -o ./models https://example.com/api/openapi.yaml
+  oastools generate --client --oauth2-flows -o ./client openapi.yaml
+  oastools generate --client --credential-mgmt --security-enforce -o ./api openapi.yaml
+  oastools generate --client --max-lines-per-file 1500 -o ./client large-api.yaml
+  cat openapi.yaml | oastools generate --client -o ./client -
+  oastools generate -s --client -o ./client openapi.yaml  # Include line numbers in issues
+
+Pipelining:
+  Use '-' as the file path to read the OpenAPI specification from stdin.
+  Example: oastools convert -t 3.0.3 swagger.yaml | oastools generate --client -o ./client -
+
+Notes:
+  - At least one of --client, --server, or --types must be enabled
+  - Types are always generated when --client or --server is enabled
+  - Security helpers are generated by default when --client is enabled
+  - Generated code uses Go idioms and best practices
+  - Server interface is framework-agnostic
+Usage: oastools generate [flags] <file|url|->
+
+Generate Go code from an OpenAPI specification.
+
+Flags:
+  -client
+    	generate HTTP client code
+  -credential-mgmt
+    	generate credential management interfaces
+  -max-lines-per-file int
+    	maximum lines per generated file (0 = no limit) (default 2000)
+  -max-ops-per-file int
+    	maximum operations per generated file (0 = no limit) (default 100)
+  -max-types-per-file int
+    	maximum types per generated file (0 = no limit) (default 200)
+  -no-pointers
+    	don't use pointer types for optional fields
+  -no-readme
+    	don't generate README.md file
+  -no-security
+    	don't generate security helper functions
+  -no-split-by-path
+    	don't split files by path prefix
+  -no-split-by-tag
+    	don't split files by operation tag
+  -no-validation
+    	don't include validation tags
+  -no-warnings
+    	suppress warning and info messages
+  -o string
+    	output directory for generated files (required)
+  -oauth2-flows
+    	generate OAuth2 token flow helpers
+  -oidc-discovery
+    	generate OpenID Connect discovery client
+  -output string
+    	output directory for generated files (required)
+  -p string
+    	Go package name for generated code (default "api")
+  -package string
+    	Go package name for generated code (default "api")
+  -s	include line numbers in generation issues (IDE-friendly format)
+  -security-enforce
+    	generate security enforcement middleware
+  -server
+    	generate server interface code
+  -source-map
+    	include line numbers in generation issues (IDE-friendly format)
+  -strict
+    	fail on any generation issues (even warnings)
+  -types
+    	generate type definitions from schemas (default true)
+
+Examples:
+  oastools generate --client -o ./client openapi.yaml
+  oastools generate --server -o ./server -p myapi openapi.yaml
+  oastools generate --client --server -o ./api petstore.yaml
+  oastools generate --types -o ./models https://example.com/api/openapi.yaml
+  oastools generate --client --oauth2-flows -o ./client openapi.yaml
+  oastools generate --client --credential-mgmt --security-enforce -o ./api openapi.yaml
+  oastools generate --client --max-lines-per-file 1500 -o ./client large-api.yaml
+  cat openapi.yaml | oastools generate --client -o ./client -
+  oastools generate -s --client -o ./client openapi.yaml  # Include line numbers in issues
+
+Pipelining:
+  Use '-' as the file path to read the OpenAPI specification from stdin.
+  Example: oastools convert -t 3.0.3 swagger.yaml | oastools generate --client -o ./client -
+
+Notes:
+  - At least one of --client, --server, or --types must be enabled
+  - Types are always generated when --client or --server is enabled
+  - Security helpers are generated by default when --client is enabled
+  - Generated code uses Go idioms and best practices
+  - Server interface is framework-agnostic
+Usage: oastools join [flags] <file1> <file2> [file3...]
+
+Join multiple OpenAPI specification files into a single document.
+
+Flags:
+  -always-prefix
+    	apply namespace prefix to all schemas, not just on collision
+  -collision-report
+    	generate detailed collision analysis report
+  -component-strategy string
+    	collision strategy for other components
+  -equivalence-mode string
+    	schema comparison mode for deduplication (none, shallow, deep) (default "none")
+  -namespace-prefix value
+    	namespace prefix for source file (format: source=prefix, can be repeated)
+  -no-dedup-tags
+    	don't deduplicate tags by name
+  -no-merge-arrays
+    	don't merge arrays (servers, security, etc.)
+  -o string
+    	output file path (default: stdout)
+  -output string
+    	output file path (default: stdout)
+  -path-strategy string
+    	collision strategy for paths (accept-left, accept-right, fail, fail-on-paths)
+  -q	quiet mode: suppress diagnostic messages (for pipelining)
+  -quiet
+    	quiet mode: suppress diagnostic messages (for pipelining)
+  -rename-template string
+    	template for renamed schema names (default "{{.Name}}_{{.Source}}")
+  -s	include line numbers in collision warnings (IDE-friendly format)
+  -schema-strategy string
+    	collision strategy for schemas (accept-left, accept-right, rename-left, rename-right, deduplicate, fail)
+  -semantic-dedup
+    	enable semantic deduplication to consolidate identical schemas
+  -source-map
+    	include line numbers in collision warnings (IDE-friendly format)
+
+Collision Strategies:
+  accept-left      Keep the first value when collisions occur
+  accept-right     Keep the last value when collisions occur (overwrite)
+  rename-left      Rename left schema, keep right under original name
+  rename-right     Rename right schema, keep left under original name
+  deduplicate      Merge structurally identical schemas (requires equivalence-mode)
+  fail             Fail with an error on any collision
+  fail-on-paths    Fail only on path collisions, allow schema collisions
+
+Namespace Prefixes:
+  Use --namespace-prefix to add source-based prefixes to schema names.
+  Format: source=prefix (can be specified multiple times)
+  By default, prefix is only applied on collision. Use --always-prefix to
+  apply namespace prefixes to all schemas from the configured sources.
+
+Examples:
+  oastools join -o merged.yaml base.yaml extensions.yaml
+  oastools join --path-strategy accept-left -o api.yaml spec1.yaml spec2.yaml
+  oastools join --schema-strategy accept-right -o output.yaml api1.yaml api2.yaml api3.yaml
+  oastools join --namespace-prefix users.yaml=Users --namespace-prefix billing.yaml=Billing -o merged.yaml users.yaml billing.yaml
+  oastools join --namespace-prefix api2.yaml=V2 --always-prefix -o merged.yaml api1.yaml api2.yaml
+  oastools join -s -o merged.yaml api1.yaml api2.yaml  # Include line numbers in warnings
+
+Pipelining:
+  oastools join -q base.yaml ext.yaml | oastools validate -q -
+  oastools join -q spec1.yaml spec2.yaml | oastools convert -q -t 3.1.0 -
+
+Notes:
+  - All input files must be the same major OAS version (2.0 or 3.x)
+  - The output will use the version of the first input file
+  - Info section is taken from the first document by default
+  - When -o is specified, file is written with restrictive permissions (0600)
+Usage: oastools join [flags] <file1> <file2> [file3...]
+
+Join multiple OpenAPI specification files into a single document.
+
+Flags:
+  -always-prefix
+    	apply namespace prefix to all schemas, not just on collision
+  -collision-report
+    	generate detailed collision analysis report
+  -component-strategy string
+    	collision strategy for other components
+  -equivalence-mode string
+    	schema comparison mode for deduplication (none, shallow, deep) (default "none")
+  -namespace-prefix value
+    	namespace prefix for source file (format: source=prefix, can be repeated)
+  -no-dedup-tags
+    	don't deduplicate tags by name
+  -no-merge-arrays
+    	don't merge arrays (servers, security, etc.)
+  -o string
+    	output file path (default: stdout)
+  -output string
+    	output file path (default: stdout)
+  -path-strategy string
+    	collision strategy for paths (accept-left, accept-right, fail, fail-on-paths)
+  -q	quiet mode: suppress diagnostic messages (for pipelining)
+  -quiet
+    	quiet mode: suppress diagnostic messages (for pipelining)
+  -rename-template string
+    	template for renamed schema names (default "{{.Name}}_{{.Source}}")
+  -s	include line numbers in collision warnings (IDE-friendly format)
+  -schema-strategy string
+    	collision strategy for schemas (accept-left, accept-right, rename-left, rename-right, deduplicate, fail)
+  -semantic-dedup
+    	enable semantic deduplication to consolidate identical schemas
+  -source-map
+    	include line numbers in collision warnings (IDE-friendly format)
+
+Collision Strategies:
+  accept-left      Keep the first value when collisions occur
+  accept-right     Keep the last value when collisions occur (overwrite)
+  rename-left      Rename left schema, keep right under original name
+  rename-right     Rename right schema, keep left under original name
+  deduplicate      Merge structurally identical schemas (requires equivalence-mode)
+  fail             Fail with an error on any collision
+  fail-on-paths    Fail only on path collisions, allow schema collisions
+
+Namespace Prefixes:
+  Use --namespace-prefix to add source-based prefixes to schema names.
+  Format: source=prefix (can be specified multiple times)
+  By default, prefix is only applied on collision. Use --always-prefix to
+  apply namespace prefixes to all schemas from the configured sources.
+
+Examples:
+  oastools join -o merged.yaml base.yaml extensions.yaml
+  oastools join --path-strategy accept-left -o api.yaml spec1.yaml spec2.yaml
+  oastools join --schema-strategy accept-right -o output.yaml api1.yaml api2.yaml api3.yaml
+  oastools join --namespace-prefix users.yaml=Users --namespace-prefix billing.yaml=Billing -o merged.yaml users.yaml billing.yaml
+  oastools join --namespace-prefix api2.yaml=V2 --always-prefix -o merged.yaml api1.yaml api2.yaml
+  oastools join -s -o merged.yaml api1.yaml api2.yaml  # Include line numbers in warnings
+
+Pipelining:
+  oastools join -q base.yaml ext.yaml | oastools validate -q -
+  oastools join -q spec1.yaml spec2.yaml | oastools convert -q -t 3.1.0 -
+
+Notes:
+  - All input files must be the same major OAS version (2.0 or 3.x)
+  - The output will use the version of the first input file
+  - Info section is taken from the first document by default
+  - When -o is specified, file is written with restrictive permissions (0600)
+invalid value "invalid" for flag -namespace-prefix: invalid namespace prefix format: "invalid" (expected source=prefix)
+Usage: oastools join [flags] <file1> <file2> [file3...]
+
+Join multiple OpenAPI specification files into a single document.
+
+Flags:
+  -always-prefix
+    	apply namespace prefix to all schemas, not just on collision
+  -collision-report
+    	generate detailed collision analysis report
+  -component-strategy string
+    	collision strategy for other components
+  -equivalence-mode string
+    	schema comparison mode for deduplication (none, shallow, deep) (default "none")
+  -namespace-prefix value
+    	namespace prefix for source file (format: source=prefix, can be repeated)
+  -no-dedup-tags
+    	don't deduplicate tags by name
+  -no-merge-arrays
+    	don't merge arrays (servers, security, etc.)
+  -o string
+    	output file path (default: stdout)
+  -output string
+    	output file path (default: stdout)
+  -path-strategy string
+    	collision strategy for paths (accept-left, accept-right, fail, fail-on-paths)
+  -q	quiet mode: suppress diagnostic messages (for pipelining)
+  -quiet
+    	quiet mode: suppress diagnostic messages (for pipelining)
+  -rename-template string
+    	template for renamed schema names (default "{{.Name}}_{{.Source}}")
+  -s	include line numbers in collision warnings (IDE-friendly format)
+  -schema-strategy string
+    	collision strategy for schemas (accept-left, accept-right, rename-left, rename-right, deduplicate, fail)
+  -semantic-dedup
+    	enable semantic deduplication to consolidate identical schemas
+  -source-map
+    	include line numbers in collision warnings (IDE-friendly format)
+
+Collision Strategies:
+  accept-left      Keep the first value when collisions occur
+  accept-right     Keep the last value when collisions occur (overwrite)
+  rename-left      Rename left schema, keep right under original name
+  rename-right     Rename right schema, keep left under original name
+  deduplicate      Merge structurally identical schemas (requires equivalence-mode)
+  fail             Fail with an error on any collision
+  fail-on-paths    Fail only on path collisions, allow schema collisions
+
+Namespace Prefixes:
+  Use --namespace-prefix to add source-based prefixes to schema names.
+  Format: source=prefix (can be specified multiple times)
+  By default, prefix is only applied on collision. Use --always-prefix to
+  apply namespace prefixes to all schemas from the configured sources.
+
+Examples:
+  oastools join -o merged.yaml base.yaml extensions.yaml
+  oastools join --path-strategy accept-left -o api.yaml spec1.yaml spec2.yaml
+  oastools join --schema-strategy accept-right -o output.yaml api1.yaml api2.yaml api3.yaml
+  oastools join --namespace-prefix users.yaml=Users --namespace-prefix billing.yaml=Billing -o merged.yaml users.yaml billing.yaml
+  oastools join --namespace-prefix api2.yaml=V2 --always-prefix -o merged.yaml api1.yaml api2.yaml
+  oastools join -s -o merged.yaml api1.yaml api2.yaml  # Include line numbers in warnings
+
+Pipelining:
+  oastools join -q base.yaml ext.yaml | oastools validate -q -
+  oastools join -q spec1.yaml spec2.yaml | oastools convert -q -t 3.1.0 -
+
+Notes:
+  - All input files must be the same major OAS version (2.0 or 3.x)
+  - The output will use the version of the first input file
+  - Info section is taken from the first document by default
+  - When -o is specified, file is written with restrictive permissions (0600)
+invalid value "=Prefix" for flag -namespace-prefix: namespace prefix requires non-empty source and prefix: "=Prefix"
+Usage: oastools join [flags] <file1> <file2> [file3...]
+
+Join multiple OpenAPI specification files into a single document.
+
+Flags:
+  -always-prefix
+    	apply namespace prefix to all schemas, not just on collision
+  -collision-report
+    	generate detailed collision analysis report
+  -component-strategy string
+    	collision strategy for other components
+  -equivalence-mode string
+    	schema comparison mode for deduplication (none, shallow, deep) (default "none")
+  -namespace-prefix value
+    	namespace prefix for source file (format: source=prefix, can be repeated)
+  -no-dedup-tags
+    	don't deduplicate tags by name
+  -no-merge-arrays
+    	don't merge arrays (servers, security, etc.)
+  -o string
+    	output file path (default: stdout)
+  -output string
+    	output file path (default: stdout)
+  -path-strategy string
+    	collision strategy for paths (accept-left, accept-right, fail, fail-on-paths)
+  -q	quiet mode: suppress diagnostic messages (for pipelining)
+  -quiet
+    	quiet mode: suppress diagnostic messages (for pipelining)
+  -rename-template string
+    	template for renamed schema names (default "{{.Name}}_{{.Source}}")
+  -s	include line numbers in collision warnings (IDE-friendly format)
+  -schema-strategy string
+    	collision strategy for schemas (accept-left, accept-right, rename-left, rename-right, deduplicate, fail)
+  -semantic-dedup
+    	enable semantic deduplication to consolidate identical schemas
+  -source-map
+    	include line numbers in collision warnings (IDE-friendly format)
+
+Collision Strategies:
+  accept-left      Keep the first value when collisions occur
+  accept-right     Keep the last value when collisions occur (overwrite)
+  rename-left      Rename left schema, keep right under original name
+  rename-right     Rename right schema, keep left under original name
+  deduplicate      Merge structurally identical schemas (requires equivalence-mode)
+  fail             Fail with an error on any collision
+  fail-on-paths    Fail only on path collisions, allow schema collisions
+
+Namespace Prefixes:
+  Use --namespace-prefix to add source-based prefixes to schema names.
+  Format: source=prefix (can be specified multiple times)
+  By default, prefix is only applied on collision. Use --always-prefix to
+  apply namespace prefixes to all schemas from the configured sources.
+
+Examples:
+  oastools join -o merged.yaml base.yaml extensions.yaml
+  oastools join --path-strategy accept-left -o api.yaml spec1.yaml spec2.yaml
+  oastools join --schema-strategy accept-right -o output.yaml api1.yaml api2.yaml api3.yaml
+  oastools join --namespace-prefix users.yaml=Users --namespace-prefix billing.yaml=Billing -o merged.yaml users.yaml billing.yaml
+  oastools join --namespace-prefix api2.yaml=V2 --always-prefix -o merged.yaml api1.yaml api2.yaml
+  oastools join -s -o merged.yaml api1.yaml api2.yaml  # Include line numbers in warnings
+
+Pipelining:
+  oastools join -q base.yaml ext.yaml | oastools validate -q -
+  oastools join -q spec1.yaml spec2.yaml | oastools convert -q -t 3.1.0 -
+
+Notes:
+  - All input files must be the same major OAS version (2.0 or 3.x)
+  - The output will use the version of the first input file
+  - Info section is taken from the first document by default
+  - When -o is specified, file is written with restrictive permissions (0600)
+invalid value "api.yaml=" for flag -namespace-prefix: namespace prefix requires non-empty source and prefix: "api.yaml="
+Usage: oastools join [flags] <file1> <file2> [file3...]
+
+Join multiple OpenAPI specification files into a single document.
+
+Flags:
+  -always-prefix
+    	apply namespace prefix to all schemas, not just on collision
+  -collision-report
+    	generate detailed collision analysis report
+  -component-strategy string
+    	collision strategy for other components
+  -equivalence-mode string
+    	schema comparison mode for deduplication (none, shallow, deep) (default "none")
+  -namespace-prefix value
+    	namespace prefix for source file (format: source=prefix, can be repeated)
+  -no-dedup-tags
+    	don't deduplicate tags by name
+  -no-merge-arrays
+    	don't merge arrays (servers, security, etc.)
+  -o string
+    	output file path (default: stdout)
+  -output string
+    	output file path (default: stdout)
+  -path-strategy string
+    	collision strategy for paths (accept-left, accept-right, fail, fail-on-paths)
+  -q	quiet mode: suppress diagnostic messages (for pipelining)
+  -quiet
+    	quiet mode: suppress diagnostic messages (for pipelining)
+  -rename-template string
+    	template for renamed schema names (default "{{.Name}}_{{.Source}}")
+  -s	include line numbers in collision warnings (IDE-friendly format)
+  -schema-strategy string
+    	collision strategy for schemas (accept-left, accept-right, rename-left, rename-right, deduplicate, fail)
+  -semantic-dedup
+    	enable semantic deduplication to consolidate identical schemas
+  -source-map
+    	include line numbers in collision warnings (IDE-friendly format)
+
+Collision Strategies:
+  accept-left      Keep the first value when collisions occur
+  accept-right     Keep the last value when collisions occur (overwrite)
+  rename-left      Rename left schema, keep right under original name
+  rename-right     Rename right schema, keep left under original name
+  deduplicate      Merge structurally identical schemas (requires equivalence-mode)
+  fail             Fail with an error on any collision
+  fail-on-paths    Fail only on path collisions, allow schema collisions
+
+Namespace Prefixes:
+  Use --namespace-prefix to add source-based prefixes to schema names.
+  Format: source=prefix (can be specified multiple times)
+  By default, prefix is only applied on collision. Use --always-prefix to
+  apply namespace prefixes to all schemas from the configured sources.
+
+Examples:
+  oastools join -o merged.yaml base.yaml extensions.yaml
+  oastools join --path-strategy accept-left -o api.yaml spec1.yaml spec2.yaml
+  oastools join --schema-strategy accept-right -o output.yaml api1.yaml api2.yaml api3.yaml
+  oastools join --namespace-prefix users.yaml=Users --namespace-prefix billing.yaml=Billing -o merged.yaml users.yaml billing.yaml
+  oastools join --namespace-prefix api2.yaml=V2 --always-prefix -o merged.yaml api1.yaml api2.yaml
+  oastools join -s -o merged.yaml api1.yaml api2.yaml  # Include line numbers in warnings
+
+Pipelining:
+  oastools join -q base.yaml ext.yaml | oastools validate -q -
+  oastools join -q spec1.yaml spec2.yaml | oastools convert -q -t 3.1.0 -
+
+Notes:
+  - All input files must be the same major OAS version (2.0 or 3.x)
+  - The output will use the version of the first input file
+  - Info section is taken from the first document by default
+  - When -o is specified, file is written with restrictive permissions (0600)
+Usage: oastools parse [flags] <file|url|->
+
+Parse and output OpenAPI document structure.
+
+Flags:
+  -insecure
+    	disable TLS certificate verification for HTTPS refs
+  -q	quiet mode: only output the document, no diagnostic messages
+  -quiet
+    	quiet mode: only output the document, no diagnostic messages
+  -resolve-http-refs
+    	resolve HTTP/HTTPS $ref URLs (requires --resolve-refs)
+  -resolve-refs
+    	resolve external $ref references
+  -validate-structure
+    	validate document structure during parsing
+
+Examples:
+  oastools parse openapi.yaml
+  oastools parse --resolve-refs openapi.yaml
+  oastools parse --resolve-refs --resolve-http-refs https://example.com/api/openapi.yaml
+  oastools parse --resolve-refs --resolve-http-refs --insecure https://internal-server/api.yaml
+  oastools parse --validate-structure https://example.com/api/openapi.yaml
+  cat openapi.yaml | oastools parse -q -
+
+HTTP Reference Resolution:
+  --resolve-http-refs enables fetching and resolving $refs that point to HTTP/HTTPS URLs.
+  This is disabled by default for security (SSRF protection).
+  Use --insecure to skip TLS certificate verification for self-signed certs.
+
+Pipelining:
+  - Use '-' as the file path to read from stdin
+  - Use --quiet/-q to suppress diagnostic output for pipelining
+
+Exit Codes:
+  0    Parsing successful
+  1    Parsing failed or validation errors found (with --validate-structure)
+Usage: oastools parse [flags] <file|url|->
+
+Parse and output OpenAPI document structure.
+
+Flags:
+  -insecure
+    	disable TLS certificate verification for HTTPS refs
+  -q	quiet mode: only output the document, no diagnostic messages
+  -quiet
+    	quiet mode: only output the document, no diagnostic messages
+  -resolve-http-refs
+    	resolve HTTP/HTTPS $ref URLs (requires --resolve-refs)
+  -resolve-refs
+    	resolve external $ref references
+  -validate-structure
+    	validate document structure during parsing
+
+Examples:
+  oastools parse openapi.yaml
+  oastools parse --resolve-refs openapi.yaml
+  oastools parse --resolve-refs --resolve-http-refs https://example.com/api/openapi.yaml
+  oastools parse --resolve-refs --resolve-http-refs --insecure https://internal-server/api.yaml
+  oastools parse --validate-structure https://example.com/api/openapi.yaml
+  cat openapi.yaml | oastools parse -q -
+
+HTTP Reference Resolution:
+  --resolve-http-refs enables fetching and resolving $refs that point to HTTP/HTTPS URLs.
+  This is disabled by default for security (SSRF protection).
+  Use --insecure to skip TLS certificate verification for self-signed certs.
+
+Pipelining:
+  - Use '-' as the file path to read from stdin
+  - Use --quiet/-q to suppress diagnostic output for pipelining
+
+Exit Codes:
+  0    Parsing successful
+  1    Parsing failed or validation errors found (with --validate-structure)
+Usage: oastools validate [flags] <file|url|->
+
+Validate an OpenAPI specification file, URL, or stdin against the specification version it declares.
+
+Flags:
+  -format string
+    	output format: text, json, or yaml (default "text")
+  -no-warnings
+    	suppress warning messages (only show errors)
+  -q	quiet mode: only output validation result, no diagnostic messages
+  -quiet
+    	quiet mode: only output validation result, no diagnostic messages
+  -s	include line numbers in validation errors (IDE-friendly format)
+  -source-map
+    	include line numbers in validation errors (IDE-friendly format)
+  -strict
+    	enable stricter validation beyond spec requirements
+
+Output Formats:
+  text (default)  Human-readable text output
+  json            JSON format for programmatic processing
+  yaml            YAML format for programmatic processing
+
+Examples:
+  oastools validate openapi.yaml
+  oastools validate https://example.com/api/openapi.yaml
+  oastools validate --strict api-spec.yaml
+  oastools validate --no-warnings openapi.json
+  cat openapi.yaml | oastools validate -q -
+  oastools validate --format json openapi.yaml | jq '.valid'
+  oastools validate -s openapi.yaml  # Include line numbers in errors
+
+Pipelining:
+  - Use '-' as the file path to read from stdin
+  - Use --quiet/-q to suppress diagnostic output for pipelining
+  - Use --format json/yaml for structured output that can be parsed
+
+Exit Codes:
+  0    Validation successful
+  1    Validation failed with errors
+Usage: oastools validate [flags] <file|url|->
+
+Validate an OpenAPI specification file, URL, or stdin against the specification version it declares.
+
+Flags:
+  -format string
+    	output format: text, json, or yaml (default "text")
+  -no-warnings
+    	suppress warning messages (only show errors)
+  -q	quiet mode: only output validation result, no diagnostic messages
+  -quiet
+    	quiet mode: only output validation result, no diagnostic messages
+  -s	include line numbers in validation errors (IDE-friendly format)
+  -source-map
+    	include line numbers in validation errors (IDE-friendly format)
+  -strict
+    	enable stricter validation beyond spec requirements
+
+Output Formats:
+  text (default)  Human-readable text output
+  json            JSON format for programmatic processing
+  yaml            YAML format for programmatic processing
+
+Examples:
+  oastools validate openapi.yaml
+  oastools validate https://example.com/api/openapi.yaml
+  oastools validate --strict api-spec.yaml
+  oastools validate --no-warnings openapi.json
+  cat openapi.yaml | oastools validate -q -
+  oastools validate --format json openapi.yaml | jq '.valid'
+  oastools validate -s openapi.yaml  # Include line numbers in errors
+
+Pipelining:
+  - Use '-' as the file path to read from stdin
+  - Use --quiet/-q to suppress diagnostic output for pipelining
+  - Use --format json/yaml for structured output that can be parsed
+
+Exit Codes:
+  0    Validation successful
+  1    Validation failed with errors
+PASS
+ok  	github.com/erraggy/oastools/cmd/oastools/commands	0.203s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/converter
+cpu: Apple M4
+BenchmarkConvertParsedOAS2ToOAS3/Small-10         	  376232	      3184 ns/op	   10277 B/op	      83 allocs/op
+BenchmarkConvertParsedOAS2ToOAS3/Small-10         	  379989	      3195 ns/op	   10277 B/op	      83 allocs/op
+BenchmarkConvertParsedOAS2ToOAS3/Small-10         	  381640	      3198 ns/op	   10277 B/op	      83 allocs/op
+BenchmarkConvertParsedOAS2ToOAS3/Small-10         	  376653	      3197 ns/op	   10277 B/op	      83 allocs/op
+BenchmarkConvertParsedOAS2ToOAS3/Small-10         	  374820	      3204 ns/op	   10277 B/op	      83 allocs/op
+BenchmarkConvertParsedOAS2ToOAS3/Medium-10        	   31314	     37806 ns/op	  121457 B/op	     687 allocs/op
+BenchmarkConvertParsedOAS2ToOAS3/Medium-10        	   31680	     37781 ns/op	  121459 B/op	     687 allocs/op
+BenchmarkConvertParsedOAS2ToOAS3/Medium-10        	   32024	     37474 ns/op	  121456 B/op	     687 allocs/op
+BenchmarkConvertParsedOAS2ToOAS3/Medium-10        	   31704	     37784 ns/op	  121457 B/op	     687 allocs/op
+BenchmarkConvertParsedOAS2ToOAS3/Medium-10        	   32000	     37497 ns/op	  121456 B/op	     687 allocs/op
+BenchmarkConvertParsedOAS3ToOAS2/Small-10         	  335799	      3559 ns/op	    8583 B/op	      89 allocs/op
+BenchmarkConvertParsedOAS3ToOAS2/Small-10         	  336105	      3552 ns/op	    8586 B/op	      89 allocs/op
+BenchmarkConvertParsedOAS3ToOAS2/Small-10         	  342501	      3561 ns/op	    8587 B/op	      89 allocs/op
+BenchmarkConvertParsedOAS3ToOAS2/Small-10         	  335086	      3566 ns/op	    8584 B/op	      89 allocs/op
+BenchmarkConvertParsedOAS3ToOAS2/Small-10         	  340938	      3561 ns/op	    8582 B/op	      89 allocs/op
+BenchmarkConvertParsedOAS3ToOAS2/Medium-10        	   26874	     44705 ns/op	  116671 B/op	     821 allocs/op
+BenchmarkConvertParsedOAS3ToOAS2/Medium-10        	   26736	     45008 ns/op	  116765 B/op	     821 allocs/op
+BenchmarkConvertParsedOAS3ToOAS2/Medium-10        	   26792	     44740 ns/op	  116711 B/op	     821 allocs/op
+BenchmarkConvertParsedOAS3ToOAS2/Medium-10        	   26820	     44676 ns/op	  116753 B/op	     821 allocs/op
+BenchmarkConvertParsedOAS3ToOAS2/Medium-10        	   26648	     44759 ns/op	  116696 B/op	     821 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/converter	25.294s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/differ
+cpu: Apple M4
+BenchmarkDiff/Parsed-10        	  113998	     10571 ns/op	   16126 B/op	     297 allocs/op
+BenchmarkDiff/Parsed-10        	  113258	     10611 ns/op	   16126 B/op	     297 allocs/op
+BenchmarkDiff/Parsed-10        	  110227	     10632 ns/op	   16127 B/op	     297 allocs/op
+BenchmarkDiff/Parsed-10        	  113943	     10574 ns/op	   16126 B/op	     297 allocs/op
+BenchmarkDiff/Parsed-10        	  112986	     10659 ns/op	   16126 B/op	     297 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/differ	10.438s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/fixer
+cpu: Apple M4
+BenchmarkFixParsed/SmallOAS3-10         	  435176	      2717 ns/op	    8535 B/op	      54 allocs/op
+BenchmarkFixParsed/SmallOAS3-10         	  431132	      2735 ns/op	    8543 B/op	      54 allocs/op
+BenchmarkFixParsed/SmallOAS3-10         	  438397	      2727 ns/op	    8543 B/op	      54 allocs/op
+BenchmarkFixParsed/SmallOAS3-10         	  440686	      2734 ns/op	    8546 B/op	      54 allocs/op
+BenchmarkFixParsed/SmallOAS3-10         	  443749	      2731 ns/op	    8544 B/op	      54 allocs/op
+BenchmarkFixParsed/MediumOAS3-10        	   37737	     31938 ns/op	  122586 B/op	     572 allocs/op
+BenchmarkFixParsed/MediumOAS3-10        	   37381	     32139 ns/op	  122568 B/op	     572 allocs/op
+BenchmarkFixParsed/MediumOAS3-10        	   36919	     32140 ns/op	  122558 B/op	     572 allocs/op
+BenchmarkFixParsed/MediumOAS3-10        	   37794	     31846 ns/op	  122524 B/op	     572 allocs/op
+BenchmarkFixParsed/MediumOAS3-10        	   37594	     31796 ns/op	  122485 B/op	     572 allocs/op
+BenchmarkFixParsed/LargeOAS3-10         	    3049	    374555 ns/op	 1226718 B/op	    5361 allocs/op
+BenchmarkFixParsed/LargeOAS3-10         	    3151	    375946 ns/op	 1226201 B/op	    5361 allocs/op
+BenchmarkFixParsed/LargeOAS3-10         	    3004	    377891 ns/op	 1226362 B/op	    5361 allocs/op
+BenchmarkFixParsed/LargeOAS3-10         	    3069	    375802 ns/op	 1226306 B/op	    5361 allocs/op
+BenchmarkFixParsed/LargeOAS3-10         	    3085	    375852 ns/op	 1226074 B/op	    5361 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/fixer	24.805s
+PASS
+ok  	github.com/erraggy/oastools/generator	67.329s
+write error: simulated write error
+write error: simulated write error
+write error: simulated write error
+write error: simulated write error
+write error: simulated write error
+PASS
+ok  	github.com/erraggy/oastools/internal/cliutil	0.375s
+?   	github.com/erraggy/oastools/internal/codegen/deepcopy	[no test files]
+PASS
+ok  	github.com/erraggy/oastools/internal/corpusutil	0.268s
+PASS
+ok  	github.com/erraggy/oastools/internal/httputil	0.280s
+PASS
+ok  	github.com/erraggy/oastools/internal/issues	0.265s
+PASS
+ok  	github.com/erraggy/oastools/internal/jsonpath	0.256s
+PASS
+ok  	github.com/erraggy/oastools/internal/schemautil	0.291s
+PASS
+ok  	github.com/erraggy/oastools/internal/severity	0.671s
+PASS
+ok  	github.com/erraggy/oastools/internal/testutil	0.400s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/joiner
+cpu: Apple M4
+BenchmarkJoinParsed/TwoDocs-10         	 1515170	       790.7 ns/op	    1912 B/op	      22 allocs/op
+BenchmarkJoinParsed/TwoDocs-10         	 1508316	       797.3 ns/op	    1912 B/op	      22 allocs/op
+BenchmarkJoinParsed/TwoDocs-10         	 1513120	       793.9 ns/op	    1912 B/op	      22 allocs/op
+BenchmarkJoinParsed/TwoDocs-10         	 1517995	       789.9 ns/op	    1912 B/op	      22 allocs/op
+BenchmarkJoinParsed/TwoDocs-10         	 1508245	       793.8 ns/op	    1912 B/op	      22 allocs/op
+BenchmarkJoinParsed/ThreeDocs-10       	 1000000	      1003 ns/op	    2088 B/op	      23 allocs/op
+BenchmarkJoinParsed/ThreeDocs-10       	 1000000	      1003 ns/op	    2088 B/op	      23 allocs/op
+BenchmarkJoinParsed/ThreeDocs-10       	 1000000	      1008 ns/op	    2088 B/op	      23 allocs/op
+BenchmarkJoinParsed/ThreeDocs-10       	 1000000	      1003 ns/op	    2088 B/op	      23 allocs/op
+BenchmarkJoinParsed/ThreeDocs-10       	 1000000	      1004 ns/op	    2088 B/op	      23 allocs/op
+BenchmarkJoinParsed/FiveDocs-10        	  531283	      2296 ns/op	    3666 B/op	      62 allocs/op
+BenchmarkJoinParsed/FiveDocs-10        	  519690	      2296 ns/op	    3666 B/op	      62 allocs/op
+BenchmarkJoinParsed/FiveDocs-10        	  524680	      2285 ns/op	    3666 B/op	      62 allocs/op
+BenchmarkJoinParsed/FiveDocs-10        	  523744	      2300 ns/op	    3666 B/op	      62 allocs/op
+BenchmarkJoinParsed/FiveDocs-10        	  533604	      2289 ns/op	    3666 B/op	      62 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/joiner	19.167s
+PASS
+ok  	github.com/erraggy/oastools/oaserrors	0.308s
+PASS
+ok  	github.com/erraggy/oastools/overlay	0.300s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/parser
+cpu: Apple M4
+BenchmarkParseBytes/SmallOAS3-10         	    8310	    133039 ns/op	  195446 B/op	    2065 allocs/op
+BenchmarkParseBytes/SmallOAS3-10         	    8820	    132896 ns/op	  195446 B/op	    2065 allocs/op
+BenchmarkParseBytes/SmallOAS3-10         	    8433	    133663 ns/op	  195447 B/op	    2065 allocs/op
+BenchmarkParseBytes/SmallOAS3-10         	    8920	    132841 ns/op	  195450 B/op	    2065 allocs/op
+BenchmarkParseBytes/SmallOAS3-10         	    9008	    133677 ns/op	  195446 B/op	    2065 allocs/op
+BenchmarkParseBytes/MediumOAS3-10        	    1051	   1140099 ns/op	 1433390 B/op	   17383 allocs/op
+BenchmarkParseBytes/MediumOAS3-10        	    1064	   1132601 ns/op	 1433352 B/op	   17383 allocs/op
+BenchmarkParseBytes/MediumOAS3-10        	    1035	   1150041 ns/op	 1433446 B/op	   17383 allocs/op
+BenchmarkParseBytes/MediumOAS3-10        	    1063	   1131454 ns/op	 1433376 B/op	   17383 allocs/op
+BenchmarkParseBytes/MediumOAS3-10        	    1060	   1134378 ns/op	 1433394 B/op	   17383 allocs/op
+BenchmarkParseCore/SmallOAS3-10          	    8834	    134885 ns/op	  195470 B/op	    2065 allocs/op
+BenchmarkParseCore/SmallOAS3-10          	    8742	    134348 ns/op	  195467 B/op	    2065 allocs/op
+BenchmarkParseCore/SmallOAS3-10          	    8876	    134325 ns/op	  195468 B/op	    2065 allocs/op
+BenchmarkParseCore/SmallOAS3-10          	    8872	    134670 ns/op	  195466 B/op	    2065 allocs/op
+BenchmarkParseCore/SmallOAS3-10          	    8971	    134650 ns/op	  195469 B/op	    2065 allocs/op
+BenchmarkParseCore/MediumOAS3-10         	    1038	   1149654 ns/op	 1433784 B/op	   17384 allocs/op
+BenchmarkParseCore/MediumOAS3-10         	    1024	   1158486 ns/op	 1433842 B/op	   17385 allocs/op
+BenchmarkParseCore/MediumOAS3-10         	    1040	   1156765 ns/op	 1433823 B/op	   17384 allocs/op
+BenchmarkParseCore/MediumOAS3-10         	    1029	   1158399 ns/op	 1433801 B/op	   17384 allocs/op
+BenchmarkParseCore/MediumOAS3-10         	    1047	   1147511 ns/op	 1433723 B/op	   17384 allocs/op
+BenchmarkParseCore/LargeOAS3-10          	      86	  13683535 ns/op	16260336 B/op	  194707 allocs/op
+BenchmarkParseCore/LargeOAS3-10          	      86	  14229869 ns/op	16260303 B/op	  194707 allocs/op
+BenchmarkParseCore/LargeOAS3-10          	      87	  13903758 ns/op	16260314 B/op	  194707 allocs/op
+BenchmarkParseCore/LargeOAS3-10          	      84	  14080435 ns/op	16260293 B/op	  194707 allocs/op
+BenchmarkParseCore/LargeOAS3-10          	      84	  14620530 ns/op	16260328 B/op	  194707 allocs/op
+BenchmarkParseCore/SmallOAS2-10          	    8666	    130843 ns/op	  172589 B/op	    2054 allocs/op
+BenchmarkParseCore/SmallOAS2-10          	    9356	    128405 ns/op	  172583 B/op	    2054 allocs/op
+BenchmarkParseCore/SmallOAS2-10          	    9163	    129589 ns/op	  172587 B/op	    2054 allocs/op
+BenchmarkParseCore/SmallOAS2-10          	    9408	    128622 ns/op	  172585 B/op	    2054 allocs/op
+BenchmarkParseCore/SmallOAS2-10          	    9265	    127585 ns/op	  172585 B/op	    2054 allocs/op
+BenchmarkParseCore/MediumOAS2-10         	    1129	   1011423 ns/op	 1217415 B/op	   16022 allocs/op
+BenchmarkParseCore/MediumOAS2-10         	    1180	   1006896 ns/op	 1217414 B/op	   16022 allocs/op
+BenchmarkParseCore/MediumOAS2-10         	    1188	   1010938 ns/op	 1217415 B/op	   16022 allocs/op
+BenchmarkParseCore/MediumOAS2-10         	    1197	   1006041 ns/op	 1217403 B/op	   16022 allocs/op
+BenchmarkParseCore/MediumOAS2-10         	    1190	   1023096 ns/op	 1217422 B/op	   16022 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/parser	83.404s
+PASS
+ok  	github.com/erraggy/oastools/parser/internal/jsonhelpers	0.308s
+goos: darwin
+goarch: arm64
+pkg: github.com/erraggy/oastools/validator
+cpu: Apple M4
+BenchmarkValidateParsed/SmallOAS3-10         	  241245	      4800 ns/op	    5821 B/op	      90 allocs/op
+BenchmarkValidateParsed/SmallOAS3-10         	  248784	      4828 ns/op	    5817 B/op	      90 allocs/op
+BenchmarkValidateParsed/SmallOAS3-10         	  247647	      4814 ns/op	    5819 B/op	      90 allocs/op
+BenchmarkValidateParsed/SmallOAS3-10         	  249898	      4820 ns/op	    5818 B/op	      90 allocs/op
+BenchmarkValidateParsed/SmallOAS3-10         	  247773	      4837 ns/op	    5817 B/op	      90 allocs/op
+BenchmarkValidateParsed/MediumOAS3-10        	   29385	     40846 ns/op	   34455 B/op	     917 allocs/op
+BenchmarkValidateParsed/MediumOAS3-10        	   29371	     40801 ns/op	   34464 B/op	     917 allocs/op
+BenchmarkValidateParsed/MediumOAS3-10        	   29490	     40759 ns/op	   34447 B/op	     917 allocs/op
+BenchmarkValidateParsed/MediumOAS3-10        	   29341	     40933 ns/op	   34450 B/op	     917 allocs/op
+BenchmarkValidateParsed/MediumOAS3-10        	   29396	     40794 ns/op	   34465 B/op	     917 allocs/op
+BenchmarkValidateParsed/LargeOAS3-10         	    2554	    465230 ns/op	  377841 B/op	   10297 allocs/op
+BenchmarkValidateParsed/LargeOAS3-10         	    2560	    464672 ns/op	  377096 B/op	   10297 allocs/op
+BenchmarkValidateParsed/LargeOAS3-10         	    2588	    465076 ns/op	  376895 B/op	   10297 allocs/op
+BenchmarkValidateParsed/LargeOAS3-10         	    2592	    461183 ns/op	  377774 B/op	   10297 allocs/op
+BenchmarkValidateParsed/LargeOAS3-10         	    2587	    463575 ns/op	  377992 B/op	   10297 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/validator	56.091s


### PR DESCRIPTION
## Summary
- Add benchmark results for v1.28.4 release
- Benchmarks confirm no performance regressions after PR #156

## Benchmark Comparison vs v1.28.2

All I/O-isolated benchmarks show **no statistically significant changes**:
- ParseCore: ~132-134µs (small), ~1.15ms (medium), ~14ms (large)
- ValidateParsed: ~4.8µs (small), ~41µs (medium), ~465µs (large)
- FixParsed: ~2.7µs (small), ~32µs (medium), ~376µs (large)
- ConvertParsed: ~3.2-3.6µs (small), ~38-45µs (medium)
- JoinParsed: ~794ns (two), ~1.0µs (three), ~2.3µs (five)
- Diff/Parsed: ~10.6µs

**Geometric mean**: +1.38% time (within normal variance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)