### PR TITLE
docs: add oastools-web UI integration links

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,6 +185,25 @@ make docs-build   # Build static site to site/
 
 For CI deployment and documentation structure, see [WORKFLOW.md](WORKFLOW.md).
 
+### ⚠️ Source vs Generated Documentation Files
+
+**CRITICAL: The `docs/packages/` directory contains GENERATED files. Do NOT edit them directly.**
+
+The documentation build process (`scripts/prepare-docs.sh`) copies files from source locations:
+
+| Source | Generated | Description |
+|--------|-----------|-------------|
+| `README.md` | `docs/index.md` | Home page |
+| `{package}/deep_dive.md` | `docs/packages/{package}.md` | Package deep dives |
+| `examples/*/README.md` | `docs/examples/*.md` | Example documentation |
+
+**Always edit the SOURCE files:**
+- To update the home page → edit `README.md`
+- To update package docs → edit `{package}/deep_dive.md` (e.g., `validator/deep_dive.md`)
+- To update examples → edit `examples/*/README.md`
+
+The `docs/packages/` directory is in `.gitignore` and gets regenerated on every `make docs-build` or `make docs-serve`.
+
 ## Architecture
 
 ### Directory Structure

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A complete, self-contained OpenAPI toolkit for Go with minimal dependencies.
 [![codecov](https://codecov.io/gh/erraggy/oastools/graph/badge.svg?token=T8768QXQAX)](https://codecov.io/gh/erraggy/oastools)
 [![Go Reference](https://pkg.go.dev/badge/github.com/erraggy/oastools.svg)](https://pkg.go.dev/github.com/erraggy/oastools)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Try it Online](https://img.shields.io/badge/Try_it-Online-blue)](https://oastools.robnrob.com)
 
 **Parse, validate, fix, convert, diff, join, generate, and build OpenAPI specs (2.0-3.2.0) with zero runtime dependencies beyond YAML for parsing, x/tools for generating, and x/text for title casing.**
 
@@ -26,19 +27,19 @@ A complete, self-contained OpenAPI toolkit for Go with minimal dependencies.
 
 ## Package Ecosystem
 
-| Package                                                               | Description                                            |
-|-----------------------------------------------------------------------|--------------------------------------------------------|
-| [parser](https://pkg.go.dev/github.com/erraggy/oastools/parser)       | Parse & analyze OAS files from files, URLs, or readers |
-| [validator](https://pkg.go.dev/github.com/erraggy/oastools/validator) | Validate specs with structural & semantic checks       |
-| [fixer](https://pkg.go.dev/github.com/erraggy/oastools/fixer)         | Auto-fix common validation errors                      |
-| [httpvalidator](https://pkg.go.dev/github.com/erraggy/oastools/httpvalidator) | Validate HTTP requests/responses against OAS at runtime |
-| [converter](https://pkg.go.dev/github.com/erraggy/oastools/converter) | Convert between OAS 2.0 and 3.x                        |
-| [joiner](https://pkg.go.dev/github.com/erraggy/oastools/joiner)       | Merge multiple OAS documents with schema deduplication |
-| [overlay](https://pkg.go.dev/github.com/erraggy/oastools/overlay)     | Apply OpenAPI Overlay v1.0.0 with JSONPath targeting   |
-| [differ](https://pkg.go.dev/github.com/erraggy/oastools/differ)       | Detect breaking changes between versions               |
-| [generator](https://pkg.go.dev/github.com/erraggy/oastools/generator) | Generate Go client/server code with security support   |
-| [builder](https://pkg.go.dev/github.com/erraggy/oastools/builder)     | Programmatically construct OAS documents with deduplication |
-| [oaserrors](https://pkg.go.dev/github.com/erraggy/oastools/oaserrors) | Structured error types for programmatic handling       |
+| Package | Description | Try |
+|---------|-------------|:---:|
+| [parser](https://pkg.go.dev/github.com/erraggy/oastools/parser) | Parse & analyze OAS files from files, URLs, or readers | |
+| [validator](https://pkg.go.dev/github.com/erraggy/oastools/validator) | Validate specs with structural & semantic checks | [🌐](https://oastools.robnrob.com/validate) |
+| [fixer](https://pkg.go.dev/github.com/erraggy/oastools/fixer) | Auto-fix common validation errors | [🌐](https://oastools.robnrob.com/fix) |
+| [httpvalidator](https://pkg.go.dev/github.com/erraggy/oastools/httpvalidator) | Validate HTTP requests/responses against OAS at runtime | |
+| [converter](https://pkg.go.dev/github.com/erraggy/oastools/converter) | Convert between OAS 2.0 and 3.x | [🌐](https://oastools.robnrob.com/convert) |
+| [joiner](https://pkg.go.dev/github.com/erraggy/oastools/joiner) | Merge multiple OAS documents with schema deduplication | [🌐](https://oastools.robnrob.com/join) |
+| [overlay](https://pkg.go.dev/github.com/erraggy/oastools/overlay) | Apply OpenAPI Overlay v1.0.0 with JSONPath targeting | [🌐](https://oastools.robnrob.com/overlay) |
+| [differ](https://pkg.go.dev/github.com/erraggy/oastools/differ) | Detect breaking changes between versions | [🌐](https://oastools.robnrob.com/diff) |
+| [generator](https://pkg.go.dev/github.com/erraggy/oastools/generator) | Generate Go client/server code with security support | |
+| [builder](https://pkg.go.dev/github.com/erraggy/oastools/builder) | Programmatically construct OAS documents with deduplication | |
+| [oaserrors](https://pkg.go.dev/github.com/erraggy/oastools/oaserrors) | Structured error types for programmatic handling | |
 
 All packages include comprehensive documentation with runnable examples. See individual package pages on [pkg.go.dev](https://pkg.go.dev/github.com/erraggy/oastools) for API details.
 
@@ -93,6 +94,12 @@ go get github.com/erraggy/oastools@latest
 ```
 
 Requires Go 1.24 or higher.
+
+## Try it Online
+
+No installation required! Use oastools directly in your browser:
+
+🌐 **[oastools.robnrob.com](https://oastools.robnrob.com)** — Validate, convert, diff, fix, join, and apply overlays without installing anything.
 
 ## Quick Start
 

--- a/converter/deep_dive.md
+++ b/converter/deep_dive.md
@@ -2,6 +2,9 @@
 
 # Converter Package Deep Dive
 
+!!! tip "Try it Online"
+    No installation required! [Try the converter in your browser →](https://oastools.robnrob.com/convert)
+
 The [`converter`](https://pkg.go.dev/github.com/erraggy/oastools/converter) package provides version conversion for OpenAPI Specification documents, supporting bidirectional conversion between OAS 2.0 and OAS 3.x.
 
 ## Table of Contents

--- a/differ/deep_dive.md
+++ b/differ/deep_dive.md
@@ -2,6 +2,9 @@
 
 # Differ Package Deep Dive
 
+!!! tip "Try it Online"
+    No installation required! [Try the differ in your browser →](https://oastools.robnrob.com/diff)
+
 ## Table of Contents
 
 - [Overview](#overview)

--- a/fixer/deep_dive.md
+++ b/fixer/deep_dive.md
@@ -2,6 +2,9 @@
 
 # Fixer Package Deep Dive
 
+!!! tip "Try it Online"
+    No installation required! [Try the fixer in your browser →](https://oastools.robnrob.com/fix)
+
 The [`fixer`](https://pkg.go.dev/github.com/erraggy/oastools/fixer) package provides automatic fixes for common OpenAPI Specification validation errors, supporting both OAS 2.0 and OAS 3.x documents.
 
 ## Table of Contents

--- a/joiner/deep_dive.md
+++ b/joiner/deep_dive.md
@@ -2,6 +2,9 @@
 
 # Joiner Package Deep Dive
 
+!!! tip "Try it Online"
+    No installation required! [Try the joiner in your browser →](https://oastools.robnrob.com/join)
+
 ## Table of Contents
 
 - [Overview](#overview)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,7 @@ markdown_extensions:
 
 nav:
   - Home: index.md
+  - "🌐 Try Online": https://oastools.robnrob.com
   - "📄 White Paper": whitepaper.md
   - Guides:
     - Developer Guide: developer-guide.md

--- a/overlay/deep_dive.md
+++ b/overlay/deep_dive.md
@@ -2,6 +2,9 @@
 
 # Overlay Package Deep Dive
 
+!!! tip "Try it Online"
+    No installation required! [Try the overlay tool in your browser →](https://oastools.robnrob.com/overlay)
+
 The [`overlay`](https://pkg.go.dev/github.com/erraggy/oastools/overlay) package implements the [OpenAPI Overlay Specification v1.0.0](https://github.com/OAI/Overlay-Specification), providing a standardized mechanism for augmenting OpenAPI documents through targeted transformations.
 
 ## Table of Contents

--- a/validator/deep_dive.md
+++ b/validator/deep_dive.md
@@ -2,6 +2,9 @@
 
 # Validator Package Deep Dive
 
+!!! tip "Try it Online"
+    No installation required! [Try the validator in your browser →](https://oastools.robnrob.com/validate)
+
 ## Table of Contents
 
 - [Overview](#overview)


### PR DESCRIPTION
## Summary

- Add links to the oastools web UI (https://oastools.robnrob.com/) throughout the documentation
- Add "Try it Online" badge to README.md and docs home page
- Add "Try it Online" section after Installation with prominent link
- Enhance Package Ecosystem table with "Try" column containing 🌐 links for 6 tools
- Add 🌐 Try Online nav entry to mkdocs.yml navigation
- Add "Try it Online" callout admonitions to 6 package deep dive docs
- Document source vs generated docs pattern in CLAUDE.md to prevent future confusion

## Web Tool URL Mapping

| Package | Web URL |
|---------|---------|
| validator | https://oastools.robnrob.com/validate |
| fixer | https://oastools.robnrob.com/fix |
| converter | https://oastools.robnrob.com/convert |
| joiner | https://oastools.robnrob.com/join |
| overlay | https://oastools.robnrob.com/overlay |
| differ | https://oastools.robnrob.com/diff |

## Test plan

- [x] Verify docs build with `make docs-serve`
- [x] Preview badge rendering on home page
- [x] Preview Package Ecosystem table with Try column
- [x] Preview "Try it Online" callout on validator deep dive page
- [x] Verify all web UI links are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)