### PR TITLE
Clarify runtime dependencies in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A complete, self-contained OpenAPI toolkit for Go with minimal dependencies.
 [![Go Reference](https://pkg.go.dev/badge/github.com/erraggy/oastools.svg)](https://pkg.go.dev/github.com/erraggy/oastools)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-**Parse, validate, fix, convert, diff, join, generate, and build OpenAPI specs (2.0-3.2.0) with zero runtime dependencies beyond YAML parsing.**
+**Parse, validate, fix, convert, diff, join, generate, and build OpenAPI specs (2.0-3.2.0) with zero runtime dependencies beyond YAML for parsing and x/tools for generating.**
 
 ## Highlights
 


### PR DESCRIPTION
Updated the README to specify 'x/tools' as a runtime dependency for generating.