### PR TITLE
fix(validate): exclude Document from JSON/YAML output by default

### DIFF
--- a/cmd/oastools/commands/validate.go
+++ b/cmd/oastools/commands/validate.go
@@ -54,6 +54,7 @@ func SetupValidateFlags() (*flag.FlagSet, *ValidateFlags) {
 		Writef(fs.Output(), "  oastools validate --no-warnings openapi.json\n")
 		Writef(fs.Output(), "  cat openapi.yaml | oastools validate -q -\n")
 		Writef(fs.Output(), "  oastools validate --format json openapi.yaml | jq '.valid'\n")
+		Writef(fs.Output(), "  oastools validate --format json --include-document openapi.yaml\n")
 		Writef(fs.Output(), "  oastools validate -s openapi.yaml  # Include line numbers in errors\n")
 		Writef(fs.Output(), "\nPipelining:\n")
 		Writef(fs.Output(), "  - Use '-' as the file path to read from stdin\n")

--- a/cmd/oastools/commands/validate_test.go
+++ b/cmd/oastools/commands/validate_test.go
@@ -23,6 +23,9 @@ func TestSetupValidateFlags(t *testing.T) {
 		if flags.Format != FormatText {
 			t.Errorf("expected Format to be '%s' by default, got '%s'", FormatText, flags.Format)
 		}
+		if flags.IncludeDocument {
+			t.Error("expected IncludeDocument to be false by default")
+		}
 	})
 
 	t.Run("parse flags", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add `-include-document` flag (default: `false`) to the validate command
- When using `-format json` or `-format yaml`, the full OAS Document is now excluded from output by default
- Users can opt-in to include the document with `--include-document`

This fixes an issue where large OAS documents made it impractical to parse validation results programmatically.

## Test plan
- [x] Verified `oastools validate -format json spec.yaml` no longer includes Document (shows `null`)
- [x] Verified `oastools validate -format json -include-document spec.yaml` includes the full Document
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)