### PR TITLE
feat(validator): add --validate-structure flag for parser control

### DIFF
--- a/cmd/oastools/commands/validate_test.go
+++ b/cmd/oastools/commands/validate_test.go
@@ -11,6 +11,9 @@ func TestSetupValidateFlags(t *testing.T) {
 		if flags.Strict {
 			t.Error("expected Strict to be false by default")
 		}
+		if !flags.ValidateStructure {
+			t.Error("expected ValidateStructure to be true by default")
+		}
 		if flags.NoWarnings {
 			t.Error("expected NoWarnings to be false by default")
 		}
@@ -42,6 +45,19 @@ func TestSetupValidateFlags(t *testing.T) {
 		}
 		if fs.Arg(0) != "test.yaml" {
 			t.Errorf("expected file arg 'test.yaml', got '%s'", fs.Arg(0))
+		}
+	})
+
+	t.Run("validate-structure flag", func(t *testing.T) {
+		// Create fresh flagset to test validate-structure flag
+		fs2, flags2 := SetupValidateFlags()
+		args := []string{"--validate-structure=false", "test.yaml"}
+		if err := fs2.Parse(args); err != nil {
+			t.Fatalf("unexpected parse error: %v", err)
+		}
+
+		if flags2.ValidateStructure {
+			t.Error("expected ValidateStructure to be false when --validate-structure=false")
 		}
 	})
 }

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -1305,6 +1305,37 @@ func TestValidateWithOptions_StrictMode(t *testing.T) {
 	// Strict mode may generate additional warnings
 }
 
+// TestValidateWithOptions_ValidateStructure tests that structure validation can be controlled
+func TestValidateWithOptions_ValidateStructure(t *testing.T) {
+	t.Run("default enabled", func(t *testing.T) {
+		result, err := ValidateWithOptions(
+			WithFilePath("../testdata/petstore-3.0.yaml"),
+			// Not specifying WithValidateStructure to test default (true)
+		)
+		require.NoError(t, err)
+		assert.True(t, result.Valid)
+	})
+
+	t.Run("explicitly enabled", func(t *testing.T) {
+		result, err := ValidateWithOptions(
+			WithFilePath("../testdata/petstore-3.0.yaml"),
+			WithValidateStructure(true),
+		)
+		require.NoError(t, err)
+		assert.True(t, result.Valid)
+	})
+
+	t.Run("explicitly disabled", func(t *testing.T) {
+		result, err := ValidateWithOptions(
+			WithFilePath("../testdata/petstore-3.0.yaml"),
+			WithValidateStructure(false),
+		)
+		require.NoError(t, err)
+		assert.True(t, result.Valid)
+		// With a valid file, both enabled and disabled should pass
+	})
+}
+
 // TestValidateWithOptions_DisableWarnings tests that warnings can be disabled
 func TestValidateWithOptions_DisableWarnings(t *testing.T) {
 	result, err := ValidateWithOptions(
@@ -1469,6 +1500,7 @@ func TestApplyOptions_Defaults_Validator(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, cfg.includeWarnings, "default includeWarnings should be true")
 	assert.False(t, cfg.strictMode, "default strictMode should be false")
+	assert.True(t, cfg.validateStructure, "default validateStructure should be true")
 	assert.Equal(t, "", cfg.userAgent, "default userAgent should be empty")
 }
 
@@ -1478,12 +1510,14 @@ func TestApplyOptions_OverrideDefaults_Validator(t *testing.T) {
 		WithFilePath("test.yaml"),
 		WithIncludeWarnings(false),
 		WithStrictMode(true),
+		WithValidateStructure(false),
 		WithUserAgent("custom/1.0"),
 	)
 
 	require.NoError(t, err)
 	assert.False(t, cfg.includeWarnings)
 	assert.True(t, cfg.strictMode)
+	assert.False(t, cfg.validateStructure)
 	assert.Equal(t, "custom/1.0", cfg.userAgent)
 }
 


### PR DESCRIPTION
## Summary

- Adds `--validate-structure` CLI flag to the `validate` command (default: `true`)
- Adds `WithValidateStructure()` option to the validator package
- Provides separate control for parser structure validation, independent of `--strict`

## Motivation

The `validate` command had a `--strict` flag for semantic validation rules, but the parser's structure validation (`ValidateStructure`) was **always enabled** regardless of user choice. This PR adds a separate flag to give users fine-grained control:

| Flag | Controls | Default |
|------|----------|---------|
| `--strict` | Semantic validation beyond spec requirements | `false` |
| `--validate-structure` | Basic structure validation during parsing | `true` |

## Changes

- `validator/validator.go`: Added `ValidateStructure` field to `Validator` struct, `WithValidateStructure()` option, and wiring in `Validate()` method
- `cmd/oastools/commands/validate.go`: Added flag and wired through all 3 code paths (stdin, file+sourcemap, file)
- Tests added for both the option and the CLI flag

## Test plan

- [x] `make check` passes (5769 tests)
- [x] Default behavior unchanged (structure validation ON)
- [x] `--validate-structure=false` disables parser structure validation
- [x] Works with all input methods (file, URL, stdin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)