### PR TITLE
fix(docs): add walker examples to documentation build

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -439,6 +439,27 @@ When adding a new package, ensure:
 4. **Documentation**: Update README.md, benchmarks.md, developer-guide.md, mkdocs.yml, CLAUDE.md (Public API list)
 5. **Verification**: Run `make check`, `make bench-<package>`, verify `go doc` works
 
+### Adding Examples Checklist
+
+When adding new examples under `examples/`, you must update **both**:
+
+1. **`mkdocs.yml`**: Add nav entries with explicit titles (not just file paths)
+   ```yaml
+   # Good - with titles
+   - Overview: examples/myexample/index.md
+   - Feature One: examples/myexample/feature-one.md
+
+   # Bad - will show "None" in nav
+   - examples/myexample/index.md
+   ```
+
+2. **`scripts/prepare-docs.sh`**: Add copy commands for new example READMEs
+   - Create target directory: `mkdir -p "$DOCS_DIR/examples/myexample"`
+   - Copy and fix links for each README
+   - Add any new sibling link patterns to `fix_example_links()`
+
+⚠️ **Common mistake**: Updating only `mkdocs.yml` without updating `prepare-docs.sh` causes 404 errors and "None" nav entries on the docs site.
+
 ## Go Module
 
 - Module path: `github.com/erraggy/oastools`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,13 +73,13 @@ nav:
       - Overview: examples/programmatic-api/index.md
       - Builder: examples/programmatic-api/builder.md
     - Walker:
-      - examples/walker/index.md
-      - examples/walker/api-statistics.md
-      - examples/walker/security-audit.md
-      - examples/walker/vendor-extensions.md
-      - examples/walker/public-api-filter.md
-      - examples/walker/api-documentation.md
-      - examples/walker/reference-collector.md
+      - Overview: examples/walker/index.md
+      - API Statistics: examples/walker/api-statistics.md
+      - Security Audit: examples/walker/security-audit.md
+      - Vendor Extensions: examples/walker/vendor-extensions.md
+      - Public API Filter: examples/walker/public-api-filter.md
+      - API Documentation: examples/walker/api-documentation.md
+      - Reference Collector: examples/walker/reference-collector.md
     - Code Generation:
       - Overview: examples/petstore/index.md
       - Standard Library: examples/petstore/stdlib.md

--- a/scripts/prepare-docs.sh
+++ b/scripts/prepare-docs.sh
@@ -140,6 +140,20 @@ fix_example_links() {
     sed -i.bak 's|](stdlib/)|](stdlib.md)|g' "$file"
     sed -i.bak 's|](chi/)|](chi.md)|g' "$file"
 
+    # Walker examples: ../sibling/ -> sibling.md
+    sed -i.bak 's|](\.\./api-statistics/)|](api-statistics.md)|g' "$file"
+    sed -i.bak 's|](\.\./security-audit/)|](security-audit.md)|g' "$file"
+    sed -i.bak 's|](\.\./vendor-extensions/)|](vendor-extensions.md)|g' "$file"
+    sed -i.bak 's|](\.\./public-api-filter/)|](public-api-filter.md)|g' "$file"
+    sed -i.bak 's|](\.\./api-documentation/)|](api-documentation.md)|g' "$file"
+    sed -i.bak 's|](\.\./reference-collector/)|](reference-collector.md)|g' "$file"
+    # Walker deep dive link: various depths -> ../../packages/walker.md (from examples/walker/)
+    sed -i.bak 's|](\.\./\.\./\.\./walker/deep_dive\.md)|](../../packages/walker.md)|g' "$file"
+    sed -i.bak 's|](\.\./\.\./walker/deep_dive\.md)|](../../packages/walker.md)|g' "$file"
+    # Walker directory links
+    sed -i.bak 's|](walker/)|](walker/index.md)|g' "$file"
+    sed -i.bak 's|](\.\./walker/)|](walker/index.md)|g' "$file"
+
     rm -f "$file.bak"
 }
 
@@ -205,5 +219,20 @@ copy_example_readme "examples/petstore/chi/README.md" "$DOCS_DIR/examples/petsto
 fix_example_links "$DOCS_DIR/examples/petstore/chi.md"
 fix_subdir_links "$DOCS_DIR/examples/petstore/chi.md"
 echo "  - examples/petstore/chi/README.md -> $DOCS_DIR/examples/petstore/chi.md"
+
+# Walker examples
+mkdir -p "$DOCS_DIR/examples/walker"
+copy_example_readme "examples/walker/README.md" "$DOCS_DIR/examples/walker/index.md"
+fix_example_links "$DOCS_DIR/examples/walker/index.md"
+fix_subdir_links "$DOCS_DIR/examples/walker/index.md"
+echo "  - examples/walker/README.md -> $DOCS_DIR/examples/walker/index.md"
+for walker_example in api-statistics security-audit vendor-extensions public-api-filter api-documentation reference-collector; do
+    if [ -f "examples/walker/$walker_example/README.md" ]; then
+        copy_example_readme "examples/walker/$walker_example/README.md" "$DOCS_DIR/examples/walker/$walker_example.md"
+        fix_example_links "$DOCS_DIR/examples/walker/$walker_example.md"
+        fix_subdir_links "$DOCS_DIR/examples/walker/$walker_example.md"
+        echo "  - examples/walker/$walker_example/README.md -> $DOCS_DIR/examples/walker/$walker_example.md"
+    fi
+done
 
 echo "Documentation preparation complete."


### PR DESCRIPTION
## Summary

Fixes the 404 errors and "None" nav entries for walker examples on the GitHub Pages docs site.

**Root cause:** PR #215 added walker examples to `mkdocs.yml` but forgot to update `scripts/prepare-docs.sh` to copy the README files to `docs/examples/walker/`.

## Changes

- **`scripts/prepare-docs.sh`**: Add walker examples section to copy READMEs and fix links
- **`mkdocs.yml`**: Add explicit titles to walker nav entries (was just file paths → showed "None")
- **`CLAUDE.md`**: Add "Adding Examples Checklist" to prevent this mistake in the future

## Test plan

- [x] `./scripts/prepare-docs.sh` successfully creates `docs/examples/walker/*.md`
- [x] All walker links (siblings, deep_dive) are properly rewritten
- [x] CI docs build should now succeed and deploy correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)