### PR TITLE
docs(builder): document WithSchemaFieldProcessor and ComposeSchemaFieldProcessors

### DIFF
--- a/builder/doc.go
+++ b/builder/doc.go
@@ -231,6 +231,33 @@
 //   - nullable=true - Explicitly nullable
 //   - deprecated=true - Mark as deprecated
 //
+// # Custom Field Processors
+//
+// For libraries that need to support custom struct tag conventions alongside
+// the standard oas:"..." tags, use WithSchemaFieldProcessor:
+//
+//	spec := builder.New(parser.OASVersion320,
+//	    builder.WithSchemaFieldProcessor(func(schema *parser.Schema, field reflect.StructField) *parser.Schema {
+//	        if desc := field.Tag.Get("description"); desc != "" {
+//	            schema.Description = desc
+//	        }
+//	        return schema
+//	    }),
+//	)
+//
+// The processor is called for each struct field after the base schema is generated
+// and after any oas:"..." tags are applied. This enables:
+//
+//   - Migration support from other OpenAPI libraries with different tag formats
+//   - Custom validation tag integration (e.g., reading from validator tags)
+//   - Documentation generators pulling from godoc-style comments
+//   - Framework integration with existing struct tag conventions
+//
+// Multiple processors can be composed using ComposeSchemaFieldProcessors:
+//
+//	composed := builder.ComposeSchemaFieldProcessors(descProcessor, enumProcessor)
+//	spec := builder.New(parser.OASVersion320, builder.WithSchemaFieldProcessor(composed))
+//
 // # Required Fields
 //
 // Required fields are determined by:

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -1249,6 +1249,31 @@ doc, err := spec.BuildOAS3()
 // Result: Only 1 schema instead of 2, with $refs automatically rewritten
 ```
 
+**Custom Field Processors:**
+
+For libraries that need to support custom struct tag conventions (e.g., migrating from other OpenAPI libraries), use `WithSchemaFieldProcessor`:
+
+```go
+// Support legacy standalone tags like `description:"..."`
+processor := func(schema *parser.Schema, field reflect.StructField) *parser.Schema {
+    if desc := field.Tag.Get("description"); desc != "" {
+        schema.Description = desc
+    }
+    return schema
+}
+
+spec := builder.New(parser.OASVersion320,
+    builder.WithSchemaFieldProcessor(processor),
+)
+```
+
+Multiple processors can be composed:
+
+```go
+composed := builder.ComposeSchemaFieldProcessors(descProcessor, enumProcessor)
+spec := builder.New(parser.OASVersion320, builder.WithSchemaFieldProcessor(composed))
+```
+
 **Vendor Extensions:**
 
 ```go


### PR DESCRIPTION
Add documentation for the new custom field processor feature introduced in #206:
- Added "Custom Field Processors" section to builder/doc.go after "Struct Tags"
- Added "Custom Field Processors" section to docs/developer-guide.md after "Semantic Deduplication"

The new sections explain how to use WithSchemaFieldProcessor for custom struct tag
conventions and how to compose multiple processors with ComposeSchemaFieldProcessors.