### PR TITLE
feat(errors): add structured error locality for builder, joiner, overlay

### DIFF
--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -493,7 +493,7 @@ func TestBuilder_AddOperation_DuplicateOperationID(t *testing.T) {
 		AddOperation(http.MethodGet, "/posts", WithOperationID("getUsers"))
 
 	assert.Len(t, b.errors, 1)
-	assert.Contains(t, b.errors[0].Error(), "duplicate operation ID")
+	assert.Contains(t, b.errors[0].Error(), "duplicate operationId")
 }
 
 func TestBuilder_AddOperation_WithRequestBody(t *testing.T) {

--- a/builder/errors.go
+++ b/builder/errors.go
@@ -1,0 +1,270 @@
+package builder
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/erraggy/oastools/oaserrors"
+)
+
+// ComponentType identifies the type of component where an error occurred.
+type ComponentType string
+
+const (
+	// ComponentOperation indicates an error in an operation definition.
+	ComponentOperation ComponentType = "operation"
+	// ComponentWebhook indicates an error in a webhook definition.
+	ComponentWebhook ComponentType = "webhook"
+	// ComponentParameter indicates an error in a parameter definition.
+	ComponentParameter ComponentType = "parameter"
+	// ComponentSchema indicates an error in a schema definition.
+	ComponentSchema ComponentType = "schema"
+	// ComponentRequestBody indicates an error in a request body definition.
+	ComponentRequestBody ComponentType = "request_body"
+	// ComponentResponse indicates an error in a response definition.
+	ComponentResponse ComponentType = "response"
+	// ComponentSecurityScheme indicates an error in a security scheme.
+	ComponentSecurityScheme ComponentType = "security_scheme"
+	// ComponentServer indicates an error in a server definition.
+	ComponentServer ComponentType = "server"
+)
+
+// operationLocation tracks where an operationID was first defined.
+type operationLocation struct {
+	Method    string
+	Path      string
+	IsWebhook bool
+}
+
+// String returns a human-readable location description.
+func (ol operationLocation) String() string {
+	if ol.IsWebhook {
+		return fmt.Sprintf("webhook %s (%s)", ol.Path, ol.Method)
+	}
+	return fmt.Sprintf("%s %s", ol.Method, ol.Path)
+}
+
+// BuilderError represents a structured error from the builder package.
+// It provides detailed context about where and why an error occurred during
+// the fluent API building process.
+type BuilderError struct {
+	// Component is the type of component where the error occurred.
+	Component ComponentType
+	// Method is the HTTP method (for operation/webhook errors).
+	Method string
+	// Path is the API path (for operation errors) or webhook name.
+	Path string
+	// OperationID is the operation identifier (if applicable).
+	OperationID string
+	// Field is the specific field with the error (e.g., "minimum").
+	Field string
+	// Message describes the error.
+	Message string
+	// Context provides additional details (e.g., conflicting values).
+	Context map[string]any
+	// FirstOccurrence tracks where a duplicate was first defined.
+	FirstOccurrence *operationLocation
+	// Cause is the underlying error, if any.
+	Cause error
+}
+
+// Error implements the error interface with a detailed, formatted message.
+func (e *BuilderError) Error() string {
+	var sb strings.Builder
+	sb.WriteString("builder")
+
+	// Add component context
+	if e.Component != "" {
+		sb.WriteString(": ")
+		sb.WriteString(string(e.Component))
+	}
+
+	// Add method and path for operations/webhooks
+	if e.Method != "" && e.Path != "" {
+		sb.WriteString(" ")
+		sb.WriteString(e.Method)
+		sb.WriteString(" ")
+		sb.WriteString(e.Path)
+	} else if e.Path != "" {
+		sb.WriteString(" ")
+		sb.WriteString(e.Path)
+	}
+
+	// Add operationID if present
+	if e.OperationID != "" {
+		sb.WriteString(" [operationId: ")
+		sb.WriteString(e.OperationID)
+		sb.WriteString("]")
+	}
+
+	// Add field if present
+	if e.Field != "" {
+		sb.WriteString(" field ")
+		sb.WriteString(e.Field)
+	}
+
+	// Add the message
+	if e.Message != "" {
+		sb.WriteString(": ")
+		sb.WriteString(e.Message)
+	}
+
+	// Add first occurrence context for duplicates
+	if e.FirstOccurrence != nil {
+		sb.WriteString(" (first defined at ")
+		sb.WriteString(e.FirstOccurrence.String())
+		sb.WriteString(")")
+	}
+
+	// Add underlying cause if present
+	if e.Cause != nil {
+		sb.WriteString(": ")
+		sb.WriteString(e.Cause.Error())
+	}
+
+	return sb.String()
+}
+
+// Unwrap returns the underlying error for errors.Is/As support.
+func (e *BuilderError) Unwrap() error {
+	return e.Cause
+}
+
+// Is reports whether target matches this error type.
+// All BuilderErrors are classified as ErrConfig errors, enabling callers to use
+// errors.Is(err, oaserrors.ErrConfig) to detect builder configuration issues.
+// This includes validation errors, duplicate detection, and unsupported features.
+func (e *BuilderError) Is(target error) bool {
+	return target == oaserrors.ErrConfig
+}
+
+// HasLocation returns true if this error has location context.
+// BuilderError uses component/method/path instead of line/column.
+func (e *BuilderError) HasLocation() bool {
+	return e.Path != "" || e.Component != ""
+}
+
+// Location returns a descriptive location string.
+func (e *BuilderError) Location() string {
+	if e.Method != "" && e.Path != "" {
+		return fmt.Sprintf("%s %s", e.Method, e.Path)
+	}
+	if e.Path != "" {
+		return e.Path
+	}
+	if e.Component != "" {
+		return string(e.Component)
+	}
+	return "unknown"
+}
+
+// NewDuplicateOperationIDError creates an error for duplicate operation IDs.
+func NewDuplicateOperationIDError(operationID, method, path string, first *operationLocation) *BuilderError {
+	return &BuilderError{
+		Component:       ComponentOperation,
+		Method:          method,
+		Path:            path,
+		OperationID:     operationID,
+		Message:         fmt.Sprintf("duplicate operationId %q", operationID),
+		FirstOccurrence: first,
+	}
+}
+
+// NewDuplicateWebhookOperationIDError creates an error for duplicate operation IDs in webhooks.
+func NewDuplicateWebhookOperationIDError(operationID, webhookName, method string, first *operationLocation) *BuilderError {
+	return &BuilderError{
+		Component:       ComponentWebhook,
+		Method:          method,
+		Path:            webhookName,
+		OperationID:     operationID,
+		Message:         fmt.Sprintf("duplicate operationId %q", operationID),
+		FirstOccurrence: first,
+	}
+}
+
+// NewUnsupportedMethodError creates an error for unsupported HTTP methods.
+func NewUnsupportedMethodError(method, path, minVersion string) *BuilderError {
+	return &BuilderError{
+		Component: ComponentOperation,
+		Method:    method,
+		Path:      path,
+		Message:   fmt.Sprintf("HTTP method %s requires OAS version %s or later", method, minVersion),
+		Context: map[string]any{
+			"min_version": minVersion,
+		},
+	}
+}
+
+// NewInvalidMethodError creates an error for invalid/unknown HTTP methods.
+func NewInvalidMethodError(method, path string) *BuilderError {
+	return &BuilderError{
+		Component: ComponentOperation,
+		Method:    method,
+		Path:      path,
+		Message:   fmt.Sprintf("unsupported HTTP method: %s", method),
+	}
+}
+
+// NewParameterConstraintError creates an error for parameter constraint violations.
+func NewParameterConstraintError(paramName, operationContext, field, message string) *BuilderError {
+	return &BuilderError{
+		Component: ComponentParameter,
+		Path:      operationContext,
+		Field:     field,
+		Message:   fmt.Sprintf("parameter %q: %s", paramName, message),
+	}
+}
+
+// NewSchemaError creates an error for schema-related issues.
+func NewSchemaError(schemaName, message string, cause error) *BuilderError {
+	return &BuilderError{
+		Component: ComponentSchema,
+		Path:      schemaName,
+		Message:   message,
+		Cause:     cause,
+	}
+}
+
+// BuilderErrors is a collection of BuilderError with formatting support.
+type BuilderErrors []*BuilderError
+
+// Error implements the error interface with a formatted multi-error message.
+func (errs BuilderErrors) Error() string {
+	if len(errs) == 0 {
+		return ""
+	}
+	if len(errs) == 1 {
+		if errs[0] == nil {
+			return ""
+		}
+		return errs[0].Error()
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("builder: %d error(s):\n", len(errs)))
+	for _, e := range errs {
+		if e == nil {
+			continue
+		}
+		sb.WriteString("  - ")
+		// Strip the "builder: " prefix for nested errors to avoid repetition
+		errMsg := strings.TrimPrefix(e.Error(), "builder: ")
+		sb.WriteString(errMsg)
+		sb.WriteString("\n")
+	}
+
+	return strings.TrimSuffix(sb.String(), "\n")
+}
+
+// Unwrap returns the errors for Go 1.20+ error wrapping semantics,
+// enabling errors.Is and errors.As to work with multiple wrapped errors.
+func (errs BuilderErrors) Unwrap() []error {
+	result := make([]error, 0, len(errs))
+	for _, e := range errs {
+		if e == nil {
+			continue
+		}
+		result = append(result, e)
+	}
+	return result
+}

--- a/builder/errors_test.go
+++ b/builder/errors_test.go
@@ -1,0 +1,414 @@
+package builder
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/erraggy/oastools/oaserrors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuilderError_Error(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      *BuilderError
+		contains []string
+	}{
+		{
+			name: "duplicate operationID with first occurrence",
+			err: NewDuplicateOperationIDError("getUser", "POST", "/users/{id}",
+				&operationLocation{Method: "GET", Path: "/users/{id}"}),
+			contains: []string{"builder", "operation", "POST /users/{id}", "duplicate", "getUser", "GET /users/{id}"},
+		},
+		{
+			name:     "duplicate operationID without first occurrence",
+			err:      NewDuplicateOperationIDError("getUser", "POST", "/users/{id}", nil),
+			contains: []string{"builder", "operation", "POST /users/{id}", "duplicate", "getUser"},
+		},
+		{
+			name:     "unsupported method TRACE",
+			err:      NewUnsupportedMethodError("TRACE", "/debug", "3.0.0"),
+			contains: []string{"builder", "operation", "TRACE", "/debug", "3.0.0"},
+		},
+		{
+			name:     "unsupported method QUERY",
+			err:      NewUnsupportedMethodError("QUERY", "/search", "3.2.0"),
+			contains: []string{"builder", "operation", "QUERY", "/search", "3.2.0"},
+		},
+		{
+			name:     "invalid method",
+			err:      NewInvalidMethodError("INVALID", "/path"),
+			contains: []string{"builder", "operation", "INVALID", "/path", "unsupported"},
+		},
+		{
+			name: "webhook duplicate operationID",
+			err: NewDuplicateWebhookOperationIDError("createUser", "myWebhook", "POST",
+				&operationLocation{Method: "POST", Path: "/users", IsWebhook: false}),
+			contains: []string{"builder", "webhook", "myWebhook", "duplicate", "createUser", "POST /users"},
+		},
+		{
+			name:     "schema error with cause",
+			err:      NewSchemaError("UserSchema", "deduplication failed", errors.New("hash collision")),
+			contains: []string{"builder", "schema", "UserSchema", "deduplication failed", "hash collision"},
+		},
+		{
+			name:     "parameter constraint error",
+			err:      NewParameterConstraintError("age", "POST /users", "minimum", "minimum (100) cannot exceed maximum (1)"),
+			contains: []string{"builder", "parameter", "POST /users", "age", "minimum"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := tt.err.Error()
+			for _, s := range tt.contains {
+				assert.Contains(t, msg, s, "error message should contain %q", s)
+			}
+		})
+	}
+}
+
+func TestBuilderError_Is(t *testing.T) {
+	err := NewDuplicateOperationIDError("test", "GET", "/", nil)
+	assert.True(t, errors.Is(err, oaserrors.ErrConfig), "BuilderError should match oaserrors.ErrConfig")
+}
+
+func TestBuilderError_Unwrap(t *testing.T) {
+	cause := errors.New("underlying error")
+	err := NewSchemaError("Test", "failed", cause)
+
+	assert.Equal(t, cause, errors.Unwrap(err), "Unwrap should return the cause")
+}
+
+func TestBuilderError_HasLocation(t *testing.T) {
+	tests := []struct {
+		name        string
+		err         *BuilderError
+		hasLocation bool
+	}{
+		{
+			name:        "with path",
+			err:         &BuilderError{Path: "/users"},
+			hasLocation: true,
+		},
+		{
+			name:        "with component only",
+			err:         &BuilderError{Component: ComponentParameter},
+			hasLocation: true,
+		},
+		{
+			name:        "without location",
+			err:         &BuilderError{Message: "something went wrong"},
+			hasLocation: false,
+		},
+		{
+			name:        "with method and path",
+			err:         &BuilderError{Method: "GET", Path: "/users"},
+			hasLocation: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.hasLocation, tt.err.HasLocation())
+		})
+	}
+}
+
+func TestBuilderError_Location(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      *BuilderError
+		expected string
+	}{
+		{
+			name:     "method and path",
+			err:      &BuilderError{Method: "GET", Path: "/users"},
+			expected: "GET /users",
+		},
+		{
+			name:     "path only",
+			err:      &BuilderError{Path: "/users"},
+			expected: "/users",
+		},
+		{
+			name:     "component only",
+			err:      &BuilderError{Component: ComponentParameter},
+			expected: "parameter",
+		},
+		{
+			name:     "no location",
+			err:      &BuilderError{Message: "error"},
+			expected: "unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.err.Location())
+		})
+	}
+}
+
+func TestBuilderErrors_Error(t *testing.T) {
+	t.Run("single error", func(t *testing.T) {
+		errs := BuilderErrors{
+			NewDuplicateOperationIDError("a", "GET", "/a", nil),
+		}
+
+		msg := errs.Error()
+		assert.Contains(t, msg, "GET /a")
+		assert.NotContains(t, msg, "error(s)") // Single error format
+	})
+
+	t.Run("multiple errors", func(t *testing.T) {
+		errs := BuilderErrors{
+			NewDuplicateOperationIDError("a", "GET", "/a", nil),
+			NewUnsupportedMethodError("TRACE", "/debug", "3.0.0"),
+		}
+
+		msg := errs.Error()
+		assert.Contains(t, msg, "2 error(s)")
+		assert.Contains(t, msg, "GET /a")
+		assert.Contains(t, msg, "TRACE /debug")
+	})
+
+	t.Run("empty errors", func(t *testing.T) {
+		errs := BuilderErrors{}
+		assert.Empty(t, errs.Error())
+	})
+}
+
+func TestBuilderErrors_Unwrap(t *testing.T) {
+	errs := BuilderErrors{
+		NewDuplicateOperationIDError("a", "GET", "/a", nil),
+		NewDuplicateOperationIDError("b", "POST", "/b", nil),
+	}
+
+	unwrapped := errs.Unwrap()
+	require.Len(t, unwrapped, 2)
+	assert.Contains(t, unwrapped[0].Error(), "GET /a")
+	assert.Contains(t, unwrapped[1].Error(), "POST /b")
+}
+
+func TestOperationLocation_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		loc      operationLocation
+		expected string
+	}{
+		{
+			name:     "operation",
+			loc:      operationLocation{Method: "GET", Path: "/users"},
+			expected: "GET /users",
+		},
+		{
+			name:     "webhook",
+			loc:      operationLocation{Method: "POST", Path: "userCreated", IsWebhook: true},
+			expected: "webhook userCreated (POST)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.loc.String())
+		})
+	}
+}
+
+func TestConstraintError_Error(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      *ConstraintError
+		contains []string
+	}{
+		{
+			name: "basic constraint error",
+			err: &ConstraintError{
+				Field:   "minimum",
+				Message: "minimum (100) cannot exceed maximum (1)",
+			},
+			contains: []string{"constraint error", "minimum", "cannot exceed maximum"},
+		},
+		{
+			name: "constraint error with param name",
+			err: &ConstraintError{
+				Field:     "minimum",
+				Message:   "value must be positive",
+				ParamName: "age",
+			},
+			contains: []string{"constraint error", "parameter", "age", "minimum"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := tt.err.Error()
+			for _, s := range tt.contains {
+				assert.Contains(t, msg, s)
+			}
+		})
+	}
+}
+
+func TestConstraintError_HasLocation(t *testing.T) {
+	tests := []struct {
+		name        string
+		err         *ConstraintError
+		hasLocation bool
+	}{
+		{
+			name:        "with param name",
+			err:         &ConstraintError{Field: "min", Message: "test", ParamName: "age"},
+			hasLocation: true,
+		},
+		{
+			name:        "with operation context",
+			err:         &ConstraintError{Field: "min", Message: "test", OperationContext: "POST /users"},
+			hasLocation: true,
+		},
+		{
+			name:        "without context",
+			err:         &ConstraintError{Field: "min", Message: "test"},
+			hasLocation: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.hasLocation, tt.err.HasLocation())
+		})
+	}
+}
+
+func TestConstraintError_Location(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      *ConstraintError
+		expected string
+	}{
+		{
+			name: "operation context and param name",
+			err: &ConstraintError{
+				Field:            "min",
+				Message:          "test",
+				ParamName:        "age",
+				OperationContext: "POST /users",
+			},
+			expected: "POST /users parameter \"age\"",
+		},
+		{
+			name:     "param name only",
+			err:      &ConstraintError{Field: "min", Message: "test", ParamName: "age"},
+			expected: "parameter \"age\"",
+		},
+		{
+			name:     "operation context only",
+			err:      &ConstraintError{Field: "min", Message: "test", OperationContext: "POST /users"},
+			expected: "POST /users",
+		},
+		{
+			name:     "field fallback",
+			err:      &ConstraintError{Field: "minimum", Message: "test"},
+			expected: "minimum",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.err.Location())
+		})
+	}
+}
+
+func TestComponentType_Values(t *testing.T) {
+	// Verify component types are defined as expected strings
+	assert.Equal(t, ComponentType("operation"), ComponentOperation)
+	assert.Equal(t, ComponentType("webhook"), ComponentWebhook)
+	assert.Equal(t, ComponentType("parameter"), ComponentParameter)
+	assert.Equal(t, ComponentType("schema"), ComponentSchema)
+	assert.Equal(t, ComponentType("request_body"), ComponentRequestBody)
+	assert.Equal(t, ComponentType("response"), ComponentResponse)
+	assert.Equal(t, ComponentType("security_scheme"), ComponentSecurityScheme)
+	assert.Equal(t, ComponentType("server"), ComponentServer)
+}
+
+func TestConstraintError_Is(t *testing.T) {
+	err := &ConstraintError{Field: "minimum", Message: "invalid"}
+	assert.True(t, errors.Is(err, oaserrors.ErrConfig), "ConstraintError should match oaserrors.ErrConfig")
+}
+
+func TestConstraintError_Unwrap(t *testing.T) {
+	err := &ConstraintError{Field: "minimum", Message: "invalid"}
+	assert.Nil(t, errors.Unwrap(err), "ConstraintError.Unwrap should return nil")
+}
+
+func TestBuilderErrors_ErrorsAs(t *testing.T) {
+	t.Run("errors.As with single BuilderError", func(t *testing.T) {
+		errs := BuilderErrors{
+			NewDuplicateOperationIDError("getUser", "GET", "/users", nil),
+		}
+
+		var be *BuilderError
+		if !errors.As(errs, &be) {
+			t.Fatal("errors.As should find BuilderError in BuilderErrors")
+		}
+		assert.Equal(t, "getUser", be.OperationID)
+	})
+
+	t.Run("errors.As with multiple BuilderErrors", func(t *testing.T) {
+		errs := BuilderErrors{
+			NewUnsupportedMethodError("TRACE", "/debug", "3.0.0"),
+			NewDuplicateOperationIDError("getUser", "GET", "/users", nil),
+		}
+
+		var be *BuilderError
+		if !errors.As(errs, &be) {
+			t.Fatal("errors.As should find BuilderError in BuilderErrors")
+		}
+		// Should find the first one
+		assert.Equal(t, "TRACE", be.Method)
+	})
+
+	t.Run("errors.Is with ErrConfig", func(t *testing.T) {
+		errs := BuilderErrors{
+			NewDuplicateOperationIDError("getUser", "GET", "/users", nil),
+		}
+
+		// errors.Is should traverse through the unwrapped errors
+		assert.True(t, errors.Is(errs, oaserrors.ErrConfig),
+			"errors.Is should find ErrConfig through BuilderErrors")
+	})
+}
+
+func TestBuilderErrors_NilHandling(t *testing.T) {
+	t.Run("Error with nil element", func(t *testing.T) {
+		errs := BuilderErrors{
+			NewDuplicateOperationIDError("a", "GET", "/a", nil),
+			nil,
+			NewDuplicateOperationIDError("b", "POST", "/b", nil),
+		}
+
+		// Should not panic
+		msg := errs.Error()
+		assert.Contains(t, msg, "GET /a")
+		assert.Contains(t, msg, "POST /b")
+	})
+
+	t.Run("Unwrap skips nil elements", func(t *testing.T) {
+		errs := BuilderErrors{
+			NewDuplicateOperationIDError("a", "GET", "/a", nil),
+			nil,
+			NewDuplicateOperationIDError("b", "POST", "/b", nil),
+		}
+
+		unwrapped := errs.Unwrap()
+		assert.Len(t, unwrapped, 2, "Unwrap should skip nil elements")
+	})
+
+	t.Run("single nil element", func(t *testing.T) {
+		errs := BuilderErrors{nil}
+		assert.Empty(t, errs.Error())
+	})
+}

--- a/builder/operation_test.go
+++ b/builder/operation_test.go
@@ -400,7 +400,8 @@ func TestBuilder_AddOperation_QueryMethod_OAS31_Error(t *testing.T) {
 		)
 
 	require.Len(t, b.errors, 1, "QUERY method should not be supported in OAS 3.1")
-	assert.Contains(t, b.errors[0].Error(), "QUERY method is only supported in OAS 3.2.0+")
+	assert.Contains(t, b.errors[0].Error(), "QUERY")
+	assert.Contains(t, b.errors[0].Error(), "3.2.0")
 }
 
 func TestBuilder_AddOperation_QueryMethod_OAS20_Error(t *testing.T) {
@@ -414,7 +415,8 @@ func TestBuilder_AddOperation_QueryMethod_OAS20_Error(t *testing.T) {
 		)
 
 	require.Len(t, b.errors, 1, "QUERY method should not be supported in OAS 2.0")
-	assert.Contains(t, b.errors[0].Error(), "QUERY method is only supported in OAS 3.2.0+")
+	assert.Contains(t, b.errors[0].Error(), "QUERY")
+	assert.Contains(t, b.errors[0].Error(), "3.2.0")
 }
 
 func TestBuilder_AddOperation_WithNoSecurity(t *testing.T) {

--- a/joiner/warnings.go
+++ b/joiner/warnings.go
@@ -1,0 +1,299 @@
+package joiner
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/erraggy/oastools/internal/severity"
+)
+
+// WarningCategory identifies the type of warning.
+type WarningCategory string
+
+const (
+	// WarnVersionMismatch indicates documents have different minor versions.
+	WarnVersionMismatch WarningCategory = "version_mismatch"
+	// WarnPathCollision indicates a path collision was resolved.
+	WarnPathCollision WarningCategory = "path_collision"
+	// WarnSchemaCollision indicates a schema/definition collision was resolved.
+	WarnSchemaCollision WarningCategory = "schema_collision"
+	// WarnWebhookCollision indicates a webhook collision was resolved.
+	WarnWebhookCollision WarningCategory = "webhook_collision"
+	// WarnSchemaRenamed indicates a schema was renamed due to collision.
+	WarnSchemaRenamed WarningCategory = "schema_renamed"
+	// WarnSchemaDeduplicated indicates a schema was deduplicated.
+	WarnSchemaDeduplicated WarningCategory = "schema_deduplicated"
+	// WarnNamespacePrefixed indicates a namespace prefix was applied.
+	WarnNamespacePrefixed WarningCategory = "namespace_prefixed"
+	// WarnMetadataOverride indicates metadata was overridden (host, basePath).
+	WarnMetadataOverride WarningCategory = "metadata_override"
+	// WarnSemanticDedup indicates semantic deduplication summary.
+	WarnSemanticDedup WarningCategory = "semantic_dedup"
+)
+
+// JoinWarning represents a structured warning from the joiner package.
+// It provides detailed context about non-fatal issues encountered during document joining.
+type JoinWarning struct {
+	// Category identifies the type of warning.
+	Category WarningCategory
+	// Path is the JSON path to the affected element.
+	Path string
+	// Message is a human-readable description.
+	Message string
+	// SourceFile is the file that triggered the warning.
+	SourceFile string
+	// Line is the 1-based line number (0 if unknown).
+	Line int
+	// Column is the 1-based column number (0 if unknown).
+	Column int
+	// Severity indicates warning severity (default: SeverityWarning).
+	Severity severity.Severity
+	// Context provides additional details.
+	Context map[string]any
+}
+
+// String returns a formatted warning message.
+// For most warnings, Context is included in Message via the constructor functions.
+// This method returns just the Message for simplicity and backward compatibility.
+func (w *JoinWarning) String() string {
+	return w.Message
+}
+
+// HasLocation returns true if source location information is available.
+func (w *JoinWarning) HasLocation() bool {
+	return w.Line > 0
+}
+
+// Location returns an IDE-friendly location string.
+func (w *JoinWarning) Location() string {
+	if w.Line == 0 {
+		if w.Path != "" {
+			return w.Path
+		}
+		return w.SourceFile
+	}
+	if w.SourceFile != "" {
+		if w.Column > 0 {
+			return fmt.Sprintf("%s:%d:%d", w.SourceFile, w.Line, w.Column)
+		}
+		return fmt.Sprintf("%s:%d", w.SourceFile, w.Line)
+	}
+	if w.Column > 0 {
+		return fmt.Sprintf("%d:%d", w.Line, w.Column)
+	}
+	return fmt.Sprintf("%d", w.Line)
+}
+
+// NewPathCollisionWarning creates a warning for path collisions.
+func NewPathCollisionWarning(path, resolution, firstFile, secondFile string, line, col int) *JoinWarning {
+	return &JoinWarning{
+		Category:   WarnPathCollision,
+		Path:       fmt.Sprintf("paths.%s", path),
+		Message:    fmt.Sprintf("path '%s' %s: %s -> %s", path, resolution, firstFile, secondFile),
+		SourceFile: secondFile,
+		Line:       line,
+		Column:     col,
+		Severity:   severity.SeverityWarning,
+		Context: map[string]any{
+			"first_file":  firstFile,
+			"second_file": secondFile,
+			"resolution":  resolution,
+		},
+	}
+}
+
+// NewWebhookCollisionWarning creates a warning for webhook collisions.
+func NewWebhookCollisionWarning(webhookName, resolution, firstFile, secondFile string, line, col int) *JoinWarning {
+	return &JoinWarning{
+		Category:   WarnWebhookCollision,
+		Path:       fmt.Sprintf("webhooks.%s", webhookName),
+		Message:    fmt.Sprintf("webhook '%s' %s: %s -> %s", webhookName, resolution, firstFile, secondFile),
+		SourceFile: secondFile,
+		Line:       line,
+		Column:     col,
+		Severity:   severity.SeverityWarning,
+		Context: map[string]any{
+			"first_file":  firstFile,
+			"second_file": secondFile,
+			"resolution":  resolution,
+		},
+	}
+}
+
+// NewSchemaCollisionWarning creates a warning for schema/definition collisions.
+func NewSchemaCollisionWarning(schemaName, resolution, section, firstFile, secondFile string, line, col int) *JoinWarning {
+	return &JoinWarning{
+		Category:   WarnSchemaCollision,
+		Path:       fmt.Sprintf("%s.%s", section, schemaName),
+		Message:    fmt.Sprintf("%s '%s' %s: source %s", section, schemaName, resolution, secondFile),
+		SourceFile: secondFile,
+		Line:       line,
+		Column:     col,
+		Severity:   severity.SeverityWarning,
+		Context: map[string]any{
+			"section":     section,
+			"first_file":  firstFile,
+			"second_file": secondFile,
+			"resolution":  resolution,
+		},
+	}
+}
+
+// NewSchemaRenamedWarning creates a warning when a schema is renamed.
+func NewSchemaRenamedWarning(originalName, newName, section, sourceFile string, line, col int, keptOriginal bool) *JoinWarning {
+	var msg string
+	if keptOriginal {
+		msg = fmt.Sprintf("%s '%s' renamed to '%s' (kept from first document)", section, originalName, newName)
+	} else {
+		msg = fmt.Sprintf("%s '%s' from %s renamed to '%s'", section, originalName, sourceFile, newName)
+	}
+	return &JoinWarning{
+		Category:   WarnSchemaRenamed,
+		Path:       fmt.Sprintf("%s.%s", section, originalName),
+		Message:    msg,
+		SourceFile: sourceFile,
+		Line:       line,
+		Column:     col,
+		Severity:   severity.SeverityInfo,
+		Context: map[string]any{
+			"original_name": originalName,
+			"new_name":      newName,
+			"section":       section,
+			"kept_original": keptOriginal,
+		},
+	}
+}
+
+// NewSchemaDedupWarning creates a warning for schema deduplication.
+func NewSchemaDedupWarning(schemaName, section, sourceFile string, line, col int) *JoinWarning {
+	return &JoinWarning{
+		Category:   WarnSchemaDeduplicated,
+		Path:       fmt.Sprintf("%s.%s", section, schemaName),
+		Message:    fmt.Sprintf("%s '%s' deduplicated (structurally equivalent): %s", section, schemaName, sourceFile),
+		SourceFile: sourceFile,
+		Line:       line,
+		Column:     col,
+		Severity:   severity.SeverityInfo,
+		Context: map[string]any{
+			"section": section,
+		},
+	}
+}
+
+// NewNamespacePrefixWarning creates a warning when a namespace prefix is applied.
+func NewNamespacePrefixWarning(originalName, newName, section, sourceFile string, line, col int) *JoinWarning {
+	return &JoinWarning{
+		Category:   WarnNamespacePrefixed,
+		Path:       fmt.Sprintf("%s.%s", section, originalName),
+		Message:    fmt.Sprintf("%s '%s' prefixed to '%s' (namespace prefix from %s)", section, originalName, newName, sourceFile),
+		SourceFile: sourceFile,
+		Line:       line,
+		Column:     col,
+		Severity:   severity.SeverityInfo,
+		Context: map[string]any{
+			"original_name": originalName,
+			"new_name":      newName,
+			"section":       section,
+		},
+	}
+}
+
+// NewVersionMismatchWarning creates a warning for version mismatches.
+func NewVersionMismatchWarning(file1, version1, file2, version2, targetVersion string) *JoinWarning {
+	return &JoinWarning{
+		Category: WarnVersionMismatch,
+		Message: fmt.Sprintf(
+			"joining documents with different minor versions: %s (%s) and %s (%s). Result will use version %s",
+			file1, version1, file2, version2, targetVersion),
+		Severity: severity.SeverityWarning,
+		Context: map[string]any{
+			"file1":          file1,
+			"version1":       version1,
+			"file2":          file2,
+			"version2":       version2,
+			"target_version": targetVersion,
+		},
+	}
+}
+
+// NewMetadataOverrideWarning creates a warning when metadata is overridden.
+func NewMetadataOverrideWarning(field, firstValue, secondValue, secondFile string) *JoinWarning {
+	return &JoinWarning{
+		Category:   WarnMetadataOverride,
+		Path:       field,
+		Message:    fmt.Sprintf("%s '%s' ignored (kept '%s' from first document)", field, secondValue, firstValue),
+		SourceFile: secondFile,
+		Severity:   severity.SeverityInfo,
+		Context: map[string]any{
+			"field":        field,
+			"first_value":  firstValue,
+			"second_value": secondValue,
+		},
+	}
+}
+
+// NewSemanticDedupSummaryWarning creates a summary warning for semantic deduplication.
+func NewSemanticDedupSummaryWarning(count int, section string) *JoinWarning {
+	return &JoinWarning{
+		Category: WarnSemanticDedup,
+		Message:  fmt.Sprintf("semantic deduplication: consolidated %d duplicate %s(s)", count, section),
+		Severity: severity.SeverityInfo,
+		Context: map[string]any{
+			"count":   count,
+			"section": section,
+		},
+	}
+}
+
+// JoinWarnings is a collection of JoinWarning.
+type JoinWarnings []*JoinWarning
+
+// Strings returns warning messages for backward compatibility.
+func (ws JoinWarnings) Strings() []string {
+	result := make([]string, len(ws))
+	for i, w := range ws {
+		if w == nil {
+			continue
+		}
+		result[i] = w.String()
+	}
+	return result
+}
+
+// ByCategory filters warnings by category.
+func (ws JoinWarnings) ByCategory(cat WarningCategory) JoinWarnings {
+	var result JoinWarnings
+	for _, w := range ws {
+		if w.Category == cat {
+			result = append(result, w)
+		}
+	}
+	return result
+}
+
+// BySeverity filters warnings by severity.
+func (ws JoinWarnings) BySeverity(sev severity.Severity) JoinWarnings {
+	var result JoinWarnings
+	for _, w := range ws {
+		if w.Severity == sev {
+			result = append(result, w)
+		}
+	}
+	return result
+}
+
+// Summary returns a formatted summary of warnings.
+func (ws JoinWarnings) Summary() string {
+	if len(ws) == 0 {
+		return ""
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d warning(s):\n", len(ws)))
+	for _, w := range ws {
+		sb.WriteString("  - ")
+		sb.WriteString(w.String())
+		sb.WriteString("\n")
+	}
+	return strings.TrimSuffix(sb.String(), "\n")
+}

--- a/joiner/warnings_test.go
+++ b/joiner/warnings_test.go
@@ -1,0 +1,400 @@
+package joiner
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/erraggy/oastools/internal/severity"
+)
+
+func TestJoinWarning_String(t *testing.T) {
+	w := &JoinWarning{
+		Category: WarnPathCollision,
+		Message:  "path '/users' overwritten",
+	}
+
+	got := w.String()
+	want := "path '/users' overwritten"
+
+	if got != want {
+		t.Errorf("String() = %q, want %q", got, want)
+	}
+}
+
+func TestJoinWarning_HasLocation(t *testing.T) {
+	tests := []struct {
+		name string
+		line int
+		want bool
+	}{
+		{"with line", 10, true},
+		{"zero line", 0, false},
+		{"negative line", -1, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := &JoinWarning{Line: tt.line}
+			if got := w.HasLocation(); got != tt.want {
+				t.Errorf("HasLocation() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestJoinWarning_Location(t *testing.T) {
+	tests := []struct {
+		name       string
+		sourceFile string
+		path       string
+		line       int
+		column     int
+		want       string
+	}{
+		{
+			name:       "file with line and column",
+			sourceFile: "api.yaml",
+			line:       42,
+			column:     5,
+			want:       "api.yaml:42:5",
+		},
+		{
+			name:       "file with line only",
+			sourceFile: "api.yaml",
+			line:       42,
+			want:       "api.yaml:42",
+		},
+		{
+			name:   "line and column only",
+			line:   42,
+			column: 5,
+			want:   "42:5",
+		},
+		{
+			name: "line only",
+			line: 42,
+			want: "42",
+		},
+		{
+			name: "path fallback",
+			path: "paths./users.get",
+			want: "paths./users.get",
+		},
+		{
+			name:       "file fallback",
+			sourceFile: "api.yaml",
+			want:       "api.yaml",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := &JoinWarning{
+				SourceFile: tt.sourceFile,
+				Path:       tt.path,
+				Line:       tt.line,
+				Column:     tt.column,
+			}
+			if got := w.Location(); got != tt.want {
+				t.Errorf("Location() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewPathCollisionWarning(t *testing.T) {
+	w := NewPathCollisionWarning("/users", "overwritten", "base.yaml", "second.yaml", 15, 3)
+
+	if w.Category != WarnPathCollision {
+		t.Errorf("Category = %v, want %v", w.Category, WarnPathCollision)
+	}
+	if w.Path != "paths./users" {
+		t.Errorf("Path = %q, want %q", w.Path, "paths./users")
+	}
+	if w.SourceFile != "second.yaml" {
+		t.Errorf("SourceFile = %q, want %q", w.SourceFile, "second.yaml")
+	}
+	if w.Line != 15 || w.Column != 3 {
+		t.Errorf("Line:Column = %d:%d, want 15:3", w.Line, w.Column)
+	}
+	if w.Severity != severity.SeverityWarning {
+		t.Errorf("Severity = %v, want %v", w.Severity, severity.SeverityWarning)
+	}
+	if w.Context["resolution"] != "overwritten" {
+		t.Errorf("Context[resolution] = %v, want %q", w.Context["resolution"], "overwritten")
+	}
+}
+
+func TestNewWebhookCollisionWarning(t *testing.T) {
+	w := NewWebhookCollisionWarning("orderCreated", "kept from first", "base.yaml", "webhooks.yaml", 25, 0)
+
+	if w.Category != WarnWebhookCollision {
+		t.Errorf("Category = %v, want %v", w.Category, WarnWebhookCollision)
+	}
+	if w.Path != "webhooks.orderCreated" {
+		t.Errorf("Path = %q, want %q", w.Path, "webhooks.orderCreated")
+	}
+	if !w.HasLocation() {
+		t.Error("HasLocation() = false, want true")
+	}
+}
+
+func TestNewSchemaCollisionWarning(t *testing.T) {
+	w := NewSchemaCollisionWarning("Pet", "overwritten", "components.schemas", "base.yaml", "pets.yaml", 100, 10)
+
+	if w.Category != WarnSchemaCollision {
+		t.Errorf("Category = %v, want %v", w.Category, WarnSchemaCollision)
+	}
+	if w.Path != "components.schemas.Pet" {
+		t.Errorf("Path = %q, want %q", w.Path, "components.schemas.Pet")
+	}
+	if w.Context["section"] != "components.schemas" {
+		t.Errorf("Context[section] = %v, want %q", w.Context["section"], "components.schemas")
+	}
+}
+
+func TestNewSchemaRenamedWarning(t *testing.T) {
+	tests := []struct {
+		name         string
+		keptOriginal bool
+		wantContains string
+	}{
+		{
+			name:         "kept original",
+			keptOriginal: true,
+			wantContains: "kept from first document",
+		},
+		{
+			name:         "renamed source",
+			keptOriginal: false,
+			wantContains: "renamed to",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := NewSchemaRenamedWarning("Pet", "PetV2", "schemas", "pets.yaml", 50, 0, tt.keptOriginal)
+
+			if w.Category != WarnSchemaRenamed {
+				t.Errorf("Category = %v, want %v", w.Category, WarnSchemaRenamed)
+			}
+			if w.Severity != severity.SeverityInfo {
+				t.Errorf("Severity = %v, want %v", w.Severity, severity.SeverityInfo)
+			}
+			if w.Context["kept_original"] != tt.keptOriginal {
+				t.Errorf("Context[kept_original] = %v, want %v", w.Context["kept_original"], tt.keptOriginal)
+			}
+		})
+	}
+}
+
+func TestNewSchemaDedupWarning(t *testing.T) {
+	w := NewSchemaDedupWarning("User", "definitions", "users.yaml", 30, 5)
+
+	if w.Category != WarnSchemaDeduplicated {
+		t.Errorf("Category = %v, want %v", w.Category, WarnSchemaDeduplicated)
+	}
+	if w.Severity != severity.SeverityInfo {
+		t.Errorf("Severity = %v, want %v", w.Severity, severity.SeverityInfo)
+	}
+	if w.Location() != "users.yaml:30:5" {
+		t.Errorf("Location() = %q, want %q", w.Location(), "users.yaml:30:5")
+	}
+}
+
+func TestNewNamespacePrefixWarning(t *testing.T) {
+	w := NewNamespacePrefixWarning("Pet", "Auth_Pet", "schemas", "auth.yaml", 0, 0)
+
+	if w.Category != WarnNamespacePrefixed {
+		t.Errorf("Category = %v, want %v", w.Category, WarnNamespacePrefixed)
+	}
+	if w.Context["original_name"] != "Pet" {
+		t.Errorf("Context[original_name] = %v, want %q", w.Context["original_name"], "Pet")
+	}
+	if w.Context["new_name"] != "Auth_Pet" {
+		t.Errorf("Context[new_name] = %v, want %q", w.Context["new_name"], "Auth_Pet")
+	}
+}
+
+func TestNewVersionMismatchWarning(t *testing.T) {
+	w := NewVersionMismatchWarning("v1.yaml", "3.0.0", "v2.yaml", "3.0.3", "3.0.3")
+
+	if w.Category != WarnVersionMismatch {
+		t.Errorf("Category = %v, want %v", w.Category, WarnVersionMismatch)
+	}
+	if w.Severity != severity.SeverityWarning {
+		t.Errorf("Severity = %v, want %v", w.Severity, severity.SeverityWarning)
+	}
+	if w.Context["target_version"] != "3.0.3" {
+		t.Errorf("Context[target_version] = %v, want %q", w.Context["target_version"], "3.0.3")
+	}
+}
+
+func TestNewMetadataOverrideWarning(t *testing.T) {
+	w := NewMetadataOverrideWarning("host", "api.example.com", "other.example.com", "second.yaml")
+
+	if w.Category != WarnMetadataOverride {
+		t.Errorf("Category = %v, want %v", w.Category, WarnMetadataOverride)
+	}
+	if w.Path != "host" {
+		t.Errorf("Path = %q, want %q", w.Path, "host")
+	}
+	if w.Context["first_value"] != "api.example.com" {
+		t.Errorf("Context[first_value] = %v, want %q", w.Context["first_value"], "api.example.com")
+	}
+}
+
+func TestNewSemanticDedupSummaryWarning(t *testing.T) {
+	w := NewSemanticDedupSummaryWarning(5, "schema")
+
+	if w.Category != WarnSemanticDedup {
+		t.Errorf("Category = %v, want %v", w.Category, WarnSemanticDedup)
+	}
+	if w.Context["count"] != 5 {
+		t.Errorf("Context[count] = %v, want 5", w.Context["count"])
+	}
+	if w.Context["section"] != "schema" {
+		t.Errorf("Context[section] = %v, want %q", w.Context["section"], "schema")
+	}
+}
+
+func TestJoinWarnings_Strings(t *testing.T) {
+	warnings := JoinWarnings{
+		{Message: "warning 1"},
+		{Message: "warning 2"},
+		{Message: "warning 3"},
+	}
+
+	got := warnings.Strings()
+
+	if len(got) != 3 {
+		t.Fatalf("len(Strings()) = %d, want 3", len(got))
+	}
+	if got[0] != "warning 1" || got[1] != "warning 2" || got[2] != "warning 3" {
+		t.Errorf("Strings() = %v, want [warning 1, warning 2, warning 3]", got)
+	}
+}
+
+func TestJoinWarnings_ByCategory(t *testing.T) {
+	warnings := JoinWarnings{
+		{Category: WarnPathCollision, Message: "path 1"},
+		{Category: WarnSchemaCollision, Message: "schema 1"},
+		{Category: WarnPathCollision, Message: "path 2"},
+	}
+
+	pathWarnings := warnings.ByCategory(WarnPathCollision)
+
+	if len(pathWarnings) != 2 {
+		t.Fatalf("ByCategory(WarnPathCollision) len = %d, want 2", len(pathWarnings))
+	}
+	for _, w := range pathWarnings {
+		if w.Category != WarnPathCollision {
+			t.Errorf("unexpected category %v in filtered results", w.Category)
+		}
+	}
+}
+
+func TestJoinWarnings_BySeverity(t *testing.T) {
+	warnings := JoinWarnings{
+		{Severity: severity.SeverityWarning, Message: "warning 1"},
+		{Severity: severity.SeverityInfo, Message: "info 1"},
+		{Severity: severity.SeverityWarning, Message: "warning 2"},
+	}
+
+	infoWarnings := warnings.BySeverity(severity.SeverityInfo)
+
+	if len(infoWarnings) != 1 {
+		t.Fatalf("BySeverity(SeverityInfo) len = %d, want 1", len(infoWarnings))
+	}
+	if infoWarnings[0].Message != "info 1" {
+		t.Errorf("wrong warning filtered: %q", infoWarnings[0].Message)
+	}
+}
+
+func TestJoinWarnings_Summary(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		var warnings JoinWarnings
+		if got := warnings.Summary(); got != "" {
+			t.Errorf("Summary() = %q, want empty string", got)
+		}
+	})
+
+	t.Run("with warnings", func(t *testing.T) {
+		warnings := JoinWarnings{
+			{Message: "first warning"},
+			{Message: "second warning"},
+		}
+
+		got := warnings.Summary()
+
+		if got == "" {
+			t.Error("Summary() returned empty string for non-empty warnings")
+		}
+		// Check it contains expected parts
+		if !strings.Contains(got, "2 warning(s)") {
+			t.Errorf("Summary() missing count: %q", got)
+		}
+		if !strings.Contains(got, "first warning") || !strings.Contains(got, "second warning") {
+			t.Errorf("Summary() missing warning messages: %q", got)
+		}
+	})
+}
+
+func TestJoinResult_WarningStrings(t *testing.T) {
+	t.Run("uses StructuredWarnings when present", func(t *testing.T) {
+		result := &JoinResult{
+			StructuredWarnings: JoinWarnings{
+				{Message: "structured warning 1"},
+				{Message: "structured warning 2"},
+			},
+			Warnings: []string{"legacy warning"},
+		}
+
+		got := result.WarningStrings()
+
+		if len(got) != 2 {
+			t.Fatalf("WarningStrings() len = %d, want 2", len(got))
+		}
+		if got[0] != "structured warning 1" {
+			t.Errorf("WarningStrings()[0] = %q, want %q", got[0], "structured warning 1")
+		}
+	})
+
+	t.Run("falls back to Warnings when StructuredWarnings empty", func(t *testing.T) {
+		result := &JoinResult{
+			Warnings: []string{"legacy warning 1", "legacy warning 2"},
+		}
+
+		got := result.WarningStrings()
+
+		if len(got) != 2 {
+			t.Fatalf("WarningStrings() len = %d, want 2", len(got))
+		}
+		if got[0] != "legacy warning 1" {
+			t.Errorf("WarningStrings()[0] = %q, want %q", got[0], "legacy warning 1")
+		}
+	})
+}
+
+func TestJoinWarnings_Strings_WithNil(t *testing.T) {
+	warnings := JoinWarnings{
+		{Message: "first"},
+		nil,
+		{Message: "third"},
+	}
+
+	got := warnings.Strings()
+
+	if len(got) != 3 {
+		t.Fatalf("Strings() len = %d, want 3", len(got))
+	}
+	if got[0] != "first" {
+		t.Errorf("Strings()[0] = %q, want %q", got[0], "first")
+	}
+	if got[1] != "" {
+		t.Errorf("Strings()[1] = %q, want empty string for nil", got[1])
+	}
+	if got[2] != "third" {
+		t.Errorf("Strings()[2] = %q, want %q", got[2], "third")
+	}
+}

--- a/overlay/warnings_test.go
+++ b/overlay/warnings_test.go
@@ -1,0 +1,269 @@
+package overlay
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestApplyWarning_String(t *testing.T) {
+	tests := []struct {
+		name    string
+		warning *ApplyWarning
+		want    string
+	}{
+		{
+			name: "with cause",
+			warning: &ApplyWarning{
+				Category:    WarnActionError,
+				ActionIndex: 2,
+				Target:      "$.paths['/users']",
+				Cause:       errors.New("invalid JSONPath"),
+			},
+			want: `action[2] target "$.paths['/users']": invalid JSONPath`,
+		},
+		{
+			name: "with message",
+			warning: &ApplyWarning{
+				Category:    WarnNoMatch,
+				ActionIndex: 0,
+				Target:      "$.info.contact",
+				Message:     "target matched 0 nodes",
+			},
+			want: `action[0] target "$.info.contact": target matched 0 nodes`,
+		},
+		{
+			name: "category fallback",
+			warning: &ApplyWarning{
+				Category:    WarnNoMatch,
+				ActionIndex: 5,
+				Target:      "$.paths",
+			},
+			want: `action[5] target "$.paths": no_match`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.warning.String(); got != tt.want {
+				t.Errorf("String() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplyWarning_HasLocation(t *testing.T) {
+	tests := []struct {
+		name        string
+		actionIndex int
+		want        bool
+	}{
+		{"zero index", 0, true},
+		{"positive index", 5, true},
+		{"negative index", -1, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := &ApplyWarning{ActionIndex: tt.actionIndex}
+			if got := w.HasLocation(); got != tt.want {
+				t.Errorf("HasLocation() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplyWarning_Location(t *testing.T) {
+	w := &ApplyWarning{ActionIndex: 3}
+
+	got := w.Location()
+	want := "action[3]"
+
+	if got != want {
+		t.Errorf("Location() = %q, want %q", got, want)
+	}
+}
+
+func TestApplyWarnings_Strings(t *testing.T) {
+	warnings := ApplyWarnings{
+		{ActionIndex: 0, Target: "$.a", Message: "first"},
+		{ActionIndex: 1, Target: "$.b", Message: "second"},
+	}
+
+	got := warnings.Strings()
+
+	if len(got) != 2 {
+		t.Fatalf("len(Strings()) = %d, want 2", len(got))
+	}
+	// Verify format matches String() output
+	if got[0] != warnings[0].String() {
+		t.Errorf("Strings()[0] = %q, want %q", got[0], warnings[0].String())
+	}
+	if got[1] != warnings[1].String() {
+		t.Errorf("Strings()[1] = %q, want %q", got[1], warnings[1].String())
+	}
+}
+
+func TestApplyResult_AddWarning(t *testing.T) {
+	result := &ApplyResult{}
+
+	w := &ApplyWarning{
+		Category:    WarnNoMatch,
+		ActionIndex: 0,
+		Target:      "$.info",
+		Message:     "no match",
+	}
+
+	result.AddWarning(w)
+
+	// Check StructuredWarnings
+	if len(result.StructuredWarnings) != 1 {
+		t.Fatalf("StructuredWarnings len = %d, want 1", len(result.StructuredWarnings))
+	}
+	if result.StructuredWarnings[0] != w {
+		t.Error("StructuredWarnings[0] != original warning")
+	}
+
+	// Check legacy Warnings (backward compatibility)
+	if len(result.Warnings) != 1 {
+		t.Fatalf("Warnings len = %d, want 1", len(result.Warnings))
+	}
+	if result.Warnings[0] != w.String() {
+		t.Errorf("Warnings[0] = %q, want %q", result.Warnings[0], w.String())
+	}
+}
+
+func TestDryRunResult_AddWarning(t *testing.T) {
+	result := &DryRunResult{}
+
+	w := &ApplyWarning{
+		Category:    WarnActionError,
+		ActionIndex: 2,
+		Target:      "$.servers",
+		Cause:       errors.New("invalid path"),
+	}
+
+	result.AddWarning(w)
+
+	// Check StructuredWarnings
+	if len(result.StructuredWarnings) != 1 {
+		t.Fatalf("StructuredWarnings len = %d, want 1", len(result.StructuredWarnings))
+	}
+	if result.StructuredWarnings[0] != w {
+		t.Error("StructuredWarnings[0] != original warning")
+	}
+
+	// Check legacy Warnings (backward compatibility)
+	if len(result.Warnings) != 1 {
+		t.Fatalf("Warnings len = %d, want 1", len(result.Warnings))
+	}
+	if result.Warnings[0] != w.String() {
+		t.Errorf("Warnings[0] = %q, want %q", result.Warnings[0], w.String())
+	}
+}
+
+func TestWarningCategories(t *testing.T) {
+	// Ensure categories have expected values for stability
+	if WarnNoMatch != "no_match" {
+		t.Errorf("WarnNoMatch = %q, want %q", WarnNoMatch, "no_match")
+	}
+	if WarnActionError != "action_error" {
+		t.Errorf("WarnActionError = %q, want %q", WarnActionError, "action_error")
+	}
+}
+
+func TestApplyWarning_Unwrap(t *testing.T) {
+	t.Run("with cause", func(t *testing.T) {
+		cause := errors.New("underlying error")
+		w := &ApplyWarning{Cause: cause}
+
+		got := w.Unwrap()
+		if got == nil || got.Error() != cause.Error() {
+			t.Errorf("Unwrap() = %v, want %v", got, cause)
+		}
+	})
+
+	t.Run("without cause", func(t *testing.T) {
+		w := &ApplyWarning{}
+
+		if got := w.Unwrap(); got != nil {
+			t.Errorf("Unwrap() = %v, want nil", got)
+		}
+	})
+
+	t.Run("Unwrap enables error inspection", func(t *testing.T) {
+		targetErr := errors.New("target")
+		w := &ApplyWarning{Cause: targetErr}
+
+		// ApplyWarning is not an error itself, but Unwrap() enables
+		// error chain inspection when the warning is converted to an error
+		got := w.Unwrap()
+		if got == nil || got.Error() != targetErr.Error() {
+			t.Error("Unwrap should return the wrapped error")
+		}
+	})
+}
+
+func TestNewNoMatchWarning(t *testing.T) {
+	w := NewNoMatchWarning(3, "$.paths")
+
+	if w.Category != WarnNoMatch {
+		t.Errorf("Category = %v, want %v", w.Category, WarnNoMatch)
+	}
+	if w.ActionIndex != 3 {
+		t.Errorf("ActionIndex = %d, want 3", w.ActionIndex)
+	}
+	if w.Target != "$.paths" {
+		t.Errorf("Target = %q, want %q", w.Target, "$.paths")
+	}
+	if w.Message == "" {
+		t.Error("Message should not be empty")
+	}
+}
+
+func TestNewActionErrorWarning(t *testing.T) {
+	cause := errors.New("invalid path")
+	w := NewActionErrorWarning(5, "$.info", cause)
+
+	if w.Category != WarnActionError {
+		t.Errorf("Category = %v, want %v", w.Category, WarnActionError)
+	}
+	if w.ActionIndex != 5 {
+		t.Errorf("ActionIndex = %d, want 5", w.ActionIndex)
+	}
+	if w.Cause == nil || w.Cause.Error() != cause.Error() {
+		t.Error("Cause should be the provided error")
+	}
+}
+
+func TestApplyWarnings_ByCategory(t *testing.T) {
+	warnings := ApplyWarnings{
+		{Category: WarnNoMatch, Target: "$.a"},
+		{Category: WarnActionError, Target: "$.b"},
+		{Category: WarnNoMatch, Target: "$.c"},
+	}
+
+	noMatchWarnings := warnings.ByCategory(WarnNoMatch)
+
+	if len(noMatchWarnings) != 2 {
+		t.Fatalf("ByCategory(WarnNoMatch) len = %d, want 2", len(noMatchWarnings))
+	}
+	for _, w := range noMatchWarnings {
+		if w.Category != WarnNoMatch {
+			t.Errorf("unexpected category %v in filtered results", w.Category)
+		}
+	}
+}
+
+func TestApplyWarnings_ByCategory_WithNil(t *testing.T) {
+	warnings := ApplyWarnings{
+		{Category: WarnNoMatch, Target: "$.a"},
+		nil,
+		{Category: WarnNoMatch, Target: "$.c"},
+	}
+
+	noMatchWarnings := warnings.ByCategory(WarnNoMatch)
+
+	if len(noMatchWarnings) != 2 {
+		t.Fatalf("ByCategory with nil elements should skip nil, got len = %d", len(noMatchWarnings))
+	}
+}


### PR DESCRIPTION
## Summary

Adds structured error and warning types across **builder**, **joiner**, and **overlay** packages to provide precise error locality information following patterns established in `fixer.Fix`, `oaserrors`, and `internal/issues.Issue`.

### Key Changes

**Builder Package:**
- New `BuilderError` structured type with `Component`, `Method`, `Path`, `OperationID`, `Field`, `Message`, `Context`, `FirstOccurrence`, and `Cause` fields
- `HasLocation()` and `Location()` methods for IDE-friendly error output (e.g., `POST /users`)
- Helper constructors: `NewDuplicateOperationIDError`, `NewUnsupportedMethodError`, `NewInvalidMethodError`
- Enhanced `ConstraintError` with location methods
- `BuilderErrors` collection type implementing `error` interface

**Joiner Package:**
- New `JoinWarning` structured type with `Category`, `Path`, `Message`, `SourceFile`, `Line`, `Column`, `Severity`, and `Context` fields
- `HasLocation()` and `Location()` methods returning IDE-friendly formats (e.g., `api.yaml:42:5`)
- 9 warning categories: `WarnVersionMismatch`, `WarnPathCollision`, `WarnSchemaCollision`, `WarnWebhookCollision`, `WarnSchemaRenamed`, `WarnSchemaDeduplicated`, `WarnNamespacePrefixed`, `WarnMetadataOverride`, `WarnSemanticDedup`
- Helper constructors for all warning types
- `JoinWarnings` collection with `ByCategory()`, `BySeverity()`, `Summary()` methods
- **Source line tracking**: All warnings now use `j.getLocation()` to provide actual line/column numbers from SourceMap

**Overlay Package:**
- New `ApplyWarning` structured type with `Category`, `ActionIndex`, `Target`, `Message`, and `Cause` fields
- `HasLocation()` and `Location()` methods (e.g., `action[2]`)
- 2 warning categories: `WarnNoMatch`, `WarnActionError`
- `ApplyWarnings` collection type

### Backward Compatibility

All packages maintain backward compatibility:
- `JoinResult.Warnings []string` and `JoinResult.StructuredWarnings JoinWarnings` both populated via `AddWarning()` helper
- `ApplyResult.Warnings []string` and `ApplyResult.StructuredWarnings ApplyWarnings` both populated via `AddWarning()` helper
- `BuilderErrors` implements `error` interface with formatted multi-line output

## Test plan

- [x] Unit tests for `BuilderError`, `BuilderErrors`, helper constructors
- [x] Unit tests for `ConstraintError.HasLocation()` and `Location()`
- [x] Unit tests for `JoinWarning`, all helper constructors, collection methods
- [x] Unit tests for `ApplyWarning`, `ApplyWarnings`, `AddWarning()` helpers
- [x] Integration tests via existing package test suites
- [x] `make check` passes (lint, fmt, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)