### PR TITLE
feat(fixer): add WithMutableInput option to skip defensive copy

### DIFF
--- a/fixer/oas2.go
+++ b/fixer/oas2.go
@@ -17,10 +17,17 @@ func (f *Fixer) fixOAS2(parseResult parser.ParseResult, result *FixResult) (*Fix
 		return nil, fmt.Errorf("fixer: expected *parser.OAS2Document, got %T", parseResult.Document)
 	}
 
-	// Deep copy the document to avoid mutating the original
-	doc, err := deepCopyOAS2Document(srcDoc)
-	if err != nil {
-		return nil, fmt.Errorf("fixer: failed to copy document: %w", err)
+	var doc *parser.OAS2Document
+	if f.MutableInput {
+		// Caller owns the document, mutate directly
+		doc = srcDoc
+	} else {
+		// Deep copy the document to avoid mutating the original
+		var err error
+		doc, err = deepCopyOAS2Document(srcDoc)
+		if err != nil {
+			return nil, fmt.Errorf("fixer: failed to copy document: %w", err)
+		}
 	}
 
 	// Apply fixes using shared pipeline

--- a/fixer/oas3.go
+++ b/fixer/oas3.go
@@ -16,10 +16,17 @@ func (f *Fixer) fixOAS3(parseResult parser.ParseResult, result *FixResult) (*Fix
 		return nil, fmt.Errorf("fixer: expected *parser.OAS3Document, got %T", parseResult.Document)
 	}
 
-	// Deep copy the document to avoid mutating the original
-	doc, err := deepCopyOAS3Document(srcDoc)
-	if err != nil {
-		return nil, fmt.Errorf("fixer: failed to copy document: %w", err)
+	var doc *parser.OAS3Document
+	if f.MutableInput {
+		// Caller owns the document, mutate directly
+		doc = srcDoc
+	} else {
+		// Deep copy the document to avoid mutating the original
+		var err error
+		doc, err = deepCopyOAS3Document(srcDoc)
+		if err != nil {
+			return nil, fmt.Errorf("fixer: failed to copy document: %w", err)
+		}
 	}
 
 	// Apply fixes using shared pipeline


### PR DESCRIPTION
## Summary

Add a `WithMutableInput(bool)` option to `fixer.FixWithOptions()` that skips the internal deep copy when the caller indicates they're passing ownership of the document.

Closes #283

## Changes

- Added `MutableInput` field to `Fixer` struct
- Added `WithMutableInput(bool)` option function
- Updated `fixOAS2` and `fixOAS3` to conditionally skip deep copy
- Added comprehensive tests and examples

## Test plan

- [ ] Verify `WithMutableInput(true)` mutates the original document
- [ ] Verify `WithMutableInput(false)` preserves the original document
- [ ] Verify default behavior is defensive copy
- [ ] Run `make check`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)