### PR TITLE
feat(mcp): add offset/limit pagination to all MCP tools

### DIFF
--- a/docs/plans/2026-02-14-plugin-corpus-bug-hunt-design.md
+++ b/docs/plans/2026-02-14-plugin-corpus-bug-hunt-design.md
@@ -1,0 +1,65 @@
+# Plugin Corpus Bug Hunt Design
+
+**Date**: 2026-02-14
+**Goal**: Stress-test the oastools Claude plugin (MCP server + skills) against the full corpus to find bugs, crashes, incorrect output, and performance issues.
+
+## Corpus Files
+
+| File | Size | Format | Expected OAS |
+|------|------|--------|-------------|
+| petstore-swagger.json | 14KB | JSON | 2.0 |
+| nws-openapi.json | 112KB | JSON | 3.0 |
+| discord-openapi.json | 1MB | JSON | 3.0 |
+| digitalocean-public.v2.yaml | 2.5MB | YAML | 3.0 |
+| asana-oas.yaml | 2.7MB | YAML | 3.0 |
+| google-maps-platform.json | 2.7MB | JSON | 3.0 |
+| plaid-2020-09-14.yml | 2.9MB | YAML | 3.0 |
+| stripe-spec3.json | 7.6MB | JSON | 3.0 |
+| github-api.json | 11.7MB | JSON | 3.0 |
+| msgraph-openapi.yaml | 36.4MB | YAML | 3.0/3.1 |
+
+## Approach: Workflow-Based + Sweep
+
+### Phase 1: Workflow Testing
+
+**Workflow 1 — Explore API** (all 10 files):
+1. `parse` → overview
+2. `walk_operations` → list endpoints (summary)
+3. `walk_schemas` → component schemas
+4. `walk_operations` with tag/path filter
+5. `walk_parameters`, `walk_responses`, `walk_security` for one endpoint
+
+**Workflow 2 — Validate & Fix** (all 10 files):
+1. `validate` → find errors
+2. `fix` with `dry_run: true` → preview fixes
+
+**Workflow 3 — Diff Specs** (2-3 pairs):
+- Same file vs itself (zero changes expected)
+- petstore (2.0) vs nws (3.0) — cross-version
+- stripe vs github — large JSON
+
+**Workflow 4 — Generate Code** (2-3 files):
+- petstore (small), nws (medium), stripe or discord (large)
+
+**Workflow 5 — Convert** (petstore OAS 2.0 → 3.x)
+
+### Phase 2: Cleanup Sweep
+
+Fill gaps not covered by workflows:
+- `overlay_apply` and `overlay_validate`
+- `join` (multiple specs)
+- `validate` with `strict: true`
+- `walk_*` with `detail: true` on large files
+- `fix` flags: `prune`, `stub_missing_refs`, `fix_schema_names`, `fix_duplicate_operationids`
+
+## What We Check
+
+- **Crashes/errors**: Tool returns error or times out
+- **Correctness**: Counts match, filters work, output makes sense
+- **Performance**: Hangs or unreasonably slow on large files
+- **Edge cases**: Missing fields, empty results, truncated output
+- **MCP protocol**: JSON response parses correctly
+
+## Deliverable
+
+Bug report with: tool, file, input, error/unexpected behavior, severity.

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -97,6 +97,22 @@ func registerAllTools(server *mcp.Server) {
 	}, handleWalkPaths)
 }
 
+// paginate applies offset/limit pagination to a slice, returning the
+// requested page. A non-positive limit defaults to defaultWalkLimit.
+func paginate[T any](items []T, offset, limit int) []T {
+	if limit <= 0 {
+		limit = defaultWalkLimit
+	}
+	if offset < 0 || offset >= len(items) {
+		return nil
+	}
+	end := offset + limit
+	if end < offset || end > len(items) { // overflow or beyond slice
+		end = len(items)
+	}
+	return items[offset:end]
+}
+
 // makeSlice returns nil when n is 0 (preserving omitempty JSON semantics),
 // otherwise returns make([]T, 0, n) for pre-allocated appending.
 func makeSlice[T any](n int) []T {

--- a/internal/mcpserver/server_test.go
+++ b/internal/mcpserver/server_test.go
@@ -1,0 +1,120 @@
+package mcpserver
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPaginate(t *testing.T) {
+	items := []int{0, 1, 2, 3, 4}
+
+	tests := []struct {
+		name   string
+		items  []int
+		offset int
+		limit  int
+		want   []int
+	}{
+		{
+			name:   "default limit returns all when under 100",
+			items:  items,
+			offset: 0,
+			limit:  0,
+			want:   []int{0, 1, 2, 3, 4},
+		},
+		{
+			name:   "explicit limit",
+			items:  items,
+			offset: 0,
+			limit:  2,
+			want:   []int{0, 1},
+		},
+		{
+			name:   "offset only",
+			items:  items,
+			offset: 2,
+			limit:  0,
+			want:   []int{2, 3, 4},
+		},
+		{
+			name:   "offset and limit",
+			items:  items,
+			offset: 1,
+			limit:  2,
+			want:   []int{1, 2},
+		},
+		{
+			name:   "offset at end",
+			items:  items,
+			offset: 4,
+			limit:  2,
+			want:   []int{4},
+		},
+		{
+			name:   "offset beyond end",
+			items:  items,
+			offset: 5,
+			limit:  2,
+			want:   nil,
+		},
+		{
+			name:   "negative offset",
+			items:  items,
+			offset: -1,
+			limit:  2,
+			want:   nil,
+		},
+		{
+			name:   "limit exceeds remaining",
+			items:  items,
+			offset: 3,
+			limit:  10,
+			want:   []int{3, 4},
+		},
+		{
+			name:   "nil slice",
+			items:  nil,
+			offset: 0,
+			limit:  2,
+			want:   nil,
+		},
+		{
+			name:   "empty slice",
+			items:  []int{},
+			offset: 0,
+			limit:  2,
+			want:   nil,
+		},
+		{
+			name:   "negative limit treated as default",
+			items:  items,
+			offset: 0,
+			limit:  -1,
+			want:   []int{0, 1, 2, 3, 4},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := paginate(tt.items, tt.offset, tt.limit)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestPaginate_OverflowLimit(t *testing.T) {
+	items := []int{0, 1, 2}
+	got := paginate(items, 1, math.MaxInt)
+	assert.Equal(t, []int{1, 2}, got)
+}
+
+func TestPaginate_DefaultLimit(t *testing.T) {
+	items := make([]int, 150)
+	for i := range items {
+		items[i] = i
+	}
+	got := paginate(items, 0, 0)
+	assert.Len(t, got, 100, "default limit should cap at 100 items")
+}

--- a/internal/mcpserver/tools_diff.go
+++ b/internal/mcpserver/tools_diff.go
@@ -13,6 +13,8 @@ type diffInput struct {
 	Revision     specInput `json:"revision"                jsonschema:"The revised OAS document to compare against the base"`
 	BreakingOnly bool      `json:"breaking_only,omitempty" jsonschema:"Only show breaking changes"`
 	NoInfo       bool      `json:"no_info,omitempty"       jsonschema:"Suppress informational changes"`
+	Offset       int       `json:"offset,omitempty"        jsonschema:"Skip the first N changes (for pagination)"`
+	Limit        int       `json:"limit,omitempty"         jsonschema:"Maximum number of changes to return (default 100)"`
 }
 
 type diffChange struct {
@@ -27,6 +29,7 @@ type diffOutput struct {
 	BreakingCount int          `json:"breaking_count"`
 	WarningCount  int          `json:"warning_count"`
 	InfoCount     int          `json:"info_count"`
+	Returned      int          `json:"returned"`
 	Changes       []diffChange `json:"changes,omitempty"`
 	Summary       string       `json:"summary"`
 }
@@ -88,6 +91,9 @@ func handleDiff(_ context.Context, _ *mcp.CallToolRequest, input diffInput) (*mc
 
 	output.TotalChanges = len(output.Changes)
 	output.Summary = buildDiffSummary(output)
+
+	output.Changes = paginate(output.Changes, input.Offset, input.Limit)
+	output.Returned = len(output.Changes)
 
 	return nil, output, nil
 }

--- a/internal/mcpserver/tools_validate_test.go
+++ b/internal/mcpserver/tools_validate_test.go
@@ -39,3 +39,73 @@ paths: {}
 	assert.False(t, output.Valid)
 	assert.NotEmpty(t, output.Errors)
 }
+
+func TestValidateTool_Pagination(t *testing.T) {
+	// This spec has multiple validation errors (missing info fields and responses).
+	content := `openapi: "3.0.0"
+info: {}
+paths:
+  /a:
+    get: {}
+  /b:
+    post: {}
+  /c:
+    put: {}
+`
+	// Baseline: get total error count without pagination.
+	input := validateInput{
+		Spec: specInput{Content: content},
+	}
+	_, baseline, err := handleValidate(context.Background(), &mcp.CallToolRequest{}, input)
+	require.NoError(t, err)
+	require.False(t, baseline.Valid)
+	require.Greater(t, baseline.ErrorCount, 2, "need at least 3 errors for pagination test")
+
+	t.Run("limit", func(t *testing.T) {
+		_, output, err := handleValidate(context.Background(), &mcp.CallToolRequest{}, validateInput{
+			Spec:       specInput{Content: content},
+			NoWarnings: true,
+			Limit:      1,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, baseline.ErrorCount, output.ErrorCount)
+		assert.Equal(t, 1, output.Returned)
+		assert.Len(t, output.Errors, 1)
+	})
+
+	t.Run("offset", func(t *testing.T) {
+		_, output, err := handleValidate(context.Background(), &mcp.CallToolRequest{}, validateInput{
+			Spec:       specInput{Content: content},
+			NoWarnings: true,
+			Offset:     1,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, baseline.ErrorCount, output.ErrorCount)
+		assert.Equal(t, baseline.ErrorCount-1, output.Returned)
+	})
+
+	t.Run("offset and limit", func(t *testing.T) {
+		_, output, err := handleValidate(context.Background(), &mcp.CallToolRequest{}, validateInput{
+			Spec:       specInput{Content: content},
+			NoWarnings: true,
+			Offset:     1,
+			Limit:      2,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, baseline.ErrorCount, output.ErrorCount)
+		assert.Equal(t, 2, output.Returned)
+		assert.Len(t, output.Errors, 2)
+	})
+
+	t.Run("offset beyond total", func(t *testing.T) {
+		_, output, err := handleValidate(context.Background(), &mcp.CallToolRequest{}, validateInput{
+			Spec:       specInput{Content: content},
+			NoWarnings: true,
+			Offset:     baseline.ErrorCount,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, baseline.ErrorCount, output.ErrorCount)
+		assert.Equal(t, 0, output.Returned)
+		assert.Nil(t, output.Errors)
+	})
+}

--- a/internal/mcpserver/tools_walk_operations.go
+++ b/internal/mcpserver/tools_walk_operations.go
@@ -22,6 +22,7 @@ type walkOperationsInput struct {
 	ResolveRefs bool      `json:"resolve_refs,omitempty"     jsonschema:"Resolve $ref pointers before output"`
 	Detail      bool      `json:"detail,omitempty"           jsonschema:"Return full operation objects instead of summaries"`
 	Limit       int       `json:"limit,omitempty"            jsonschema:"Maximum number of results to return (default 100)"`
+	Offset      int       `json:"offset,omitempty"           jsonschema:"Skip the first N results (for pagination)"`
 }
 
 type operationSummary struct {
@@ -71,15 +72,8 @@ func handleWalkOperations(_ context.Context, _ *mcp.CallToolRequest, input walkO
 		return errResult(err), nil, nil
 	}
 
-	// Apply limit.
-	limit := input.Limit
-	if limit <= 0 {
-		limit = defaultWalkLimit
-	}
-	returned := matched
-	if len(returned) > limit {
-		returned = returned[:limit]
-	}
+	// Apply offset/limit pagination.
+	returned := paginate(matched, input.Offset, input.Limit)
 
 	output := walkOperationsOutput{
 		Total:    len(collector.All),

--- a/internal/mcpserver/tools_walk_operations_test.go
+++ b/internal/mcpserver/tools_walk_operations_test.go
@@ -292,3 +292,30 @@ func TestWalkOperations_InvalidSpec(t *testing.T) {
 	require.NotNil(t, result)
 	assert.True(t, result.IsError)
 }
+
+func TestWalkOperations_Offset(t *testing.T) {
+	input := walkOperationsInput{
+		Spec:   specInput{Content: walkOperationsTestSpec},
+		Offset: 2,
+	}
+	_, output := callWalkOperations(t, input)
+
+	assert.Equal(t, 5, output.Total)
+	assert.Equal(t, 5, output.Matched)
+	assert.Equal(t, 3, output.Returned)
+	assert.Len(t, output.Summaries, 3)
+}
+
+func TestWalkOperations_OffsetAndLimit(t *testing.T) {
+	input := walkOperationsInput{
+		Spec:   specInput{Content: walkOperationsTestSpec},
+		Offset: 1,
+		Limit:  2,
+	}
+	_, output := callWalkOperations(t, input)
+
+	assert.Equal(t, 5, output.Total)
+	assert.Equal(t, 5, output.Matched)
+	assert.Equal(t, 2, output.Returned)
+	assert.Len(t, output.Summaries, 2)
+}

--- a/internal/mcpserver/tools_walk_parameters.go
+++ b/internal/mcpserver/tools_walk_parameters.go
@@ -20,6 +20,7 @@ type walkParametersInput struct {
 	ResolveRefs bool      `json:"resolve_refs,omitempty"   jsonschema:"Resolve $ref pointers before output"`
 	Detail      bool      `json:"detail,omitempty"         jsonschema:"Return full parameter objects instead of summaries"`
 	Limit       int       `json:"limit,omitempty"          jsonschema:"Maximum number of results to return (default 100)"`
+	Offset      int       `json:"offset,omitempty"         jsonschema:"Skip the first N results (for pagination)"`
 }
 
 type parameterSummary struct {
@@ -68,15 +69,8 @@ func handleWalkParameters(_ context.Context, _ *mcp.CallToolRequest, input walkP
 		return errResult(err), nil, nil
 	}
 
-	// Apply limit.
-	limit := input.Limit
-	if limit <= 0 {
-		limit = defaultWalkLimit
-	}
-	returned := matched
-	if len(returned) > limit {
-		returned = returned[:limit]
-	}
+	// Apply offset/limit pagination.
+	returned := paginate(matched, input.Offset, input.Limit)
 
 	output := walkParametersOutput{
 		Total:    len(collector.All),

--- a/internal/mcpserver/tools_walk_parameters_test.go
+++ b/internal/mcpserver/tools_walk_parameters_test.go
@@ -217,3 +217,30 @@ func TestWalkParameters_NoMatches(t *testing.T) {
 	assert.Equal(t, 0, output.Matched)
 	assert.Nil(t, output.Summaries)
 }
+
+func TestWalkParameters_Offset(t *testing.T) {
+	input := walkParametersInput{
+		Spec:   specInput{Content: walkParametersTestSpec},
+		Offset: 2,
+	}
+	_, output := callWalkParameters(t, input)
+
+	assert.Equal(t, 4, output.Total)
+	assert.Equal(t, 4, output.Matched)
+	assert.Equal(t, 2, output.Returned)
+	assert.Len(t, output.Summaries, 2)
+}
+
+func TestWalkParameters_OffsetAndLimit(t *testing.T) {
+	input := walkParametersInput{
+		Spec:   specInput{Content: walkParametersTestSpec},
+		Offset: 1,
+		Limit:  2,
+	}
+	_, output := callWalkParameters(t, input)
+
+	assert.Equal(t, 4, output.Total)
+	assert.Equal(t, 4, output.Matched)
+	assert.Equal(t, 2, output.Returned)
+	assert.Len(t, output.Summaries, 2)
+}

--- a/internal/mcpserver/tools_walk_paths.go
+++ b/internal/mcpserver/tools_walk_paths.go
@@ -15,6 +15,7 @@ type walkPathsInput struct {
 	ResolveRefs bool      `json:"resolve_refs,omitempty"   jsonschema:"Resolve $ref pointers before output"`
 	Detail      bool      `json:"detail,omitempty"         jsonschema:"Return full path item objects instead of summaries"`
 	Limit       int       `json:"limit,omitempty"          jsonschema:"Maximum number of results to return (default 100)"`
+	Offset      int       `json:"offset,omitempty"         jsonschema:"Skip the first N results (for pagination)"`
 }
 
 type pathSummary struct {
@@ -77,15 +78,8 @@ func handleWalkPaths(_ context.Context, _ *mcp.CallToolRequest, input walkPathsI
 		return errResult(err), nil, nil
 	}
 
-	// Apply limit.
-	limit := input.Limit
-	if limit <= 0 {
-		limit = defaultWalkLimit
-	}
-	returned := matched
-	if len(returned) > limit {
-		returned = returned[:limit]
-	}
+	// Apply offset/limit pagination.
+	returned := paginate(matched, input.Offset, input.Limit)
 
 	output := walkPathsOutput{
 		Total:    len(all),

--- a/internal/mcpserver/tools_walk_paths_test.go
+++ b/internal/mcpserver/tools_walk_paths_test.go
@@ -168,6 +168,33 @@ func TestWalkPaths_NoMatches(t *testing.T) {
 	assert.Nil(t, output.Summaries)
 }
 
+func TestWalkPaths_Offset(t *testing.T) {
+	input := walkPathsInput{
+		Spec:   specInput{Content: walkPathsTestSpec},
+		Offset: 1,
+	}
+	_, output := callWalkPaths(t, input)
+
+	assert.Equal(t, 3, output.Total)
+	assert.Equal(t, 3, output.Matched)
+	assert.Equal(t, 2, output.Returned)
+	assert.Len(t, output.Summaries, 2)
+}
+
+func TestWalkPaths_OffsetAndLimit(t *testing.T) {
+	input := walkPathsInput{
+		Spec:   specInput{Content: walkPathsTestSpec},
+		Offset: 1,
+		Limit:  1,
+	}
+	_, output := callWalkPaths(t, input)
+
+	assert.Equal(t, 3, output.Total)
+	assert.Equal(t, 3, output.Matched)
+	assert.Equal(t, 1, output.Returned)
+	assert.Len(t, output.Summaries, 1)
+}
+
 func TestWalkPaths_FilterByExtension(t *testing.T) {
 	spec := `openapi: "3.0.0"
 info:

--- a/internal/mcpserver/tools_walk_responses.go
+++ b/internal/mcpserver/tools_walk_responses.go
@@ -18,6 +18,7 @@ type walkResponsesInput struct {
 	ResolveRefs bool      `json:"resolve_refs,omitempty"   jsonschema:"Resolve $ref pointers before output"`
 	Detail      bool      `json:"detail,omitempty"         jsonschema:"Return full response objects instead of summaries"`
 	Limit       int       `json:"limit,omitempty"          jsonschema:"Maximum number of results to return (default 100)"`
+	Offset      int       `json:"offset,omitempty"         jsonschema:"Skip the first N results (for pagination)"`
 }
 
 type responseSummary struct {
@@ -64,15 +65,8 @@ func handleWalkResponses(_ context.Context, _ *mcp.CallToolRequest, input walkRe
 		return errResult(err), nil, nil
 	}
 
-	// Apply limit.
-	limit := input.Limit
-	if limit <= 0 {
-		limit = defaultWalkLimit
-	}
-	returned := matched
-	if len(returned) > limit {
-		returned = returned[:limit]
-	}
+	// Apply offset/limit pagination.
+	returned := paginate(matched, input.Offset, input.Limit)
 
 	output := walkResponsesOutput{
 		Total:    len(collector.All),

--- a/internal/mcpserver/tools_walk_responses_test.go
+++ b/internal/mcpserver/tools_walk_responses_test.go
@@ -182,6 +182,33 @@ func TestWalkResponses_NoMatches(t *testing.T) {
 	assert.Nil(t, output.Summaries)
 }
 
+func TestWalkResponses_Offset(t *testing.T) {
+	input := walkResponsesInput{
+		Spec:   specInput{Content: walkResponsesTestSpec},
+		Offset: 3,
+	}
+	_, output := callWalkResponses(t, input)
+
+	assert.Equal(t, 8, output.Total)
+	assert.Equal(t, 8, output.Matched)
+	assert.Equal(t, 5, output.Returned)
+	assert.Len(t, output.Summaries, 5)
+}
+
+func TestWalkResponses_OffsetAndLimit(t *testing.T) {
+	input := walkResponsesInput{
+		Spec:   specInput{Content: walkResponsesTestSpec},
+		Offset: 3,
+		Limit:  3,
+	}
+	_, output := callWalkResponses(t, input)
+
+	assert.Equal(t, 8, output.Total)
+	assert.Equal(t, 8, output.Matched)
+	assert.Equal(t, 3, output.Returned)
+	assert.Len(t, output.Summaries, 3)
+}
+
 func TestStatusCodeMatches(t *testing.T) {
 	tests := []struct {
 		statusCode string

--- a/internal/mcpserver/tools_walk_schemas.go
+++ b/internal/mcpserver/tools_walk_schemas.go
@@ -20,6 +20,7 @@ type walkSchemasInput struct {
 	ResolveRefs bool      `json:"resolve_refs,omitempty"   jsonschema:"Resolve $ref pointers"`
 	Detail      bool      `json:"detail,omitempty"         jsonschema:"Return full schema objects"`
 	Limit       int       `json:"limit,omitempty"          jsonschema:"Maximum results (default 100)"`
+	Offset      int       `json:"offset,omitempty"         jsonschema:"Skip the first N results (for pagination)"`
 }
 
 type schemaSummary struct {
@@ -79,15 +80,8 @@ func handleWalkSchemas(_ context.Context, _ *mcp.CallToolRequest, input walkSche
 		return errResult(err), nil, nil
 	}
 
-	// Apply limit.
-	limit := input.Limit
-	if limit <= 0 {
-		limit = defaultWalkLimit
-	}
-	returned := filtered
-	if len(returned) > limit {
-		returned = returned[:limit]
-	}
+	// Apply offset/limit pagination.
+	returned := paginate(filtered, input.Offset, input.Limit)
 
 	output := walkSchemasOutput{
 		Total:    len(collector.All),

--- a/internal/mcpserver/tools_walk_schemas_test.go
+++ b/internal/mcpserver/tools_walk_schemas_test.go
@@ -257,3 +257,30 @@ func TestWalkSchemas_InvalidSpec(t *testing.T) {
 	require.NotNil(t, result)
 	assert.True(t, result.IsError)
 }
+
+func TestWalkSchemas_Offset(t *testing.T) {
+	input := walkSchemasInput{
+		Spec:      specInput{Content: walkSchemasTestSpec},
+		Component: true,
+		Offset:    3,
+	}
+	_, output := callWalkSchemas(t, input)
+
+	assert.Equal(t, 8, output.Matched)
+	assert.Equal(t, 5, output.Returned)
+	assert.Len(t, output.Summaries, 5)
+}
+
+func TestWalkSchemas_OffsetAndLimit(t *testing.T) {
+	input := walkSchemasInput{
+		Spec:      specInput{Content: walkSchemasTestSpec},
+		Component: true,
+		Offset:    3,
+		Limit:     2,
+	}
+	_, output := callWalkSchemas(t, input)
+
+	assert.Equal(t, 8, output.Matched)
+	assert.Equal(t, 2, output.Returned)
+	assert.Len(t, output.Summaries, 2)
+}

--- a/internal/mcpserver/tools_walk_security_test.go
+++ b/internal/mcpserver/tools_walk_security_test.go
@@ -160,6 +160,33 @@ func TestWalkSecurity_NoMatches(t *testing.T) {
 	assert.Nil(t, output.Summaries)
 }
 
+func TestWalkSecurity_Offset(t *testing.T) {
+	input := walkSecurityInput{
+		Spec:   specInput{Content: walkSecurityTestSpec},
+		Offset: 1,
+	}
+	_, output := callWalkSecurity(t, input)
+
+	assert.Equal(t, 3, output.Total)
+	assert.Equal(t, 3, output.Matched)
+	assert.Equal(t, 2, output.Returned)
+	assert.Len(t, output.Summaries, 2)
+}
+
+func TestWalkSecurity_OffsetAndLimit(t *testing.T) {
+	input := walkSecurityInput{
+		Spec:   specInput{Content: walkSecurityTestSpec},
+		Offset: 1,
+		Limit:  1,
+	}
+	_, output := callWalkSecurity(t, input)
+
+	assert.Equal(t, 3, output.Total)
+	assert.Equal(t, 3, output.Matched)
+	assert.Equal(t, 1, output.Returned)
+	assert.Len(t, output.Summaries, 1)
+}
+
 func TestWalkSecurity_FilterByExtension(t *testing.T) {
 	spec := `openapi: "3.0.0"
 info:

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "oastools",
   "description": "OpenAPI Specification tools — validate, fix, convert, diff, walk, and generate from OAS 2.0-3.2 documents",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "erraggy",
     "url": "https://github.com/erraggy"

--- a/plugin/CLAUDE.md
+++ b/plugin/CLAUDE.md
@@ -29,8 +29,13 @@ Special cases:
 2. **Explore before modifying.** Use `parse` for a high-level overview and `walk_*` tools to drill into specific parts before running `fix` or `convert`.
 3. **Validate after changes.** Always run `validate` after `fix`, `convert`, or `overlay_apply` to confirm the result is valid.
 4. **Use `dry_run` for fix.** Preview what the `fix` tool will change before applying.
-5. **Filter walk results.** Walk tools support filters (method, path, tag, status, name, type) and return summaries by default. Use `detail: true` only when you need full objects.
+5. 🔍 **Filter before paging.** All walk tools and `validate`, `fix`, `diff` support filters that reduce result size more effectively than pagination. Key filters:
+   - `walk_*`: `tag`, `method`, `path`, `status`, `name`, `type`, `component` (schemas only)
+   - `validate`: `no_warnings: true` — suppresses warnings for error-focused triage
+   - `diff`: `breaking_only: true` — shows only breaking changes (usually fewest and most important)
+   - Use `detail: true` only after filtering to specific items — full objects can be very large
 6. **Check breaking changes.** When diffing specs, use `breaking_only: true` to focus on changes that will break API consumers.
+7. 📄 **Page through large results.** Tools that return arrays (`validate`, `fix`, `diff`, `walk_*`) support `offset` and `limit` params (default limit: 100). When `returned` is less than the total count, use `offset` to page through. Prefer filtering over paging when possible.
 
 ## Common Workflows
 
@@ -50,3 +55,10 @@ Special cases:
 1. `diff` with both specs to see all changes
 2. Review breaking changes and their severity
 3. Use `walk_operations` on the revision to understand new/modified endpoints
+
+**Explore a large API (100+ operations):**
+1. 📊 `parse` to get counts and tag list
+2. 🏷️ `walk_operations` with `tag` filter — work through one tag at a time
+3. 📋 `walk_schemas` with `component: true` — named schemas only (skip inline)
+4. 🔍 Drill into specifics with `operation_id` or `path` + `detail: true`
+5. ✅ Use `validate` with `no_warnings: true` for error-focused triage

--- a/plugin/skills/diff-specs.md
+++ b/plugin/skills/diff-specs.md
@@ -7,6 +7,8 @@ description: Compare two OpenAPI spec versions, highlight breaking changes, and 
 
 ## Step 1: Compare the specs
 
+> ⚠️ **Note:** The `diff` tool is designed for comparing **versions of the same API** (e.g., v1.2 vs v1.3). Diffing unrelated APIs (e.g., Stripe vs GitHub) will produce thousands of changes that aren't meaningful. If the user wants to compare different APIs, suggest exploring each one separately with the `explore-api` workflow.
+
 Call the `diff` tool with both spec versions:
 
 ```json
@@ -27,6 +29,20 @@ To focus only on breaking changes:
 ```
 
 ## Step 2: Categorize changes
+
+### Paginating large diffs
+
+Results are paginated (default limit: 100). When `returned < total_changes`, there are more changes:
+
+```json
+{
+  "base": {"file": "<old-version-path>"},
+  "revision": {"file": "<new-version-path>"},
+  "offset": 100, "limit": 100
+}
+```
+
+⚠️ **Strategy for large diffs:** Start with `breaking_only: true` to see all breaking changes first — these are usually the most important and fewest. Then page through the full diff only if the user needs the complete picture. The `total_changes`, `breaking_count`, `warning_count`, and `info_count` fields always reflect the full result, even when paginated.
 
 Present the diff results organized by severity:
 

--- a/plugin/skills/fix-spec.md
+++ b/plugin/skills/fix-spec.md
@@ -30,6 +30,16 @@ Show the user a clear summary of planned fixes:
 - Number of fixes that will be applied
 - For each fix: what it changes, where (JSON path), and why
 
+### Paginating large fix lists
+
+Results are paginated (default limit: 100). When `returned < fix_count`, there are more fixes:
+
+```json
+{"spec": {"file": "<path>"}, "dry_run": true, "offset": 100, "limit": 100}
+```
+
+✅ Page through all fixes so the user gets a complete picture before confirming. Group fixes by type for readability (e.g., "842 missing path parameters, 12 duplicate operationIds").
+
 Ask the user to confirm before proceeding. If they want to exclude certain fixes, adjust the flags accordingly.
 
 ## Step 3: Apply fixes

--- a/plugin/skills/validate-spec.md
+++ b/plugin/skills/validate-spec.md
@@ -15,6 +15,8 @@ Call the `validate` tool on the user's spec:
 
 If the user wants strict validation, add `"strict": true`.
 
+⚠️ **Tip for large specs:** Use `"no_warnings": true` for initial triage. Large specs can produce hundreds of warnings that obscure the actual errors. Get the error picture first, then run again without `no_warnings` to review warnings separately.
+
 ## Step 2: Report results
 
 If the spec is valid:
@@ -26,6 +28,16 @@ If the spec has errors:
 - List each error with its JSON path and a plain-language explanation
 - Group related errors (e.g., multiple missing `$ref` targets)
 - Explain **why** each error matters and what it would cause in practice (tooling failures, code generation issues, etc.)
+
+### Paginating large results
+
+Results are paginated (default limit: 100). When `returned < error_count`, there are more errors:
+
+```json
+{"spec": {"file": "<path>"}, "offset": 100, "limit": 100}
+```
+
+⚠️ **Strategy for large error sets:** Analyze the first page for patterns — if errors are repetitive (e.g., hundreds of missing path parameters), summarize the pattern and total count rather than paging through all of them. Only page further when errors appear diverse or the user needs specifics.
 
 ## Step 3: Suggest fixes
 


### PR DESCRIPTION
## Summary

- ✅ Added shared `paginate[T]` generic helper to eliminate duplication across 9 tools
- ✅ All tools that return arrays (`validate`, `fix`, `diff`, 6 `walk_*`) now support `offset` and `limit` params (default limit: 100)
- ✅ Totals (`error_count`, `fix_count`, `total_changes`, `breaking_count`) always reflect full results, even when paginated
- ✅ `returned` field indicates how many items are in the current page
- ✅ Plugin version bumped `1.0.0` → `1.1.0`
- ✅ Skills and plugin CLAUDE.md updated with usage learnings from corpus testing (large API workflow, filter-first guidance, emojis for scannability)

## Motivation

Corpus bug hunt revealed MCP output overflow on large specs:
- `validate` on GitHub API: 367KB (2,158 errors)
- `fix` on GitHub API: 381KB (2,051 fixes)  
- `diff` Stripe vs GitHub: 591KB (3,445 changes)

With pagination (limit=5), these drop to ~0.8KB while preserving full totals for context.

## Test plan

- [x] 10 `TestPaginate` unit tests (nil, empty, boundaries, negative offset, default limit)
- [x] 12 offset tests across 6 walk tools (offset-only + offset+limit)
- [x] 13 pagination subtests across validate/fix/diff (limit, offset, offset+limit, beyond total, counts unchanged)
- [x] `make check` passes — 8,055 tests, 0 lint issues
- [x] MCP re-test with corpus files confirms pagination works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)