### PR TITLE
docs: comprehensive documentation refresh with overlay --dry-run flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,10 @@ oastools generate --server --server-all -o ./server -p api openapi.yaml
 oastools join -o merged.yaml base.yaml extensions.yaml
 
 # Apply overlays for environment-specific customizations
-oastools overlay apply -s openapi.yaml production.yaml -o production-api.yaml
+oastools overlay apply -s openapi.yaml -o production-api.yaml production.yaml
+
+# Preview overlay changes without applying
+oastools overlay apply --dry-run -s openapi.yaml production.yaml
 
 # Validate an overlay document
 oastools overlay validate changes.yaml

--- a/converter/example_test.go
+++ b/converter/example_test.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	"github.com/erraggy/oastools/converter"
+	"github.com/erraggy/oastools/parser"
 )
 
 // Example demonstrates basic conversion using functional options
@@ -85,6 +86,54 @@ func Example_toParseResult() {
 	// Source: converter
 	// Version: 3.0.3
 	// Has document: true
+}
+
+// Example_convertParsed demonstrates converting an already-parsed document.
+// This is useful when you need to parse once and convert multiple times,
+// or when integrating with other oastools packages in a pipeline.
+func Example_convertParsed() {
+	// First, parse the document using the parser package
+	parsed, err := parser.ParseWithOptions(parser.WithFilePath("../testdata/petstore-2.0.yaml"))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Convert using the parsed result — no re-parsing needed
+	result, err := converter.ConvertWithOptions(
+		converter.WithParsed(*parsed),
+		converter.WithTargetVersion("3.0.3"),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Converted from %s to %s\n", result.SourceVersion, result.TargetVersion)
+	fmt.Printf("Success: %v\n", result.Success)
+	// Output:
+	// Converted from 2.0 to 3.0.3
+	// Success: true
+}
+
+// Example_upgradeOAS3 demonstrates upgrading from OAS 3.0 to OAS 3.1.
+// This is useful for modernizing specifications to take advantage of newer
+// features like webhooks, JSON Schema compatibility, and type arrays.
+func Example_upgradeOAS3() {
+	// Convert OAS 3.0 specification to OAS 3.1
+	result, err := converter.ConvertWithOptions(
+		converter.WithFilePath("../testdata/petstore-3.0.yaml"),
+		converter.WithTargetVersion("3.1.0"),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Upgraded from %s to %s\n", result.SourceVersion, result.TargetVersion)
+	fmt.Printf("Success: %v\n", result.Success)
+	fmt.Printf("Critical issues: %d\n", result.CriticalCount)
+	// Output:
+	// Upgraded from 3.0.3 to 3.1.0
+	// Success: true
+	// Critical issues: 0
 }
 
 // Example_complexConversion demonstrates converting a complex OAS 2.0 document

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1250,7 +1250,7 @@ oastools overlay <subcommand> [flags]
 Apply an overlay transformation to an OpenAPI specification.
 
 ```bash
-oastools overlay apply [flags]
+oastools overlay apply [flags] <overlay-file>
 ```
 
 #### Flags
@@ -1258,10 +1258,9 @@ oastools overlay apply [flags]
 | Flag | Short | Description |
 |------|-------|-------------|
 | `--spec` | `-s` | Path to the OpenAPI specification file (required) |
-| `--overlay` | | Path to the overlay file (or positional argument) |
 | `--output` | `-o` | Output file path (default: stdout) |
 | `--strict` | | Fail if any target matches nothing |
-| `--dry-run` | | Preview changes without applying |
+| `--dry-run` | `-n` | Preview changes without applying |
 | `--quiet` | `-q` | Suppress diagnostic output |
 | `-h, --help` | | Display help |
 
@@ -1269,22 +1268,22 @@ oastools overlay apply [flags]
 
 ```bash
 # Apply overlay and write to file
-oastools overlay apply --spec openapi.yaml --overlay changes.yaml -o result.yaml
+oastools overlay apply --spec openapi.yaml -o result.yaml changes.yaml
 
 # Apply overlay to stdout
-oastools overlay apply --spec openapi.yaml --overlay changes.yaml
+oastools overlay apply -s openapi.yaml changes.yaml
 
 # Preview changes without applying
-oastools overlay apply --spec openapi.yaml --overlay changes.yaml --dry-run
+oastools overlay apply --dry-run -s openapi.yaml changes.yaml
 
 # Strict mode (fail if targets don't match)
-oastools overlay apply --spec openapi.yaml --overlay changes.yaml --strict
+oastools overlay apply --strict -s openapi.yaml changes.yaml
 
 # From stdin
-cat openapi.yaml | oastools overlay apply --spec - --overlay changes.yaml
+cat openapi.yaml | oastools overlay apply -s - changes.yaml
 
 # Quiet mode for pipelines
-oastools overlay apply -q --spec openapi.yaml --overlay changes.yaml > result.yaml
+oastools overlay apply -q -s openapi.yaml changes.yaml > result.yaml
 ```
 
 #### Output Format
@@ -1293,40 +1292,51 @@ oastools overlay apply -q --spec openapi.yaml --overlay changes.yaml > result.ya
 OpenAPI Overlay Application
 ============================
 
-oastools version: v1.24.0
+oastools version: v1.46.2
+Specification: openapi.yaml
 Overlay: changes.yaml
-Spec: openapi.yaml
-OAS Version: 3.0.3
+Total Time: 1.2ms
 
 Actions applied: 3
 Actions skipped: 0
 
 Changes:
-  - update 1 nodes at $.info
-  - update 5 nodes at $.paths.*.get
-  - remove 2 nodes at $.paths[?@.x-internal==true]
+  [0] update: $.info (1 match(es))
+  [1] update: $.paths.*.get (5 match(es))
+  [2] remove: $.paths[?@.x-internal==true] (2 match(es))
 
 ✓ Overlay applied successfully
 ```
 
 #### Dry-Run Output
 
+When using `--dry-run` / `-n`, no changes are made to the document.
+The output shows what *would* happen:
+
 ```
 OpenAPI Overlay Dry Run
 =======================
 
-oastools version: v1.24.0
+oastools version: v1.46.2
+Specification: openapi.yaml
 Overlay: changes.yaml
-Spec: openapi.yaml
-OAS Version: 3.0.3
+Total Time: 1.1ms
 
-Would apply: 3 actions
-Would skip: 0 actions
+Would apply: 3 action(s)
+Would skip:  0 action(s)
 
-Proposed changes:
-  - update 1 nodes at $.info
-  - update 5 nodes at $.paths.*.get
-  - remove 2 nodes at $.paths[?@.x-internal==true]
+Proposed Changes:
+  [0] update: Update API info (1 match(es))
+       → $.info
+  [1] update: Add headers to all GET operations (5 match(es))
+       → $.paths./pets.get
+       → $.paths./users.get
+       ...
+  [2] remove: Remove internal endpoints (2 match(es))
+       → $.paths./internal/health
+       → $.paths./internal/metrics
+
+ℹ️  No changes were made (dry-run mode)
 ```
 
 ### overlay validate

--- a/generator/example_test.go
+++ b/generator/example_test.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	"github.com/erraggy/oastools/generator"
+	"github.com/erraggy/oastools/parser"
 )
 
 // Example demonstrates basic code generation using functional options
@@ -102,23 +103,29 @@ func Example_handleIssues() {
 		result.CriticalCount, result.WarningCount, result.InfoCount)
 }
 
-// Example_withParsedDocument demonstrates using a pre-parsed document
+// Example_withParsedDocument demonstrates using a pre-parsed document.
+// This is the recommended pattern for pipelines that parse once and generate
+// multiple outputs (types, client, server) from the same specification.
 func Example_withParsedDocument() {
-	// This example shows how to use a pre-parsed document
-	// Useful when you need to parse once and generate multiple times
-	// or when integrating with other oastools packages
-
 	// First, parse the document using the parser package
-	// parsed, _ := parser.ParseWithOptions(parser.WithFilePath("openapi.yaml"))
+	parsed, err := parser.ParseWithOptions(parser.WithFilePath("../testdata/petstore-3.0.yaml"))
+	if err != nil {
+		log.Fatal(err)
+	}
 
-	// Then generate using the parsed result
-	// result, _ := generator.GenerateWithOptions(
-	//     generator.WithParsed(*parsed),
-	//     generator.WithPackageName("api"),
-	//     generator.WithClient(true),
-	// )
+	// Generate using the parsed result — avoids re-parsing
+	result, err := generator.GenerateWithOptions(
+		generator.WithParsed(*parsed),
+		generator.WithPackageName("petstore"),
+		generator.WithClient(true),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
 
-	fmt.Println("Pre-parsed document can be used with WithParsed option")
+	fmt.Printf("Generated %d files from pre-parsed document\n", len(result.Files))
+	fmt.Printf("Source version: %s\n", result.SourceVersion)
+	fmt.Printf("Types: %d, Operations: %d\n", result.GeneratedTypes, result.GeneratedOperations)
 }
 
 // Example_withSecurityHelpers demonstrates generating security authentication helpers

--- a/httpvalidator/doc.go
+++ b/httpvalidator/doc.go
@@ -94,6 +94,31 @@
 //	result.HeaderParams["X-API"] // Deserialized header parameter
 //	result.CookieParams["token"] // Deserialized cookie parameter
 //
+// # Path Matching
+//
+// [PathMatcher] matches incoming request paths against OAS path templates,
+// extracting path parameters. [PathMatcherSet] manages multiple matchers
+// for efficient routing:
+//
+//	matcher, _ := httpvalidator.NewPathMatcher("/users/{userId}/posts/{postId}")
+//	ok, params := matcher.Match("/users/42/posts/101")
+//	// ok: true, params: {"userId": "42", "postId": "101"}
+//
+//	templates := []string{"/users", "/users/{userId}", "/users/{userId}/posts/{postId}"}
+//	set, _ := httpvalidator.NewPathMatcherSet(templates)
+//	template, params, found := set.Match("/users/42")
+//	// template: "/users/{userId}", params: {"userId": "42"}, found: true
+//
+// # Response Validation
+//
+// For middleware scenarios where you've already captured the response,
+// use [Validator.ValidateResponseData] instead of ValidateResponse:
+//
+//	result, _ := v.ValidateResponseData(req, statusCode, headers, body)
+//
+// This avoids needing a full *http.Response and works naturally with
+// httptest.ResponseRecorder patterns.
+//
 // # Schema Validation
 //
 // The validator performs JSON Schema validation on request/response bodies including:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,7 @@ site_description: High-performance Go library and CLI for working with OpenAPI S
 site_url: https://erraggy.github.io/oastools/
 repo_url: https://github.com/erraggy/oastools
 repo_name: erraggy/oastools
+edit_uri: ""
 
 theme:
   name: material

--- a/overlay/deep_dive.md
+++ b/overlay/deep_dive.md
@@ -276,7 +276,7 @@ This enables workflows like: `parse → overlay → validate → convert`
 
 ## Best Practices
 
-1. **Use dry-run first** - Preview changes before applying to production specs
+1. **Use dry-run first** - Preview changes before applying to production specs (`oastools overlay apply --dry-run -s spec.yaml overlay.yaml`)
 2. **Validate overlays** - Call `overlay.Validate()` before application
 3. **Order actions carefully** - Actions are applied in order; earlier actions affect later ones
 4. **Use StrictTargets in CI** - Catch typos in JSONPath expressions

--- a/walker/doc.go
+++ b/walker/doc.go
@@ -174,6 +174,29 @@
 //	walker.Walk(result, handlers1...)
 //	walker.Walk(result, handlers2...)
 //
+// # Built-in Collectors
+//
+// For common collection patterns, the walker provides pre-built helpers that
+// reduce boilerplate:
+//
+//   - [CollectSchemas]: Returns a [SchemaCollector] with all schemas indexed by name
+//   - [CollectOperations]: Returns an [OperationCollector] with all operations indexed by operationId
+//
+// Example:
+//
+//	schemas, err := walker.CollectSchemas(result)
+//	for name, info := range schemas.ByName {
+//	    fmt.Printf("Schema %s: %d properties\n", name, len(info.Schema.Properties))
+//	}
+//
+//	ops, err := walker.CollectOperations(result)
+//	for _, info := range ops.All {
+//	    fmt.Printf("%s %s -> %s\n", info.Method, info.PathTemplate, info.Operation.OperationID)
+//	}
+//
+// Each [OperationInfo] provides Method, PathTemplate, JSONPath, and the full [parser.Operation].
+// Each [SchemaInfo] provides Name, JSONPath, IsComponent, and the full [parser.Schema].
+//
 // # Schema Cycle Detection
 //
 // The walker automatically detects circular schema references and avoids infinite loops.


### PR DESCRIPTION
## Summary

Comprehensive documentation refresh addressing issues identified across the entire docs surface area — whitepaper, godoc, example tests, CLI reference, published docs, and build pipeline.

### New Feature
- **`overlay apply --dry-run` / `-n` CLI flag** — Preview overlay changes without modifying files, calling existing `overlay.DryRunWithOptions()` library API

### Documentation Fixes
- **Whitepaper** (`docs/whitepaper.md`): Version bump to v1.46.2, fixed `ParseResult` struct documentation (methods not fields), added `golang.org/x/text` dependency, added `OperationContext` field to `ValidationError`, new sections for v1.46.x features (operation context, `FixTypeStubMissingRefs`, empty schema preservation)
- **`walker/doc.go`**: Added Built-in Collectors section documenting `SchemaCollector`, `OperationCollector`, `CollectSchemas()`, `CollectOperations()` with correct field names (`ByName`, `All`, `PathTemplate`, `Operation.OperationID`)
- **`httpvalidator/doc.go`**: Added Path Matching section with correct API signatures (`NewPathMatcherSet([]string)` → `(template, params, found)`), Response Validation section
- **`validator/doc.go`**: Enhanced Operation Context section with code example
- **`README.md`**: Fixed overlay apply flag ordering (flags before positional arg), added `--dry-run` example

### New Example Tests
- `converter/example_test.go`: `Example_convertParsed` (pre-parsed workflow), `Example_upgradeOAS3` (3.0→3.1)
- `generator/example_test.go`: `Example_withParsedDocument` (completed placeholder with real parse→generate)
- `httpvalidator/example_test.go`: `ExampleParamDeserializer` (matrix/pipe/header styles), `ExampleValidator_ValidateRequest_strictMode`

### CLI & Published Docs
- `docs/cli-reference.md`: Fixed overlay section — removed ghost `--overlay` flag, added `-n` short flag, updated usage/output format
- `overlay/deep_dive.md`: Added CLI dry-run to best practices section

### Build Pipeline
- `scripts/prepare-docs.sh`: Added `copy_if_exists()` helper, guarded `fix_example_links`/`fix_subdir_links` with `[ -f ] || return 0`, added GitHub absolute link transforms for docs site
- `mkdocs.yml`: Added `edit_uri: ""` to prevent broken "Edit this page" links

### Bug Fixes
- `handleOverlayDryRun` now respects `--quiet` flag (was unconditionally writing diagnostics)
- Fixed overlay apply README example: flags must precede positional arg per Go's `flag` package behavior

## Test plan
- [x] `go test -run Example ./...` — all example tests pass
- [x] `go_diagnostics` on all modified Go files — no diagnostics
- [x] `make check` — 7912 tests pass, 0 failures
- [x] `./scripts/prepare-docs.sh` — builds without warnings
- [x] `go run ./cmd/oastools/ overlay apply --dry-run -s testdata/overlay/fixtures/petstore-base.yaml testdata/overlay/fixtures/petstore-overlay.yaml` — produces expected output
- [x] Verified `--quiet` suppresses dry-run output

🤖 Generated with [Claude Code](https://claude.com/claude-code)