### PR TITLE
feat(converter,joiner): add ToParseResult() methods for package chaining

### DIFF
--- a/converter/doc.go
+++ b/converter/doc.go
@@ -71,6 +71,36 @@
 // Pre-conversion overlays are useful for normalizing or fixing the source document.
 // Post-conversion overlays can add version-specific extensions to the result.
 //
+// # Chaining with Other Packages
+//
+// Use [ConversionResult.ToParseResult] to convert the result for use with other packages:
+//
+//	// Convert to OAS 3.1
+//	convResult, _ := converter.ConvertWithOptions(
+//	    converter.WithFilePath("swagger.yaml"),
+//	    converter.WithTargetVersion("3.1.0"),
+//	)
+//
+//	// Validate the converted result
+//	v := validator.New()
+//	validationResult, _ := v.ValidateParsed(*convResult.ToParseResult())
+//
+//	// Or join with other specifications
+//	j := joiner.New(joiner.DefaultConfig())
+//	joinResult, _ := j.JoinParsed([]parser.ParseResult{
+//	    *convResult.ToParseResult(),
+//	    otherSpec,
+//	})
+//
+//	// Or diff against the original
+//	diffResult, _ := differ.DiffWithOptions(
+//	    differ.WithSourceFilePath("swagger.yaml"),
+//	    differ.WithTargetParsed(*convResult.ToParseResult()),
+//	)
+//
+// The returned [parser.ParseResult] uses the target version (post-conversion) for
+// version fields and converts all conversion issues to warnings.
+//
 // # Related Packages
 //
 // Conversion integrates with other oastools packages:

--- a/joiner/doc.go
+++ b/joiner/doc.go
@@ -365,6 +365,33 @@
 //   - Available via result.StructuredWarnings.ByCategory(WarnGenericSourceName)
 //   - Also included in result.Warnings string slice for backward compatibility
 //
+// # Chaining with Other Packages
+//
+// Use [JoinResult.ToParseResult] to convert the join result for use with other packages:
+//
+//	// Join documents
+//	joinResult, _ := joiner.JoinWithOptions(
+//	    joiner.WithFilePaths([]string{"users-api.yaml", "orders-api.yaml"}),
+//	)
+//
+//	// Validate the joined result
+//	v := validator.New()
+//	validationResult, _ := v.ValidateParsed(*joinResult.ToParseResult())
+//
+//	// Or convert to a different version
+//	c := converter.New()
+//	convResult, _ := c.ConvertParsed(*joinResult.ToParseResult(), "3.1.0")
+//
+//	// Or diff against another document
+//	diffResult, _ := differ.DiffWithOptions(
+//	    differ.WithSourceParsed(*joinResult.ToParseResult()),
+//	    differ.WithTargetFilePath("production.yaml"),
+//	)
+//
+// The returned [parser.ParseResult] has Document populated (the typed OAS document)
+// and all metadata fields (Version, OASVersion, SourceFormat, Stats, Warnings).
+// The Data field is nil as downstream consumers use Document, not Data.
+//
 // # Related Packages
 //
 // The joiner integrates with other oastools packages:

--- a/joiner/joiner.go
+++ b/joiner/joiner.go
@@ -181,6 +181,27 @@ func (r *JoinResult) WarningStrings() []string {
 	return r.Warnings
 }
 
+// ToParseResult converts the JoinResult to a ParseResult for use with
+// other packages like validator, fixer, converter, and differ.
+// The returned ParseResult has Document populated but Data is nil
+// (consumers use Document, not Data).
+func (r *JoinResult) ToParseResult() *parser.ParseResult {
+	sourcePath := r.firstFilePath
+	if sourcePath == "" {
+		sourcePath = "joiner"
+	}
+	return &parser.ParseResult{
+		SourcePath:   sourcePath,
+		SourceFormat: r.SourceFormat,
+		Version:      r.Version,
+		OASVersion:   r.OASVersion,
+		Document:     r.Document,
+		Errors:       make([]error, 0),
+		Warnings:     r.WarningStrings(),
+		Stats:        r.Stats,
+	}
+}
+
 // documentContext tracks the source file and document for error reporting
 type documentContext struct {
 	filePath string


### PR DESCRIPTION
## Summary

- Add `JoinResult.ToParseResult()` method to enable seamless integration with downstream packages (validator, fixer, converter, differ)
- Add `ConversionResult.ToParseResult()` method with severity-prefixed warnings for programmatic filtering
- Update package documentation with chaining examples

## Problem

Users working with joined or converted specifications needed hacky workarounds to use them with other packages:

```go
// Previous hacky workaround
data, _ := json.Marshal(joinResult.Document)
var rawData map[string]any
json.Unmarshal(data, &rawData)
parseResult := &parser.ParseResult{
    Document: joinResult.Document,
    Data:     rawData,  // Manual reconstruction
    // ...other fields manually set
}
```

## Solution

```go
// Now simple and type-safe
joinResult, _ := joiner.JoinWithOptions(...)
valResult, _ := validator.ValidateParsed(*joinResult.ToParseResult())

convResult, _ := converter.ConvertWithOptions(...)
diffResult, _ := differ.DiffWithOptions(
    differ.WithSourceFilePath("original.yaml"),
    differ.WithTargetParsed(*convResult.ToParseResult()),
)
```

## Design Decisions

1. **Data field is nil**: Following `builder.BuildResult()` pattern - all downstream consumers use `Document`, not `Data`
2. **Severity prefix for converter**: Warnings include `[critical]`, `[warning]`, `[info]` prefix for programmatic filtering while retaining visual symbols (✗, ⚠, ℹ)
3. **Source path conventions**: JoinResult uses first file path (or "joiner" fallback), ConversionResult uses "converter"
4. **Target version for converter**: Uses post-conversion version fields, not source version

## Test Plan

- [x] Tests for `JoinResult.ToParseResult()` covering OAS2/OAS3, empty paths, structured warnings, legacy warnings fallback
- [x] Tests for `ConversionResult.ToParseResult()` covering OAS2/OAS3, severity prefixes, empty issues
- [x] All 5606 tests pass
- [x] Documentation examples validated for correct API signatures

🤖 Generated with [Claude Code](https://claude.com/claude-code)