### PR TITLE
chore: prepare v1.48.1 release

### DIFF
--- a/benchmarks/benchmark-v1.48.1.txt
+++ b/benchmarks/benchmark-v1.48.1.txt
@@ -1,372 +1,372 @@
-2026/01/28 21:21:07 WARN equalDocument: unknown document type, using reflect.DeepEqual fallback type_a="map[string]interface {}" type_b="map[string]interface {}"
-2026/01/28 21:21:07 WARN equalDocument: unknown document type, using reflect.DeepEqual fallback type_a="map[string]interface {}" type_b="map[string]interface {}"
-2026/01/28 21:21:07 WARN equalDocument: unknown document type, using reflect.DeepEqual fallback type_a="struct { Name string }" type_b="struct { Name string }"
-2026/01/28 21:21:07 WARN equalDocument: unknown document type, using reflect.DeepEqual fallback type_a="struct { Name string }" type_b="struct { Name string }"
-2026/01/28 21:21:07 WARN equalDocument: unknown document type, using reflect.DeepEqual fallback type_a="struct { Name string }" type_b="struct { Title string }"
-2026/01/28 21:21:07 WARN equalDocument: unknown document type, using reflect.DeepEqual fallback type_a="map[string]interface {}" type_b="map[string]interface {}"
-2026/01/28 21:21:07 WARN equalDocument: unknown document type, using reflect.DeepEqual fallback type_a="map[string]interface {}" type_b="map[string]interface {}"
-2026/01/28 21:21:07 WARN equalDocument: unknown document type, using reflect.DeepEqual fallback type_a="struct { X int }" type_b="struct { X int }"
-2026/01/28 21:21:07 WARN equalDocument: unknown document type, using reflect.DeepEqual fallback type_a="struct { X int }" type_b="struct { X int }"
+2026/01/28 21:24:56 WARN equalDocument: unknown document type, using reflect.DeepEqual fallback type_a="map[string]interface {}" type_b="map[string]interface {}"
+2026/01/28 21:24:56 WARN equalDocument: unknown document type, using reflect.DeepEqual fallback type_a="map[string]interface {}" type_b="map[string]interface {}"
+2026/01/28 21:24:56 WARN equalDocument: unknown document type, using reflect.DeepEqual fallback type_a="struct { Name string }" type_b="struct { Name string }"
+2026/01/28 21:24:56 WARN equalDocument: unknown document type, using reflect.DeepEqual fallback type_a="struct { Name string }" type_b="struct { Name string }"
+2026/01/28 21:24:56 WARN equalDocument: unknown document type, using reflect.DeepEqual fallback type_a="struct { Name string }" type_b="struct { Title string }"
+2026/01/28 21:24:56 WARN equalDocument: unknown document type, using reflect.DeepEqual fallback type_a="map[string]interface {}" type_b="map[string]interface {}"
+2026/01/28 21:24:56 WARN equalDocument: unknown document type, using reflect.DeepEqual fallback type_a="map[string]interface {}" type_b="map[string]interface {}"
+2026/01/28 21:24:56 WARN equalDocument: unknown document type, using reflect.DeepEqual fallback type_a="struct { X int }" type_b="struct { X int }"
+2026/01/28 21:24:56 WARN equalDocument: unknown document type, using reflect.DeepEqual fallback type_a="struct { X int }" type_b="struct { X int }"
 goos: linux
 goarch: amd64
 pkg: github.com/erraggy/oastools/parser
-cpu: Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
-BenchmarkParseResultEquals/Identical/SmallOAS3-4         	 2846632	      2112 ns/op	       0 B/op	       0 allocs/op
-BenchmarkParseResultEquals/Identical/MediumOAS3-4        	  160944	     37014 ns/op	    6696 B/op	       9 allocs/op
-BenchmarkParseResultEquals/Identical/LargeOAS3-4         	   12924	    464735 ns/op	   54152 B/op	      15 allocs/op
-BenchmarkParseResultEquals/Identical/SmallOAS2-4         	 3343704	      1797 ns/op	       0 B/op	       0 allocs/op
-BenchmarkParseResultEquals/Identical/MediumOAS2-4        	  185366	     32621 ns/op	    6696 B/op	       9 allocs/op
-BenchmarkEquals_EarlyExit/DifferentVersion-4             	1000000000	         5.000 ns/op	       0 B/op	       0 allocs/op
+cpu: AMD EPYC 7763 64-Core Processor                
+BenchmarkParseResultEquals/Identical/SmallOAS3-4         	 2599134	      2310 ns/op	       0 B/op	       0 allocs/op
+BenchmarkParseResultEquals/Identical/MediumOAS3-4        	  149372	     39742 ns/op	    6696 B/op	       9 allocs/op
+BenchmarkParseResultEquals/Identical/LargeOAS3-4         	   12708	    472198 ns/op	   54152 B/op	      15 allocs/op
+BenchmarkParseResultEquals/Identical/SmallOAS2-4         	 3104997	      1936 ns/op	       0 B/op	       0 allocs/op
+BenchmarkParseResultEquals/Identical/MediumOAS2-4        	  170892	     35081 ns/op	    6696 B/op	       9 allocs/op
+BenchmarkEquals_EarlyExit/DifferentVersion-4             	1000000000	         5.612 ns/op	       0 B/op	       0 allocs/op
 BenchmarkEquals_EarlyExit/DifferentOASVersion-4          	1000000000	         5.000 ns/op	       0 B/op	       0 allocs/op
-BenchmarkEquals_EarlyExit/DifferentInfo-4                	494604998	        12.13 ns/op	       0 B/op	       0 allocs/op
-BenchmarkEquals_EarlyExit/DifferentLastPath-4            	  275900	     21275 ns/op	    6696 B/op	       9 allocs/op
-BenchmarkSchemaEquals/Simple-4                           	36478456	       156.9 ns/op	       0 B/op	       0 allocs/op
-BenchmarkSchemaEquals/WithProperties-4                   	 5029023	      1193 ns/op	       0 B/op	       0 allocs/op
-BenchmarkSchemaEquals/Complex-4                          	 2722188	      2196 ns/op	     456 B/op	       3 allocs/op
-BenchmarkSchemaEquals/Nested-4                           	 5537112	      1084 ns/op	       0 B/op	       0 allocs/op
-BenchmarkDocumentEquals/OAS3/Small-4                     	 2908240	      2062 ns/op	       0 B/op	       0 allocs/op
-BenchmarkDocumentEquals/OAS3/Medium-4                    	  166513	     36631 ns/op	    6696 B/op	       9 allocs/op
-BenchmarkDocumentEquals/OAS3/Large-4                     	   12577	    476088 ns/op	   54152 B/op	      15 allocs/op
-BenchmarkDocumentEquals/OAS2/Small-4                     	 3400492	      1763 ns/op	       0 B/op	       0 allocs/op
-BenchmarkDocumentEquals/OAS2/Medium-4                    	  180949	     32509 ns/op	    6696 B/op	       9 allocs/op
-BenchmarkMarshalInfo/NoExtra-4                           	 6301293	       949.9 ns/op	     192 B/op	       2 allocs/op
-BenchmarkMarshalInfo/Extra1-4                            	 2707545	      2196 ns/op	     896 B/op	      16 allocs/op
-BenchmarkMarshalInfo/Extra5-4                            	 1637590	      3669 ns/op	    1376 B/op	      24 allocs/op
-BenchmarkMarshalInfo/Extra10-4                           	  907662	      6628 ns/op	    2697 B/op	      37 allocs/op
-BenchmarkMarshalInfo/Extra20-4                           	  464894	     12291 ns/op	    5228 B/op	      59 allocs/op
-BenchmarkMarshalContact/NoExtra-4                        	 6327922	       953.1 ns/op	     192 B/op	       2 allocs/op
-BenchmarkMarshalContact/WithExtra-4                      	 1585645	      3772 ns/op	    1376 B/op	      24 allocs/op
-BenchmarkMarshalServer/NoExtra-4                         	 7180510	       827.5 ns/op	     160 B/op	       2 allocs/op
-BenchmarkMarshalServer/WithExtra-4                       	 1000000	      5241 ns/op	    2297 B/op	      30 allocs/op
-BenchmarkMarshalOAS3Document/Small-4                     	  146880	     39465 ns/op	    7010 B/op	      66 allocs/op
-BenchmarkMarshalOAS3Document/Medium-4                    	   13819	    434350 ns/op	   66067 B/op	     471 allocs/op
-BenchmarkMarshalOAS3Document/Large-4                     	    1120	   5314668 ns/op	  850917 B/op	    5336 allocs/op
-BenchmarkMarshalOAS2Document/Small-4                     	  169100	     35094 ns/op	    6375 B/op	      58 allocs/op
-BenchmarkMarshalOAS2Document/Medium-4                    	   16724	    357534 ns/op	   53798 B/op	     396 allocs/op
-BenchmarkUnmarshalInfo/NoExtra-4                         	 1832973	      3267 ns/op	    1176 B/op	      28 allocs/op
-BenchmarkUnmarshalInfo/WithExtra-4                       	  887772	      6768 ns/op	    1736 B/op	      46 allocs/op
-BenchmarkJSONFastPath/FastPath-4                         	    4278	   1295304 ns/op	  781984 B/op	   11513 allocs/op
-BenchmarkJSONFastPath/YAMLPath_SourceMap-4               	    1260	   4718400 ns/op	 5854170 B/op	   19887 allocs/op
-BenchmarkJSONFastPath/YAMLPath_PreserveOrder-4           	    1267	   4727944 ns/op	 5605799 B/op	   19207 allocs/op
-BenchmarkMarshalOrderedJSON/SmallOAS3-4                  	  256796	     23289 ns/op	    4818 B/op	     204 allocs/op
-BenchmarkMarshalOrderedJSON/MediumOAS3-4                 	   25610	    236228 ns/op	   49411 B/op	    1918 allocs/op
-BenchmarkMarshalOrderedJSON/LargeOAS3-4                  	    2199	   2677206 ns/op	  564449 B/op	   21156 allocs/op
-BenchmarkMarshalOrderedYAML/SmallOAS3-4                  	   51180	    116783 ns/op	  191482 B/op	     437 allocs/op
-BenchmarkMarshalOrderedYAML/MediumOAS3-4                 	    4431	   1357532 ns/op	 1830188 B/op	    3890 allocs/op
-BenchmarkMarshalOrderedYAML/LargeOAS3-4                  	     367	  16105778 ns/op	22628860 B/op	   42587 allocs/op
-BenchmarkMarshalOrderedJSONIndent-4                      	   18848	    317695 ns/op	   69933 B/op	    1919 allocs/op
-BenchmarkMarshalOrderedJSON_vs_Standard/OrderPreserving-4         	   25064	    239548 ns/op	   49416 B/op	    1918 allocs/op
-BenchmarkMarshalOrderedJSON_vs_Standard/Standard-4                	   13597	    440248 ns/op	   66107 B/op	     471 allocs/op
-BenchmarkPreserveOrderOverhead/WithPreserveOrder-4                	    1524	   3901806 ns/op	 1907901 B/op	   22376 allocs/op
-BenchmarkPreserveOrderOverhead/WithoutPreserveOrder-4             	    2084	   2975707 ns/op	 1608800 B/op	   17649 allocs/op
-BenchmarkParse/SmallOAS3-4                                        	   17427	    341823 ns/op	  208904 B/op	    2100 allocs/op
-BenchmarkParse/MediumOAS3-4                                       	    2030	   3034140 ns/op	 1622504 B/op	   17649 allocs/op
-BenchmarkParse/LargeOAS3-4                                        	     165	  36230147 ns/op	18305317 B/op	  196754 allocs/op
-BenchmarkParse/SmallOAS2-4                                        	   18259	    328597 ns/op	  185113 B/op	    2082 allocs/op
-BenchmarkParse/MediumOAS2-4                                       	    2385	   2565542 ns/op	 1387040 B/op	   16228 allocs/op
-BenchmarkParseNoValidation/SmallOAS3-4                            	   18003	    336453 ns/op	  208061 B/op	    2077 allocs/op
-BenchmarkParseNoValidation/MediumOAS3-4                           	    2048	   2996490 ns/op	 1617816 B/op	   17555 allocs/op
-BenchmarkParseBytes/SmallOAS3-4                                   	   18068	    330209 ns/op	  207138 B/op	    2095 allocs/op
-BenchmarkParseBytes/MediumOAS3-4                                  	    2043	   2981059 ns/op	 1608572 B/op	   17644 allocs/op
-BenchmarkParseCore/SmallOAS3-4                                    	   17972	    333536 ns/op	  207148 B/op	    2095 allocs/op
-BenchmarkParseCore/MediumOAS3-4                                   	    1930	   3055227 ns/op	 1608683 B/op	   17645 allocs/op
-BenchmarkParseCore/LargeOAS3-4                                    	     164	  36229283 ns/op	18141148 B/op	  196749 allocs/op
-BenchmarkParseCore/SmallOAS2-4                                    	   18465	    327757 ns/op	  183484 B/op	    2077 allocs/op
-BenchmarkParseCore/MediumOAS2-4                                   	    2283	   2579946 ns/op	 1374400 B/op	   16223 allocs/op
-BenchmarkParseWithOptions/FilePath/SmallOAS3-4                    	   17152	    347851 ns/op	  209214 B/op	    2107 allocs/op
-BenchmarkParseWithOptions/Bytes/SmallOAS3-4                       	   17821	    335242 ns/op	  207447 B/op	    2101 allocs/op
-BenchmarkParseWithOptions/ResolveRefs/SmallOAS3-4                 	   12484	    480627 ns/op	  375992 B/op	    2484 allocs/op
-BenchmarkParseReader/MediumOAS3-4                                 	    1959	   3102236 ns/op	 1671274 B/op	   17658 allocs/op
-BenchmarkParseResultCopy/SmallOAS3-4                              	  453139	     12799 ns/op	   18664 B/op	     113 allocs/op
-BenchmarkParseResolveRefs/MediumOAS3-4                            	     517	  11386836 ns/op	 7212254 B/op	   42461 allocs/op
-BenchmarkFormatBytes-4                                            	 7260972	       830.4 ns/op	      64 B/op	       8 allocs/op
-BenchmarkDeepCopy/SmallOAS3-4                                     	 1343511	      4460 ns/op	    7936 B/op	      44 allocs/op
-BenchmarkDeepCopy/MediumOAS3-4                                    	   92896	     64779 ns/op	  121603 B/op	     466 allocs/op
-BenchmarkDeepCopy/LargeOAS3-4                                     	    5992	   1005556 ns/op	 1313691 B/op	    4878 allocs/op
-BenchmarkDeepCopy/SmallOAS2-4                                     	 1627009	      3673 ns/op	    6768 B/op	      38 allocs/op
-BenchmarkDeepCopy/MediumOAS2-4                                    	  109827	     54541 ns/op	  106258 B/op	     387 allocs/op
-BenchmarkSourceMapOverhead/Small/Default-4                        	   17082	    349379 ns/op	  209216 B/op	    2107 allocs/op
-BenchmarkSourceMapOverhead/Small/SourceMapDisabled-4              	   17062	    352884 ns/op	  209233 B/op	    2108 allocs/op
-BenchmarkSourceMapOverhead/Small/SourceMapEnabled-4               	   12524	    480460 ns/op	  278725 B/op	    2742 allocs/op
-BenchmarkSourceMapOverhead/Medium/Default-4                       	    1898	   3056091 ns/op	 1622842 B/op	   17657 allocs/op
-BenchmarkSourceMapOverhead/Medium/SourceMapDisabled-4             	    1974	   3079927 ns/op	 1622855 B/op	   17658 allocs/op
-BenchmarkSourceMapOverhead/Medium/SourceMapEnabled-4              	    1368	   4351028 ns/op	 2191245 B/op	   23132 allocs/op
-BenchmarkSourceMapOverhead/Large/Default-4                        	     160	  37266394 ns/op	18305633 B/op	  196762 allocs/op
-BenchmarkSourceMapOverhead/Large/SourceMapDisabled-4              	     160	  37276950 ns/op	18305637 B/op	  196762 allocs/op
-BenchmarkSourceMapOverhead/Large/SourceMapEnabled-4               	     100	  50121579 ns/op	24069370 B/op	  257459 allocs/op
-BenchmarkParseURL_CustomClient-4                                  	    6248	    970643 ns/op	  436600 B/op	    4700 allocs/op
-BenchmarkParseURL_DefaultClient-4                                 	    5271	   1012668 ns/op	  436599 B/op	    4700 allocs/op
-BenchmarkMarshalBufferPool-4                                      	338617543	        17.75 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMarshalBufferNoPool-4                                    	 4273386	      1389 ns/op	    4144 B/op	       2 allocs/op
-BenchmarkMarshalBufferPool_LargePayload-4                         	 3951206	      1518 ns/op	       0 B/op	       0 allocs/op
-BenchmarkParameterSlice_WithPool-4                                	22752885	       252.5 ns/op	     704 B/op	       2 allocs/op
-BenchmarkParameterSlice_WithoutPool-4                             	26491123	       236.7 ns/op	     704 B/op	       2 allocs/op
-BenchmarkServerSlice_WithPool-4                                   	75579489	        80.06 ns/op	      96 B/op	       2 allocs/op
-BenchmarkServerSlice_WithoutPool-4                                	99986044	        62.72 ns/op	      96 B/op	       2 allocs/op
-BenchmarkStringSlice_WithPool-4                                   	400505751	        15.00 ns/op	       0 B/op	       0 allocs/op
+BenchmarkEquals_EarlyExit/DifferentInfo-4                	344328837	        17.57 ns/op	       0 B/op	       0 allocs/op
+BenchmarkEquals_EarlyExit/DifferentLastPath-4            	  260438	     22843 ns/op	    6696 B/op	       9 allocs/op
+BenchmarkSchemaEquals/Simple-4                           	32338567	       186.6 ns/op	       0 B/op	       0 allocs/op
+BenchmarkSchemaEquals/WithProperties-4                   	 4494268	      1338 ns/op	       0 B/op	       0 allocs/op
+BenchmarkSchemaEquals/Complex-4                          	 2560485	      2341 ns/op	     456 B/op	       3 allocs/op
+BenchmarkSchemaEquals/Nested-4                           	 5127340	      1170 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDocumentEquals/OAS3/Small-4                     	 2632564	      2278 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDocumentEquals/OAS3/Medium-4                    	  150806	     39576 ns/op	    6696 B/op	       9 allocs/op
+BenchmarkDocumentEquals/OAS3/Large-4                     	   12686	    472690 ns/op	   54152 B/op	      15 allocs/op
+BenchmarkDocumentEquals/OAS2/Small-4                     	 3145285	      1915 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDocumentEquals/OAS2/Medium-4                    	  170620	     34928 ns/op	    6696 B/op	       9 allocs/op
+BenchmarkMarshalInfo/NoExtra-4                           	 5937730	      1010 ns/op	     192 B/op	       2 allocs/op
+BenchmarkMarshalInfo/Extra1-4                            	 2810528	      2134 ns/op	     896 B/op	      16 allocs/op
+BenchmarkMarshalInfo/Extra5-4                            	 1619394	      3696 ns/op	    1376 B/op	      24 allocs/op
+BenchmarkMarshalInfo/Extra10-4                           	  889472	      6805 ns/op	    2697 B/op	      37 allocs/op
+BenchmarkMarshalInfo/Extra20-4                           	  466578	     12881 ns/op	    5228 B/op	      59 allocs/op
+BenchmarkMarshalContact/NoExtra-4                        	 5913332	      1013 ns/op	     192 B/op	       2 allocs/op
+BenchmarkMarshalContact/WithExtra-4                      	 1561108	      3838 ns/op	    1376 B/op	      24 allocs/op
+BenchmarkMarshalServer/NoExtra-4                         	 7006231	       853.6 ns/op	     160 B/op	       2 allocs/op
+BenchmarkMarshalServer/WithExtra-4                       	 1000000	      5341 ns/op	    2297 B/op	      30 allocs/op
+BenchmarkMarshalOAS3Document/Small-4                     	  141181	     41841 ns/op	    7010 B/op	      66 allocs/op
+BenchmarkMarshalOAS3Document/Medium-4                    	   12667	    473572 ns/op	   66074 B/op	     471 allocs/op
+BenchmarkMarshalOAS3Document/Large-4                     	    1060	   5667443 ns/op	  851571 B/op	    5336 allocs/op
+BenchmarkMarshalOAS2Document/Small-4                     	  161025	     37028 ns/op	    6376 B/op	      58 allocs/op
+BenchmarkMarshalOAS2Document/Medium-4                    	   15679	    382247 ns/op	   53778 B/op	     396 allocs/op
+BenchmarkUnmarshalInfo/NoExtra-4                         	 1818603	      3308 ns/op	    1176 B/op	      28 allocs/op
+BenchmarkUnmarshalInfo/WithExtra-4                       	  827292	      7152 ns/op	    1736 B/op	      46 allocs/op
+BenchmarkJSONFastPath/FastPath-4                         	    4504	   1329322 ns/op	  781996 B/op	   11513 allocs/op
+BenchmarkJSONFastPath/YAMLPath_SourceMap-4               	    1278	   4712719 ns/op	 5854262 B/op	   19888 allocs/op
+BenchmarkJSONFastPath/YAMLPath_PreserveOrder-4           	    1302	   4591954 ns/op	 5605807 B/op	   19207 allocs/op
+BenchmarkMarshalOrderedJSON/SmallOAS3-4                  	  267280	     22266 ns/op	    4818 B/op	     204 allocs/op
+BenchmarkMarshalOrderedJSON/MediumOAS3-4                 	   26342	    227800 ns/op	   49413 B/op	    1918 allocs/op
+BenchmarkMarshalOrderedJSON/LargeOAS3-4                  	    2340	   2549936 ns/op	  564441 B/op	   21156 allocs/op
+BenchmarkMarshalOrderedYAML/SmallOAS3-4                  	   53440	    112955 ns/op	  191478 B/op	     437 allocs/op
+BenchmarkMarshalOrderedYAML/MediumOAS3-4                 	    4471	   1324272 ns/op	 1830184 B/op	    3890 allocs/op
+BenchmarkMarshalOrderedYAML/LargeOAS3-4                  	     393	  14974026 ns/op	22628796 B/op	   42585 allocs/op
+BenchmarkMarshalOrderedJSONIndent-4                      	   19120	    313849 ns/op	   69924 B/op	    1919 allocs/op
+BenchmarkMarshalOrderedJSON_vs_Standard/OrderPreserving-4         	   26170	    229553 ns/op	   49415 B/op	    1918 allocs/op
+BenchmarkMarshalOrderedJSON_vs_Standard/Standard-4                	   12616	    475355 ns/op	   66100 B/op	     471 allocs/op
+BenchmarkPreserveOrderOverhead/WithPreserveOrder-4                	    1542	   3866897 ns/op	 1907831 B/op	   22375 allocs/op
+BenchmarkPreserveOrderOverhead/WithoutPreserveOrder-4             	    2049	   2933143 ns/op	 1608687 B/op	   17648 allocs/op
+BenchmarkParse/SmallOAS3-4                                        	   17254	    347739 ns/op	  208891 B/op	    2100 allocs/op
+BenchmarkParse/MediumOAS3-4                                       	    2011	   2956776 ns/op	 1622328 B/op	   17647 allocs/op
+BenchmarkParse/LargeOAS3-4                                        	     168	  35531535 ns/op	18305323 B/op	  196755 allocs/op
+BenchmarkParse/SmallOAS2-4                                        	   17792	    336224 ns/op	  185104 B/op	    2082 allocs/op
+BenchmarkParse/MediumOAS2-4                                       	    2323	   2565811 ns/op	 1386966 B/op	   16227 allocs/op
+BenchmarkParseNoValidation/SmallOAS3-4                            	   17443	    343873 ns/op	  208057 B/op	    2077 allocs/op
+BenchmarkParseNoValidation/MediumOAS3-4                           	    2044	   2960161 ns/op	 1617783 B/op	   17555 allocs/op
+BenchmarkParseBytes/SmallOAS3-4                                   	   18129	    331002 ns/op	  207131 B/op	    2095 allocs/op
+BenchmarkParseBytes/MediumOAS3-4                                  	    2025	   2951063 ns/op	 1608500 B/op	   17644 allocs/op
+BenchmarkParseCore/SmallOAS3-4                                    	   17930	    335209 ns/op	  207141 B/op	    2095 allocs/op
+BenchmarkParseCore/MediumOAS3-4                                   	    1978	   3030360 ns/op	 1608621 B/op	   17645 allocs/op
+BenchmarkParseCore/LargeOAS3-4                                    	     169	  35401576 ns/op	18141121 B/op	  196749 allocs/op
+BenchmarkParseCore/SmallOAS2-4                                    	   18582	    323539 ns/op	  183477 B/op	    2077 allocs/op
+BenchmarkParseCore/MediumOAS2-4                                   	    2328	   2541007 ns/op	 1374357 B/op	   16222 allocs/op
+BenchmarkParseWithOptions/FilePath/SmallOAS3-4                    	   17028	    352448 ns/op	  209208 B/op	    2107 allocs/op
+BenchmarkParseWithOptions/Bytes/SmallOAS3-4                       	   17983	    333892 ns/op	  207439 B/op	    2101 allocs/op
+BenchmarkParseWithOptions/ResolveRefs/SmallOAS3-4                 	   12270	    488717 ns/op	  375978 B/op	    2484 allocs/op
+BenchmarkParseReader/MediumOAS3-4                                 	    1912	   3101840 ns/op	 1671225 B/op	   17657 allocs/op
+BenchmarkParseResultCopy/SmallOAS3-4                              	  495367	     11846 ns/op	   18664 B/op	     113 allocs/op
+BenchmarkParseResolveRefs/MediumOAS3-4                            	     520	  11470702 ns/op	 7212248 B/op	   42461 allocs/op
+BenchmarkFormatBytes-4                                            	 7342730	       817.8 ns/op	      64 B/op	       8 allocs/op
+BenchmarkDeepCopy/SmallOAS3-4                                     	 1484306	      4041 ns/op	    7936 B/op	      44 allocs/op
+BenchmarkDeepCopy/MediumOAS3-4                                    	  100568	     59703 ns/op	  121603 B/op	     466 allocs/op
+BenchmarkDeepCopy/LargeOAS3-4                                     	    6538	    926627 ns/op	 1313694 B/op	    4878 allocs/op
+BenchmarkDeepCopy/SmallOAS2-4                                     	 1673851	      3579 ns/op	    6768 B/op	      38 allocs/op
+BenchmarkDeepCopy/MediumOAS2-4                                    	  113155	     50247 ns/op	  106258 B/op	     387 allocs/op
+BenchmarkSourceMapOverhead/Small/Default-4                        	   16918	    354775 ns/op	  209209 B/op	    2107 allocs/op
+BenchmarkSourceMapOverhead/Small/SourceMapDisabled-4              	   16803	    357275 ns/op	  209226 B/op	    2108 allocs/op
+BenchmarkSourceMapOverhead/Small/SourceMapEnabled-4               	   12404	    483643 ns/op	  278718 B/op	    2742 allocs/op
+BenchmarkSourceMapOverhead/Medium/Default-4                       	    1968	   3055769 ns/op	 1622779 B/op	   17656 allocs/op
+BenchmarkSourceMapOverhead/Medium/SourceMapDisabled-4             	    1957	   3052998 ns/op	 1622799 B/op	   17657 allocs/op
+BenchmarkSourceMapOverhead/Medium/SourceMapEnabled-4              	    1426	   4202335 ns/op	 2191180 B/op	   23131 allocs/op
+BenchmarkSourceMapOverhead/Large/Default-4                        	     166	  35987093 ns/op	18305605 B/op	  196761 allocs/op
+BenchmarkSourceMapOverhead/Large/SourceMapDisabled-4              	     166	  35881884 ns/op	18305647 B/op	  196763 allocs/op
+BenchmarkSourceMapOverhead/Large/SourceMapEnabled-4               	     123	  48058904 ns/op	24061012 B/op	  257458 allocs/op
+BenchmarkParseURL_CustomClient-4                                  	    6398	    939270 ns/op	  436563 B/op	    4700 allocs/op
+BenchmarkParseURL_DefaultClient-4                                 	    6231	    939566 ns/op	  436577 B/op	    4700 allocs/op
+BenchmarkMarshalBufferPool-4                                      	285399171	        20.73 ns/op	       0 B/op	       0 allocs/op
+BenchmarkMarshalBufferNoPool-4                                    	 5285533	      1203 ns/op	    4144 B/op	       2 allocs/op
+BenchmarkMarshalBufferPool_LargePayload-4                         	 4145788	      1513 ns/op	       0 B/op	       0 allocs/op
+BenchmarkParameterSlice_WithPool-4                                	26037817	       232.4 ns/op	     704 B/op	       2 allocs/op
+BenchmarkParameterSlice_WithoutPool-4                             	29464566	       208.4 ns/op	     704 B/op	       2 allocs/op
+BenchmarkServerSlice_WithPool-4                                   	75802148	        77.69 ns/op	      96 B/op	       2 allocs/op
+BenchmarkServerSlice_WithoutPool-4                                	95992588	        62.24 ns/op	      96 B/op	       2 allocs/op
+BenchmarkStringSlice_WithPool-4                                   	338147443	        17.75 ns/op	       0 B/op	       0 allocs/op
 BenchmarkStringSlice_WithoutPool-4                                	1000000000	         5.000 ns/op	       0 B/op	       0 allocs/op
-BenchmarkDeepCopyWork_WithPool-4                                  	145995547	        41.08 ns/op	       0 B/op	       0 allocs/op
-BenchmarkDeepCopyWork_WithoutPool-4                               	206257929	        29.08 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMarshalToJSON-4                                          	 5970564	      1010 ns/op	     368 B/op	      11 allocs/op
+BenchmarkDeepCopyWork_WithPool-4                                  	132848835	        45.15 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDeepCopyWork_WithoutPool-4                               	159218392	        37.70 ns/op	       0 B/op	       0 allocs/op
+BenchmarkMarshalToJSON-4                                          	 6307112	       949.4 ns/op	     368 B/op	      11 allocs/op
 PASS
-ok  	github.com/erraggy/oastools/parser	575.883s
+ok  	github.com/erraggy/oastools/parser	578.870s
 goos: linux
 goarch: amd64
 pkg: github.com/erraggy/oastools/validator
-cpu: Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
-BenchmarkValidate/SmallOAS3-4    	   18135	    328400 ns/op	  216636 B/op	    2196 allocs/op
-BenchmarkValidate/MediumOAS3-4   	    2126	   2824227 ns/op	 1678840 B/op	   18650 allocs/op
-BenchmarkValidate/LargeOAS3-4    	     168	  35531485 ns/op	18815608 B/op	  207716 allocs/op
-BenchmarkValidate/SmallOAS2-4    	   19311	    309970 ns/op	  192055 B/op	    2161 allocs/op
-BenchmarkValidate/MediumOAS2-4   	    2394	   2505905 ns/op	 1434260 B/op	   17134 allocs/op
-BenchmarkValidateNoWarnings/SmallOAS3-4         	   18336	    326972 ns/op	  216429 B/op	    2195 allocs/op
-BenchmarkValidateNoWarnings/MediumOAS3-4        	    2062	   2840412 ns/op	 1676568 B/op	   18649 allocs/op
-BenchmarkValidateNoWarnings/LargeOAS3-4         	     168	  35559121 ns/op	18814395 B/op	  207715 allocs/op
-BenchmarkValidateParsed/SmallOAS3-4             	  524744	     11429 ns/op	    6167 B/op	      92 allocs/op
-BenchmarkValidateParsed/MediumOAS3-4            	   57139	    104969 ns/op	   43203 B/op	     996 allocs/op
-BenchmarkValidateParsed/LargeOAS3-4             	    4597	   1311910 ns/op	  471224 B/op	   10947 allocs/op
-BenchmarkValidateStrictMode/SmallOAS3-4         	   18162	    330428 ns/op	  216873 B/op	    2196 allocs/op
-BenchmarkValidateStrictMode/MediumOAS3-4        	    2089	   2878416 ns/op	 1680199 B/op	   18650 allocs/op
-BenchmarkValidateStrictMode/LargeOAS3-4         	     165	  36022146 ns/op	18813800 B/op	  207715 allocs/op
-BenchmarkValidateWithOptions/FilePath/SmallOAS3-4         	   18146	    330442 ns/op	  217330 B/op	    2200 allocs/op
-BenchmarkValidateWithOptions/Parsed/SmallOAS3-4           	  520232	     11613 ns/op	    6432 B/op	      95 allocs/op
+cpu: AMD EPYC 7763 64-Core Processor                
+BenchmarkValidate/SmallOAS3-4    	   16597	    359934 ns/op	  216172 B/op	    2195 allocs/op
+BenchmarkValidate/MediumOAS3-4   	    2043	   2974532 ns/op	 1676726 B/op	   18649 allocs/op
+BenchmarkValidate/LargeOAS3-4    	     160	  36961163 ns/op	18813871 B/op	  207716 allocs/op
+BenchmarkValidate/SmallOAS2-4    	   17536	    344037 ns/op	  191696 B/op	    2161 allocs/op
+BenchmarkValidate/MediumOAS2-4   	    2244	   2640396 ns/op	 1431652 B/op	   17133 allocs/op
+BenchmarkValidateNoWarnings/SmallOAS3-4         	   16696	    359364 ns/op	  216248 B/op	    2195 allocs/op
+BenchmarkValidateNoWarnings/MediumOAS3-4        	    2023	   2973672 ns/op	 1675231 B/op	   18649 allocs/op
+BenchmarkValidateNoWarnings/LargeOAS3-4         	     162	  36820330 ns/op	18812977 B/op	  207715 allocs/op
+BenchmarkValidateParsed/SmallOAS3-4             	  490221	     12318 ns/op	    6162 B/op	      92 allocs/op
+BenchmarkValidateParsed/MediumOAS3-4            	   52294	    114972 ns/op	   43152 B/op	     996 allocs/op
+BenchmarkValidateParsed/LargeOAS3-4             	    4347	   1377885 ns/op	  470178 B/op	   10947 allocs/op
+BenchmarkValidateStrictMode/SmallOAS3-4         	   16705	    359617 ns/op	  216201 B/op	    2195 allocs/op
+BenchmarkValidateStrictMode/MediumOAS3-4        	    2005	   2966244 ns/op	 1674256 B/op	   18648 allocs/op
+BenchmarkValidateStrictMode/LargeOAS3-4         	     163	  36699483 ns/op	18810577 B/op	  207714 allocs/op
+BenchmarkValidateWithOptions/FilePath/SmallOAS3-4         	   16692	    359708 ns/op	  216431 B/op	    2199 allocs/op
+BenchmarkValidateWithOptions/Parsed/SmallOAS3-4           	  483610	     12482 ns/op	    6422 B/op	      95 allocs/op
 PASS
-ok  	github.com/erraggy/oastools/validator	95.849s
+ok  	github.com/erraggy/oastools/validator	96.013s
 goos: linux
 goarch: amd64
 pkg: github.com/erraggy/oastools/fixer
-cpu: Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
-BenchmarkFixDocuments/SmallOAS3-4         	   18526	    321601 ns/op	  219496 B/op	    2159 allocs/op
-BenchmarkFixDocuments/MediumOAS3-4        	    2120	   2812937 ns/op	 1772276 B/op	   18235 allocs/op
-BenchmarkFixDocuments/LargeOAS3-4         	     169	  35314029 ns/op	19712997 B/op	  202207 allocs/op
-BenchmarkFixDocuments/SmallOAS2-4         	   19608	    306629 ns/op	  194258 B/op	    2135 allocs/op
-BenchmarkFixDocuments/MediumOAS2-4        	    2451	   2430143 ns/op	 1511951 B/op	   16727 allocs/op
-BenchmarkFixWithInferTypes/SmallOAS3-4    	   18326	    324736 ns/op	  219627 B/op	    2160 allocs/op
-BenchmarkFixWithInferTypes/MediumOAS3-4   	    2096	   2847523 ns/op	 1772017 B/op	   18238 allocs/op
-BenchmarkFixWithInferTypes/LargeOAS3-4    	     166	  35829439 ns/op	19711256 B/op	  202207 allocs/op
-BenchmarkFixParsed/SmallOAS3-4            	  930976	      6357 ns/op	    9138 B/op	      56 allocs/op
-BenchmarkFixParsed/MediumOAS3-4           	   75360	     79770 ns/op	  136624 B/op	     580 allocs/op
-BenchmarkFixParsed/LargeOAS3-4            	    5982	   1000915 ns/op	 1379290 B/op	    5442 allocs/op
-BenchmarkFixWithOptions/FilePath/SmallOAS3-4         	   18564	    322876 ns/op	  220387 B/op	    2166 allocs/op
-BenchmarkFixWithOptions/Parsed/SmallOAS3-4           	  877741	      6691 ns/op	    9772 B/op	      61 allocs/op
-BenchmarkFix-4                                       	  550200	     10827 ns/op	   14999 B/op	     108 allocs/op
+cpu: AMD EPYC 7763 64-Core Processor                
+BenchmarkFixDocuments/SmallOAS3-4         	   16894	    359712 ns/op	  219188 B/op	    2159 allocs/op
+BenchmarkFixDocuments/MediumOAS3-4        	    2028	   2975233 ns/op	 1770726 B/op	   18234 allocs/op
+BenchmarkFixDocuments/LargeOAS3-4         	     158	  37678385 ns/op	19711737 B/op	  202207 allocs/op
+BenchmarkFixDocuments/SmallOAS2-4         	   17595	    339593 ns/op	  193963 B/op	    2135 allocs/op
+BenchmarkFixDocuments/MediumOAS2-4        	    2326	   2617431 ns/op	 1511397 B/op	   16727 allocs/op
+BenchmarkFixWithInferTypes/SmallOAS3-4    	   16652	    359982 ns/op	  219568 B/op	    2159 allocs/op
+BenchmarkFixWithInferTypes/MediumOAS3-4   	    1988	   3032957 ns/op	 1771230 B/op	   18237 allocs/op
+BenchmarkFixWithInferTypes/LargeOAS3-4    	     159	  37625057 ns/op	19713829 B/op	  202207 allocs/op
+BenchmarkFixParsed/SmallOAS3-4            	  915273	      6500 ns/op	    9133 B/op	      56 allocs/op
+BenchmarkFixParsed/MediumOAS3-4           	   76388	     78966 ns/op	  136276 B/op	     580 allocs/op
+BenchmarkFixParsed/LargeOAS3-4            	    6136	    969376 ns/op	 1379309 B/op	    5442 allocs/op
+BenchmarkFixWithOptions/FilePath/SmallOAS3-4         	   16596	    363616 ns/op	  220446 B/op	    2166 allocs/op
+BenchmarkFixWithOptions/Parsed/SmallOAS3-4           	  878158	      6743 ns/op	    9764 B/op	      61 allocs/op
+BenchmarkFix-4                                       	  544041	     11129 ns/op	   14988 B/op	     108 allocs/op
 PASS
-ok  	github.com/erraggy/oastools/fixer	83.564s
+ok  	github.com/erraggy/oastools/fixer	84.176s
 goos: linux
 goarch: amd64
 pkg: github.com/erraggy/oastools/httpvalidator
 cpu: AMD EPYC 7763 64-Core Processor                
-BenchmarkValidateRequest/SmallOAS3-4    	12307503	       490.0 ns/op	     528 B/op	       8 allocs/op
-BenchmarkValidateRequest/MediumOAS3-4   	 9336915	       606.1 ns/op	     528 B/op	       8 allocs/op
-BenchmarkValidateRequest/LargeOAS3-4    	 5398207	      1111 ns/op	     528 B/op	       8 allocs/op
-BenchmarkValidateRequestWithParams-4    	12458140	       483.5 ns/op	     528 B/op	       8 allocs/op
-BenchmarkValidateRequestWithBody-4      	 5374479	      1116 ns/op	    1520 B/op	      16 allocs/op
-BenchmarkValidateResponse-4             	25249500	       237.9 ns/op	     256 B/op	       2 allocs/op
-BenchmarkValidateStrictMode-4           	12425806	       485.5 ns/op	     528 B/op	       8 allocs/op
-BenchmarkValidateRequestWithOptions/FilePath/SmallOAS3-4         	   16788	    357526 ns/op	  218446 B/op	    2236 allocs/op
-BenchmarkValidateRequestWithOptions/Parsed/SmallOAS3-4           	  705693	      8511 ns/op	    9268 B/op	     130 allocs/op
-BenchmarkPathMatching/SmallOAS3-4                                	12137797	       491.4 ns/op	     528 B/op	       8 allocs/op
-BenchmarkPathMatching/MediumOAS3-4                               	 9298792	       644.4 ns/op	     528 B/op	       8 allocs/op
-BenchmarkPathMatching/LargeOAS3-4                                	 2621704	      2281 ns/op	     528 B/op	       8 allocs/op
-BenchmarkParameterDeserialization-4                              	12274052	       488.8 ns/op	     528 B/op	       8 allocs/op
-BenchmarkSchemaValidation-4                                      	 5334475	      1124 ns/op	    1520 B/op	      16 allocs/op
+BenchmarkValidateRequest/SmallOAS3-4    	12332338	       488.3 ns/op	     528 B/op	       8 allocs/op
+BenchmarkValidateRequest/MediumOAS3-4   	10525371	       581.6 ns/op	     528 B/op	       8 allocs/op
+BenchmarkValidateRequest/LargeOAS3-4    	 5520296	      1087 ns/op	     528 B/op	       8 allocs/op
+BenchmarkValidateRequestWithParams-4    	12612842	       466.2 ns/op	     528 B/op	       8 allocs/op
+BenchmarkValidateRequestWithBody-4      	 5604444	      1073 ns/op	    1520 B/op	      16 allocs/op
+BenchmarkValidateResponse-4             	26344497	       229.3 ns/op	     256 B/op	       2 allocs/op
+BenchmarkValidateStrictMode-4           	12871438	       465.8 ns/op	     528 B/op	       8 allocs/op
+BenchmarkValidateRequestWithOptions/FilePath/SmallOAS3-4         	   17478	    343892 ns/op	  218443 B/op	    2236 allocs/op
+BenchmarkValidateRequestWithOptions/Parsed/SmallOAS3-4           	  711781	      8145 ns/op	    9268 B/op	     130 allocs/op
+BenchmarkPathMatching/SmallOAS3-4                                	12620973	       472.3 ns/op	     528 B/op	       8 allocs/op
+BenchmarkPathMatching/MediumOAS3-4                               	 9737695	       627.6 ns/op	     528 B/op	       8 allocs/op
+BenchmarkPathMatching/LargeOAS3-4                                	 2701716	      2234 ns/op	     528 B/op	       8 allocs/op
+BenchmarkParameterDeserialization-4                              	12011838	       496.6 ns/op	     528 B/op	       8 allocs/op
+BenchmarkSchemaValidation-4                                      	 5509784	      1110 ns/op	    1520 B/op	      16 allocs/op
 PASS
-ok  	github.com/erraggy/oastools/httpvalidator	83.810s
+ok  	github.com/erraggy/oastools/httpvalidator	84.184s
 goos: linux
 goarch: amd64
 pkg: github.com/erraggy/oastools/converter
-cpu: Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
-BenchmarkConvertOAS2ToOAS3/Small-4   	   18057	    332879 ns/op	  196342 B/op	    2171 allocs/op
-BenchmarkConvertOAS2ToOAS3/Medium-4  	    2317	   2612188 ns/op	 1522430 B/op	   16932 allocs/op
-BenchmarkConvertOAS3ToOAS2/Small-4   	   17497	    345151 ns/op	  219451 B/op	    2195 allocs/op
-BenchmarkConvertOAS3ToOAS2/Medium-4  	    1974	   3035282 ns/op	 1762954 B/op	   18490 allocs/op
-BenchmarkConvertParsedOAS2ToOAS3/Small-4         	  662439	      8003 ns/op	   11138 B/op	      86 allocs/op
-BenchmarkConvertParsedOAS2ToOAS3/Medium-4        	   65652	     92055 ns/op	  135435 B/op	     702 allocs/op
-BenchmarkConvertParsedOAS3ToOAS2/Small-4         	  688350	      8985 ns/op	    9164 B/op	      92 allocs/op
-BenchmarkConvertParsedOAS3ToOAS2/Medium-4        	   55509	    108469 ns/op	  129911 B/op	     836 allocs/op
-BenchmarkConvertNoInfo/Small-4                   	   18283	    329997 ns/op	  196344 B/op	    2171 allocs/op
-BenchmarkConvertNoInfo/Medium-4                  	    2317	   2652691 ns/op	 1522454 B/op	   16932 allocs/op
-BenchmarkConvertWithOptions/FilePath/Small-4     	   18295	    326439 ns/op	  196499 B/op	    2175 allocs/op
-BenchmarkConvertWithOptions/Parsed/Small-4       	  687469	      8236 ns/op	   11467 B/op	      90 allocs/op
-BenchmarkConvertOAS30ToOAS31/Small-4             	   17440	    343982 ns/op	  217900 B/op	    2175 allocs/op
+cpu: AMD EPYC 7763 64-Core Processor                
+BenchmarkConvertOAS2ToOAS3/Small-4   	   17761	    340414 ns/op	  196341 B/op	    2171 allocs/op
+BenchmarkConvertOAS2ToOAS3/Medium-4  	    2320	   2593412 ns/op	 1522440 B/op	   16932 allocs/op
+BenchmarkConvertOAS3ToOAS2/Small-4   	   16800	    356648 ns/op	  219237 B/op	    2195 allocs/op
+BenchmarkConvertOAS3ToOAS2/Medium-4  	    2008	   3006171 ns/op	 1760490 B/op	   18489 allocs/op
+BenchmarkConvertParsedOAS2ToOAS3/Small-4         	  735494	      7843 ns/op	   11138 B/op	      86 allocs/op
+BenchmarkConvertParsedOAS2ToOAS3/Medium-4        	   64762	     92472 ns/op	  135432 B/op	     702 allocs/op
+BenchmarkConvertParsedOAS3ToOAS2/Small-4         	  668838	      9101 ns/op	    9161 B/op	      92 allocs/op
+BenchmarkConvertParsedOAS3ToOAS2/Medium-4        	   53332	    112607 ns/op	  129863 B/op	     836 allocs/op
+BenchmarkConvertNoInfo/Small-4                   	   17774	    337618 ns/op	  196341 B/op	    2171 allocs/op
+BenchmarkConvertNoInfo/Medium-4                  	    2310	   2592614 ns/op	 1522404 B/op	   16932 allocs/op
+BenchmarkConvertWithOptions/FilePath/Small-4     	   17713	    338799 ns/op	  196494 B/op	    2175 allocs/op
+BenchmarkConvertWithOptions/Parsed/Small-4       	  727710	      8123 ns/op	   11466 B/op	      90 allocs/op
+BenchmarkConvertOAS30ToOAS31/Small-4             	   17130	    350671 ns/op	  217890 B/op	    2175 allocs/op
 PASS
-ok  	github.com/erraggy/oastools/converter	77.489s
-2026/01/28 21:21:06 joiner: template execution error for schema "User": template "{{.InvalidField}}": template: rename:1:2: executing "rename" at <.InvalidField>: can't evaluate field InvalidField in type joiner.RenameContext
+ok  	github.com/erraggy/oastools/converter	77.885s
+2026/01/28 21:24:52 joiner: template execution error for schema "User": template "{{.InvalidField}}": template: rename:1:2: executing "rename" at <.InvalidField>: can't evaluate field InvalidField in type joiner.RenameContext
 goos: linux
 goarch: amd64
 pkg: github.com/erraggy/oastools/joiner
-cpu: Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
-BenchmarkCompareSchemas/SimpleSchemas-4         	21763810	       273.6 ns/op	     128 B/op	       1 allocs/op
-BenchmarkCompareSchemas/ObjectWithProperties-4  	 4427028	      1325 ns/op	     192 B/op	       3 allocs/op
-BenchmarkCompareSchemas/NestedSchemas-4         	 2689429	      2238 ns/op	     128 B/op	       1 allocs/op
-BenchmarkCompareSchemas/AllOfComposition-4      	 2683471	      2238 ns/op	     137 B/op	       4 allocs/op
-BenchmarkCompareSchemas/DeeplyNested-4          	 2557676	      2338 ns/op	     384 B/op	       2 allocs/op
-BenchmarkCompareSchemas/ShallowMode-4           	23903200	       251.0 ns/op	     128 B/op	       1 allocs/op
-BenchmarkComparePath/StringConcat-4             	49279105	       119.1 ns/op	      72 B/op	       3 allocs/op
-BenchmarkComparePath/ComparePathSlice-4         	47817546	       117.4 ns/op	     160 B/op	       2 allocs/op
-BenchmarkComparePath/ComparePathSliceDeep-4     	47381088	       133.9 ns/op	     160 B/op	       2 allocs/op
-BenchmarkCompareSchemasDifferences/SingleDifference-4         	16503643	       353.7 ns/op	     224 B/op	       2 allocs/op
-BenchmarkCompareSchemasDifferences/MultipleDifferences-4      	11827905	       482.4 ns/op	     448 B/op	       5 allocs/op
-BenchmarkCompareSchemasDifferences/NestedDifference-4         	 4626036	      1294 ns/op	     272 B/op	       3 allocs/op
-BenchmarkJoin/TwoDocs-4                                       	   24632	    244229 ns/op	  147939 B/op	    1519 allocs/op
-BenchmarkJoin/ThreeDocs-4                                     	   16510	    368073 ns/op	  219464 B/op	    2237 allocs/op
-BenchmarkJoin/FiveDocs-4                                      	    9540	    628123 ns/op	  369332 B/op	    3821 allocs/op
-BenchmarkJoinParsed/TwoDocs-4                                 	 3020362	      1978 ns/op	    1992 B/op	      22 allocs/op
-BenchmarkJoinParsed/ThreeDocs-4                               	 2480554	      2360 ns/op	    2184 B/op	      23 allocs/op
-BenchmarkJoinParsed/FiveDocs-4                                	  760123	      8273 ns/op	    6025 B/op	     110 allocs/op
-BenchmarkJoinStrategy/AcceptLeft-4                            	   24585	    240757 ns/op	  147940 B/op	    1519 allocs/op
-BenchmarkJoinStrategy/AcceptRight-4                           	   25064	    248163 ns/op	  147942 B/op	    1519 allocs/op
-BenchmarkJoinOptions/MergeArrays-4                            	   23364	    248783 ns/op	  147943 B/op	    1519 allocs/op
-BenchmarkJoinOptions/DeduplicateTags-4                        	   26035	    243592 ns/op	  147943 B/op	    1519 allocs/op
-BenchmarkJoinWithOptions/FilePaths-4                          	   22702	    259901 ns/op	  148537 B/op	    1526 allocs/op
-BenchmarkJoinWithOptions/Parsed-4                             	 2411469	      2415 ns/op	    3288 B/op	      29 allocs/op
-BenchmarkJoinWriteResult-4                                    	   27912	    228773 ns/op	   90500 B/op	     416 allocs/op
-BenchmarkJoinHelpers/DefaultConfig-4                          	134218867	        44.30 ns/op	      48 B/op	       1 allocs/op
-BenchmarkJoinHelpers/IsValidStrategy-4                        	650297192	         9.231 ns/op	       0 B/op	       0 allocs/op
-BenchmarkJoinHelpers/ValidStrategies-4                        	132605762	        44.82 ns/op	     112 B/op	       1 allocs/op
+cpu: AMD EPYC 7763 64-Core Processor                
+BenchmarkCompareSchemas/SimpleSchemas-4         	19662996	       290.0 ns/op	     128 B/op	       1 allocs/op
+BenchmarkCompareSchemas/ObjectWithProperties-4  	 4327522	      1373 ns/op	     192 B/op	       3 allocs/op
+BenchmarkCompareSchemas/NestedSchemas-4         	 2570162	      2338 ns/op	     128 B/op	       1 allocs/op
+BenchmarkCompareSchemas/AllOfComposition-4      	 2652573	      2262 ns/op	     137 B/op	       4 allocs/op
+BenchmarkCompareSchemas/DeeplyNested-4          	 2635930	      2281 ns/op	     384 B/op	       2 allocs/op
+BenchmarkCompareSchemas/ShallowMode-4           	24397002	       244.2 ns/op	     128 B/op	       1 allocs/op
+BenchmarkComparePath/StringConcat-4             	53147932	       111.7 ns/op	      72 B/op	       3 allocs/op
+BenchmarkComparePath/ComparePathSlice-4         	52776268	       113.0 ns/op	     160 B/op	       2 allocs/op
+BenchmarkComparePath/ComparePathSliceDeep-4     	46571392	       129.9 ns/op	     160 B/op	       2 allocs/op
+BenchmarkCompareSchemasDifferences/SingleDifference-4         	16831786	       355.5 ns/op	     224 B/op	       2 allocs/op
+BenchmarkCompareSchemasDifferences/MultipleDifferences-4      	12521929	       480.3 ns/op	     448 B/op	       5 allocs/op
+BenchmarkCompareSchemasDifferences/NestedDifference-4         	 4817431	      1246 ns/op	     272 B/op	       3 allocs/op
+BenchmarkJoin/TwoDocs-4                                       	   24147	    248244 ns/op	  147940 B/op	    1519 allocs/op
+BenchmarkJoin/ThreeDocs-4                                     	   16294	    368019 ns/op	  219465 B/op	    2237 allocs/op
+BenchmarkJoin/FiveDocs-4                                      	    9460	    624305 ns/op	  369329 B/op	    3821 allocs/op
+BenchmarkJoinParsed/TwoDocs-4                                 	 3379404	      1782 ns/op	    1992 B/op	      22 allocs/op
+BenchmarkJoinParsed/ThreeDocs-4                               	 2751950	      2184 ns/op	    2184 B/op	      23 allocs/op
+BenchmarkJoinParsed/FiveDocs-4                                	  779203	      7661 ns/op	    6025 B/op	     110 allocs/op
+BenchmarkJoinStrategy/AcceptLeft-4                            	   24120	    249828 ns/op	  147939 B/op	    1519 allocs/op
+BenchmarkJoinStrategy/AcceptRight-4                           	   23809	    250993 ns/op	  147938 B/op	    1519 allocs/op
+BenchmarkJoinOptions/MergeArrays-4                            	   23881	    250706 ns/op	  147938 B/op	    1519 allocs/op
+BenchmarkJoinOptions/DeduplicateTags-4                        	   24034	    249467 ns/op	  147938 B/op	    1519 allocs/op
+BenchmarkJoinWithOptions/FilePaths-4                          	   23956	    250957 ns/op	  148531 B/op	    1526 allocs/op
+BenchmarkJoinWithOptions/Parsed-4                             	 2566309	      2339 ns/op	    3288 B/op	      29 allocs/op
+BenchmarkJoinWriteResult-4                                    	   30423	    191419 ns/op	   90499 B/op	     416 allocs/op
+BenchmarkJoinHelpers/DefaultConfig-4                          	143136835	        41.97 ns/op	      48 B/op	       1 allocs/op
+BenchmarkJoinHelpers/IsValidStrategy-4                        	513647521	        11.70 ns/op	       0 B/op	       0 allocs/op
+BenchmarkJoinHelpers/ValidStrategies-4                        	139671256	        42.98 ns/op	     112 B/op	       1 allocs/op
 PASS
-ok  	github.com/erraggy/oastools/joiner	167.784s
+ok  	github.com/erraggy/oastools/joiner	167.418s
 goos: linux
 goarch: amd64
 pkg: github.com/erraggy/oastools/differ
 cpu: AMD EPYC 7763 64-Core Processor                
-BenchmarkDiff/FilePath-4     	    4965	   1186757 ns/op	  666114 B/op	    7375 allocs/op
-BenchmarkDiff/Parsed-4       	  183411	     32961 ns/op	   21723 B/op	     369 allocs/op
-BenchmarkDiffMode/Simple-4   	  174636	     32466 ns/op	   21723 B/op	     369 allocs/op
-BenchmarkDiffMode/Breaking-4 	  186447	     32471 ns/op	   21724 B/op	     369 allocs/op
-BenchmarkDiffIncludeInfo/WithInfo-4         	  185476	     32572 ns/op	   21724 B/op	     369 allocs/op
-BenchmarkDiffIncludeInfo/WithoutInfo-4      	  182373	     33106 ns/op	   23516 B/op	     370 allocs/op
-BenchmarkDiffIdentical-4                    	  226419	     26608 ns/op	   16706 B/op	     325 allocs/op
-BenchmarkDiffWithOptions/FilePath-4         	    5058	   1173647 ns/op	  666379 B/op	    7382 allocs/op
-BenchmarkChangeString-4                     	 6485133	       918.5 ns/op	     400 B/op	      15 allocs/op
+BenchmarkDiff/FilePath-4     	    5041	   1175340 ns/op	  666101 B/op	    7374 allocs/op
+BenchmarkDiff/Parsed-4       	  186656	     32179 ns/op	   21723 B/op	     369 allocs/op
+BenchmarkDiffMode/Simple-4   	  187492	     32149 ns/op	   21723 B/op	     369 allocs/op
+BenchmarkDiffMode/Breaking-4 	  185900	     32448 ns/op	   21723 B/op	     369 allocs/op
+BenchmarkDiffIncludeInfo/WithInfo-4         	  186844	     32485 ns/op	   21723 B/op	     369 allocs/op
+BenchmarkDiffIncludeInfo/WithoutInfo-4      	  182107	     32901 ns/op	   23516 B/op	     370 allocs/op
+BenchmarkDiffIdentical-4                    	  224775	     26446 ns/op	   16706 B/op	     325 allocs/op
+BenchmarkDiffWithOptions/FilePath-4         	    5122	   1166911 ns/op	  666380 B/op	    7382 allocs/op
+BenchmarkChangeString-4                     	 6545850	       913.9 ns/op	     400 B/op	      15 allocs/op
 PASS
-ok  	github.com/erraggy/oastools/differ	53.711s
+ok  	github.com/erraggy/oastools/differ	54.007s
 goos: linux
 goarch: amd64
 pkg: github.com/erraggy/oastools/generator
 cpu: AMD EPYC 7763 64-Core Processor                
-BenchmarkGenerate/Types-4               	    2360	   2543512 ns/op	   83645 B/op	    1434 allocs/op
-BenchmarkGenerate/Client-4              	     930	   6465395 ns/op	  441000 B/op	    8903 allocs/op
-BenchmarkGenerate/Server-4              	    1168	   5108892 ns/op	  179005 B/op	    2758 allocs/op
-BenchmarkGenerate/All-4                 	     690	   8717235 ns/op	  491380 B/op	    8787 allocs/op
-BenchmarkTemplateBuffer_WithPool-4      	275911966	        21.76 ns/op	       0 B/op	       0 allocs/op
-BenchmarkTemplateBuffer_WithoutPool-4   	  726207	     10100 ns/op	   32816 B/op	       2 allocs/op
+BenchmarkGenerate/Types-4               	    2253	   2653527 ns/op	   83675 B/op	    1434 allocs/op
+BenchmarkGenerate/Client-4              	     896	   6699209 ns/op	  441215 B/op	    8903 allocs/op
+BenchmarkGenerate/Server-4              	    1126	   5323047 ns/op	  178319 B/op	    2758 allocs/op
+BenchmarkGenerate/All-4                 	     662	   9138971 ns/op	  491304 B/op	    8787 allocs/op
+BenchmarkTemplateBuffer_WithPool-4      	279066172	        21.56 ns/op	       0 B/op	       0 allocs/op
+BenchmarkTemplateBuffer_WithoutPool-4   	  681027	      9881 ns/op	   32816 B/op	       2 allocs/op
 PASS
-ok  	github.com/erraggy/oastools/generator	39.260s
+ok  	github.com/erraggy/oastools/generator	38.787s
 goos: linux
 goarch: amd64
 pkg: github.com/erraggy/oastools/builder
 cpu: AMD EPYC 7763 64-Core Processor                
-BenchmarkBuilderNew-4                   	 9002572	       665.3 ns/op	    1152 B/op	      18 allocs/op
-BenchmarkBuilderSetInfo-4               	 8424160	       733.1 ns/op	    1264 B/op	      19 allocs/op
-BenchmarkSchemaFrom/Primitive-4         	 6928246	       869.6 ns/op	    2048 B/op	      19 allocs/op
-BenchmarkSchemaFrom/Struct-4            	  651955	      9271 ns/op	   17400 B/op	      92 allocs/op
-BenchmarkSchemaFrom/NestedStruct-4      	  436076	     13595 ns/op	   26600 B/op	     110 allocs/op
-BenchmarkSchemaFrom/Slice-4             	  639344	      9449 ns/op	   18296 B/op	      93 allocs/op
-BenchmarkSchemaFrom/Map-4               	  636804	      9472 ns/op	   18296 B/op	      93 allocs/op
-BenchmarkBuilderAddOperation/Simple-4   	  511015	     11528 ns/op	   21205 B/op	     117 allocs/op
-BenchmarkBuilderAddOperation/WithParams-4         	  371367	     16090 ns/op	   29831 B/op	     159 allocs/op
-BenchmarkBuilderAddOperation/WithRequestBody-4    	  305916	     19555 ns/op	   35945 B/op	     170 allocs/op
-BenchmarkBuilderBuild-4                           	  279396	     21519 ns/op	   38449 B/op	     232 allocs/op
-BenchmarkBuilderMarshal/YAML-4                    	   71196	     83792 ns/op	   94575 B/op	     500 allocs/op
-BenchmarkBuilderMarshal/JSON-4                    	  143384	     41771 ns/op	    8500 B/op	      38 allocs/op
-BenchmarkOASTag/Apply-4                           	 9194613	       653.3 ns/op	    1280 B/op	       7 allocs/op
-BenchmarkOASTag/Parse-4                           	15383186	       390.3 ns/op	     368 B/op	       4 allocs/op
-BenchmarkBuilderFormParams/OAS2-4                 	 1000000	      5881 ns/op	   12187 B/op	      84 allocs/op
-BenchmarkBuilderFormParams/OAS3-4                 	  891150	      6813 ns/op	   15348 B/op	      90 allocs/op
-BenchmarkSchemaNaming/default-4                   	 1000000	      5600 ns/op	   10698 B/op	      63 allocs/op
-BenchmarkSchemaNaming/pascal-4                    	 1000000	      5799 ns/op	   10722 B/op	      66 allocs/op
-BenchmarkSchemaNaming/camel-4                     	 1000000	      5902 ns/op	   10738 B/op	      67 allocs/op
-BenchmarkSchemaNaming/snake-4                     	 1000000	      5829 ns/op	   10730 B/op	      66 allocs/op
-BenchmarkSchemaNaming/kebab-4                     	 1000000	      5907 ns/op	   10746 B/op	      67 allocs/op
-BenchmarkSchemaNaming/type_only-4                 	 1000000	      5554 ns/op	   10658 B/op	      62 allocs/op
-BenchmarkSchemaNaming/full_path-4                 	 1000000	      5667 ns/op	   10754 B/op	      63 allocs/op
-BenchmarkGenericNaming/underscore-4               	  723697	      8146 ns/op	   13195 B/op	      81 allocs/op
-BenchmarkGenericNaming/of-4                       	  746132	      8122 ns/op	   13195 B/op	      81 allocs/op
-BenchmarkGenericNaming/for-4                      	  743770	      8122 ns/op	   13219 B/op	      81 allocs/op
-BenchmarkGenericNaming/flat-4                     	  750145	      8038 ns/op	   13179 B/op	      80 allocs/op
-BenchmarkGenericNaming/angle_brackets-4           	  753928	      8115 ns/op	   13195 B/op	      81 allocs/op
-BenchmarkSchemaNameTemplate/simple-4              	  361861	     16506 ns/op	   20094 B/op	     136 allocs/op
-BenchmarkSchemaNameTemplate/pascal-4              	  256029	     23542 ns/op	   21190 B/op	     179 allocs/op
-BenchmarkSchemaNameTemplate/complex-4             	  229800	     26251 ns/op	   21822 B/op	     195 allocs/op
-BenchmarkSchemaNameTemplate/generic_aware-4       	  263494	     22747 ns/op	   21245 B/op	     173 allocs/op
-BenchmarkCaseConversions/toPascalCase-4           	33156855	       178.8 ns/op	      56 B/op	       3 allocs/op
-BenchmarkCaseConversions/toCamelCase-4            	16995391	       353.0 ns/op	      80 B/op	       4 allocs/op
-BenchmarkCaseConversions/toSnakeCase-4            	29049416	       206.1 ns/op	      56 B/op	       3 allocs/op
-BenchmarkCaseConversions/toKebabCase-4            	20648290	       288.9 ns/op	      80 B/op	       4 allocs/op
-BenchmarkCaseConversions_Separators/toPascalCase-4         	29430796	       203.5 ns/op	      56 B/op	       3 allocs/op
-BenchmarkCaseConversions_Separators/toCamelCase-4          	14814456	       405.7 ns/op	      88 B/op	       4 allocs/op
-BenchmarkCaseConversions_Separators/toSnakeCase-4          	25066957	       230.9 ns/op	      56 B/op	       3 allocs/op
-BenchmarkCaseConversions_Separators/toKebabCase-4          	18290103	       327.8 ns/op	      88 B/op	       4 allocs/op
-BenchmarkExtractGenericParams/simple-4                     	68980689	        85.35 ns/op	      24 B/op	       2 allocs/op
-BenchmarkExtractGenericParams/multi-4                      	34316064	       173.3 ns/op	      64 B/op	       4 allocs/op
-BenchmarkExtractGenericParams/nested-4                     	39180590	       153.2 ns/op	      40 B/op	       3 allocs/op
-BenchmarkExtractGenericParams/triple-4                     	28901389	       207.4 ns/op	     136 B/op	       6 allocs/op
-BenchmarkExtractGenericParams/deeply_nested-4              	23890117	       251.6 ns/op	      72 B/op	       4 allocs/op
-BenchmarkExtractGenericParams/none-4                       	461617178	        13.01 ns/op	       0 B/op	       0 allocs/op
-BenchmarkExtractBaseTypeName/generic-4                     	964519435	         6.230 ns/op	       0 B/op	       0 allocs/op
-BenchmarkExtractBaseTypeName/non_generic-4                 	916759009	         6.563 ns/op	       0 B/op	       0 allocs/op
-BenchmarkExtractBaseTypeName/nested-4                      	877455154	         6.853 ns/op	       0 B/op	       0 allocs/op
-BenchmarkSanitizeSchemaName/clean-4                        	99765030	        60.27 ns/op	       0 B/op	       0 allocs/op
-BenchmarkSanitizeSchemaName/brackets-4                     	41185750	       145.3 ns/op	      32 B/op	       2 allocs/op
-BenchmarkSanitizeSchemaName/complex-4                      	22107559	       271.4 ns/op	      96 B/op	       4 allocs/op
-BenchmarkSanitizeSchemaName/spaces-4                       	52116650	       114.0 ns/op	      16 B/op	       1 allocs/op
-BenchmarkSchemaNamer_Name/default_simple-4                 	27831255	       214.9 ns/op	      72 B/op	       2 allocs/op
-BenchmarkSchemaNamer_Name/default_generic-4                	 6320281	       948.3 ns/op	     272 B/op	      10 allocs/op
-BenchmarkSchemaNamer_Name/pascal_simple-4                  	16181766	       369.4 ns/op	      96 B/op	       5 allocs/op
-BenchmarkSchemaNamer_Name/pascal_generic-4                 	 4996768	      1206 ns/op	     336 B/op	      14 allocs/op
-BenchmarkSchemaNamer_Name/snake_nested-4                   	15107952	       397.3 ns/op	     104 B/op	       5 allocs/op
-BenchmarkSchemaNamer_BuildContext/simple-4                 	35035557	       150.4 ns/op	      48 B/op	       1 allocs/op
-BenchmarkSchemaNamer_BuildContext/generic-4                	 6734024	       889.2 ns/op	     240 B/op	       9 allocs/op
-BenchmarkSchemaNamer_BuildContext/nested_generic-4         	 6727986	       888.4 ns/op	     240 B/op	       9 allocs/op
-BenchmarkGenericNamingConfig/default-4                     	  720352	      8199 ns/op	   13243 B/op	      81 allocs/op
-BenchmarkGenericNamingConfig/of_strategy-4                 	  731918	      8201 ns/op	   13243 B/op	      81 allocs/op
-BenchmarkGenericNamingConfig/include_package-4             	  727279	      8384 ns/op	   13443 B/op	      82 allocs/op
-BenchmarkGenericNamingConfig/apply_casing-4                	  729286	      8187 ns/op	   13243 B/op	      81 allocs/op
-BenchmarkGenericNamingConfig/custom_separators-4           	  746234	      8166 ns/op	   13267 B/op	      81 allocs/op
-BenchmarkBuilderWithNamingOptions/default-4                	  385046	     15295 ns/op	   26391 B/op	     139 allocs/op
-BenchmarkBuilderWithNamingOptions/with_pascal_naming-4     	  378579	     15943 ns/op	   26527 B/op	     150 allocs/op
-BenchmarkBuilderWithNamingOptions/with_template-4          	  180674	     33409 ns/op	   34946 B/op	     252 allocs/op
-BenchmarkBuilderWithNamingOptions/with_custom_func-4       	  377980	     15832 ns/op	   26527 B/op	     150 allocs/op
-BenchmarkBuilderWithNamingOptions/combined_pascal_of-4     	  376616	     15877 ns/op	   26543 B/op	     151 allocs/op
-BenchmarkSchemaNameFunc/simple_func_non_generic-4          	36721590	       161.2 ns/op	      48 B/op	       1 allocs/op
-BenchmarkSchemaNameFunc/simple_func_generic-4              	 6599072	       910.7 ns/op	     240 B/op	       9 allocs/op
-BenchmarkSchemaNameFunc/complex_func_non_generic-4         	20681869	       290.4 ns/op	      80 B/op	       3 allocs/op
-BenchmarkSchemaNameFunc/complex_func_generic-4             	 6408376	       936.0 ns/op	     264 B/op	      10 allocs/op
-BenchmarkFormatGenericSuffix/underscore-4                  	64515172	        91.96 ns/op	      32 B/op	       2 allocs/op
-BenchmarkFormatGenericSuffix/of-4                          	63511388	        92.33 ns/op	      32 B/op	       2 allocs/op
-BenchmarkFormatGenericSuffix/for-4                         	64837197	        92.33 ns/op	      32 B/op	       2 allocs/op
-BenchmarkFormatGenericSuffix/flat-4                        	150296946	        39.90 ns/op	      16 B/op	       1 allocs/op
-BenchmarkFormatGenericSuffix/angle-4                       	65628631	        91.57 ns/op	      32 B/op	       2 allocs/op
-BenchmarkSanitizeGenericParams/exclude_package-4           	26464878	       226.6 ns/op	      48 B/op	       1 allocs/op
-BenchmarkSanitizeGenericParams/include_package-4           	14932868	       401.5 ns/op	      96 B/op	       4 allocs/op
-BenchmarkSanitizeGenericParams/apply_casing-4              	14605407	       409.9 ns/op	      72 B/op	       4 allocs/op
-BenchmarkTemplateParsing/simple-4                          	 1000000	      5846 ns/op	    6041 B/op	      45 allocs/op
-BenchmarkTemplateParsing/pascal-4                          	  676483	      8824 ns/op	    6673 B/op	      66 allocs/op
-BenchmarkTemplateParsing/complex-4                         	  556206	     10745 ns/op	    7233 B/op	      81 allocs/op
-BenchmarkTemplateParsing/full-4                            	  603603	      9939 ns/op	    7249 B/op	      77 allocs/op
-BenchmarkSanitizePath/short-4                              	437193152	        13.72 ns/op	       0 B/op	       0 allocs/op
-BenchmarkSanitizePath/medium-4                             	84326728	        69.89 ns/op	      24 B/op	       1 allocs/op
-BenchmarkSanitizePath/long-4                               	56164750	       107.3 ns/op	      64 B/op	       1 allocs/op
+BenchmarkBuilderNew-4                   	 8994580	       674.0 ns/op	    1152 B/op	      18 allocs/op
+BenchmarkBuilderSetInfo-4               	 8404666	       714.0 ns/op	    1264 B/op	      19 allocs/op
+BenchmarkSchemaFrom/Primitive-4         	 6918523	       867.9 ns/op	    2048 B/op	      19 allocs/op
+BenchmarkSchemaFrom/Struct-4            	  647052	      9293 ns/op	   17400 B/op	      92 allocs/op
+BenchmarkSchemaFrom/NestedStruct-4      	  394927	     13637 ns/op	   26600 B/op	     110 allocs/op
+BenchmarkSchemaFrom/Slice-4             	  632378	      9509 ns/op	   18296 B/op	      93 allocs/op
+BenchmarkSchemaFrom/Map-4               	  628344	      9495 ns/op	   18296 B/op	      93 allocs/op
+BenchmarkBuilderAddOperation/Simple-4   	  520714	     11609 ns/op	   21205 B/op	     117 allocs/op
+BenchmarkBuilderAddOperation/WithParams-4         	  376707	     15895 ns/op	   29831 B/op	     159 allocs/op
+BenchmarkBuilderAddOperation/WithRequestBody-4    	  307615	     19609 ns/op	   35945 B/op	     170 allocs/op
+BenchmarkBuilderBuild-4                           	  278216	     21716 ns/op	   38449 B/op	     232 allocs/op
+BenchmarkBuilderMarshal/YAML-4                    	   70519	     84245 ns/op	   94574 B/op	     500 allocs/op
+BenchmarkBuilderMarshal/JSON-4                    	  140004	     42365 ns/op	    8501 B/op	      38 allocs/op
+BenchmarkOASTag/Apply-4                           	 9178789	       654.5 ns/op	    1280 B/op	       7 allocs/op
+BenchmarkOASTag/Parse-4                           	15487754	       389.6 ns/op	     368 B/op	       4 allocs/op
+BenchmarkBuilderFormParams/OAS2-4                 	  998650	      5913 ns/op	   12187 B/op	      84 allocs/op
+BenchmarkBuilderFormParams/OAS3-4                 	  876271	      6839 ns/op	   15348 B/op	      90 allocs/op
+BenchmarkSchemaNaming/default-4                   	 1000000	      5609 ns/op	   10698 B/op	      63 allocs/op
+BenchmarkSchemaNaming/pascal-4                    	 1000000	      5791 ns/op	   10722 B/op	      66 allocs/op
+BenchmarkSchemaNaming/camel-4                     	 1000000	      5910 ns/op	   10738 B/op	      67 allocs/op
+BenchmarkSchemaNaming/snake-4                     	 1000000	      5826 ns/op	   10730 B/op	      66 allocs/op
+BenchmarkSchemaNaming/kebab-4                     	 1000000	      5918 ns/op	   10746 B/op	      67 allocs/op
+BenchmarkSchemaNaming/type_only-4                 	 1000000	      5532 ns/op	   10658 B/op	      62 allocs/op
+BenchmarkSchemaNaming/full_path-4                 	 1000000	      5613 ns/op	   10754 B/op	      63 allocs/op
+BenchmarkGenericNaming/underscore-4               	  733825	      8147 ns/op	   13195 B/op	      81 allocs/op
+BenchmarkGenericNaming/of-4                       	  734259	      8214 ns/op	   13195 B/op	      81 allocs/op
+BenchmarkGenericNaming/for-4                      	  728452	      8278 ns/op	   13219 B/op	      81 allocs/op
+BenchmarkGenericNaming/flat-4                     	  748380	      8136 ns/op	   13179 B/op	      80 allocs/op
+BenchmarkGenericNaming/angle_brackets-4           	  734550	      8209 ns/op	   13195 B/op	      81 allocs/op
+BenchmarkSchemaNameTemplate/simple-4              	  350880	     16886 ns/op	   20093 B/op	     136 allocs/op
+BenchmarkSchemaNameTemplate/pascal-4              	  248860	     24010 ns/op	   21190 B/op	     179 allocs/op
+BenchmarkSchemaNameTemplate/complex-4             	  223502	     26887 ns/op	   21822 B/op	     195 allocs/op
+BenchmarkSchemaNameTemplate/generic_aware-4       	  255388	     23237 ns/op	   21245 B/op	     173 allocs/op
+BenchmarkCaseConversions/toPascalCase-4           	33217474	       179.7 ns/op	      56 B/op	       3 allocs/op
+BenchmarkCaseConversions/toCamelCase-4            	17150092	       352.3 ns/op	      80 B/op	       4 allocs/op
+BenchmarkCaseConversions/toSnakeCase-4            	28975419	       208.7 ns/op	      56 B/op	       3 allocs/op
+BenchmarkCaseConversions/toKebabCase-4            	20452783	       291.9 ns/op	      80 B/op	       4 allocs/op
+BenchmarkCaseConversions_Separators/toPascalCase-4         	28917292	       206.3 ns/op	      56 B/op	       3 allocs/op
+BenchmarkCaseConversions_Separators/toCamelCase-4          	14573014	       410.6 ns/op	      88 B/op	       4 allocs/op
+BenchmarkCaseConversions_Separators/toSnakeCase-4          	25748852	       235.0 ns/op	      56 B/op	       3 allocs/op
+BenchmarkCaseConversions_Separators/toKebabCase-4          	18111477	       332.7 ns/op	      88 B/op	       4 allocs/op
+BenchmarkExtractGenericParams/simple-4                     	68091236	        86.45 ns/op	      24 B/op	       2 allocs/op
+BenchmarkExtractGenericParams/multi-4                      	34101036	       177.2 ns/op	      64 B/op	       4 allocs/op
+BenchmarkExtractGenericParams/nested-4                     	38227866	       155.1 ns/op	      40 B/op	       3 allocs/op
+BenchmarkExtractGenericParams/triple-4                     	28901887	       208.7 ns/op	     136 B/op	       6 allocs/op
+BenchmarkExtractGenericParams/deeply_nested-4              	23392930	       256.7 ns/op	      72 B/op	       4 allocs/op
+BenchmarkExtractGenericParams/none-4                       	461309020	        13.03 ns/op	       0 B/op	       0 allocs/op
+BenchmarkExtractBaseTypeName/generic-4                     	963880443	         6.237 ns/op	       0 B/op	       0 allocs/op
+BenchmarkExtractBaseTypeName/non_generic-4                 	917354172	         6.578 ns/op	       0 B/op	       0 allocs/op
+BenchmarkExtractBaseTypeName/nested-4                      	877745590	         6.860 ns/op	       0 B/op	       0 allocs/op
+BenchmarkSanitizeSchemaName/clean-4                        	100000000	        60.17 ns/op	       0 B/op	       0 allocs/op
+BenchmarkSanitizeSchemaName/brackets-4                     	40990056	       146.3 ns/op	      32 B/op	       2 allocs/op
+BenchmarkSanitizeSchemaName/complex-4                      	21627298	       277.1 ns/op	      96 B/op	       4 allocs/op
+BenchmarkSanitizeSchemaName/spaces-4                       	51374743	       115.2 ns/op	      16 B/op	       1 allocs/op
+BenchmarkSchemaNamer_Name/default_simple-4                 	27584914	       216.1 ns/op	      72 B/op	       2 allocs/op
+BenchmarkSchemaNamer_Name/default_generic-4                	 6302907	       956.7 ns/op	     272 B/op	      10 allocs/op
+BenchmarkSchemaNamer_Name/pascal_simple-4                  	15996738	       371.6 ns/op	      96 B/op	       5 allocs/op
+BenchmarkSchemaNamer_Name/pascal_generic-4                 	 4936992	      1219 ns/op	     336 B/op	      14 allocs/op
+BenchmarkSchemaNamer_Name/snake_nested-4                   	15024828	       401.1 ns/op	     104 B/op	       5 allocs/op
+BenchmarkSchemaNamer_BuildContext/simple-4                 	39266432	       150.2 ns/op	      48 B/op	       1 allocs/op
+BenchmarkSchemaNamer_BuildContext/generic-4                	 6710914	       895.3 ns/op	     240 B/op	       9 allocs/op
+BenchmarkSchemaNamer_BuildContext/nested_generic-4         	 6670425	       896.4 ns/op	     240 B/op	       9 allocs/op
+BenchmarkGenericNamingConfig/default-4                     	  721616	      8205 ns/op	   13243 B/op	      81 allocs/op
+BenchmarkGenericNamingConfig/of_strategy-4                 	  721363	      8247 ns/op	   13243 B/op	      81 allocs/op
+BenchmarkGenericNamingConfig/include_package-4             	  713124	      8386 ns/op	   13443 B/op	      82 allocs/op
+BenchmarkGenericNamingConfig/apply_casing-4                	  744700	      8194 ns/op	   13243 B/op	      81 allocs/op
+BenchmarkGenericNamingConfig/custom_separators-4           	  729075	      8173 ns/op	   13267 B/op	      81 allocs/op
+BenchmarkBuilderWithNamingOptions/default-4                	  393566	     15320 ns/op	   26391 B/op	     139 allocs/op
+BenchmarkBuilderWithNamingOptions/with_pascal_naming-4     	  380439	     15931 ns/op	   26527 B/op	     150 allocs/op
+BenchmarkBuilderWithNamingOptions/with_template-4          	  177901	     33574 ns/op	   34945 B/op	     252 allocs/op
+BenchmarkBuilderWithNamingOptions/with_custom_func-4       	  379333	     15936 ns/op	   26527 B/op	     150 allocs/op
+BenchmarkBuilderWithNamingOptions/combined_pascal_of-4     	  374136	     16201 ns/op	   26543 B/op	     151 allocs/op
+BenchmarkSchemaNameFunc/simple_func_non_generic-4          	36391004	       162.5 ns/op	      48 B/op	       1 allocs/op
+BenchmarkSchemaNameFunc/simple_func_generic-4              	 6540121	       920.1 ns/op	     240 B/op	       9 allocs/op
+BenchmarkSchemaNameFunc/complex_func_non_generic-4         	20454723	       294.3 ns/op	      80 B/op	       3 allocs/op
+BenchmarkSchemaNameFunc/complex_func_generic-4             	 6289950	       954.9 ns/op	     264 B/op	      10 allocs/op
+BenchmarkFormatGenericSuffix/underscore-4                  	64476576	        92.10 ns/op	      32 B/op	       2 allocs/op
+BenchmarkFormatGenericSuffix/of-4                          	64818270	        93.25 ns/op	      32 B/op	       2 allocs/op
+BenchmarkFormatGenericSuffix/for-4                         	63608754	        92.90 ns/op	      32 B/op	       2 allocs/op
+BenchmarkFormatGenericSuffix/flat-4                        	148456507	        40.42 ns/op	      16 B/op	       1 allocs/op
+BenchmarkFormatGenericSuffix/angle-4                       	65093722	        92.31 ns/op	      32 B/op	       2 allocs/op
+BenchmarkSanitizeGenericParams/exclude_package-4           	25967482	       230.5 ns/op	      48 B/op	       1 allocs/op
+BenchmarkSanitizeGenericParams/include_package-4           	14646624	       406.2 ns/op	      96 B/op	       4 allocs/op
+BenchmarkSanitizeGenericParams/apply_casing-4              	14374006	       413.5 ns/op	      72 B/op	       4 allocs/op
+BenchmarkTemplateParsing/simple-4                          	  977869	      5952 ns/op	    6041 B/op	      45 allocs/op
+BenchmarkTemplateParsing/pascal-4                          	  672175	      9018 ns/op	    6673 B/op	      66 allocs/op
+BenchmarkTemplateParsing/complex-4                         	  538243	     11027 ns/op	    7233 B/op	      81 allocs/op
+BenchmarkTemplateParsing/full-4                            	  595100	     10042 ns/op	    7249 B/op	      77 allocs/op
+BenchmarkSanitizePath/short-4                              	436432939	        13.73 ns/op	       0 B/op	       0 allocs/op
+BenchmarkSanitizePath/medium-4                             	84610398	        70.77 ns/op	      24 B/op	       1 allocs/op
+BenchmarkSanitizePath/long-4                               	54427873	       108.8 ns/op	      64 B/op	       1 allocs/op
 PASS
-ok  	github.com/erraggy/oastools/builder	542.642s
+ok  	github.com/erraggy/oastools/builder	542.999s
 goos: linux
 goarch: amd64
 pkg: github.com/erraggy/oastools/walker
-cpu: Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
-BenchmarkWalk_WithPooling-4          	 2865999	      2081 ns/op	     856 B/op	      16 allocs/op
-BenchmarkWalk_WithMapRefTracking-4   	 3890941	      1479 ns/op	     784 B/op	      11 allocs/op
-BenchmarkWalk_WithParentTracking/without_parent_tracking-4         	 1781836	      3354 ns/op	    1272 B/op	      21 allocs/op
-BenchmarkWalk_WithParentTracking/with_parent_tracking-4            	 1605891	      3786 ns/op	    1904 B/op	      33 allocs/op
-BenchmarkWalk_WithPostHandler-4                                    	   64784	     88846 ns/op	   32278 B/op	     708 allocs/op
-BenchmarkWalk_WithRefTracking-4                                    	 2435041	      2457 ns/op	     928 B/op	      14 allocs/op
-BenchmarkWalk_WithoutRefTracking-4                                 	 2319597	      2615 ns/op	     880 B/op	      13 allocs/op
-BenchmarkWalkSmallDocument-4                                       	 3915704	      1520 ns/op	     720 B/op	      12 allocs/op
-BenchmarkWalkMediumDocument-4                                      	   74599	     80762 ns/op	   20340 B/op	     457 allocs/op
-BenchmarkWalkNoHandlers-4                                          	 6230446	       930.5 ns/op	     616 B/op	       8 allocs/op
-BenchmarkWalkAllHandlers-4                                         	 2644518	      2320 ns/op	    1016 B/op	      27 allocs/op
-BenchmarkWalkSchemaOnly-4                                          	 2933240	      2041 ns/op	     864 B/op	      12 allocs/op
-BenchmarkWalkWithStop-4                                            	  714438	      8219 ns/op	    2232 B/op	       6 allocs/op
-BenchmarkWalkOAS2-4                                                	 3923032	      1597 ns/op	     744 B/op	      13 allocs/op
+cpu: AMD EPYC 7763 64-Core Processor                
+BenchmarkWalk_WithPooling-4          	 3018140	      2007 ns/op	     856 B/op	      16 allocs/op
+BenchmarkWalk_WithMapRefTracking-4   	 4269792	      1408 ns/op	     784 B/op	      11 allocs/op
+BenchmarkWalk_WithParentTracking/without_parent_tracking-4         	 1892204	      3154 ns/op	    1272 B/op	      21 allocs/op
+BenchmarkWalk_WithParentTracking/with_parent_tracking-4            	 1626183	      3681 ns/op	    1904 B/op	      33 allocs/op
+BenchmarkWalk_WithPostHandler-4                                    	   69532	     87155 ns/op	   32278 B/op	     708 allocs/op
+BenchmarkWalk_WithRefTracking-4                                    	 2602509	      2301 ns/op	     928 B/op	      14 allocs/op
+BenchmarkWalk_WithoutRefTracking-4                                 	 2508116	      2394 ns/op	     880 B/op	      13 allocs/op
+BenchmarkWalkSmallDocument-4                                       	 4163646	      1445 ns/op	     720 B/op	      12 allocs/op
+BenchmarkWalkMediumDocument-4                                      	   74662	     79228 ns/op	   20340 B/op	     457 allocs/op
+BenchmarkWalkNoHandlers-4                                          	 6941643	       866.2 ns/op	     616 B/op	       8 allocs/op
+BenchmarkWalkAllHandlers-4                                         	 2445313	      2459 ns/op	    1016 B/op	      27 allocs/op
+BenchmarkWalkSchemaOnly-4                                          	 3422091	      1769 ns/op	     864 B/op	      12 allocs/op
+BenchmarkWalkWithStop-4                                            	  758894	      7745 ns/op	    2232 B/op	       6 allocs/op
+BenchmarkWalkOAS2-4                                                	 4004554	      1498 ns/op	     744 B/op	      13 allocs/op
 PASS
-ok  	github.com/erraggy/oastools/walker	83.637s
+ok  	github.com/erraggy/oastools/walker	83.977s


### PR DESCRIPTION
## Summary

Prepare v1.48.1 release with performance optimizations for path building.

### Changes since v1.48.0

| Commit | Type | Description |
|--------|------|-------------|
| e1a170b | perf | Migrate validator, fixer, builder, joiner to pathutil (#289) |
| 47200e6 | feat | Add internal/pathutil package for efficient path building (#288) |
| a66defe | perf | Reduce allocations in joiner's pathJoin and compareDeep (#287) |

### Pre-release Validation

| Check | Status |
|-------|--------|
| Quick benchmarks | ✅ No regressions |
| Full CI benchmarks | ✅ Completed |
| Documentation | ✅ No updates needed |
| Code review | ✅ APPROVED |
| Godoc examples | ✅ All 58 pass |
| Tests | ✅ 8,056 pass |
| Lint | ✅ 0 issues |
| Security (govulncheck) | ✅ Clean |

### Release Classification

**Patch release** - Internal performance optimizations only, no public API changes.

---

🤖 Generated with [Claude Code](https://claude.ai/code)