### PR TITLE
fix(docs): correct relative link depth for nested example pages

### DIFF
--- a/examples/programmatic-api/builder/README.md
+++ b/examples/programmatic-api/builder/README.md
@@ -338,7 +338,7 @@ srv.Use(func(next http.Handler) http.Handler {
 
 ## Next Steps
 
-- [Builder Deep Dive](../../packages/builder/) - Complete documentation
+- [Builder Deep Dive](../../../packages/builder/) - Complete documentation
 - [HTTPValidator](../../workflows/http-validation/) - Validate requests against your spec
 - [Code Generation](../../petstore/) - Generate server code from specs
 

--- a/examples/workflows/breaking-change-detection/README.md
+++ b/examples/workflows/breaking-change-detection/README.md
@@ -139,8 +139,8 @@ Use the exit code for pipeline gates:
 
 ## Next Steps
 
-- [Differ Deep Dive](../../packages/differ/) - Complete differ documentation
-- [Breaking Changes Guide](../../breaking-changes/) - Detailed explanation
+- [Differ Deep Dive](../../../packages/differ/) - Complete differ documentation
+- [Breaking Changes Guide](../../../breaking-changes/) - Detailed explanation
 - [Multi-API Merge](../multi-api-merge/) - Merge API versions
 
 ---

--- a/examples/workflows/http-validation/README.md
+++ b/examples/workflows/http-validation/README.md
@@ -154,7 +154,7 @@ func validationMiddleware(next http.Handler) http.Handler {
 
 ## Next Steps
 
-- [HTTPValidator Deep Dive](../../packages/httpvalidator/) - Complete documentation
+- [HTTPValidator Deep Dive](../../../packages/httpvalidator/) - Complete documentation
 - [Validate and Fix](../validate-and-fix/) - Fix spec validation errors
 - [Builder](../../programmatic-api/builder/) - Build specs programmatically
 

--- a/examples/workflows/multi-api-merge/README.md
+++ b/examples/workflows/multi-api-merge/README.md
@@ -114,7 +114,7 @@ When `MergeArrays: true`:
 
 ## Next Steps
 
-- [Joiner Deep Dive](../../packages/joiner/) - Complete joiner documentation
+- [Joiner Deep Dive](../../../packages/joiner/) - Complete joiner documentation
 - [Breaking Change Detection](../breaking-change-detection/) - Compare merged versions
 - [Overlay Transformations](../overlay-transformations/) - Apply post-merge customizations
 

--- a/examples/workflows/overlay-transformations/README.md
+++ b/examples/workflows/overlay-transformations/README.md
@@ -118,7 +118,7 @@ actions:
 
 ## Next Steps
 
-- [Overlay Deep Dive](../../packages/overlay/) - Complete overlay documentation
+- [Overlay Deep Dive](../../../packages/overlay/) - Complete overlay documentation
 - [OpenAPI Overlay Spec](https://spec.openapis.org/overlay/v1.0.0.html) - Official specification
 - [HTTP Validation](../http-validation/) - Validate requests against the spec
 

--- a/examples/workflows/validate-and-fix/README.md
+++ b/examples/workflows/validate-and-fix/README.md
@@ -91,7 +91,7 @@ Use `WithDryRun(true)` to preview what fixes would be applied without modifying 
 
 ## Next Steps
 
-- [Fixer Deep Dive](../../packages/fixer/) - Complete fixer documentation
+- [Fixer Deep Dive](../../../packages/fixer/) - Complete fixer documentation
 - [Validation Pipeline](../../validation-pipeline/) - Validation with severity reporting
 - [Version Conversion](../version-conversion/) - Convert between OAS versions
 

--- a/examples/workflows/version-conversion/README.md
+++ b/examples/workflows/version-conversion/README.md
@@ -99,7 +99,7 @@ The converter supports both directions:
 
 ## Next Steps
 
-- [Converter Deep Dive](../../packages/converter/) - Complete converter documentation
+- [Converter Deep Dive](../../../packages/converter/) - Complete converter documentation
 - [Breaking Change Detection](../breaking-change-detection/) - Compare API versions
 - [Multi-API Merge](../multi-api-merge/) - Merge multiple specifications
 


### PR DESCRIPTION
## Summary

Fixes broken links in nested example pages that were pointing to `/examples/packages/...` instead of `/packages/...`.

## Problem

Files like `examples/workflows/*/README.md` become `docs/examples/workflows/*.md` (not `*/index.md`), which means they serve at URLs like `/examples/workflows/breaking-change-detection/`.

From that URL depth, `../../packages/differ/` incorrectly resolves to `/examples/packages/differ/` (404) instead of `/packages/differ/`.

## Fix

Changed `../../packages/` to `../../../packages/` for 7 nested example files:
- `examples/programmatic-api/builder/README.md`
- `examples/workflows/breaking-change-detection/README.md`
- `examples/workflows/http-validation/README.md`
- `examples/workflows/multi-api-merge/README.md`
- `examples/workflows/overlay-transformations/README.md`
- `examples/workflows/validate-and-fix/README.md`
- `examples/workflows/version-conversion/README.md`

## Test plan

- [ ] Verify [Builder Deep Dive](https://erraggy.github.io/oastools/examples/programmatic-api/builder/#next-steps) link works after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)