### PR TITLE
feat(api): add ToParseResult() methods for complete package chaining

### DIFF
--- a/fixer/deep_dive.md
+++ b/fixer/deep_dive.md
@@ -15,6 +15,7 @@ The [`fixer`](https://pkg.go.dev/github.com/erraggy/oastools/fixer) package prov
 - [Practical Examples](#practical-examples)
 - [Generic Naming Strategies](#generic-naming-strategies)
 - [Configuration Reference](#configuration-reference)
+- [Package Chaining](#package-chaining)
 - [Best Practices](#best-practices)
 
 ---
@@ -219,6 +220,37 @@ Configure with `WithGenericNaming()` or `WithGenericNamingConfig()`.
 | `Fixes` | `[]Fix` | Applied fixes with details |
 | `FixCount` | `int` | Total fixes applied |
 | `SourceFormat` | `SourceFormat` | Preserved format |
+| `ToParseResult()` | `*parser.ParseResult` | Converts result for package chaining |
+
+[Back to top](#top)
+
+---
+
+## Package Chaining
+
+The `ToParseResult()` method enables seamless chaining with other oastools packages by converting `FixResult` to a `parser.ParseResult`:
+
+```go
+// Fix then validate
+fixResult, err := fixer.FixWithOptions(
+    fixer.WithFilePath("openapi.yaml"),
+    fixer.WithInferTypes(true),
+)
+if err != nil {
+    log.Fatal(err)
+}
+
+// Chain to validator
+v := validator.New()
+valResult, _ := v.ValidateParsed(*fixResult.ToParseResult())
+fmt.Printf("Valid: %v\n", valResult.Valid)
+
+// Or chain to converter
+c := converter.New()
+convResult, _ := c.ConvertParsed(*fixResult.ToParseResult(), "3.1.0")
+```
+
+This enables workflows like: `parse → fix → validate → convert → join`
 
 [Back to top](#top)
 

--- a/fixer/doc.go
+++ b/fixer/doc.go
@@ -104,6 +104,33 @@
 //	# Fix and save
 //	oastools fix api.yaml -o fixed.yaml
 //
+// # Chaining with Other Packages
+//
+// Use [FixResult.ToParseResult] to convert the fix result for use with other packages:
+//
+//	// Fix a specification
+//	fixResult, _ := fixer.FixWithOptions(
+//	    fixer.WithFilePath("api.yaml"),
+//	)
+//
+//	// Validate the fixed result
+//	v := validator.New()
+//	validationResult, _ := v.ValidateParsed(*fixResult.ToParseResult())
+//
+//	// Or convert to a different version
+//	c := converter.New()
+//	convResult, _ := c.ConvertParsed(*fixResult.ToParseResult(), "3.1.0")
+//
+//	// Or diff against another document
+//	diffResult, _ := differ.DiffWithOptions(
+//	    differ.WithSourceParsed(*fixResult.ToParseResult()),
+//	    differ.WithTargetFilePath("production.yaml"),
+//	)
+//
+// The returned [parser.ParseResult] uses the source version (the version of the
+// fixed document). Errors and Warnings are empty slices since fixes are
+// informational, not validation errors.
+//
 // # Related Packages
 //
 // The fixer integrates with other oastools packages:

--- a/fixer/fixer.go
+++ b/fixer/fixer.go
@@ -85,6 +85,33 @@ func (r *FixResult) HasFixes() bool {
 	return r.FixCount > 0
 }
 
+// ToParseResult converts the FixResult to a ParseResult for use with
+// other packages like validator, converter, joiner, and differ.
+// The returned ParseResult has Document populated but Data is nil
+// (consumers use Document, not Data).
+// Errors and Warnings are empty slices since fixes are informational,
+// not validation errors.
+func (r *FixResult) ToParseResult() *parser.ParseResult {
+	sourcePath := r.SourcePath
+	if sourcePath == "" {
+		sourcePath = "fixer"
+	}
+	warnings := make([]string, 0)
+	if r.Document == nil {
+		warnings = append(warnings, "fixer: ToParseResult: Document is nil, downstream operations may fail")
+	}
+	return &parser.ParseResult{
+		SourcePath:   sourcePath,
+		SourceFormat: r.SourceFormat,
+		Version:      r.SourceVersion,
+		OASVersion:   r.SourceOASVersion,
+		Document:     r.Document,
+		Errors:       make([]error, 0),
+		Warnings:     warnings,
+		Stats:        r.Stats,
+	}
+}
+
 // Fixer handles automatic fixing of OAS validation issues
 type Fixer struct {
 	// InferTypes enables type inference for path parameters based on naming conventions.

--- a/overlay/deep_dive.md
+++ b/overlay/deep_dive.md
@@ -15,6 +15,7 @@ The [`overlay`](https://pkg.go.dev/github.com/erraggy/oastools/overlay) package 
 - [Practical Examples](#practical-examples)
 - [JSONPath Reference](#jsonpath-reference)
 - [Configuration Reference](#configuration-reference)
+- [Package Chaining](#package-chaining)
 - [Best Practices](#best-practices)
 
 ---
@@ -237,6 +238,37 @@ if errs := overlay.Validate(o); len(errs) > 0 {
 | `Changes` | `[]Change` | Details of each change (for dry-run) |
 | `Warnings` | `[]string` | Non-fatal warnings during application |
 | `Document` | `any` | The modified document |
+| `ToParseResult()` | `*parser.ParseResult` | Converts result for package chaining |
+
+[Back to top](#top)
+
+---
+
+## Package Chaining
+
+The `ToParseResult()` method enables seamless chaining with other oastools packages by converting `ApplyResult` to a `parser.ParseResult`:
+
+```go
+// Apply overlay then validate
+applyResult, err := overlay.ApplyWithOptions(
+    overlay.WithSpecFilePath("openapi.yaml"),
+    overlay.WithOverlayFilePath("changes.yaml"),
+)
+if err != nil {
+    log.Fatal(err)
+}
+
+// Chain to validator
+v := validator.New()
+valResult, _ := v.ValidateParsed(*applyResult.ToParseResult())
+fmt.Printf("Valid: %v\n", valResult.Valid)
+
+// Or chain to converter
+c := converter.New()
+convResult, _ := c.ConvertParsed(*applyResult.ToParseResult(), "3.1.0")
+```
+
+This enables workflows like: `parse → overlay → validate → convert`
 
 [Back to top](#top)
 

--- a/overlay/doc.go
+++ b/overlay/doc.go
@@ -118,6 +118,24 @@
 //
 // For backward compatibility, warnings are also available as []string via result.Warnings.
 //
+// # Package Chaining with ToParseResult
+//
+// The overlay package supports chaining with other oastools packages through
+// the [ApplyResult.ToParseResult] method. This enables workflows like:
+//
+//	// Parse → Apply Overlay → Validate
+//	parsed, _ := parser.ParseWithOptions(parser.WithFilePath("openapi.yaml"))
+//	result, _ := overlay.ApplyWithOptions(
+//	    overlay.WithSpecParsed(*parsed),
+//	    overlay.WithOverlayFilePath("changes.yaml"),
+//	)
+//	issues, _ := validator.ValidateWithOptions(validator.WithParsed(*result.ToParseResult()))
+//
+// Note that when the overlay is applied to a raw map[string]any document (rather than
+// a typed *parser.OAS3Document or *parser.OAS2Document), the version information in
+// the resulting ParseResult will be empty. For full version tracking, ensure the input
+// document is a typed document obtained from parsing.
+//
 // # Related Packages
 //
 // The overlay package integrates with other oastools packages:

--- a/validator/doc.go
+++ b/validator/doc.go
@@ -43,8 +43,28 @@
 //   - Errors: Validation errors with JSON path locations
 //   - Warnings: Best practice warnings (if IncludeWarnings is true)
 //   - ErrorCount, WarningCount: Issue counts
+//   - Document: The validated document for chaining with other packages
 //
 // See the exported ValidationError and ValidationResult types for complete details.
+//
+// # Package Chaining with ToParseResult
+//
+// The ValidationResult.ToParseResult() method enables chaining validation with other
+// oastools packages. This converts the validation result back to a ParseResult that
+// can be passed to fixer, converter, joiner, or differ:
+//
+//	// Parse and validate, then fix any issues
+//	parseResult, _ := parser.ParseWithOptions(parser.WithFilePath("api.yaml"))
+//	valResult, _ := validator.ValidateWithOptions(validator.WithParsed(*parseResult))
+//	if !valResult.Valid {
+//	    fixResult, _ := fixer.FixWithOptions(fixer.WithParsed(*valResult.ToParseResult()))
+//	    // Use fixResult...
+//	}
+//
+// Validation errors and warnings are converted to string warnings in the ParseResult
+// with severity prefixes for programmatic filtering:
+//   - "[error] path: message" for validation errors
+//   - "[warning] path: message" for validation warnings
 //
 // # Related Packages
 //

--- a/validator/example_test.go
+++ b/validator/example_test.go
@@ -81,3 +81,27 @@ func Example_customValidation() {
 	// StrictMode treats warnings as errors for result.Valid
 	// IncludeWarnings populates result.Errors with warning-level issues
 }
+
+// Example_toParseResult demonstrates using ToParseResult for package chaining.
+// This pattern allows validated documents to be passed to other oastools packages.
+func Example_toParseResult() {
+	// Validate a specification
+	v := validator.New()
+	testFile := filepath.Join("testdata", "petstore-3.0.yaml")
+	result, err := v.Validate(testFile)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Valid: %v\n", result.Valid)
+
+	// Convert to ParseResult for use with other packages
+	parseResult := result.ToParseResult()
+	fmt.Printf("SourcePath: %s\n", parseResult.SourcePath)
+	fmt.Printf("Version: %s\n", parseResult.Version)
+
+	// The ParseResult can now be passed to fixer, converter, joiner, etc.
+	// For example:
+	//   fixResult, _ := fixer.FixWithOptions(fixer.WithParsed(*parseResult))
+	//   convertResult, _ := converter.ConvertWithOptions(converter.WithParsed(*parseResult), ...)
+}


### PR DESCRIPTION
## Summary

This PR extends the `ToParseResult()` pattern (introduced in b3e2d1d for converter and joiner) to all applicable result types, enabling seamless chaining between oastools packages.

### Changes

**New ToParseResult() Methods:**
- `fixer.FixResult.ToParseResult()` - Convert fix results for downstream validation
- `overlay.ApplyResult.ToParseResult()` - Convert overlay results with version extraction
- `validator.ValidationResult.ToParseResult()` - Convert validation results with error/warning conversion
- `differ.DiffResult.ToParseResult()` - Convert diff results (returns target document for pipeline model)

**Package Chaining Now Supported:**
```go
// Full pipeline example
parsed, _ := parser.ParseWithOptions(parser.WithFilePath("api.yaml"))
fixed, _ := fixer.FixWithOptions(fixer.WithParsed(*parsed))
overlaid, _ := overlay.ApplyWithOptions(
    overlay.WithSpecParsed(*fixed.ToParseResult()),
    overlay.WithOverlayFilePath("changes.yaml"),
)
validated, _ := validator.ValidateWithOptions(validator.WithParsed(*overlaid.ToParseResult()))
converted, _ := converter.ConvertWithOptions(
    converter.WithParsed(*validated.ToParseResult()),
    converter.WithTargetVersion(parser.OASVersion310),
)
// Continue with joiner, differ, etc.
```

**Defensive Programming:**
- Added nil document warnings to prevent silent downstream failures
- Added exhaustive type switch handling in overlay
- Added SourcePath preservation in validator

**Documentation:**
- Updated all 6 package deep_dive.md files with ToParseResult() sections
- Updated developer-guide.md with Package Chaining section
- Added comprehensive examples showing real-world workflows

### Files Changed

| Package | Files | Description |
|---------|-------|-------------|
| fixer | fixer.go, fixer_test.go, deep_dive.md | ToParseResult() with nil document warning |
| overlay | types.go, apply_test.go, doc.go, deep_dive.md | ToParseResult() with version extraction |
| validator | validator.go, validator_test.go, doc.go, deep_dive.md | ToParseResult() with SourcePath preservation |
| differ | differ.go, differ_test.go, doc.go, deep_dive.md | ToParseResult() with OAS2 support |
| converter | deep_dive.md | Documentation update |
| joiner | deep_dive.md | Documentation update |
| docs | developer-guide.md | New Package Chaining section |

### Test Plan

- [x] All existing tests pass (5,600+ tests)
- [x] New tests for ToParseResult() in all 4 packages
- [x] Tests for nil document handling
- [x] Tests for OAS2/OAS3 version extraction
- [x] Tests for SourcePath preservation
- [x] `make check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)