### PR TITLE
chore(ci): add walker package to benchmark workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -9,7 +9,7 @@
 #   - artifact: Upload only, no commit (for batch backfill)
 #
 # Strategy:
-#   - Matrix runs 9 packages in parallel (~5 min wall time)
+#   - Matrix runs 10 packages in parallel (~5 min wall time)
 #   - Results combined into benchmarks/benchmark-v1.X.Y.txt
 #
 # Usage:
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: [parser, validator, fixer, httpvalidator, converter, joiner, differ, generator, builder]
+        package: [parser, validator, fixer, httpvalidator, converter, joiner, differ, generator, builder, walker]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -108,6 +108,7 @@ jobs:
               bench-results/bench-differ/bench-differ.txt \
               bench-results/bench-generator/bench-generator.txt \
               bench-results/bench-builder/bench-builder.txt \
+              bench-results/bench-walker/bench-walker.txt \
               > benchmarks/benchmark-${VERSION}.txt
 
           echo "Combined benchmark file:"


### PR DESCRIPTION
## Summary
- Add walker package to the CI benchmark matrix
- Include walker benchmarks in combined benchmark file

This is needed before v1.37.0 release so the benchmark workflow includes the new walker package.

## Test plan
- [x] Workflow file syntax valid
- [ ] Merge and re-run benchmark workflow for v1.37.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)