### PR TITLE
chore: prepare v1.33.1 release

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -127,12 +127,18 @@ if err != nil {
     log.Fatal(err)
 }
 
-// Access parsed document
+// Access parsed document (version-specific)
 switch doc := result.Document.(type) {
 case *parser.OAS2Document:
     fmt.Printf("Swagger %s: %s\n", doc.Swagger, doc.Info.Title)
 case *parser.OAS3Document:
     fmt.Printf("OpenAPI %s: %s\n", doc.OpenAPI, doc.Info.Title)
+}
+
+// Or use version-agnostic access with DocumentAccessor
+if accessor := result.AsAccessor(); accessor != nil {
+    fmt.Printf("API: %s\n", accessor.GetInfo().Title)
+    fmt.Printf("Schemas: %d\n", len(accessor.GetSchemas()))
 }
 ```
 

--- a/parser/deep_dive.md
+++ b/parser/deep_dive.md
@@ -14,6 +14,7 @@ The [`parser`](https://pkg.go.dev/github.com/erraggy/oastools/parser) package pr
 - [Practical Examples](#practical-examples)
 - [Configuration Reference](#configuration-reference)
 - [Document Type Helpers](#document-type-helpers)
+- [Version-Agnostic Access (DocumentAccessor)](#version-agnostic-access-documentaccessor)
 - [Best Practices](#best-practices)
 
 ---
@@ -368,6 +369,48 @@ if doc, ok := result.OAS2Document(); ok {
 
 ---
 
+## Version-Agnostic Access (DocumentAccessor)
+
+See also: [DocumentAccessor example](https://pkg.go.dev/github.com/erraggy/oastools/parser#example-package-DocumentAccessor) on pkg.go.dev
+
+For code that needs to work uniformly across both OAS 2.0 and 3.x documents without type switches, use the `DocumentAccessor` interface:
+
+```go
+result, _ := parser.ParseWithOptions(parser.WithFilePath("api.yaml"))
+if accessor := result.AsAccessor(); accessor != nil {
+    // These methods work identically for both versions
+    for path := range accessor.GetPaths() {
+        fmt.Println("Path:", path)
+    }
+
+    // GetSchemas() abstracts the difference:
+    // - OAS 2.0: returns doc.Definitions
+    // - OAS 3.x: returns doc.Components.Schemas
+    for name := range accessor.GetSchemas() {
+        fmt.Println("Schema:", name)
+    }
+
+    // Get the $ref prefix for schema references
+    fmt.Println("Prefix:", accessor.SchemaRefPrefix())
+}
+```
+
+### DocumentAccessor Methods
+
+| Method | OAS 2.0 Source | OAS 3.x Source |
+|--------|---------------|----------------|
+| `GetInfo()` | `doc.Info` | `doc.Info` |
+| `GetPaths()` | `doc.Paths` | `doc.Paths` |
+| `GetSchemas()` | `doc.Definitions` | `doc.Components.Schemas` |
+| `GetSecuritySchemes()` | `doc.SecurityDefinitions` | `doc.Components.SecuritySchemes` |
+| `GetParameters()` | `doc.Parameters` | `doc.Components.Parameters` |
+| `GetResponses()` | `doc.Responses` | `doc.Components.Responses` |
+| `SchemaRefPrefix()` | `#/definitions/` | `#/components/schemas/` |
+
+[Back to top](#top)
+
+---
+
 ## Best Practices
 
 1. **Parse once, use many** - Cache ParseResult for operations like validate, convert, diff
@@ -389,3 +432,4 @@ For additional examples and complete API documentation:
 - 🌐 [HTTP refs example](https://pkg.go.dev/github.com/erraggy/oastools/parser#example-package-ParseWithHTTPRefs) - Resolve external HTTP references
 - 📋 [DeepCopy example](https://pkg.go.dev/github.com/erraggy/oastools/parser#example-package-DeepCopy) - Safe document mutation
 - 🔍 [Type helpers example](https://pkg.go.dev/github.com/erraggy/oastools/parser#example-package-DocumentTypeHelpers) - Version checking and type assertions
+- 🔀 [DocumentAccessor example](https://pkg.go.dev/github.com/erraggy/oastools/parser#example-package-DocumentAccessor) - Version-agnostic document access

--- a/parser/doc.go
+++ b/parser/doc.go
@@ -150,6 +150,29 @@
 //
 // These helpers eliminate the need for manual type switches on the Document field.
 //
+// # Version-Agnostic Access
+//
+// For code that needs to work uniformly across OAS 2.0 and 3.x documents without
+// version-specific type switches, use the [DocumentAccessor] interface:
+//
+//	result, _ := parser.ParseWithOptions(parser.WithFilePath("api.yaml"))
+//	if accessor := result.AsAccessor(); accessor != nil {
+//	    // Unified access to paths, schemas, etc.
+//	    for path := range accessor.GetPaths() {
+//	        fmt.Println("Path:", path)
+//	    }
+//	    for name := range accessor.GetSchemas() {
+//	        // Returns Definitions (2.0) or Components.Schemas (3.x)
+//	        fmt.Println("Schema:", name)
+//	    }
+//	    // Get the schema $ref prefix for this version
+//	    fmt.Println("Prefix:", accessor.SchemaRefPrefix())
+//	}
+//
+// DocumentAccessor provides methods like GetPaths, GetSchemas, GetSecuritySchemes,
+// GetParameters, and GetResponses that automatically map to the correct location
+// for each OAS version.
+//
 // # Related Packages
 //
 // After parsing, use these packages for additional operations:

--- a/parser/example_test.go
+++ b/parser/example_test.go
@@ -144,6 +144,35 @@ func Example_deepCopy() {
 	// Copy title: Modified Petstore API
 }
 
+// Example_documentAccessor demonstrates using the DocumentAccessor interface
+// for version-agnostic access to OpenAPI documents. This allows writing code
+// that works identically for both OAS 2.0 and OAS 3.x without type switches.
+func Example_documentAccessor() {
+	result, err := parser.ParseWithOptions(
+		parser.WithFilePath("../testdata/petstore-3.0.yaml"),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Get version-agnostic accessor
+	accessor := result.AsAccessor()
+	if accessor == nil {
+		log.Fatal("unsupported document type")
+	}
+
+	// Works identically for both OAS 2.0 and OAS 3.x
+	fmt.Printf("API: %s\n", accessor.GetInfo().Title)
+	fmt.Printf("Paths: %d\n", len(accessor.GetPaths()))
+	fmt.Printf("Schemas: %d\n", len(accessor.GetSchemas()))
+	fmt.Printf("Schema ref prefix: %s\n", accessor.SchemaRefPrefix())
+	// Output:
+	// API: Petstore API
+	// Paths: 2
+	// Schemas: 4
+	// Schema ref prefix: #/components/schemas/
+}
+
 // Example_documentTypeHelpers demonstrates using the type assertion helper methods
 // to safely extract version-specific documents and check document versions.
 func Example_documentTypeHelpers() {


### PR DESCRIPTION
## Summary

Prepares release v1.33.1 with documentation updates for the new DocumentAccessor interface.

## Changes

- ✅ Add `Example_documentAccessor` to parser/example_test.go
- ✅ Add "Version-Agnostic Access" section to parser/doc.go
- ✅ Add DocumentAccessor section with methods table to parser/deep_dive.md
- ✅ Update docs/developer-guide.md with AsAccessor usage example

## Pre-Release Checklist

- ✅ All 4605 tests pass
- ✅ No security vulnerabilities (govulncheck clean)
- ✅ 78.5% parser coverage (above 70% threshold)
- ✅ Lint clean

## Release Notes Preview

### Features
- **DocumentAccessor interface** - Version-agnostic access to OAS 2.0 and 3.x documents

### Documentation
- Added runnable Example_documentAccessor godoc example
- Updated parser package docs, deep dive guide, and developer guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)