### PR TITLE
fix(docs): use GitHub URLs for examples links in deep dive

### DIFF
--- a/generator/deep_dive.md
+++ b/generator/deep_dive.md
@@ -1427,6 +1427,6 @@ For additional examples and complete API documentation:
 
 ### Full Working Examples
 
-The [`examples/`](../examples/) directory contains complete, generated modules you can browse:
+The [`examples/`](https://github.com/erraggy/oastools/tree/main/examples) directory contains complete, generated modules you can browse:
 
-- **[examples/petstore/](../examples/petstore/)** - Full client/server with OAuth2 flows, OIDC discovery, credential management, security enforcement, and all server extensions generated from the [Swagger Petstore API](https://petstore.swagger.io/)
+- **[examples/petstore/](https://github.com/erraggy/oastools/tree/main/examples/petstore)** - Full client/server with OAuth2 flows, OIDC discovery, credential management, security enforcement, and all server extensions generated from the [Swagger Petstore API](https://petstore.swagger.io/)


### PR DESCRIPTION
## Summary

Fix 404 errors for examples links in the generator deep dive documentation on the MkDocs site.

## Problem

The relative paths `../examples/` and `../examples/petstore/` work when viewing markdown on GitHub, but MkDocs resolves them to non-existent paths on the docs site:
- https://erraggy.github.io/oastools/packages/examples/ → 404
- https://erraggy.github.io/oastools/packages/examples/petstore/ → 404

## Solution

Changed to absolute GitHub URLs that work everywhere:
- `https://github.com/erraggy/oastools/tree/main/examples`
- `https://github.com/erraggy/oastools/tree/main/examples/petstore`

## Test plan

- [x] Links point to correct GitHub locations

🤖 Generated with [Claude Code](https://claude.com/claude-code)