### PR TITLE
chore: prepare v1.30.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A complete, self-contained OpenAPI toolkit for Go with minimal dependencies.
 - **Minimal Dependencies** - Only [`go.yaml.in/yaml`](https://pkg.go.dev/go.yaml.in/yaml/v4) and [`golang.org/x/tools`](https://pkg.go.dev/golang.org/x/tools) at runtime
 - **Battle-Tested** - 3000+ tests against 10 production APIs (Discord, Stripe, GitHub, MS Graph 34MB)
 - **Complete Toolset** - 10 packages covering the full OpenAPI lifecycle
-- **Performance Optimized** - 130+ benchmarks; pre-parsed workflows 9-150x faster
+- **Performance Optimized** - 90+ benchmarks; pre-parsed workflows 9-150x faster
 - **Type-Safe Cloning** - Generated `DeepCopy()` methods preserve types across OAS versions (no JSON marshal hacks)
 - **Enterprise Ready** - Structured errors with `errors.Is()`/`errors.As()`, pluggable logging, configurable resource limits
 - **Well Documented** - Every package has godoc, runnable examples, and [deep dive guides](#deep-dive-guides) for advanced usage


### PR DESCRIPTION
## Summary

Prepare v1.30.1 patch release.

### Changes
- Fix benchmark count in README.md (130+ → 90+)

### Pre-Release Verification

| Check | Status |
|-------|--------|
| `make check` | ✅ PASS |
| `govulncheck` | ✅ PASS |
| gopls diagnostics | ✅ PASS |
| Godoc examples | ✅ PASS (45 examples) |
| Documentation review | ✅ PASS |

🤖 Generated with [Claude Code](https://claude.com/claude-code)