### PR TITLE
fix: suppress benchmark log warnings and add missing README dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,10 +253,11 @@ For complete API documentation and examples, see [pkg.go.dev](https://pkg.go.dev
 ```
 github.com/erraggy/oastools
 ├── go.yaml.in/yaml/v4  (YAML parsing)
+├── golang.org/x/text   (Title casing)
 └── golang.org/x/tools  (Code generation - imports analysis)
 ```
 
-Unlike many OpenAPI tools that pull in dozens of transitive dependencies, oastools is designed to be self-contained. The `stretchr/testify` dependency is test-only and not included in your production builds.
+Unlike many OpenAPI tools that pull in dozens of transitive dependencies, oastools is designed to be self-contained. The `stretchr/testify` dependency is test-only and not included in your production builds. The `golang.org/x/text` and `golang.org/x/tools` packages are the only non-YAML production dependencies.
 
 ### Battle-Tested Quality
 

--- a/joiner/joiner_test.go
+++ b/joiner/joiner_test.go
@@ -1,6 +1,8 @@
 package joiner
 
 import (
+	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1199,6 +1201,11 @@ func TestJoinWithOptions_NewStrategies(t *testing.T) {
 	})
 
 	t.Run("with invalid template falls back to default", func(t *testing.T) {
+		// Suppress expected WARN output from template execution fallback
+		original := joinerLogger
+		joinerLogger = slog.New(slog.NewTextHandler(io.Discard, nil))
+		t.Cleanup(func() { joinerLogger = original })
+
 		result, err := JoinWithOptions(
 			WithFilePaths(
 				filepath.Join(testdataDir, "join-collision-rename-base-3.0.yaml"),

--- a/parser/equals.go
+++ b/parser/equals.go
@@ -12,6 +12,10 @@ import (
 	"slices"
 )
 
+// equalsLogger is used for warnings in equality comparison functions.
+// Tests can replace this with a discard logger to suppress expected warnings.
+var equalsLogger = slog.Default()
+
 // equalFloat64Ptr compares two *float64 pointers for equality.
 // Both nil returns true, both non-nil with equal values returns true.
 func equalFloat64Ptr(a, b *float64) bool {
@@ -371,7 +375,7 @@ func equalDocument(a, b any) bool {
 		// Unknown document type - log warning and fall back to reflect.DeepEqual.
 		// This should only happen with future OAS versions (e.g., OAS4).
 		// When adding support for new versions, add an explicit case above.
-		slog.Warn("equalDocument: unknown document type, using reflect.DeepEqual fallback",
+		equalsLogger.Warn("equalDocument: unknown document type, using reflect.DeepEqual fallback",
 			"type_a", reflect.TypeOf(a).String(),
 			"type_b", reflect.TypeOf(b).String())
 		return reflect.DeepEqual(a, b)

--- a/parser/equals_parseresult_test.go
+++ b/parser/equals_parseresult_test.go
@@ -1,6 +1,8 @@
 package parser
 
 import (
+	"io"
+	"log/slog"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -345,6 +347,11 @@ func TestParseResultDocumentEquals(t *testing.T) {
 }
 
 func TestEqualDocument(t *testing.T) {
+	// Suppress expected WARN output from equalDocument fallback (unknown type subtests)
+	original := equalsLogger
+	equalsLogger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	t.Cleanup(func() { equalsLogger = original })
+
 	oas3Doc1 := &OAS3Document{
 		OpenAPI:    "3.0.3",
 		OASVersion: OASVersion303,
@@ -484,6 +491,11 @@ func TestEqualDocument(t *testing.T) {
 // TestEqualDocumentUnknownTypeFallback tests the reflect.DeepEqual fallback
 // for unknown document types (e.g., future OAS versions).
 func TestEqualDocumentUnknownTypeFallback(t *testing.T) {
+	// Suppress expected WARN output from equalDocument fallback
+	original := equalsLogger
+	equalsLogger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	t.Cleanup(func() { equalsLogger = original })
+
 	tests := []struct {
 		name string
 		a    any


### PR DESCRIPTION
## Summary

- Replace direct `slog.Warn`/`log.Printf` calls with package-level logger variables in `parser/equals.go` and `joiner/joiner.go` so tests that deliberately trigger fallback paths can redirect warnings to `io.Discard`
- Upgrade joiner from unstructured `log.Printf` to structured `slog.Warn` with key-value args
- Add missing `golang.org/x/text` to README dependency tree diagram

## Context

The v1.51.0 benchmark output contained two categories of noise:
1. `equalDocument: unknown document type, using reflect.DeepEqual fallback` WARN messages (lines 1-9) from tests exercising the unknown-type fallback path
2. `joiner: template execution error` (line 194) from a test that deliberately passes an invalid template

Both are tests exercising *intentional* fallback behavior. The warnings are correct but leaked to stderr during benchmarks.

## Test plan

- [x] `go_diagnostics` on all modified files — no diagnostics
- [x] `go test -v -run TestEqualDocumentUnknownTypeFallback ./parser/` — PASS, no WARN output
- [x] `go test -v -run TestEqualDocument ./parser/` — PASS, no WARN output
- [x] `go test -v -run "TestJoinWithOptions_NewStrategies/with_invalid_template" ./joiner/` — PASS, no error output
- [x] `make check` — 8016 tests PASS, lint clean, formatting clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)