### PR TITLE
feat: trigger oastools-web dependency update on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,3 +31,12 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+
+      - name: Trigger oastools-web dependency update
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.OASTOOLS_WEB_PAT }}
+        run: |
+          gh api repos/erraggy/oastools-web/dispatches \
+            -f event_type=oastools-release \
+            -f 'client_payload[version]=${{ github.ref_name }}'


### PR DESCRIPTION
## Summary
- Adds `repository_dispatch` step to release workflow after GoReleaser succeeds
- Fires `oastools-release` event to `erraggy/oastools-web` with the version tag in the payload
- Uses `OASTOOLS_WEB_PAT` secret (fine-grained PAT, already configured)

## Test plan
- [ ] Merge companion PR in oastools-web first (adds the receiving workflow)
- [ ] Next oastools release will trigger the full pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined release workflow to improve operational efficiency and post-release processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->