### PR TITLE
docs: fix unlinked URLs in breaking-changes.md

### DIFF
--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -314,8 +314,8 @@ exit 0
 
 ## Additional Resources
 
-- **OpenAPI Specification:** https://spec.openapis.org/
-- **Semantic Versioning:** https://semver.org/
-- **oastools differ package:** `go doc github.com/erraggy/oastools/differ`
+- **OpenAPI Specification:** [spec.openapis.org/oas](https://spec.openapis.org/oas/)
+- **Semantic Versioning:** [semver.org](https://semver.org/)
+- **oastools differ package:** [pkg.go.dev/github.com/erraggy/oastools/differ](https://pkg.go.dev/github.com/erraggy/oastools/differ)
 
-For questions or issues, please open an issue at https://github.com/erraggy/oastools/issues.
+For questions or issues, please [open an issue](https://github.com/erraggy/oastools/issues).


### PR DESCRIPTION
## Summary

- Converts plain text URLs in the Additional Resources section to proper markdown links

### Changes

| Before | After |
|--------|-------|
| `https://spec.openapis.org/` | [spec.openapis.org/oas](https://spec.openapis.org/oas/) |
| `https://semver.org/` | [semver.org](https://semver.org/) |
| `` `go doc github.com/erraggy/oastools/differ` `` | [pkg.go.dev/...](https://pkg.go.dev/github.com/erraggy/oastools/differ) |
| `https://github.com/erraggy/oastools/issues` | [open an issue](https://github.com/erraggy/oastools/issues) |

## Test plan

- [ ] Verify links render correctly in `make docs-serve`

🤖 Generated with [Claude Code](https://claude.com/claude-code)