### PR TITLE
ci(claude): enhance GitHub Action with Opus model and write permissions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -9,19 +9,30 @@ on:
     types: [opened, assigned]
   pull_request_review:
     types: [submitted]
+  workflow_dispatch:
+    inputs:
+      prompt:
+        description: 'Prompt for Claude to execute'
+        required: true
+        type: string
+      pr_number:
+        description: 'PR number to operate on (optional)'
+        required: false
+        type: string
 
 jobs:
   claude:
     if: |
+      github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write  # Allow Claude to push commits to PRs
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
@@ -36,15 +47,15 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
+          # Use prompt from workflow_dispatch input when manually triggered
+          prompt: ${{ github.event_name == 'workflow_dispatch' && inputs.prompt || '' }}
+
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
 
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
-
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
-
+          # Model and tool configuration
+          # Custom instructions are read from CLAUDE.md and AGENTS.md in the repo
+          claude_args: |
+            --model=opus
+            --allowed-tools "Bash(gh:*)"


### PR DESCRIPTION
## Summary

Enhances the Claude Code GitHub Action configuration for improved functionality and flexibility.

## Changes

| Feature | Before | After |
|---------|--------|-------|
| **Model** | Default | `--model=opus` |
| **Tools** | None | `--allowed-tools "Bash(gh:*)"` |
| **contents** | `read` | `write` (push commits) |
| **pull-requests** | `read` | `write` (comment on PRs) |
| **issues** | `read` | `write` (comment on issues) |
| **Manual trigger** | None | `workflow_dispatch` with prompt input |

## Why These Changes

1. **Opus model** - Better reasoning for complex architectural decisions
2. **Write permissions** - Allow Claude to push commits and comment on PRs/issues
3. **Full gh CLI access** - Enable GitHub operations (PR updates, issue management)
4. **workflow_dispatch** - Enable manual testing from any branch

## Custom Instructions

Rather than using an invalid `custom_instructions` input, the architect orchestration guidance is read from:
- `CLAUDE.md` - Project conventions and patterns
- `AGENTS.md` - Agent workflow and responsibilities

## Test Plan

- [ ] Merge this PR
- [ ] Rebase PR #179 onto updated main
- [ ] Trigger `@claude` on PR #179 to verify the new configuration

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)