### PR TITLE
feat(mcp): add group_by aggregation, walk_headers, walk_refs, and usability improvements

### DIFF
--- a/docs/plans/2026-02-14-mcp-walk-usability-design.md
+++ b/docs/plans/2026-02-14-mcp-walk-usability-design.md
@@ -1,0 +1,197 @@
+# MCP Walk Tool Usability Improvements
+
+**Date:** 2026-02-14
+**Status:** Approved
+**Motivation:** AI agent friction when navigating large OpenAPI specs (MS Graph: 16K operations, 4K schemas)
+
+## Problem Statement
+
+The oastools MCP walk tools have three categories of usability issues that cause AI agents to waste tool calls:
+
+1. **Path glob matching is broken for real-world use** — `*` matches exactly one segment with no `**` support, so agents can't search across path depths
+2. **No cross-referencing capability** — no way to count `$ref` references or map schemas to operations
+3. **Tool descriptions mislead agents** — descriptions underspecify behavior, causing trial-and-error
+
+## Design
+
+### 1. Path Glob Matching Upgrade
+
+**File:** `internal/mcpserver/tools_walk_operations.go` — `matchWalkPath()`
+
+**Current behavior:** `*` matches exactly one path segment. Pattern must have same segment count as path.
+
+**New behavior:**
+
+| Pattern | Meaning | Example |
+|---------|---------|---------|
+| `*` | One segment (unchanged) | `/users/*` matches `/users/{id}` |
+| `**` | Zero or more segments (new) | `/drives/**/workbook/**` matches `/drives/{id}/items/{id}/workbook/functions/abs` |
+
+**Implementation:** Replace hand-rolled matcher with `**`-aware recursive matching. When a `**` segment is encountered, try matching the remaining pattern against every possible suffix of the remaining path segments.
+
+**Impact:** All 4 tools using `matchWalkPath` (walk_operations, walk_paths, walk_parameters, walk_responses) get the upgrade.
+
+### 2. Schema Name Glob Matching
+
+**File:** `internal/mcpserver/tools_walk_schemas.go` — `filterWalkSchemas()`
+
+**Current behavior:** `strings.EqualFold` — exact match only.
+
+**New behavior:** If name contains `*` or `?`, treat as case-insensitive glob pattern. Otherwise exact match (backwards-compatible).
+
+**Implementation:** New `matchName(name, pattern string) bool` helper that checks for glob characters and branches to `filepath.Match` (lowercased) or `strings.EqualFold`.
+
+### 3. New `walk_refs` Tool
+
+**File:** New `internal/mcpserver/tools_walk_refs.go`
+
+Walk all `$ref` occurrences using the existing `walker.WithRefHandler` + `walker.WithMapRefTracking` infrastructure.
+
+**Two modes:**
+
+**Summary mode (default):** Returns unique ref targets ranked by count (most-referenced first).
+
+```json
+{
+  "total": 15234,
+  "matched": 15234,
+  "returned": 5,
+  "refs": [
+    {"ref": "#/components/schemas/BaseCollectionPaginationCountResponse", "count": 1478},
+    {"ref": "#/components/schemas/microsoft.graph.entity", "count": 669}
+  ]
+}
+```
+
+**Detail mode (detail=true):** Returns individual source locations for a specific target.
+
+```json
+{
+  "total": 15234,
+  "matched": 618,
+  "returned": 5,
+  "refs": [
+    {
+      "ref": "#/components/schemas/microsoft.graph.workbookRange",
+      "source_path": "$.paths['/drives/...'].get.responses['2XX'].content['application/json'].schema.anyOf[0]",
+      "node_type": "schema"
+    }
+  ]
+}
+```
+
+**Input parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `spec` | object | Required. The OAS document (file/url/content) |
+| `target` | string | Filter by ref target (supports `*` glob, e.g. `*schemas/microsoft.graph.workbook*`) |
+| `node_type` | string | Filter by: schema, parameter, response, requestBody, header, pathItem |
+| `detail` | bool | Show source locations instead of aggregated counts |
+| `limit` | int | Max results (default 100) |
+| `offset` | int | Pagination offset |
+
+### 4. Tool Description Audit
+
+All tool descriptions and parameter descriptions updated for AI agent optimization. Principles:
+
+1. Lead with "when to use" signal
+2. Include examples in parameter descriptions
+3. Encode strategy hints ("filter by tag first for large APIs")
+4. State limitations explicitly
+
+#### Core Tool Description Changes
+
+**validate:**
+> Validate an OpenAPI Specification document against its version schema. Returns errors and warnings with JSON path locations. For large specs, use no_warnings to focus on errors first. Use offset/limit to paginate through results.
+
+**parse:**
+> Parse an OpenAPI Specification document. Returns a structural summary: title, version, OAS version, path/operation/schema counts, servers, and tags. Use full=true only for small specs; for large specs use walk_* tools to explore specific sections.
+
+- `full` parameter: Add `"WARNING: produces very large output for big specs — prefer walk_* tools instead."`
+
+**fix:**
+> Automatically fix common issues in an OpenAPI Specification document. Fix types: generic schema names, duplicate operationIds, missing path parameters, unused schemas/empty paths (prune), missing $ref targets (stub). Use dry_run=true to preview fixes before applying. Use output to write to a file instead of returning inline.
+
+**diff:**
+> Compare two versions of the same OpenAPI Specification document and report differences. Detects breaking changes, additions, removals, and modifications with severity levels. Use breaking_only=true to focus on breaking changes first. Both base and revision must be provided.
+
+**join:**
+> Join multiple OpenAPI Specification documents into a single merged document. Requires at least 2 specs via the specs array. Collision strategies: accept_left, accept_right, fail (paths/schemas), rename (schemas only). Use semantic_dedup to merge equivalent schemas.
+
+**generate:**
+> Generate Go code from an OpenAPI Specification document. Set exactly one of: types (type definitions only), client (HTTP client), or server (server interfaces and handlers). Requires output_dir. Returns a manifest of generated files.
+
+**convert, overlay_apply, overlay_validate:** No changes needed.
+
+#### Walk Tool Description Changes
+
+**walk_operations:**
+> Walk and query operations in an OpenAPI Specification document. Filter by method, path, tag, operationId, deprecated status, or extension. Returns summaries (method, path, operationId, tags) by default or full operation objects with detail=true. For large APIs, filter by tag first (most selective), then narrow with path or method. Path patterns support * (one segment) and ** (zero or more segments).
+
+**walk_schemas:**
+> Walk and query schemas in an OpenAPI Specification document. Filter by name, type, component/inline location, or extension. Returns summaries (name, type, JSON path, component status) by default or full schema objects with detail=true. Use component=true to see only named component schemas (skips inline schemas, reducing results 3-5x). Avoid detail=true without filters on large specs.
+
+**walk_parameters:**
+> Walk and query parameters in an OpenAPI Specification document. Filter by location (in), name, path pattern, method, or extension. Returns summaries (name, location, path, method) by default or full parameter objects with detail=true.
+
+**walk_responses:**
+> Walk and query responses in an OpenAPI Specification document. Filter by status code, path pattern, method, or extension. Returns summaries (status code, path, method, description) by default or full response objects with detail=true.
+
+**walk_security:**
+> Walk and query security schemes defined in components. Filter by name or type (apiKey, http, oauth2, openIdConnect). Returns summaries (name, type, location) by default or full security scheme objects with detail=true.
+
+**walk_paths:**
+> Walk and query path items in an OpenAPI Specification document. Filter by path pattern or extension. Returns summaries (path, method count) by default or full path item objects with detail=true. Path patterns support * (one segment) and ** (zero or more segments), e.g. /users/** matches all paths under /users.
+
+**walk_refs (new):**
+> Walk and count $ref references in an OpenAPI Specification document. By default, returns unique ref targets ranked by reference count (most-referenced first). Use target to filter to a specific ref (supports * glob, e.g. *schemas/microsoft.graph.*). Use detail=true to see individual source locations instead of counts. Filter by node_type to narrow to schema, parameter, response, requestBody, header, or pathItem refs.
+
+#### Parameter Description Standardization
+
+**Path filter (4 tools):**
+> Filter by path pattern (* = one segment, ** = zero or more segments, e.g. /users/* or /drives/**/workbook/**)
+
+**Schema name filter:**
+> Filter by schema name (exact match, or glob with * and ? for pattern matching, e.g. *workbook* or microsoft.graph.*)
+
+**Tag filter:**
+> Filter by tag name (exact match, case-sensitive)
+
+**operation_id filter:**
+> Select a single operation by operationId (exact match)
+
+**Parameter name filter:**
+> Filter by parameter name (case-insensitive exact match)
+
+**Status code filter:**
+> Filter by status code: exact (200, 404), wildcard (2xx, 4xx, 5xx), or default (case-insensitive)
+
+**resolve_refs (standardize across all):**
+> Resolve $ref pointers in output. Inlines referenced objects instead of showing $ref strings.
+
+**component (walk_schemas):**
+> Only show component schemas (defined in components/schemas or definitions). Mutually exclusive with inline.
+
+**inline (walk_schemas):**
+> Only show inline schemas (embedded in operations, not in components). Mutually exclusive with component.
+
+**detail (walk_schemas, add warning):**
+> Return full schema objects. WARNING: produces large output without name/type filters on big specs.
+
+**full (parse, add warning):**
+> Return full parsed document instead of summary. WARNING: produces very large output for big specs — prefer walk_* tools instead.
+
+## Priority Order
+
+1. **P0 — Path glob `**` support** (fixes the #1 friction, affects 4 tools)
+2. **P0 — Tool description audit** (zero-code-change, high-impact for agent usability)
+3. **P1 — Schema name glob** (small fix, one tool)
+4. **P2 — `walk_refs` tool** (new capability, medium effort)
+
+## Testing Strategy
+
+- Path glob: Unit tests for `matchWalkPath` covering `**` with 0, 1, N segment matches, edge cases (trailing `**`, leading `**`, `**` in middle)
+- Schema name glob: Unit tests for `matchName` with exact, glob, case-insensitive cases
+- `walk_refs`: Integration tests against petstore + MS Graph corpus fixtures for both summary and detail modes
+- Description changes: Manual verification via MCP tool listing

--- a/docs/plans/2026-02-14-mcp-walk-usability-implementation.md
+++ b/docs/plans/2026-02-14-mcp-walk-usability-implementation.md
@@ -1,0 +1,914 @@
+# MCP Walk Tool Usability Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Fix path glob matching, add schema name glob, add walk_refs tool, and audit all tool descriptions for AI agent usability.
+
+**Architecture:** All changes are in `internal/mcpserver/`. The glob upgrade replaces `matchWalkPath()` with `**`-aware matching. Schema name glob adds a `matchGlobName()` helper. `walk_refs` is a new tool file following the existing walk tool pattern (input struct → handler → collector → filter → paginate → output). Descriptions are string-only changes in `server.go` and jsonschema tags.
+
+**Tech Stack:** Go stdlib (`strings`, `path/filepath`), `walker.WithRefHandler` + `walker.WithMapRefTracking`, `stretchr/testify`
+
+**Design doc:** `docs/plans/2026-02-14-mcp-walk-usability-design.md`
+
+---
+
+### Task 1: Upgrade `matchWalkPath` — Write Failing Tests
+
+**Files:**
+- Modify: `internal/mcpserver/tools_walk_operations_test.go`
+
+**Step 1: Write failing tests for `**` glob support**
+
+Add these tests after the existing `TestWalkOperations_FilterByPath` test (line ~139):
+
+```go
+func TestMatchWalkPath_DoubleStarMiddle(t *testing.T) {
+	assert.True(t, matchWalkPath("/drives/{drive-id}/items/{driveItem-id}/workbook/functions/abs", "/drives/**/workbook/**"))
+	assert.True(t, matchWalkPath("/drives/{drive-id}/items/{driveItem-id}/workbook/names/{id}/range()", "/drives/**/workbook/**"))
+}
+
+func TestMatchWalkPath_DoubleStarLeading(t *testing.T) {
+	assert.True(t, matchWalkPath("/users/{id}/posts/{postId}", "/**/posts/*"))
+	assert.True(t, matchWalkPath("/posts/{postId}", "/**/posts/*"))
+}
+
+func TestMatchWalkPath_DoubleStarTrailing(t *testing.T) {
+	assert.True(t, matchWalkPath("/users/{id}", "/users/**"))
+	assert.True(t, matchWalkPath("/users/{id}/posts", "/users/**"))
+	assert.True(t, matchWalkPath("/users", "/users/**"))
+}
+
+func TestMatchWalkPath_DoubleStarMatchesZeroSegments(t *testing.T) {
+	// ** can match zero segments.
+	assert.True(t, matchWalkPath("/users/{id}", "/**/users/*"))
+}
+
+func TestMatchWalkPath_DoubleStarNoMatch(t *testing.T) {
+	assert.False(t, matchWalkPath("/pets/{petId}", "/users/**"))
+	assert.False(t, matchWalkPath("/stores", "/users/**/stores"))
+}
+
+func TestMatchWalkPath_SingleStarUnchanged(t *testing.T) {
+	// Existing behavior: * matches exactly one segment.
+	assert.True(t, matchWalkPath("/pets/{petId}", "/pets/*"))
+	assert.False(t, matchWalkPath("/pets/{petId}/toys", "/pets/*"))
+}
+
+func TestMatchWalkPath_ExactMatchUnchanged(t *testing.T) {
+	assert.True(t, matchWalkPath("/pets", "/pets"))
+	assert.False(t, matchWalkPath("/pets", "/stores"))
+}
+
+func TestMatchWalkPath_EmptyPattern(t *testing.T) {
+	assert.True(t, matchWalkPath("/anything", ""))
+}
+
+func TestMatchWalkPath_MixedStars(t *testing.T) {
+	// Mix of * and ** in one pattern.
+	assert.True(t, matchWalkPath("/sites/{id}/termStore/groups/{gid}/sets/{sid}/children/{tid}", "/sites/*/termStore/**"))
+	assert.False(t, matchWalkPath("/sites/{id}/other/groups", "/sites/*/termStore/**"))
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/mcpserver/ -run "TestMatchWalkPath_DoubleStar|TestMatchWalkPath_Mixed" -v`
+Expected: FAIL — `matchWalkPath` doesn't handle `**`
+
+**Step 3: Commit failing tests**
+
+```bash
+git add internal/mcpserver/tools_walk_operations_test.go
+git commit -m "test(mcp): add failing tests for ** glob path matching"
+```
+
+---
+
+### Task 2: Implement `**` Glob Matching in `matchWalkPath`
+
+**Files:**
+- Modify: `internal/mcpserver/tools_walk_operations.go:150-173`
+
+**Step 1: Replace `matchWalkPath` implementation**
+
+Replace the function at lines 150-173 with:
+
+```go
+// matchWalkPath checks if a path template matches a pattern.
+// Supports glob matching: * matches one path segment, ** matches zero or more segments.
+func matchWalkPath(pathTemplate, pattern string) bool {
+	if pattern == "" {
+		return true
+	}
+	patternParts := strings.Split(pattern, "/")
+	pathParts := strings.Split(pathTemplate, "/")
+	return matchPathParts(pathParts, patternParts)
+}
+
+// matchPathParts recursively matches path segments against pattern segments.
+// * matches exactly one segment, ** matches zero or more segments.
+func matchPathParts(path, pattern []string) bool {
+	for len(pattern) > 0 {
+		seg := pattern[0]
+		pattern = pattern[1:]
+
+		if seg == "**" {
+			// If ** is the last pattern segment, it matches everything remaining.
+			if len(pattern) == 0 {
+				return true
+			}
+			// Try matching the rest of the pattern at every possible position.
+			for i := 0; i <= len(path); i++ {
+				if matchPathParts(path[i:], pattern) {
+					return true
+				}
+			}
+			return false
+		}
+
+		if len(path) == 0 {
+			return false
+		}
+
+		if seg != "*" && seg != path[0] {
+			return false
+		}
+
+		path = path[1:]
+	}
+	return len(path) == 0
+}
+```
+
+**Step 2: Run all matchWalkPath tests**
+
+Run: `go test ./internal/mcpserver/ -run "TestMatchWalkPath|TestWalkOperations_FilterByPath" -v`
+Expected: ALL PASS
+
+**Step 3: Run full mcpserver tests to check for regressions**
+
+Run: `go test ./internal/mcpserver/ -v -count=1`
+Expected: ALL PASS
+
+**Step 4: Run gopls diagnostics**
+
+Run: `go_diagnostics` on `internal/mcpserver/tools_walk_operations.go`
+
+**Step 5: Commit**
+
+```bash
+git add internal/mcpserver/tools_walk_operations.go
+git commit -m "feat(mcp): add ** glob support for path matching in walk tools
+
+Replaces single-segment-only * matching with recursive ** support.
+** matches zero or more path segments, enabling patterns like
+/drives/**/workbook/** that work across path depths.
+
+Affects: walk_operations, walk_paths, walk_parameters, walk_responses."
+```
+
+---
+
+### Task 3: Add Integration Test for `**` via `walk_operations`
+
+**Files:**
+- Modify: `internal/mcpserver/tools_walk_operations_test.go`
+
+**Step 1: Write integration test using the walk tool directly**
+
+Add a test spec with nested paths and test `**` filtering through the handler:
+
+```go
+const walkOperationsDeepPathSpec = `openapi: "3.0.0"
+info:
+  title: Deep Path Test
+  version: "1.0.0"
+paths:
+  /drives/{driveId}/items/{itemId}/workbook/functions/abs:
+    post:
+      operationId: workbook.functions.abs
+      summary: Invoke abs
+      responses:
+        "200":
+          description: OK
+  /drives/{driveId}/items/{itemId}/workbook/worksheets/{wsId}/range:
+    get:
+      operationId: workbook.worksheets.range
+      summary: Get range
+      responses:
+        "200":
+          description: OK
+  /users/{userId}/posts:
+    get:
+      operationId: users.listPosts
+      summary: List posts
+      responses:
+        "200":
+          description: OK
+`
+
+func TestWalkOperations_FilterByPathDoubleStar(t *testing.T) {
+	input := walkOperationsInput{
+		Spec: specInput{Content: walkOperationsDeepPathSpec},
+		Path: "/drives/**/workbook/**",
+	}
+	_, output := callWalkOperations(t, input)
+
+	assert.Equal(t, 3, output.Total)
+	assert.Equal(t, 2, output.Matched)
+	ids := make([]string, 0, len(output.Summaries))
+	for _, s := range output.Summaries {
+		ids = append(ids, s.OperationID)
+	}
+	assert.Contains(t, ids, "workbook.functions.abs")
+	assert.Contains(t, ids, "workbook.worksheets.range")
+}
+
+func TestWalkOperations_FilterByPathDoubleStarTrailing(t *testing.T) {
+	input := walkOperationsInput{
+		Spec: specInput{Content: walkOperationsDeepPathSpec},
+		Path: "/users/**",
+	}
+	_, output := callWalkOperations(t, input)
+
+	assert.Equal(t, 1, output.Matched)
+	assert.Equal(t, "users.listPosts", output.Summaries[0].OperationID)
+}
+```
+
+**Step 2: Run the tests**
+
+Run: `go test ./internal/mcpserver/ -run "TestWalkOperations_FilterByPathDoubleStar" -v`
+Expected: PASS
+
+**Step 3: Commit**
+
+```bash
+git add internal/mcpserver/tools_walk_operations_test.go
+git commit -m "test(mcp): add integration tests for ** path glob in walk_operations"
+```
+
+---
+
+### Task 4: Add Schema Name Glob — Write Failing Test
+
+**Files:**
+- Modify: `internal/mcpserver/tools_walk_schemas_test.go`
+
+**Step 1: Write failing tests**
+
+Add after the existing `TestWalkSchemas_FilterByName` test:
+
+```go
+func TestWalkSchemas_FilterByNameGlob(t *testing.T) {
+	input := walkSchemasInput{
+		Spec: specInput{Content: walkSchemasTestSpec},
+		Name: "*et*",
+	}
+	_, output := callWalkSchemas(t, input)
+
+	// Should match "Pet" (case-insensitive glob).
+	assert.Equal(t, 1, output.Matched)
+	require.Len(t, output.Summaries, 1)
+	assert.Equal(t, "Pet", output.Summaries[0].Name)
+}
+
+func TestWalkSchemas_FilterByNameGlobStar(t *testing.T) {
+	input := walkSchemasInput{
+		Spec:      specInput{Content: walkSchemasTestSpec},
+		Name:      "*",
+		Component: true,
+	}
+	_, output := callWalkSchemas(t, input)
+
+	// Glob * matches all names — should return all component schemas.
+	assert.Equal(t, 8, output.Matched)
+}
+
+func TestWalkSchemas_FilterByNameGlobPrefix(t *testing.T) {
+	input := walkSchemasInput{
+		Spec:      specInput{Content: walkSchemasTestSpec},
+		Name:      "P*",
+		Component: true,
+	}
+	_, output := callWalkSchemas(t, input)
+
+	// Should match "Pet" only (not "Error" or "Tag").
+	assert.GreaterOrEqual(t, output.Matched, 1)
+	for _, s := range output.Summaries {
+		assert.True(t, strings.HasPrefix(strings.ToLower(s.Name), "p"),
+			"expected name starting with P, got %q", s.Name)
+	}
+}
+
+func TestWalkSchemas_FilterByNameExactUnchanged(t *testing.T) {
+	// No glob chars → exact match (case-insensitive), unchanged behavior.
+	input := walkSchemasInput{
+		Spec: specInput{Content: walkSchemasTestSpec},
+		Name: "pet",
+	}
+	_, output := callWalkSchemas(t, input)
+
+	assert.Equal(t, 1, output.Matched)
+	assert.Equal(t, "Pet", output.Summaries[0].Name)
+}
+```
+
+NOTE: You'll need `"strings"` in the import block.
+
+**Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/mcpserver/ -run "TestWalkSchemas_FilterByNameGlob" -v`
+Expected: FAIL — exact match doesn't support `*et*`
+
+**Step 3: Commit**
+
+```bash
+git add internal/mcpserver/tools_walk_schemas_test.go
+git commit -m "test(mcp): add failing tests for schema name glob matching"
+```
+
+---
+
+### Task 5: Implement Schema Name Glob Matching
+
+**Files:**
+- Modify: `internal/mcpserver/tools_walk_schemas.go:1-10` (imports), `tools_walk_schemas.go:118-146` (filterWalkSchemas)
+
+**Step 1: Add `matchGlobName` helper and update filter**
+
+Add the helper function after `schemaTypeString` (at the end of the file):
+
+```go
+// matchGlobName matches a name against a pattern. If the pattern contains
+// glob characters (* or ?), it uses case-insensitive filepath.Match.
+// Otherwise, it falls back to case-insensitive exact match.
+func matchGlobName(name, pattern string) bool {
+	if strings.ContainsAny(pattern, "*?") {
+		matched, err := filepath.Match(strings.ToLower(pattern), strings.ToLower(name))
+		return err == nil && matched
+	}
+	return strings.EqualFold(name, pattern)
+}
+```
+
+Add `"path/filepath"` to the imports.
+
+Then update line 134 in `filterWalkSchemas`:
+
+Change:
+```go
+if input.Name != "" && !strings.EqualFold(info.Name, input.Name) {
+```
+
+To:
+```go
+if input.Name != "" && !matchGlobName(info.Name, input.Name) {
+```
+
+**Step 2: Run tests**
+
+Run: `go test ./internal/mcpserver/ -run "TestWalkSchemas_FilterByName" -v`
+Expected: ALL PASS (both old exact and new glob tests)
+
+**Step 3: Run gopls diagnostics**
+
+Run: `go_diagnostics` on `internal/mcpserver/tools_walk_schemas.go`
+
+**Step 4: Commit**
+
+```bash
+git add internal/mcpserver/tools_walk_schemas.go
+git commit -m "feat(mcp): add glob pattern matching for schema name filter
+
+Schema name filter now supports * and ? glob patterns via filepath.Match
+(case-insensitive). Non-glob names use exact match (backwards-compatible)."
+```
+
+---
+
+### Task 6: Add `walk_refs` Tool — Write Failing Test
+
+**Files:**
+- Create: `internal/mcpserver/tools_walk_refs_test.go`
+
+**Step 1: Write tests for both summary and detail modes**
+
+```go
+package mcpserver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const walkRefsTestSpec = `openapi: "3.0.0"
+info:
+  title: Walk Refs Test
+  version: "1.0.0"
+paths:
+  /pets:
+    get:
+      summary: List pets
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Pet"
+    post:
+      summary: Create a pet
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+      responses:
+        "201":
+          description: Created
+        "400":
+          $ref: "#/components/responses/BadRequest"
+  /pets/{petId}:
+    get:
+      summary: Get a pet
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /errors:
+    get:
+      summary: List errors
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+    Error:
+      type: object
+      properties:
+        code:
+          type: integer
+        message:
+          type: string
+  responses:
+    BadRequest:
+      description: Bad request
+    NotFound:
+      description: Not found
+`
+
+func callWalkRefs(t *testing.T, input walkRefsInput) (*mcp.CallToolResult, walkRefsOutput) {
+	t.Helper()
+	result, out, err := handleWalkRefs(context.Background(), &mcp.CallToolRequest{}, input)
+	require.NoError(t, err)
+	if out == nil {
+		return result, walkRefsOutput{}
+	}
+	wo, ok := out.(walkRefsOutput)
+	require.True(t, ok, "expected walkRefsOutput, got %T", out)
+	return result, wo
+}
+
+func TestWalkRefs_SummaryMode(t *testing.T) {
+	input := walkRefsInput{
+		Spec: specInput{Content: walkRefsTestSpec},
+	}
+	_, output := callWalkRefs(t, input)
+
+	assert.Greater(t, output.Total, 0)
+	assert.Greater(t, output.Matched, 0)
+	require.NotEmpty(t, output.Summaries)
+
+	// Pet should be the most-referenced schema (3 refs).
+	assert.Equal(t, "#/components/schemas/Pet", output.Summaries[0].Ref)
+	assert.Equal(t, 3, output.Summaries[0].Count)
+
+	// Verify sorted descending by count.
+	for i := 1; i < len(output.Summaries); i++ {
+		assert.GreaterOrEqual(t, output.Summaries[i-1].Count, output.Summaries[i].Count)
+	}
+}
+
+func TestWalkRefs_FilterByTarget(t *testing.T) {
+	input := walkRefsInput{
+		Spec:   specInput{Content: walkRefsTestSpec},
+		Target: "*schemas/Pet",
+	}
+	_, output := callWalkRefs(t, input)
+
+	assert.Equal(t, 1, output.Matched)
+	require.Len(t, output.Summaries, 1)
+	assert.Equal(t, "#/components/schemas/Pet", output.Summaries[0].Ref)
+	assert.Equal(t, 3, output.Summaries[0].Count)
+}
+
+func TestWalkRefs_FilterByNodeType(t *testing.T) {
+	input := walkRefsInput{
+		Spec:     specInput{Content: walkRefsTestSpec},
+		NodeType: "response",
+	}
+	_, output := callWalkRefs(t, input)
+
+	// Only response refs: BadRequest and NotFound.
+	assert.Equal(t, 2, output.Matched)
+	for _, s := range output.Summaries {
+		assert.Contains(t, s.Ref, "#/components/responses/")
+	}
+}
+
+func TestWalkRefs_DetailMode(t *testing.T) {
+	input := walkRefsInput{
+		Spec:   specInput{Content: walkRefsTestSpec},
+		Target: "*schemas/Pet",
+		Detail: true,
+	}
+	_, output := callWalkRefs(t, input)
+
+	assert.Nil(t, output.Summaries)
+	require.Len(t, output.Details, 3)
+	for _, d := range output.Details {
+		assert.Equal(t, "#/components/schemas/Pet", d.Ref)
+		assert.NotEmpty(t, d.SourcePath)
+		assert.Equal(t, "schema", d.NodeType)
+	}
+}
+
+func TestWalkRefs_Pagination(t *testing.T) {
+	input := walkRefsInput{
+		Spec:  specInput{Content: walkRefsTestSpec},
+		Limit: 2,
+	}
+	_, output := callWalkRefs(t, input)
+
+	assert.Equal(t, 2, output.Returned)
+	require.Len(t, output.Summaries, 2)
+}
+
+func TestWalkRefs_TargetGlob(t *testing.T) {
+	input := walkRefsInput{
+		Spec:   specInput{Content: walkRefsTestSpec},
+		Target: "*schemas/*",
+	}
+	_, output := callWalkRefs(t, input)
+
+	// Should match Pet and Error schemas.
+	assert.Equal(t, 2, output.Matched)
+}
+```
+
+**Step 2: Run tests — expect compile errors**
+
+Run: `go test ./internal/mcpserver/ -run "TestWalkRefs" -v`
+Expected: FAIL — `handleWalkRefs`, `walkRefsInput`, `walkRefsOutput` undefined
+
+**Step 3: Commit**
+
+```bash
+git add internal/mcpserver/tools_walk_refs_test.go
+git commit -m "test(mcp): add tests for new walk_refs tool"
+```
+
+---
+
+### Task 7: Implement `walk_refs` Tool
+
+**Files:**
+- Create: `internal/mcpserver/tools_walk_refs.go`
+- Modify: `internal/mcpserver/server.go:23-98` (register the tool)
+
+**Step 1: Create `tools_walk_refs.go`**
+
+```go
+package mcpserver
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	"github.com/erraggy/oastools/parser"
+	"github.com/erraggy/oastools/walker"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type walkRefsInput struct {
+	Spec     specInput `json:"spec"                   jsonschema:"The OAS document to walk"`
+	Target   string    `json:"target,omitempty"        jsonschema:"Filter by ref target (supports * and ? glob, e.g. *schemas/Pet or *responses/*)"`
+	NodeType string    `json:"node_type,omitempty"     jsonschema:"Filter by ref node type: schema, parameter, response, requestBody, header, pathItem"`
+	Detail   bool      `json:"detail,omitempty"        jsonschema:"Return individual source locations instead of aggregated counts"`
+	Limit    int       `json:"limit,omitempty"         jsonschema:"Maximum number of results to return (default 100)"`
+	Offset   int       `json:"offset,omitempty"        jsonschema:"Skip the first N results (for pagination)"`
+}
+
+type refSummary struct {
+	Ref   string `json:"ref"`
+	Count int    `json:"count"`
+}
+
+type refDetail struct {
+	Ref        string `json:"ref"`
+	SourcePath string `json:"source_path"`
+	NodeType   string `json:"node_type"`
+}
+
+type walkRefsOutput struct {
+	Total     int          `json:"total"`
+	Matched   int          `json:"matched"`
+	Returned  int          `json:"returned"`
+	Summaries []refSummary `json:"refs,omitempty"`
+	Details   []refDetail  `json:"details,omitempty"`
+}
+
+func handleWalkRefs(_ context.Context, _ *mcp.CallToolRequest, input walkRefsInput) (*mcp.CallToolResult, any, error) {
+	result, err := input.Spec.resolve()
+	if err != nil {
+		return errResult(err), nil, nil
+	}
+
+	// Collect all refs via the walker.
+	var allRefs []*walker.RefInfo
+	err = walker.Walk(result,
+		walker.WithMapRefTracking(),
+		walker.WithRefHandler(func(wc *walker.WalkContext, ref *walker.RefInfo) walker.Action {
+			allRefs = append(allRefs, ref)
+			return walker.Continue
+		}),
+	)
+	if err != nil {
+		return errResult(err), nil, nil
+	}
+
+	// Filter refs.
+	filtered := filterRefs(allRefs, input)
+
+	totalUnique := countUniqueRefs(allRefs)
+	matchedUnique := countUniqueRefs(filtered)
+
+	if input.Detail {
+		// Detail mode: return individual ref locations.
+		paged := paginate(filtered, input.Offset, input.Limit)
+		output := walkRefsOutput{
+			Total:    len(allRefs),
+			Matched:  len(filtered),
+			Returned: len(paged),
+			Details:  makeSlice[refDetail](len(paged)),
+		}
+		for _, ref := range paged {
+			output.Details = append(output.Details, refDetail{
+				Ref:        ref.Ref,
+				SourcePath: ref.SourcePath,
+				NodeType:   string(ref.NodeType),
+			})
+		}
+		return nil, output, nil
+	}
+
+	// Summary mode: aggregate by ref target, sort by count desc.
+	counts := make(map[string]int)
+	for _, ref := range filtered {
+		counts[ref.Ref]++
+	}
+
+	summaries := make([]refSummary, 0, len(counts))
+	for ref, count := range counts {
+		summaries = append(summaries, refSummary{Ref: ref, Count: count})
+	}
+	sort.Slice(summaries, func(i, j int) bool {
+		if summaries[i].Count != summaries[j].Count {
+			return summaries[i].Count > summaries[j].Count
+		}
+		return summaries[i].Ref < summaries[j].Ref
+	})
+
+	paged := paginate(summaries, input.Offset, input.Limit)
+	output := walkRefsOutput{
+		Total:     totalUnique,
+		Matched:   matchedUnique,
+		Returned:  len(paged),
+		Summaries: paged,
+	}
+	return nil, output, nil
+}
+
+// filterRefs applies target and node_type filters to refs.
+func filterRefs(refs []*walker.RefInfo, input walkRefsInput) []*walker.RefInfo {
+	if input.Target == "" && input.NodeType == "" {
+		return refs
+	}
+	var filtered []*walker.RefInfo
+	for _, ref := range refs {
+		if input.Target != "" && !matchGlobName(ref.Ref, input.Target) {
+			continue
+		}
+		if input.NodeType != "" && !strings.EqualFold(string(ref.NodeType), input.NodeType) {
+			continue
+		}
+		filtered = append(filtered, ref)
+	}
+	return filtered
+}
+
+// countUniqueRefs returns the number of distinct ref targets.
+func countUniqueRefs(refs []*walker.RefInfo) int {
+	seen := make(map[string]struct{}, len(refs))
+	for _, ref := range refs {
+		seen[ref.Ref] = struct{}{}
+	}
+	return len(seen)
+}
+```
+
+**Step 2: Register the tool in `server.go`**
+
+In `registerAllTools`, add before the closing `}` (after walk_paths registration):
+
+```go
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "walk_refs",
+		Description: "Walk and count $ref references in an OpenAPI Specification document. By default, returns unique ref targets ranked by reference count (most-referenced first). Use target to filter to a specific ref (supports * glob, e.g. *schemas/microsoft.graph.*). Use detail=true to see individual source locations instead of counts. Filter by node_type to narrow to schema, parameter, response, requestBody, header, or pathItem refs.",
+	}, handleWalkRefs)
+```
+
+NOTE: The `matchGlobName` helper was created in Task 5 in `tools_walk_schemas.go`. To keep it accessible from `tools_walk_refs.go`, it's already in the same package (`mcpserver`) — no move needed.
+
+**Step 3: Run walk_refs tests**
+
+Run: `go test ./internal/mcpserver/ -run "TestWalkRefs" -v`
+Expected: ALL PASS
+
+**Step 4: Run gopls diagnostics**
+
+Run: `go_diagnostics` on `internal/mcpserver/tools_walk_refs.go` and `internal/mcpserver/server.go`
+
+**Step 5: Run full mcpserver test suite**
+
+Run: `go test ./internal/mcpserver/ -v -count=1`
+Expected: ALL PASS
+
+**Step 6: Commit**
+
+```bash
+git add internal/mcpserver/tools_walk_refs.go internal/mcpserver/server.go
+git commit -m "feat(mcp): add walk_refs tool for $ref counting and cross-referencing
+
+New tool walks all \$ref occurrences using walker.WithRefHandler and
+WithMapRefTracking. Summary mode returns unique targets ranked by
+frequency. Detail mode shows individual source locations. Supports
+target glob filtering and node_type filtering."
+```
+
+---
+
+### Task 8: Update All Tool Descriptions
+
+**Files:**
+- Modify: `internal/mcpserver/server.go:24-97` (tool descriptions)
+- Modify: `internal/mcpserver/tools_walk_operations.go:14-26` (jsonschema tags)
+- Modify: `internal/mcpserver/tools_walk_schemas.go:14-24` (jsonschema tags)
+- Modify: `internal/mcpserver/tools_walk_parameters.go:14-24` (jsonschema tags)
+- Modify: `internal/mcpserver/tools_walk_responses.go:13-22` (jsonschema tags)
+- Modify: `internal/mcpserver/tools_walk_paths.go:12-18` (jsonschema tags)
+- Modify: `internal/mcpserver/tools_walk_security.go:13-20` (jsonschema tags)
+- Modify: `internal/mcpserver/tools_validate.go:11-15` (jsonschema tags)
+- Modify: `internal/mcpserver/tools_parse.go:11-13` (jsonschema tags)
+- Modify: `internal/mcpserver/tools_fix.go:15-24` (jsonschema tags)
+- Modify: `internal/mcpserver/tools_diff.go:12-17` (jsonschema tags)
+- Modify: `internal/mcpserver/tools_join.go:15-19` (jsonschema tags)
+- Modify: `internal/mcpserver/tools_generate.go:12-17` (jsonschema tags)
+
+**Step 1: Update all tool descriptions in `server.go`**
+
+Use the exact description text from the design doc section "Tool Description Audit". Apply every `Description:` string change. The full list is in `docs/plans/2026-02-14-mcp-walk-usability-design.md` sections "Core Tool Description Changes" and "Walk Tool Description Changes".
+
+**Step 2: Update all jsonschema tags**
+
+Apply parameter description changes from the design doc section "Parameter Description Standardization":
+
+- **Path filter** in walk_operations, walk_paths, walk_parameters, walk_responses: `"Filter by path pattern (* = one segment, ** = zero or more segments, e.g. /users/* or /drives/**/workbook/**)"`
+- **Schema name** in walk_schemas: `"Filter by schema name (exact match, or glob with * and ? for pattern matching, e.g. *workbook* or microsoft.graph.*)"`
+- **Tag** in walk_operations: `"Filter by tag name (exact match, case-sensitive)"`
+- **operation_id** in walk_operations: `"Select a single operation by operationId (exact match)"`
+- **Parameter name** in walk_parameters: `"Filter by parameter name (case-insensitive exact match)"`
+- **Status** in walk_responses: `"Filter by status code: exact (200, 404), wildcard (2xx, 4xx, 5xx), or default (case-insensitive)"`
+- **resolve_refs** in all walk tools: `"Resolve $ref pointers in output. Inlines referenced objects instead of showing $ref strings."`
+- **component** in walk_schemas: `"Only show component schemas (defined in components/schemas or definitions). Mutually exclusive with inline."`
+- **inline** in walk_schemas: `"Only show inline schemas (embedded in operations, not in components). Mutually exclusive with component."`
+- **detail** in walk_schemas: `"Return full schema objects. WARNING: produces large output without name/type filters on big specs."`
+- **full** in tools_parse: `"Return full parsed document instead of summary. WARNING: produces very large output for big specs — prefer walk_* tools instead."`
+
+**Step 3: Run gopls diagnostics on all modified files**
+
+**Step 4: Run full mcpserver tests**
+
+Run: `go test ./internal/mcpserver/ -v -count=1`
+Expected: ALL PASS (description-only changes shouldn't break tests)
+
+**Step 5: Commit**
+
+```bash
+git add internal/mcpserver/
+git commit -m "docs(mcp): audit and improve all tool descriptions for AI agent usability
+
+Updates all 16 tool descriptions and parameter jsonschema tags with:
+- Strategy hints (filter by tag first for large APIs)
+- Examples in parameter descriptions (glob patterns, status wildcards)
+- Explicit limitations (WARNING on full/detail for large specs)
+- Consistent wording across shared parameters (resolve_refs, limit, detail)
+- Accurate behavior documentation (exact match vs glob, case sensitivity)"
+```
+
+---
+
+### Task 9: Update `explore-api` Skill with walk_refs Guidance
+
+**Files:**
+- Modify: `plugin/skills/explore-api/SKILL.md`
+
+**Step 1: Add walk_refs to the explore-api skill**
+
+Add a new step between the existing step 4 (drill into specifics) and step 5 (summarize):
+
+```markdown
+5. **Analyze references** with walk_refs
+   - Use walk_refs (no filters) to see which schemas/responses are most-referenced
+   - Use walk_refs with target filter to trace a specific schema's usage
+   - Use walk_refs with node_type to narrow to schema vs response vs parameter refs
+   - Use walk_refs with detail=true + target to see exact source locations
+```
+
+Also update the path pattern examples in the skill to show `**` usage.
+
+**Step 2: Commit**
+
+```bash
+git add plugin/skills/explore-api/SKILL.md
+git commit -m "docs(plugin): add walk_refs guidance to explore-api skill"
+```
+
+---
+
+### Task 10: Run `make check` and Fix Any Issues
+
+**Files:** Any files that fail lint/format checks
+
+**Step 1: Run make check**
+
+Run: `make check`
+Expected: ALL PASS
+
+**Step 2: Fix any issues found**
+
+Common issues: trailing whitespace, import ordering, formatting.
+
+**Step 3: Commit fixes if needed**
+
+```bash
+git commit -am "fix: address make check findings"
+```
+
+---
+
+### Task 11: Manual Smoke Test with MS Graph Corpus
+
+This is a verification task, not TDD.
+
+**Step 1: Build and test walk_refs on MS Graph**
+
+Run: `go run ./cmd/oastools mcp` in a test harness, or run the MCP integration test.
+
+Verify that `walk_refs` on `testdata/corpus/msgraph-openapi.yaml`:
+- Returns `BaseCollectionPaginationCountResponse` as the top ref
+- Returns correct counts
+- `target` glob filtering works
+- `detail` mode shows source paths
+
+**Step 2: Test `**` path matching on MS Graph via walk_operations**
+
+Verify: `walk_operations` with `path: /drives/**/workbook/**` returns workbook operations.
+
+**Step 3: Test schema name glob on MS Graph via walk_schemas**
+
+Verify: `walk_schemas` with `name: microsoft.graph.workbook*` returns workbookRange, workbookFunctionResult, etc.

--- a/docs/plans/2026-02-15-walk-aggregation-design.md
+++ b/docs/plans/2026-02-15-walk-aggregation-design.md
@@ -1,0 +1,169 @@
+# Walk Tool Aggregation & walk_headers Design
+
+## Goal
+
+Add `group_by` aggregation to the four collector-based walk tools and introduce a new `walk_headers` tool, improving the MCP server's ability to answer distribution questions ("how many operations per tag?") without paging through thousands of items.
+
+## Motivation
+
+The walker's collectors (`CollectOperations`, `CollectSchemas`, `CollectParameters`, `CollectResponses`) already compute groupings (`.ByTag`, `.ByMethod`, `.ByStatusCode`, `.ByLocation`), but the MCP tools only use these for pre-filtering, never for aggregation output. The data is already grouped in memory -- we're just not exposing it.
+
+For headers, there's no way to directly query response headers or component headers. They're only visible deeply nested inside `walk_responses` or `walk_parameters` with `detail: true`.
+
+## Feature A: `group_by` for Walk Tools
+
+### Scope
+
+All four collector-based walk tools get a `group_by` parameter:
+
+| Tool | `group_by` values |
+|------|-------------------|
+| `walk_operations` | `tag`, `method` |
+| `walk_schemas` | `type`, `location` |
+| `walk_parameters` | `location`, `name` |
+| `walk_responses` | `status_code`, `method` |
+
+### Semantics
+
+- **Filters apply before grouping** (SQL WHERE + GROUP BY). Example: `walk_operations(group_by="method", tag="Users")` returns method distribution *within* the Users tag.
+- **Mutually exclusive with `detail`**. Setting both returns an error: `"cannot use both group_by and detail"`.
+- **Invalid values return an error** with the tool-specific allowed values listed.
+- **Groups sorted by count descending**, ties broken alphabetically by key.
+- **Pagination applies to groups** (`offset`/`limit`).
+
+### Output Shape
+
+When `group_by` is set, the `groups` array replaces `summaries` and detail arrays:
+
+```go
+type groupCount struct {
+    Key   string `json:"key"`
+    Count int    `json:"count"`
+}
+```
+
+```json
+{
+  "total": 16000,
+  "matched": 16000,
+  "returned": 4,
+  "groups": [
+    {"key": "GET", "count": 8500},
+    {"key": "POST", "count": 4200},
+    {"key": "DELETE", "count": 2100},
+    {"key": "PATCH", "count": 1200}
+  ]
+}
+```
+
+### Grouping Implementation
+
+Filters first, then group from the filtered slice (don't use collector indexes directly when filters are active):
+
+```
+collect -> filter -> group -> sort -> paginate
+```
+
+### Tool-Specific Notes
+
+- **walk_operations `group_by=tag`**: Untagged operations are excluded from groups (matching `collector.ByTag` behavior). The difference `matched - sum(groups[*].count)` reveals the untagged count.
+- **walk_schemas `group_by=location`**: Two groups: "component" and "inline".
+- **walk_schemas `group_by=type`**: Groups by schema type string ("object", "array", "string", etc.). Schemas with no type get key "".
+
+### jsonschema Descriptions
+
+Allowed values are embedded directly in the jsonschema description string for vanilla MCP client discoverability:
+
+```
+"Group results and return counts instead of individual items. Values: tag\\, method"
+```
+
+## Feature B: `walk_headers` Tool
+
+### Purpose
+
+Expose response headers and component headers as first-class walkable items.
+
+### Implementation Pattern
+
+Uses raw `Walk()` + `WithHeaderHandler` (no collector exists for headers). Same pattern as `walk_paths` and `walk_refs`.
+
+### Input
+
+```go
+type walkHeadersInput struct {
+    Spec        specInput `json:"spec"                     jsonschema:"..."`
+    Name        string    `json:"name,omitempty"           jsonschema:"Filter by header name (exact match\\, or glob with * and ?)"`
+    Path        string    `json:"path,omitempty"           jsonschema:"Filter by path pattern (* = one segment\\, ** = zero or more segments)"`
+    Method      string    `json:"method,omitempty"         jsonschema:"Filter by HTTP method"`
+    Status      string    `json:"status,omitempty"         jsonschema:"Filter by status code: exact (200)\\, wildcard (2xx)\\, or default"`
+    Component   bool      `json:"component,omitempty"      jsonschema:"Only show component headers (defined in components/headers)"`
+    ResolveRefs bool      `json:"resolve_refs,omitempty"   jsonschema:"Resolve $ref pointers in output"`
+    Detail      bool      `json:"detail,omitempty"         jsonschema:"Return full header objects instead of summaries"`
+    GroupBy     string    `json:"group_by,omitempty"       jsonschema:"Group results and return counts. Values: name\\, status_code"`
+    Limit       int       `json:"limit,omitempty"          jsonschema:"Maximum results (default 100)"`
+    Offset      int       `json:"offset,omitempty"         jsonschema:"Skip the first N results (for pagination)"`
+}
+```
+
+### Output
+
+Summary mode:
+
+```go
+type headerSummary struct {
+    Name        string `json:"name"`
+    Path        string `json:"path,omitempty"`
+    Method      string `json:"method,omitempty"`
+    Status      string `json:"status,omitempty"`
+    Description string `json:"description,omitempty"`
+    Required    bool   `json:"required,omitempty"`
+    Deprecated  bool   `json:"deprecated,omitempty"`
+}
+```
+
+Detail mode: full `*parser.Header` object.
+
+Group-by: `name` (header distribution across API) and `status_code` (header distribution across status codes).
+
+### WalkContext Fields Used
+
+- `wc.Name` -> header name
+- `wc.JSONPath` -> full path
+- `wc.IsComponent` -> component vs inline
+- `wc.PathTemplate` -> owning path (empty for component headers)
+- `wc.Method` -> owning method (empty for component headers)
+- `wc.StatusCode` -> owning response status (empty for component headers)
+
+### OAS 2.0 Compatibility
+
+OAS 2.0 has response headers too. The walker's `WithHeaderHandler` handles both versions. No special casing needed.
+
+### Tool Registration
+
+Tool count: 16 -> 17. Description:
+
+> Walk and query response headers and component headers in an OpenAPI Specification document. Filter by name, path, method, status code, or component location. Returns summaries (name, path, method, status, description) by default or full header objects with detail=true. Use group_by=name to find the most commonly used headers across the API.
+
+## Plugin Guidance Updates
+
+### plugin/CLAUDE.md
+
+- Tool count: 16 -> 17
+- Add `walk_headers` to Walk tool list
+- Add best practice for `group_by`: "Use `group_by` to get distributions in a single call"
+
+### explore-api Skill
+
+- Step 2 (endpoints): Add `group_by` examples for tag and method distribution
+- Step 3 (schemas): Add `group_by` example for type distribution
+- Step 4 (specifics): Add walk_headers guidance
+- All examples use jsonschema-documented values
+
+## Edge Cases
+
+- `group_by` + `detail` -> error
+- Invalid `group_by` value -> error with tool-specific allowed values
+- Empty results with `group_by` -> `{"total": N, "matched": 0, "returned": 0, "groups": []}`
+- walk_headers on OAS 2.0 -> works (walker handles both versions)
+- Operations without tags in `group_by=tag` -> excluded from groups, detectable via matched vs sum

--- a/docs/plans/2026-02-15-walk-aggregation-implementation.md
+++ b/docs/plans/2026-02-15-walk-aggregation-implementation.md
@@ -1,0 +1,1339 @@
+# Walk Tool Aggregation & walk_headers Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add `group_by` aggregation to all four collector-based walk tools and introduce a `walk_headers` tool.
+
+**Architecture:** Each walk tool gets a `group_by` string parameter that switches output from item lists to `[{key, count}]` groups. A shared `groupCount` type and `groupAndSort` helper in `server.go` handle the common logic. `walk_headers` uses raw `Walk()` + `WithHeaderHandler`. Filters apply before grouping (WHERE + GROUP BY).
+
+**Tech Stack:** Go 1.24, MCP go-sdk, walker package, testify
+
+---
+
+### Task 1: Shared group_by infrastructure + walk_operations group_by
+
+This task establishes the pattern that all subsequent tasks follow.
+
+**Files:**
+- Modify: `internal/mcpserver/server.go` (add `groupCount` type, `groupAndSort` helper, `validateGroupBy` helper)
+- Modify: `internal/mcpserver/tools_walk_operations.go` (add `GroupBy` to input, `Groups` to output, grouping logic)
+- Modify: `internal/mcpserver/tools_walk_operations_test.go` (add group_by tests)
+
+**Step 1: Write failing tests**
+
+Add these tests to `internal/mcpserver/tools_walk_operations_test.go`:
+
+```go
+func TestWalkOperations_GroupByTag(t *testing.T) {
+	input := walkOperationsInput{
+		Spec:    specInput{Content: walkOperationsTestSpec},
+		GroupBy: "tag",
+	}
+	_, output := callWalkOperations(t, input)
+
+	assert.Equal(t, 5, output.Total)
+	assert.Equal(t, 5, output.Matched)
+	require.NotEmpty(t, output.Groups)
+	assert.Nil(t, output.Summaries)
+
+	// pets tag has 3 ops (listPets, createPet, getPet), admin has 1 (deletePet), stores has 1.
+	groupMap := make(map[string]int)
+	for _, g := range output.Groups {
+		groupMap[g.Key] = g.Count
+	}
+	assert.Equal(t, 3, groupMap["pets"])
+	assert.Equal(t, 1, groupMap["admin"])
+	assert.Equal(t, 1, groupMap["stores"])
+
+	// Sorted descending by count.
+	assert.Equal(t, "pets", output.Groups[0].Key)
+}
+
+func TestWalkOperations_GroupByMethod(t *testing.T) {
+	input := walkOperationsInput{
+		Spec:    specInput{Content: walkOperationsTestSpec},
+		GroupBy: "method",
+	}
+	_, output := callWalkOperations(t, input)
+
+	assert.Equal(t, 5, output.Total)
+	require.NotEmpty(t, output.Groups)
+	assert.Nil(t, output.Summaries)
+
+	groupMap := make(map[string]int)
+	for _, g := range output.Groups {
+		groupMap[g.Key] = g.Count
+	}
+	assert.Equal(t, 3, groupMap["GET"])
+	assert.Equal(t, 1, groupMap["POST"])
+	assert.Equal(t, 1, groupMap["DELETE"])
+}
+
+func TestWalkOperations_GroupByWithFilter(t *testing.T) {
+	// group_by=method, filtered to tag=pets: should show method distribution within pets tag.
+	input := walkOperationsInput{
+		Spec:    specInput{Content: walkOperationsTestSpec},
+		Tag:     "pets",
+		GroupBy: "method",
+	}
+	_, output := callWalkOperations(t, input)
+
+	assert.Equal(t, 5, output.Total)
+	assert.Equal(t, 3, output.Matched) // 3 pets-tagged ops
+	groupMap := make(map[string]int)
+	for _, g := range output.Groups {
+		groupMap[g.Key] = g.Count
+	}
+	assert.Equal(t, 2, groupMap["GET"])  // listPets + getPet
+	assert.Equal(t, 1, groupMap["POST"]) // createPet
+}
+
+func TestWalkOperations_GroupByAndDetailError(t *testing.T) {
+	input := walkOperationsInput{
+		Spec:    specInput{Content: walkOperationsTestSpec},
+		GroupBy: "tag",
+		Detail:  true,
+	}
+	result, _ := callWalkOperations(t, input)
+	require.NotNil(t, result)
+	assert.True(t, result.IsError)
+}
+
+func TestWalkOperations_GroupByInvalid(t *testing.T) {
+	input := walkOperationsInput{
+		Spec:    specInput{Content: walkOperationsTestSpec},
+		GroupBy: "invalid",
+	}
+	result, _ := callWalkOperations(t, input)
+	require.NotNil(t, result)
+	assert.True(t, result.IsError)
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/mcpserver/ -run "TestWalkOperations_GroupBy" -v`
+Expected: FAIL — `Groups` field does not exist on `walkOperationsOutput`
+
+**Step 3: Add shared infrastructure to server.go**
+
+Add after the `errResult` function in `internal/mcpserver/server.go`:
+
+```go
+// groupCount represents a single group in group_by results.
+type groupCount struct {
+	Key   string `json:"key"`
+	Count int    `json:"count"`
+}
+
+// groupAndSort groups items by key, sorts by count descending (ties
+// broken alphabetically by key), and returns the sorted groups.
+func groupAndSort[T any](items []T, keyFn func(T) []string) []groupCount {
+	counts := make(map[string]int)
+	for _, item := range items {
+		for _, key := range keyFn(item) {
+			counts[key]++
+		}
+	}
+	groups := make([]groupCount, 0, len(counts))
+	for key, count := range counts {
+		groups = append(groups, groupCount{Key: key, Count: count})
+	}
+	sort.Slice(groups, func(i, j int) bool {
+		if groups[i].Count != groups[j].Count {
+			return groups[i].Count > groups[j].Count
+		}
+		return groups[i].Key < groups[j].Key
+	})
+	return groups
+}
+
+// validateGroupBy checks that group_by is a valid value and is not combined with detail.
+func validateGroupBy(groupBy string, detail bool, allowed []string) error {
+	if groupBy == "" {
+		return nil
+	}
+	if detail {
+		return fmt.Errorf("cannot use both group_by and detail")
+	}
+	for _, a := range allowed {
+		if strings.EqualFold(groupBy, a) {
+			return nil
+		}
+	}
+	return fmt.Errorf("invalid group_by value %q; valid values: %s", groupBy, strings.Join(allowed, ", "))
+}
+```
+
+Add `"fmt"`, `"sort"`, and `"strings"` to the imports if not already present (check — `sort` is likely new).
+
+**Step 4: Add group_by to walk_operations**
+
+In `internal/mcpserver/tools_walk_operations.go`:
+
+1. Add to `walkOperationsInput`:
+```go
+GroupBy string `json:"group_by,omitempty" jsonschema:"Group results and return counts instead of individual items. Values: tag\\, method"`
+```
+
+2. Add to `walkOperationsOutput`:
+```go
+Groups []groupCount `json:"groups,omitempty"`
+```
+
+3. In `handleWalkOperations`, add validation after `input.Spec.resolve()`:
+```go
+if err := validateGroupBy(input.GroupBy, input.Detail, []string{"tag", "method"}); err != nil {
+    return errResult(err), nil, nil
+}
+```
+
+4. After filtering, add the group_by branch before the existing summary/detail logic:
+```go
+if input.GroupBy != "" {
+    groups := groupAndSort(matched, func(op *walker.OperationInfo) []string {
+        switch strings.ToLower(input.GroupBy) {
+        case "tag":
+            if len(op.Operation.Tags) == 0 {
+                return nil
+            }
+            return op.Operation.Tags
+        case "method":
+            return []string{strings.ToUpper(op.Method)}
+        default:
+            return nil
+        }
+    })
+    paged := paginate(groups, input.Offset, input.Limit)
+    output := walkOperationsOutput{
+        Total:    len(collector.All),
+        Matched:  len(matched),
+        Returned: len(paged),
+        Groups:   paged,
+    }
+    return nil, output, nil
+}
+```
+
+**Step 5: Run tests to verify they pass**
+
+Run: `go test ./internal/mcpserver/ -run "TestWalkOperations" -v`
+Expected: ALL PASS
+
+**Step 6: Commit**
+
+```bash
+git add internal/mcpserver/server.go internal/mcpserver/tools_walk_operations.go internal/mcpserver/tools_walk_operations_test.go
+git commit -m "feat(mcp): add group_by aggregation to walk_operations"
+```
+
+---
+
+### Task 2: walk_schemas group_by
+
+**Files:**
+- Modify: `internal/mcpserver/tools_walk_schemas.go` (add `GroupBy` to input, `Groups` to output)
+- Modify: `internal/mcpserver/tools_walk_schemas_test.go` (add group_by tests)
+
+**Step 1: Write failing tests**
+
+Add to `internal/mcpserver/tools_walk_schemas_test.go`:
+
+```go
+func TestWalkSchemas_GroupByType(t *testing.T) {
+	input := walkSchemasInput{
+		Spec:      specInput{Content: walkSchemasTestSpec},
+		Component: true,
+		GroupBy:   "type",
+	}
+	_, output := callWalkSchemas(t, input)
+
+	assert.Equal(t, 8, output.Matched)
+	require.NotEmpty(t, output.Groups)
+	assert.Nil(t, output.Summaries)
+
+	groupMap := make(map[string]int)
+	for _, g := range output.Groups {
+		groupMap[g.Key] = g.Count
+	}
+	// Pet(object) + Error(object) = 2 object schemas, Tag(string) = 1 string schema,
+	// plus property schemas: id(integer)*2, name(string)*1, tag(string)*1,
+	// code(integer)*1, message(string)*1. Total: object=2, string=3, integer=3
+	assert.Greater(t, groupMap["object"], 0)
+	assert.Greater(t, groupMap["string"], 0)
+	assert.Greater(t, groupMap["integer"], 0)
+}
+
+func TestWalkSchemas_GroupByLocation(t *testing.T) {
+	input := walkSchemasInput{
+		Spec:    specInput{Content: walkSchemasTestSpec},
+		GroupBy: "location",
+	}
+	_, output := callWalkSchemas(t, input)
+
+	require.NotEmpty(t, output.Groups)
+	assert.Nil(t, output.Summaries)
+
+	groupMap := make(map[string]int)
+	for _, g := range output.Groups {
+		groupMap[g.Key] = g.Count
+	}
+	assert.Greater(t, groupMap["component"], 0)
+	assert.Greater(t, groupMap["inline"], 0)
+}
+
+func TestWalkSchemas_GroupByAndDetailError(t *testing.T) {
+	input := walkSchemasInput{
+		Spec:    specInput{Content: walkSchemasTestSpec},
+		GroupBy: "type",
+		Detail:  true,
+	}
+	result, _ := callWalkSchemas(t, input)
+	require.NotNil(t, result)
+	assert.True(t, result.IsError)
+}
+
+func TestWalkSchemas_GroupByInvalid(t *testing.T) {
+	input := walkSchemasInput{
+		Spec:    specInput{Content: walkSchemasTestSpec},
+		GroupBy: "invalid",
+	}
+	result, _ := callWalkSchemas(t, input)
+	require.NotNil(t, result)
+	assert.True(t, result.IsError)
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/mcpserver/ -run "TestWalkSchemas_GroupBy" -v`
+Expected: FAIL
+
+**Step 3: Implement**
+
+In `internal/mcpserver/tools_walk_schemas.go`:
+
+1. Add to `walkSchemasInput`:
+```go
+GroupBy string `json:"group_by,omitempty" jsonschema:"Group results and return counts instead of individual items. Values: type\\, location"`
+```
+
+2. Add to `walkSchemasOutput`:
+```go
+Groups []groupCount `json:"groups,omitempty"`
+```
+
+3. In `handleWalkSchemas`, add validation right after the `component && inline` check:
+```go
+if err := validateGroupBy(input.GroupBy, input.Detail, []string{"type", "location"}); err != nil {
+    return errResult(err), nil, nil
+}
+```
+
+4. After filtering, add the group_by branch:
+```go
+if input.GroupBy != "" {
+    groups := groupAndSort(filtered, func(info *walker.SchemaInfo) []string {
+        switch strings.ToLower(input.GroupBy) {
+        case "type":
+            t := schemaTypeString(info.Schema.Type)
+            if t == "" {
+                return []string{""}
+            }
+            return []string{t}
+        case "location":
+            return []string{schemaLocation(info.IsComponent)}
+        default:
+            return nil
+        }
+    })
+    paged := paginate(groups, input.Offset, input.Limit)
+    output := walkSchemasOutput{
+        Total:    len(collector.All),
+        Matched:  len(filtered),
+        Returned: len(paged),
+        Groups:   paged,
+    }
+    return nil, output, nil
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/mcpserver/ -run "TestWalkSchemas" -v`
+Expected: ALL PASS
+
+**Step 5: Commit**
+
+```bash
+git add internal/mcpserver/tools_walk_schemas.go internal/mcpserver/tools_walk_schemas_test.go
+git commit -m "feat(mcp): add group_by aggregation to walk_schemas"
+```
+
+---
+
+### Task 3: walk_parameters group_by
+
+**Files:**
+- Modify: `internal/mcpserver/tools_walk_parameters.go`
+- Modify: `internal/mcpserver/tools_walk_parameters_test.go`
+
+**Step 1: Write failing tests**
+
+Add to `internal/mcpserver/tools_walk_parameters_test.go`:
+
+```go
+func TestWalkParameters_GroupByLocation(t *testing.T) {
+	input := walkParametersInput{
+		Spec:    specInput{Content: walkParametersTestSpec},
+		GroupBy: "location",
+	}
+	_, output := callWalkParameters(t, input)
+
+	assert.Equal(t, 4, output.Total)
+	require.NotEmpty(t, output.Groups)
+	assert.Nil(t, output.Summaries)
+
+	groupMap := make(map[string]int)
+	for _, g := range output.Groups {
+		groupMap[g.Key] = g.Count
+	}
+	assert.Equal(t, 2, groupMap["query"])  // limit, offset
+	assert.Equal(t, 1, groupMap["header"]) // X-Request-Id
+	assert.Equal(t, 1, groupMap["path"])   // petId
+}
+
+func TestWalkParameters_GroupByName(t *testing.T) {
+	input := walkParametersInput{
+		Spec:    specInput{Content: walkParametersTestSpec},
+		GroupBy: "name",
+	}
+	_, output := callWalkParameters(t, input)
+
+	require.NotEmpty(t, output.Groups)
+	// Each parameter has a unique name in test spec, so each group has count 1.
+	for _, g := range output.Groups {
+		assert.Equal(t, 1, g.Count)
+	}
+}
+
+func TestWalkParameters_GroupByWithFilter(t *testing.T) {
+	input := walkParametersInput{
+		Spec:    specInput{Content: walkParametersTestSpec},
+		Path:    "/pets",
+		GroupBy: "location",
+	}
+	_, output := callWalkParameters(t, input)
+
+	assert.Equal(t, 3, output.Matched)
+	groupMap := make(map[string]int)
+	for _, g := range output.Groups {
+		groupMap[g.Key] = g.Count
+	}
+	assert.Equal(t, 2, groupMap["query"])
+	assert.Equal(t, 1, groupMap["header"])
+}
+
+func TestWalkParameters_GroupByAndDetailError(t *testing.T) {
+	input := walkParametersInput{
+		Spec:    specInput{Content: walkParametersTestSpec},
+		GroupBy: "location",
+		Detail:  true,
+	}
+	result, _ := callWalkParameters(t, input)
+	require.NotNil(t, result)
+	assert.True(t, result.IsError)
+}
+
+func TestWalkParameters_GroupByInvalid(t *testing.T) {
+	input := walkParametersInput{
+		Spec:    specInput{Content: walkParametersTestSpec},
+		GroupBy: "invalid",
+	}
+	result, _ := callWalkParameters(t, input)
+	require.NotNil(t, result)
+	assert.True(t, result.IsError)
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/mcpserver/ -run "TestWalkParameters_GroupBy" -v`
+Expected: FAIL
+
+**Step 3: Implement**
+
+In `internal/mcpserver/tools_walk_parameters.go`:
+
+1. Add to `walkParametersInput`:
+```go
+GroupBy string `json:"group_by,omitempty" jsonschema:"Group results and return counts instead of individual items. Values: location\\, name"`
+```
+
+2. Add to `walkParametersOutput`:
+```go
+Groups []groupCount `json:"groups,omitempty"`
+```
+
+3. In `handleWalkParameters`, add validation after `input.Spec.resolve()`:
+```go
+if err := validateGroupBy(input.GroupBy, input.Detail, []string{"location", "name"}); err != nil {
+    return errResult(err), nil, nil
+}
+```
+
+4. After filtering, add group_by branch:
+```go
+if input.GroupBy != "" {
+    groups := groupAndSort(matched, func(info *walker.ParameterInfo) []string {
+        switch strings.ToLower(input.GroupBy) {
+        case "location":
+            return []string{info.In}
+        case "name":
+            return []string{info.Name}
+        default:
+            return nil
+        }
+    })
+    paged := paginate(groups, input.Offset, input.Limit)
+    output := walkParametersOutput{
+        Total:    len(collector.All),
+        Matched:  len(matched),
+        Returned: len(paged),
+        Groups:   paged,
+    }
+    return nil, output, nil
+}
+```
+
+**Step 4: Run tests**
+
+Run: `go test ./internal/mcpserver/ -run "TestWalkParameters" -v`
+Expected: ALL PASS
+
+**Step 5: Commit**
+
+```bash
+git add internal/mcpserver/tools_walk_parameters.go internal/mcpserver/tools_walk_parameters_test.go
+git commit -m "feat(mcp): add group_by aggregation to walk_parameters"
+```
+
+---
+
+### Task 4: walk_responses group_by
+
+**Files:**
+- Modify: `internal/mcpserver/tools_walk_responses.go`
+- Modify: `internal/mcpserver/tools_walk_responses_test.go`
+
+**Step 1: Write failing tests**
+
+Add to `internal/mcpserver/tools_walk_responses_test.go`. The test spec for responses (`walkResponsesTestSpec`) should be checked first — read the file to confirm the fixture. Use the same `walkOperationsTestSpec` which has responses at 200, 201, 204.
+
+Actually, use `walkResponsesTestSpec` if it exists, or define a local spec. Check the test file first. The response test fixture likely has several status codes. Use this test:
+
+```go
+func TestWalkResponses_GroupByStatusCode(t *testing.T) {
+	input := walkResponsesInput{
+		Spec:    specInput{Content: walkResponsesTestSpec},
+		GroupBy: "status_code",
+	}
+	_, output := callWalkResponses(t, input)
+
+	require.NotEmpty(t, output.Groups)
+	assert.Nil(t, output.Summaries)
+
+	// Verify groups are sorted descending by count.
+	for i := 1; i < len(output.Groups); i++ {
+		assert.GreaterOrEqual(t, output.Groups[i-1].Count, output.Groups[i].Count)
+	}
+}
+
+func TestWalkResponses_GroupByMethod(t *testing.T) {
+	input := walkResponsesInput{
+		Spec:    specInput{Content: walkResponsesTestSpec},
+		GroupBy: "method",
+	}
+	_, output := callWalkResponses(t, input)
+
+	require.NotEmpty(t, output.Groups)
+	assert.Nil(t, output.Summaries)
+
+	// All keys should be uppercase methods.
+	for _, g := range output.Groups {
+		assert.Equal(t, strings.ToUpper(g.Key), g.Key)
+	}
+}
+
+func TestWalkResponses_GroupByWithFilter(t *testing.T) {
+	input := walkResponsesInput{
+		Spec:    specInput{Content: walkResponsesTestSpec},
+		Status:  "2xx",
+		GroupBy: "method",
+	}
+	_, output := callWalkResponses(t, input)
+
+	assert.Greater(t, output.Matched, 0)
+	require.NotEmpty(t, output.Groups)
+}
+
+func TestWalkResponses_GroupByAndDetailError(t *testing.T) {
+	input := walkResponsesInput{
+		Spec:    specInput{Content: walkResponsesTestSpec},
+		GroupBy: "status_code",
+		Detail:  true,
+	}
+	result, _ := callWalkResponses(t, input)
+	require.NotNil(t, result)
+	assert.True(t, result.IsError)
+}
+
+func TestWalkResponses_GroupByInvalid(t *testing.T) {
+	input := walkResponsesInput{
+		Spec:    specInput{Content: walkResponsesTestSpec},
+		GroupBy: "invalid",
+	}
+	result, _ := callWalkResponses(t, input)
+	require.NotNil(t, result)
+	assert.True(t, result.IsError)
+}
+```
+
+Note: If `walkResponsesTestSpec` is not defined in the test file, check the file and use whatever constant is defined. If needed, use `walkOperationsTestSpec` which also has responses.
+
+**Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/mcpserver/ -run "TestWalkResponses_GroupBy" -v`
+Expected: FAIL
+
+**Step 3: Implement**
+
+In `internal/mcpserver/tools_walk_responses.go`:
+
+1. Add to `walkResponsesInput`:
+```go
+GroupBy string `json:"group_by,omitempty" jsonschema:"Group results and return counts instead of individual items. Values: status_code\\, method"`
+```
+
+2. Add to `walkResponsesOutput`:
+```go
+Groups []groupCount `json:"groups,omitempty"`
+```
+
+3. In `handleWalkResponses`, add validation after `input.Spec.resolve()`:
+```go
+if err := validateGroupBy(input.GroupBy, input.Detail, []string{"status_code", "method"}); err != nil {
+    return errResult(err), nil, nil
+}
+```
+
+4. After filtering, add group_by branch:
+```go
+if input.GroupBy != "" {
+    groups := groupAndSort(matched, func(info *walker.ResponseInfo) []string {
+        switch strings.ToLower(input.GroupBy) {
+        case "status_code":
+            return []string{info.StatusCode}
+        case "method":
+            return []string{strings.ToUpper(info.Method)}
+        default:
+            return nil
+        }
+    })
+    paged := paginate(groups, input.Offset, input.Limit)
+    output := walkResponsesOutput{
+        Total:    len(collector.All),
+        Matched:  len(matched),
+        Returned: len(paged),
+        Groups:   paged,
+    }
+    return nil, output, nil
+}
+```
+
+**Step 4: Run tests**
+
+Run: `go test ./internal/mcpserver/ -run "TestWalkResponses" -v`
+Expected: ALL PASS
+
+**Step 5: Commit**
+
+```bash
+git add internal/mcpserver/tools_walk_responses.go internal/mcpserver/tools_walk_responses_test.go
+git commit -m "feat(mcp): add group_by aggregation to walk_responses"
+```
+
+---
+
+### Task 5: walk_headers tool
+
+**Files:**
+- Create: `internal/mcpserver/tools_walk_headers.go`
+- Create: `internal/mcpserver/tools_walk_headers_test.go`
+- Modify: `internal/mcpserver/server.go` (register tool)
+- Modify: `internal/mcpserver/integration_test.go` (16 -> 17 tools, add walk_headers)
+
+**Step 1: Write failing tests**
+
+Create `internal/mcpserver/tools_walk_headers_test.go`:
+
+```go
+package mcpserver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const walkHeadersTestSpec = `openapi: "3.0.0"
+info:
+  title: Walk Headers Test
+  version: "1.0.0"
+paths:
+  /pets:
+    get:
+      summary: List pets
+      responses:
+        "200":
+          description: OK
+          headers:
+            X-Rate-Limit:
+              description: Rate limit per hour
+              schema:
+                type: integer
+            X-Request-Id:
+              description: Request identifier
+              schema:
+                type: string
+        "404":
+          description: Not found
+          headers:
+            X-Request-Id:
+              description: Request identifier
+              schema:
+                type: string
+    post:
+      summary: Create a pet
+      responses:
+        "201":
+          description: Created
+          headers:
+            X-Request-Id:
+              description: Request identifier
+              schema:
+                type: string
+            Location:
+              description: URL of created resource
+              required: true
+              schema:
+                type: string
+  /stores:
+    get:
+      summary: List stores
+      responses:
+        "200":
+          description: OK
+          headers:
+            X-Rate-Limit:
+              description: Rate limit per hour
+              schema:
+                type: integer
+components:
+  headers:
+    TraceId:
+      description: Distributed tracing identifier
+      schema:
+        type: string
+`
+
+func callWalkHeaders(t *testing.T, input walkHeadersInput) (*mcp.CallToolResult, walkHeadersOutput) {
+	t.Helper()
+	result, out, err := handleWalkHeaders(context.Background(), &mcp.CallToolRequest{}, input)
+	require.NoError(t, err)
+	if out == nil {
+		return result, walkHeadersOutput{}
+	}
+	wo, ok := out.(walkHeadersOutput)
+	require.True(t, ok, "expected walkHeadersOutput, got %T", out)
+	return result, wo
+}
+
+func TestWalkHeaders_AllHeaders(t *testing.T) {
+	input := walkHeadersInput{
+		Spec: specInput{Content: walkHeadersTestSpec},
+	}
+	_, output := callWalkHeaders(t, input)
+
+	// 5 response headers + 1 component header = 6 total.
+	assert.Equal(t, 6, output.Total)
+	assert.Equal(t, 6, output.Matched)
+	require.Len(t, output.Summaries, 6)
+}
+
+func TestWalkHeaders_FilterByName(t *testing.T) {
+	input := walkHeadersInput{
+		Spec: specInput{Content: walkHeadersTestSpec},
+		Name: "X-Rate-Limit",
+	}
+	_, output := callWalkHeaders(t, input)
+
+	assert.Equal(t, 2, output.Matched)
+	for _, s := range output.Summaries {
+		assert.Equal(t, "X-Rate-Limit", s.Name)
+	}
+}
+
+func TestWalkHeaders_FilterByNameGlob(t *testing.T) {
+	input := walkHeadersInput{
+		Spec: specInput{Content: walkHeadersTestSpec},
+		Name: "X-*",
+	}
+	_, output := callWalkHeaders(t, input)
+
+	// X-Rate-Limit (2) + X-Request-Id (3) = 5
+	assert.Equal(t, 5, output.Matched)
+}
+
+func TestWalkHeaders_FilterByPath(t *testing.T) {
+	input := walkHeadersInput{
+		Spec: specInput{Content: walkHeadersTestSpec},
+		Path: "/pets",
+	}
+	_, output := callWalkHeaders(t, input)
+
+	// /pets GET 200 has 2 headers, GET 404 has 1, POST 201 has 2 = 5.
+	assert.Equal(t, 5, output.Matched)
+	for _, s := range output.Summaries {
+		assert.Equal(t, "/pets", s.Path)
+	}
+}
+
+func TestWalkHeaders_FilterByMethod(t *testing.T) {
+	input := walkHeadersInput{
+		Spec:   specInput{Content: walkHeadersTestSpec},
+		Method: "post",
+	}
+	_, output := callWalkHeaders(t, input)
+
+	assert.Equal(t, 2, output.Matched) // POST /pets 201 has X-Request-Id + Location
+	for _, s := range output.Summaries {
+		assert.Equal(t, "POST", s.Method)
+	}
+}
+
+func TestWalkHeaders_FilterByStatus(t *testing.T) {
+	input := walkHeadersInput{
+		Spec:   specInput{Content: walkHeadersTestSpec},
+		Status: "404",
+	}
+	_, output := callWalkHeaders(t, input)
+
+	assert.Equal(t, 1, output.Matched)
+	assert.Equal(t, "X-Request-Id", output.Summaries[0].Name)
+	assert.Equal(t, "404", output.Summaries[0].Status)
+}
+
+func TestWalkHeaders_ComponentFilter(t *testing.T) {
+	input := walkHeadersInput{
+		Spec:      specInput{Content: walkHeadersTestSpec},
+		Component: true,
+	}
+	_, output := callWalkHeaders(t, input)
+
+	assert.Equal(t, 1, output.Matched)
+	assert.Equal(t, "TraceId", output.Summaries[0].Name)
+}
+
+func TestWalkHeaders_DetailMode(t *testing.T) {
+	input := walkHeadersInput{
+		Spec:   specInput{Content: walkHeadersTestSpec},
+		Name:   "Location",
+		Detail: true,
+	}
+	_, output := callWalkHeaders(t, input)
+
+	assert.Equal(t, 1, output.Matched)
+	assert.Nil(t, output.Summaries)
+	require.Len(t, output.Headers, 1)
+	assert.Equal(t, "Location", output.Headers[0].Name)
+	assert.NotNil(t, output.Headers[0].Header)
+	assert.True(t, output.Headers[0].Header.Required)
+}
+
+func TestWalkHeaders_GroupByName(t *testing.T) {
+	input := walkHeadersInput{
+		Spec:    specInput{Content: walkHeadersTestSpec},
+		GroupBy: "name",
+	}
+	_, output := callWalkHeaders(t, input)
+
+	require.NotEmpty(t, output.Groups)
+	assert.Nil(t, output.Summaries)
+
+	groupMap := make(map[string]int)
+	for _, g := range output.Groups {
+		groupMap[g.Key] = g.Count
+	}
+	assert.Equal(t, 3, groupMap["X-Request-Id"]) // appears in 3 responses
+	assert.Equal(t, 2, groupMap["X-Rate-Limit"])  // appears in 2 responses
+	assert.Equal(t, 1, groupMap["Location"])       // appears in 1 response
+	assert.Equal(t, 1, groupMap["TraceId"])        // component header
+
+	// Most-referenced first.
+	assert.Equal(t, "X-Request-Id", output.Groups[0].Key)
+}
+
+func TestWalkHeaders_GroupByStatusCode(t *testing.T) {
+	input := walkHeadersInput{
+		Spec:    specInput{Content: walkHeadersTestSpec},
+		GroupBy: "status_code",
+	}
+	_, output := callWalkHeaders(t, input)
+
+	require.NotEmpty(t, output.Groups)
+	groupMap := make(map[string]int)
+	for _, g := range output.Groups {
+		groupMap[g.Key] = g.Count
+	}
+	assert.Equal(t, 3, groupMap["200"])  // GET /pets 200 (2) + GET /stores 200 (1)
+	assert.Equal(t, 2, groupMap["201"])  // POST /pets 201 (2)
+	assert.Equal(t, 1, groupMap["404"])  // GET /pets 404 (1)
+	// Component header (TraceId) has no status code — excluded from status_code grouping.
+}
+
+func TestWalkHeaders_Pagination(t *testing.T) {
+	input := walkHeadersInput{
+		Spec:  specInput{Content: walkHeadersTestSpec},
+		Limit: 2,
+	}
+	_, output := callWalkHeaders(t, input)
+
+	assert.Equal(t, 6, output.Total)
+	assert.Equal(t, 6, output.Matched)
+	assert.Equal(t, 2, output.Returned)
+	assert.Len(t, output.Summaries, 2)
+}
+
+func TestWalkHeaders_GroupByAndDetailError(t *testing.T) {
+	input := walkHeadersInput{
+		Spec:    specInput{Content: walkHeadersTestSpec},
+		GroupBy: "name",
+		Detail:  true,
+	}
+	result, _ := callWalkHeaders(t, input)
+	require.NotNil(t, result)
+	assert.True(t, result.IsError)
+}
+
+func TestWalkHeaders_InvalidSpec(t *testing.T) {
+	input := walkHeadersInput{
+		Spec: specInput{Content: "not valid yaml: ["},
+	}
+	result, _ := callWalkHeaders(t, input)
+	require.NotNil(t, result)
+	assert.True(t, result.IsError)
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/mcpserver/ -run "TestWalkHeaders" -v`
+Expected: FAIL — `walkHeadersInput` type does not exist
+
+**Step 3: Implement walk_headers**
+
+Create `internal/mcpserver/tools_walk_headers.go`:
+
+```go
+package mcpserver
+
+import (
+	"context"
+	"strings"
+
+	"github.com/erraggy/oastools/parser"
+	"github.com/erraggy/oastools/walker"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type walkHeadersInput struct {
+	Spec        specInput `json:"spec"                     jsonschema:"The OAS document to walk"`
+	Name        string    `json:"name,omitempty"           jsonschema:"Filter by header name (exact match\\, or glob with * and ? for pattern matching\\, e.g. X-Rate-* or *Token*)"`
+	Path        string    `json:"path,omitempty"           jsonschema:"Filter by path pattern (* = one segment\\, ** = zero or more segments)"`
+	Method      string    `json:"method,omitempty"         jsonschema:"Filter by HTTP method (get\\, post\\, put\\, delete\\, patch\\, etc.)"`
+	Status      string    `json:"status,omitempty"         jsonschema:"Filter by status code: exact (200\\, 404)\\, wildcard (2xx\\, 4xx)\\, or default"`
+	Component   bool      `json:"component,omitempty"      jsonschema:"Only show component headers (defined in components/headers)"`
+	ResolveRefs bool      `json:"resolve_refs,omitempty"   jsonschema:"Resolve $ref pointers in output. Inlines referenced objects instead of showing $ref strings."`
+	Detail      bool      `json:"detail,omitempty"         jsonschema:"Return full header objects instead of summaries"`
+	GroupBy     string    `json:"group_by,omitempty"       jsonschema:"Group results and return counts instead of individual items. Values: name\\, status_code"`
+	Limit       int       `json:"limit,omitempty"          jsonschema:"Maximum results (default 100)"`
+	Offset      int       `json:"offset,omitempty"         jsonschema:"Skip the first N results (for pagination)"`
+}
+
+type headerInfo struct {
+	Header       *parser.Header
+	Name         string
+	JSONPath     string
+	PathTemplate string
+	Method       string
+	StatusCode   string
+	IsComponent  bool
+}
+
+type headerSummary struct {
+	Name        string `json:"name"`
+	Path        string `json:"path,omitempty"`
+	Method      string `json:"method,omitempty"`
+	Status      string `json:"status,omitempty"`
+	Description string `json:"description,omitempty"`
+	Required    bool   `json:"required,omitempty"`
+	Deprecated  bool   `json:"deprecated,omitempty"`
+}
+
+type headerDetail struct {
+	Name     string         `json:"name"`
+	Path     string         `json:"path,omitempty"`
+	Method   string         `json:"method,omitempty"`
+	Status   string         `json:"status,omitempty"`
+	Header   *parser.Header `json:"header"`
+}
+
+type walkHeadersOutput struct {
+	Total     int             `json:"total"`
+	Matched   int             `json:"matched"`
+	Returned  int             `json:"returned"`
+	Summaries []headerSummary `json:"summaries,omitempty"`
+	Headers   []headerDetail  `json:"headers,omitempty"`
+	Groups    []groupCount    `json:"groups,omitempty"`
+}
+
+func handleWalkHeaders(_ context.Context, _ *mcp.CallToolRequest, input walkHeadersInput) (*mcp.CallToolResult, any, error) {
+	if err := validateGroupBy(input.GroupBy, input.Detail, []string{"name", "status_code"}); err != nil {
+		return errResult(err), nil, nil
+	}
+
+	var extraOpts []parser.Option
+	if input.ResolveRefs {
+		extraOpts = append(extraOpts, parser.WithResolveRefs(true))
+	}
+
+	result, err := input.Spec.resolve(extraOpts...)
+	if err != nil {
+		return errResult(err), nil, nil
+	}
+
+	// Collect all headers via the walker.
+	var allHeaders []*headerInfo
+	err = walker.Walk(result,
+		walker.WithHeaderHandler(func(wc *walker.WalkContext, header *parser.Header) walker.Action {
+			allHeaders = append(allHeaders, &headerInfo{
+				Header:       header,
+				Name:         wc.Name,
+				JSONPath:     wc.JSONPath,
+				PathTemplate: wc.PathTemplate,
+				Method:       wc.Method,
+				StatusCode:   wc.StatusCode,
+				IsComponent:  wc.IsComponent,
+			})
+			return walker.Continue
+		}),
+	)
+	if err != nil {
+		return errResult(err), nil, nil
+	}
+
+	// Filter headers.
+	filtered := filterWalkHeaders(allHeaders, input)
+
+	// Group-by mode.
+	if input.GroupBy != "" {
+		groups := groupAndSort(filtered, func(h *headerInfo) []string {
+			switch strings.ToLower(input.GroupBy) {
+			case "name":
+				return []string{h.Name}
+			case "status_code":
+				if h.StatusCode == "" {
+					return nil // component headers have no status code
+				}
+				return []string{h.StatusCode}
+			default:
+				return nil
+			}
+		})
+		paged := paginate(groups, input.Offset, input.Limit)
+		output := walkHeadersOutput{
+			Total:    len(allHeaders),
+			Matched:  len(filtered),
+			Returned: len(paged),
+			Groups:   paged,
+		}
+		return nil, output, nil
+	}
+
+	// Apply pagination.
+	returned := paginate(filtered, input.Offset, input.Limit)
+
+	output := walkHeadersOutput{
+		Total:    len(allHeaders),
+		Matched:  len(filtered),
+		Returned: len(returned),
+	}
+
+	if input.Detail {
+		output.Headers = makeSlice[headerDetail](len(returned))
+		for _, h := range returned {
+			output.Headers = append(output.Headers, headerDetail{
+				Name:   h.Name,
+				Path:   h.PathTemplate,
+				Method: strings.ToUpper(h.Method),
+				Status: h.StatusCode,
+				Header: h.Header,
+			})
+		}
+	} else {
+		output.Summaries = makeSlice[headerSummary](len(returned))
+		for _, h := range returned {
+			output.Summaries = append(output.Summaries, headerSummary{
+				Name:        h.Name,
+				Path:        h.PathTemplate,
+				Method:      strings.ToUpper(h.Method),
+				Status:      h.StatusCode,
+				Description: h.Header.Description,
+				Required:    h.Header.Required,
+				Deprecated:  h.Header.Deprecated,
+			})
+		}
+	}
+
+	return nil, output, nil
+}
+
+// filterWalkHeaders applies name, path, method, status, and component filters.
+func filterWalkHeaders(headers []*headerInfo, input walkHeadersInput) []*headerInfo {
+	if input.Name == "" && input.Path == "" && input.Method == "" && input.Status == "" && !input.Component {
+		return headers
+	}
+	var filtered []*headerInfo
+	for _, h := range headers {
+		if input.Name != "" && !matchGlobName(h.Name, input.Name) {
+			continue
+		}
+		if input.Path != "" && !matchWalkPath(h.PathTemplate, input.Path) {
+			continue
+		}
+		if input.Method != "" && !strings.EqualFold(h.Method, input.Method) {
+			continue
+		}
+		if input.Status != "" && !statusCodeMatches(h.StatusCode, input.Status) {
+			continue
+		}
+		if input.Component && !h.IsComponent {
+			continue
+		}
+		filtered = append(filtered, h)
+	}
+	return filtered
+}
+```
+
+**Step 4: Register in server.go**
+
+Add to `registerAllTools` in `internal/mcpserver/server.go`:
+
+```go
+mcp.AddTool(server, &mcp.Tool{
+    Name:        "walk_headers",
+    Description: "Walk and query response headers and component headers in an OpenAPI Specification document. Filter by name, path, method, status code, or component location. Returns summaries (name, path, method, status, description) by default or full header objects with detail=true. Use group_by=name to find the most commonly used headers across the API.",
+}, handleWalkHeaders)
+```
+
+**Step 5: Update integration test**
+
+In `internal/mcpserver/integration_test.go`:
+- Change `assert.Len(t, result.Tools, 16` to `assert.Len(t, result.Tools, 17`
+- Change comment from `16 tools: 9 core + 7 walk` to `17 tools: 9 core + 8 walk`
+- Add `"walk_headers"` to the `expectedTools` slice
+
+**Step 6: Run tests**
+
+Run: `go test ./internal/mcpserver/ -run "TestWalkHeaders|TestIntegration_ListTools" -v`
+Expected: ALL PASS
+
+**Step 7: Commit**
+
+```bash
+git add internal/mcpserver/tools_walk_headers.go internal/mcpserver/tools_walk_headers_test.go internal/mcpserver/server.go internal/mcpserver/integration_test.go
+git commit -m "feat(mcp): add walk_headers tool with group_by support"
+```
+
+---
+
+### Task 6: Update tool descriptions for group_by
+
+**Files:**
+- Modify: `internal/mcpserver/server.go` (update 4 walk tool descriptions to mention group_by)
+
+**Step 1: Update descriptions**
+
+Update the description for each tool that now has `group_by`:
+
+- **walk_operations**: Append to description: `Use group_by (tag or method) to get distribution counts instead of individual items.`
+- **walk_schemas**: Append to description: `Use group_by (type or location) to get distribution counts instead of individual items.`
+- **walk_parameters**: Append to description: `Use group_by (location or name) to get distribution counts instead of individual items.`
+- **walk_responses**: Append to description: `Use group_by (status_code or method) to get distribution counts instead of individual items.`
+
+**Step 2: Run integration test**
+
+Run: `go test ./internal/mcpserver/ -run "TestIntegration" -v`
+Expected: PASS
+
+**Step 3: Commit**
+
+```bash
+git add internal/mcpserver/server.go
+git commit -m "docs(mcp): update walk tool descriptions to document group_by"
+```
+
+---
+
+### Task 7: Plugin guidance updates
+
+**Files:**
+- Modify: `plugin/CLAUDE.md`
+- Modify: `plugin/skills/explore-api/SKILL.md`
+
+**Step 1: Update plugin/CLAUDE.md**
+
+1. Change tool counts: `16` -> `17` everywhere
+2. Change Walk tool list: add `walk_headers`
+3. After best practice #5 about filtering, add: `8. **Aggregate with `group_by`.** The walk tools (`walk_operations`, `walk_schemas`, `walk_parameters`, `walk_responses`, `walk_headers`) support a `group_by` parameter that returns `{key, count}` groups instead of individual items. Use this for distribution questions ("how many operations per tag?") instead of paging through all results.`
+4. In the "Explore a large API" workflow, add between steps 3 and 4: `3.5. `walk_operations` with `group_by: "tag"` — operation count per tag at a glance`
+
+**Step 2: Update explore-api SKILL.md**
+
+1. In Step 2 (List endpoints), add before the filtering guidance:
+```markdown
+For a quick overview of a large API, use `group_by` first:
+
+```json
+{"spec": {"file": "<path>"}, "group_by": "tag"}
+```
+
+This returns operation counts per tag — the fastest way to understand API scope.
+
+```json
+{"spec": {"file": "<path>"}, "group_by": "method"}
+```
+
+This shows the HTTP method distribution (e.g., 60% GET, 25% POST, etc.).
+```
+
+2. In Step 3 (List data models), add:
+```markdown
+Get schema type distribution:
+
+```json
+{"spec": {"file": "<path>"}, "group_by": "type", "component": true}
+```
+```
+
+3. In Step 4 (Drill into specifics), add a section for headers:
+```markdown
+**Response headers:**
+
+```json
+{"spec": {"file": "<path>"}, "group_by": "name"}
+```
+
+(using `walk_headers` — shows which headers are most common across the API)
+
+**Headers for a specific endpoint:**
+
+```json
+{"spec": {"file": "<path>"}, "path": "/users", "method": "get"}
+```
+
+(using `walk_headers`)
+```
+
+**Step 3: Commit**
+
+```bash
+git add plugin/CLAUDE.md plugin/skills/explore-api/SKILL.md
+git commit -m "docs(plugin): add group_by and walk_headers guidance to plugin skills"
+```
+
+---
+
+### Task 8: make check
+
+**Files:** None (validation only)
+
+**Step 1: Run make check**
+
+Run: `make check`
+Expected: 0 issues, all tests pass
+
+**Step 2: Fix any issues**
+
+If `go fmt` or linter issues are found, fix them. Common issues:
+- Missing imports (e.g., `"sort"` in server.go)
+- Unused variables from copy-paste
+- `unparam` warnings if any test helpers have unused return values
+
+**Step 3: Commit fixes if needed**
+
+```bash
+git add -A
+git commit -m "fix: address make check findings for walk aggregation"
+```
+
+---
+
+### Task 9: Smoke test against MS Graph corpus
+
+**Files:** None (manual verification)
+
+**Step 1: Run group_by tests against MS Graph**
+
+Write a temporary test in `internal/mcpserver/` (delete after):
+
+```go
+func TestCorpusSmoke_GroupBy(t *testing.T) {
+	if testing.Short() {
+		t.Skip("corpus smoke test")
+	}
+	spec := specInput{File: "../../corpus/microsoft-graph.yaml"}
+
+	// walk_operations group_by=tag: should return tag distribution.
+	_, opOut := callWalkOperations(t, walkOperationsInput{Spec: spec, GroupBy: "tag"})
+	t.Logf("Operations: %d total, %d tag groups, top: %s (%d)",
+		opOut.Total, len(opOut.Groups), opOut.Groups[0].Key, opOut.Groups[0].Count)
+	assert.Greater(t, len(opOut.Groups), 10)
+
+	// walk_operations group_by=method: should return method distribution.
+	_, methodOut := callWalkOperations(t, walkOperationsInput{Spec: spec, GroupBy: "method"})
+	t.Logf("Methods: %d groups", len(methodOut.Groups))
+	assert.Greater(t, len(methodOut.Groups), 2)
+
+	// walk_schemas group_by=type: schema type distribution.
+	_, schemaOut := callWalkSchemas(t, walkSchemasInput{Spec: spec, Component: true, GroupBy: "type"})
+	t.Logf("Schema types: %d groups, top: %s (%d)",
+		len(schemaOut.Groups), schemaOut.Groups[0].Key, schemaOut.Groups[0].Count)
+
+	// walk_headers group_by=name: header distribution.
+	_, headerOut := callWalkHeaders(t, walkHeadersInput{Spec: spec, GroupBy: "name"})
+	t.Logf("Headers: %d total, %d unique names, top: %s (%d)",
+		headerOut.Total, len(headerOut.Groups), headerOut.Groups[0].Key, headerOut.Groups[0].Count)
+}
+```
+
+Run: `go test ./internal/mcpserver/ -run "TestCorpusSmoke_GroupBy" -v -timeout 120s`
+
+Verify all pass and numbers look reasonable. Then delete the temporary test file.
+
+**Step 2: No commit needed** (temp file deleted)

--- a/internal/mcpserver/integration_test.go
+++ b/internal/mcpserver/integration_test.go
@@ -103,8 +103,8 @@ func TestIntegration_ListTools(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
-	// We expect 15 tools: 9 core + 6 walk.
-	assert.Len(t, result.Tools, 15, "expected 15 registered tools")
+	// We expect 17 tools: 9 core + 8 walk.
+	assert.Len(t, result.Tools, 17, "expected 17 registered tools")
 
 	// Collect tool names and verify expected ones are present.
 	names := make([]string, 0, len(result.Tools))
@@ -128,6 +128,8 @@ func TestIntegration_ListTools(t *testing.T) {
 		"walk_responses",
 		"walk_security",
 		"walk_paths",
+		"walk_refs",
+		"walk_headers",
 	}
 
 	for _, name := range expectedTools {

--- a/internal/mcpserver/tools_parse.go
+++ b/internal/mcpserver/tools_parse.go
@@ -10,7 +10,7 @@ import (
 type parseInput struct {
 	Spec        specInput `json:"spec"                     jsonschema:"The OAS document to parse"`
 	ResolveRefs bool      `json:"resolve_refs,omitempty"   jsonschema:"Resolve $ref pointers before returning"`
-	Full        bool      `json:"full,omitempty"           jsonschema:"Return full parsed document instead of summary"`
+	Full        bool      `json:"full,omitempty"           jsonschema:"Return full parsed document instead of summary. WARNING: produces very large output for big specs — prefer walk_* tools instead."`
 }
 
 type parseSummaryServer struct {

--- a/internal/mcpserver/tools_walk_headers.go
+++ b/internal/mcpserver/tools_walk_headers.go
@@ -1,0 +1,211 @@
+package mcpserver
+
+import (
+	"context"
+	"strings"
+
+	"github.com/erraggy/oastools/parser"
+	"github.com/erraggy/oastools/walker"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type walkHeadersInput struct {
+	Spec        specInput `json:"spec"                     jsonschema:"The OAS document to walk"`
+	Name        string    `json:"name,omitempty"           jsonschema:"Filter by header name (exact match\\, or glob with * and ? for pattern matching\\, e.g. X-Rate-* or X-Request-*)"`
+	Path        string    `json:"path,omitempty"           jsonschema:"Filter by path pattern (* = one segment\\, ** = zero or more segments\\, e.g. /users/* or /drives/**/workbook/**)"`
+	Method      string    `json:"method,omitempty"         jsonschema:"Filter by HTTP method (get\\, post\\, put\\, delete\\, patch\\, etc.)"`
+	Status      string    `json:"status,omitempty"         jsonschema:"Filter by status code: exact (200\\, 404)\\, wildcard (2xx\\, 4xx\\, 5xx)\\, or default (case-insensitive)"`
+	Extension   string    `json:"extension,omitempty"      jsonschema:"Filter by extension key=value (e.g. x-internal=true)"`
+	Component   bool      `json:"component,omitempty"      jsonschema:"Only show component headers (defined in components/headers)"`
+	ResolveRefs bool      `json:"resolve_refs,omitempty"   jsonschema:"Resolve $ref pointers in output. Inlines referenced objects instead of showing $ref strings."`
+	Detail      bool      `json:"detail,omitempty"         jsonschema:"Return full header objects instead of summaries"`
+	GroupBy     string    `json:"group_by,omitempty"       jsonschema:"Group results and return counts instead of individual items. Values: name\\, status_code"`
+	Limit       int       `json:"limit,omitempty"          jsonschema:"Maximum number of results to return (default 100)"`
+	Offset      int       `json:"offset,omitempty"         jsonschema:"Skip the first N results (for pagination)"`
+}
+
+// headerInfo holds walker context for a single header occurrence.
+type headerInfo struct {
+	Name        string
+	Path        string
+	Method      string
+	StatusCode  string
+	IsComponent bool
+	Header      *parser.Header
+}
+
+type headerSummary struct {
+	Name        string `json:"name"`
+	Path        string `json:"path,omitempty"`
+	Method      string `json:"method,omitempty"`
+	Status      string `json:"status,omitempty"`
+	Description string `json:"description,omitempty"`
+	Required    bool   `json:"required,omitempty"`
+	Deprecated  bool   `json:"deprecated,omitempty"`
+}
+
+type headerDetail struct {
+	Name   string         `json:"name"`
+	Path   string         `json:"path,omitempty"`
+	Method string         `json:"method,omitempty"`
+	Status string         `json:"status,omitempty"`
+	Header *parser.Header `json:"header"`
+}
+
+type walkHeadersOutput struct {
+	Total     int             `json:"total"`
+	Matched   int             `json:"matched"`
+	Returned  int             `json:"returned"`
+	Summaries []headerSummary `json:"summaries,omitempty"`
+	Headers   []headerDetail  `json:"headers,omitempty"`
+	Groups    []groupCount    `json:"groups,omitempty"`
+}
+
+func handleWalkHeaders(_ context.Context, _ *mcp.CallToolRequest, input walkHeadersInput) (*mcp.CallToolResult, any, error) {
+	var extraOpts []parser.Option
+	if input.ResolveRefs {
+		extraOpts = append(extraOpts, parser.WithResolveRefs(true))
+	}
+
+	result, err := input.Spec.resolve(extraOpts...)
+	if err != nil {
+		return errResult(err), nil, nil
+	}
+
+	if err := validateGroupBy(input.GroupBy, input.Detail, []string{"name", "status_code"}); err != nil {
+		return errResult(err), nil, nil
+	}
+
+	// Collect all headers using the walker.
+	var all []*headerInfo
+	err = walker.Walk(result,
+		walker.WithHeaderHandler(func(wc *walker.WalkContext, header *parser.Header) walker.Action {
+			all = append(all, &headerInfo{
+				Name:        wc.Name,
+				Path:        wc.PathTemplate,
+				Method:      wc.Method,
+				StatusCode:  wc.StatusCode,
+				IsComponent: wc.IsComponent,
+				Header:      header,
+			})
+			return walker.Continue
+		}),
+	)
+	if err != nil {
+		return errResult(err), nil, nil
+	}
+
+	// Filter headers.
+	matched, err := filterWalkHeaders(all, input)
+	if err != nil {
+		return errResult(err), nil, nil
+	}
+
+	// group_by: aggregate matched headers and return counts.
+	if input.GroupBy != "" {
+		groups := groupAndSort(matched, func(info *headerInfo) []string {
+			switch strings.ToLower(input.GroupBy) {
+			case "name":
+				return []string{info.Name}
+			case "status_code":
+				if info.StatusCode == "" {
+					return nil
+				}
+				return []string{info.StatusCode}
+			default:
+				return nil
+			}
+		})
+		paged := paginate(groups, input.Offset, input.Limit)
+		output := walkHeadersOutput{
+			Total:    len(all),
+			Matched:  len(matched),
+			Returned: len(paged),
+			Groups:   paged,
+		}
+		return nil, output, nil
+	}
+
+	// Apply offset/limit pagination.
+	returned := paginate(matched, input.Offset, input.Limit)
+
+	output := walkHeadersOutput{
+		Total:    len(all),
+		Matched:  len(matched),
+		Returned: len(returned),
+	}
+
+	if input.Detail {
+		output.Headers = makeSlice[headerDetail](len(returned))
+		for _, info := range returned {
+			output.Headers = append(output.Headers, headerDetail{
+				Name:   info.Name,
+				Path:   info.Path,
+				Method: strings.ToUpper(info.Method),
+				Status: info.StatusCode,
+				Header: info.Header,
+			})
+		}
+	} else {
+		output.Summaries = makeSlice[headerSummary](len(returned))
+		for _, info := range returned {
+			s := headerSummary{
+				Name:   info.Name,
+				Path:   info.Path,
+				Method: strings.ToUpper(info.Method),
+				Status: info.StatusCode,
+			}
+			if info.Header != nil {
+				s.Description = info.Header.Description
+				s.Required = info.Header.Required
+				s.Deprecated = info.Header.Deprecated
+			}
+			output.Summaries = append(output.Summaries, s)
+		}
+	}
+
+	return nil, output, nil
+}
+
+// filterWalkHeaders applies all header filters and returns the matching subset.
+func filterWalkHeaders(headers []*headerInfo, input walkHeadersInput) ([]*headerInfo, error) {
+	if err := validateGlobPattern(input.Name); err != nil {
+		return nil, err
+	}
+
+	var extKey, extValue string
+	var hasExtFilter bool
+	if input.Extension != "" {
+		key, val, err := parseExtensionKeyValue(input.Extension)
+		if err != nil {
+			return nil, err
+		}
+		extKey = key
+		extValue = val
+		hasExtFilter = true
+	}
+
+	var matched []*headerInfo
+	for _, info := range headers {
+		if input.Name != "" && !matchGlobName(info.Name, input.Name) {
+			continue
+		}
+		if input.Path != "" && !matchWalkPath(info.Path, input.Path) {
+			continue
+		}
+		if input.Method != "" && !strings.EqualFold(info.Method, input.Method) {
+			continue
+		}
+		if input.Status != "" && !statusCodeMatches(info.StatusCode, input.Status) {
+			continue
+		}
+		if hasExtFilter && (info.Header == nil || !matchExtension(info.Header.Extra, extKey, extValue)) {
+			continue
+		}
+		if input.Component && !info.IsComponent {
+			continue
+		}
+		matched = append(matched, info)
+	}
+	return matched, nil
+}

--- a/internal/mcpserver/tools_walk_headers_test.go
+++ b/internal/mcpserver/tools_walk_headers_test.go
@@ -1,0 +1,305 @@
+package mcpserver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const walkHeadersTestSpec = `openapi: "3.0.0"
+info:
+  title: Walk Headers Test
+  version: "1.0.0"
+paths:
+  /pets:
+    get:
+      summary: List pets
+      responses:
+        "200":
+          description: OK
+          headers:
+            X-Rate-Limit:
+              description: Rate limit per hour
+              schema:
+                type: integer
+            X-Request-Id:
+              description: Request identifier
+              schema:
+                type: string
+        "404":
+          description: Not found
+          headers:
+            X-Request-Id:
+              description: Request identifier
+              schema:
+                type: string
+    post:
+      summary: Create a pet
+      responses:
+        "201":
+          description: Created
+          headers:
+            X-Request-Id:
+              description: Request identifier
+              schema:
+                type: string
+            Location:
+              description: URL of created resource
+              required: true
+              schema:
+                type: string
+  /stores:
+    get:
+      summary: List stores
+      responses:
+        "200":
+          description: OK
+          headers:
+            X-Rate-Limit:
+              description: Rate limit per hour
+              schema:
+                type: integer
+components:
+  headers:
+    TraceId:
+      description: Distributed tracing identifier
+      schema:
+        type: string
+`
+
+func callWalkHeaders(t *testing.T, input walkHeadersInput) (*mcp.CallToolResult, walkHeadersOutput) {
+	t.Helper()
+	result, out, err := handleWalkHeaders(context.Background(), &mcp.CallToolRequest{}, input)
+	require.NoError(t, err)
+	if out == nil {
+		return result, walkHeadersOutput{}
+	}
+	wo, ok := out.(walkHeadersOutput)
+	require.True(t, ok, "expected walkHeadersOutput, got %T", out)
+	return result, wo
+}
+
+func TestWalkHeaders_AllHeaders(t *testing.T) {
+	input := walkHeadersInput{
+		Spec: specInput{Content: walkHeadersTestSpec},
+	}
+	_, output := callWalkHeaders(t, input)
+
+	// 6 response headers + 1 component header = 7 total.
+	assert.Equal(t, 7, output.Total)
+	assert.Equal(t, 7, output.Matched)
+	require.Len(t, output.Summaries, 7)
+}
+
+func TestWalkHeaders_FilterByName(t *testing.T) {
+	input := walkHeadersInput{
+		Spec: specInput{Content: walkHeadersTestSpec},
+		Name: "X-Rate-Limit",
+	}
+	_, output := callWalkHeaders(t, input)
+
+	assert.Equal(t, 2, output.Matched)
+	for _, s := range output.Summaries {
+		assert.Equal(t, "X-Rate-Limit", s.Name)
+	}
+}
+
+func TestWalkHeaders_FilterByNameGlob(t *testing.T) {
+	input := walkHeadersInput{
+		Spec: specInput{Content: walkHeadersTestSpec},
+		Name: "X-*",
+	}
+	_, output := callWalkHeaders(t, input)
+
+	// X-Rate-Limit (2) + X-Request-Id (3) = 5
+	assert.Equal(t, 5, output.Matched)
+}
+
+func TestWalkHeaders_FilterByPath(t *testing.T) {
+	input := walkHeadersInput{
+		Spec: specInput{Content: walkHeadersTestSpec},
+		Path: "/pets",
+	}
+	_, output := callWalkHeaders(t, input)
+
+	// /pets GET 200 has 2 headers, GET 404 has 1, POST 201 has 2 = 5.
+	assert.Equal(t, 5, output.Matched)
+	for _, s := range output.Summaries {
+		assert.Equal(t, "/pets", s.Path)
+	}
+}
+
+func TestWalkHeaders_FilterByMethod(t *testing.T) {
+	input := walkHeadersInput{
+		Spec:   specInput{Content: walkHeadersTestSpec},
+		Method: "post",
+	}
+	_, output := callWalkHeaders(t, input)
+
+	assert.Equal(t, 2, output.Matched) // POST /pets 201 has X-Request-Id + Location
+	for _, s := range output.Summaries {
+		assert.Equal(t, "POST", s.Method)
+	}
+}
+
+func TestWalkHeaders_FilterByStatus(t *testing.T) {
+	input := walkHeadersInput{
+		Spec:   specInput{Content: walkHeadersTestSpec},
+		Status: "404",
+	}
+	_, output := callWalkHeaders(t, input)
+
+	assert.Equal(t, 1, output.Matched)
+	require.Len(t, output.Summaries, 1)
+	assert.Equal(t, "X-Request-Id", output.Summaries[0].Name)
+	assert.Equal(t, "404", output.Summaries[0].Status)
+}
+
+func TestWalkHeaders_ComponentFilter(t *testing.T) {
+	input := walkHeadersInput{
+		Spec:      specInput{Content: walkHeadersTestSpec},
+		Component: true,
+	}
+	_, output := callWalkHeaders(t, input)
+
+	assert.Equal(t, 1, output.Matched)
+	require.Len(t, output.Summaries, 1)
+	assert.Equal(t, "TraceId", output.Summaries[0].Name)
+}
+
+func TestWalkHeaders_DetailMode(t *testing.T) {
+	input := walkHeadersInput{
+		Spec:   specInput{Content: walkHeadersTestSpec},
+		Name:   "Location",
+		Detail: true,
+	}
+	_, output := callWalkHeaders(t, input)
+
+	assert.Equal(t, 1, output.Matched)
+	assert.Nil(t, output.Summaries)
+	require.Len(t, output.Headers, 1)
+	assert.Equal(t, "Location", output.Headers[0].Name)
+	assert.NotNil(t, output.Headers[0].Header)
+	assert.True(t, output.Headers[0].Header.Required)
+}
+
+func TestWalkHeaders_GroupByName(t *testing.T) {
+	input := walkHeadersInput{
+		Spec:    specInput{Content: walkHeadersTestSpec},
+		GroupBy: "name",
+	}
+	_, output := callWalkHeaders(t, input)
+
+	require.NotEmpty(t, output.Groups)
+	assert.Nil(t, output.Summaries)
+
+	groupMap := make(map[string]int)
+	for _, g := range output.Groups {
+		groupMap[g.Key] = g.Count
+	}
+	assert.Equal(t, 3, groupMap["X-Request-Id"]) // appears in 3 responses
+	assert.Equal(t, 2, groupMap["X-Rate-Limit"]) // appears in 2 responses
+	assert.Equal(t, 1, groupMap["Location"])     // appears in 1 response
+	assert.Equal(t, 1, groupMap["TraceId"])      // component header
+
+	// Most-referenced first.
+	assert.Equal(t, "X-Request-Id", output.Groups[0].Key)
+}
+
+func TestWalkHeaders_GroupByStatusCode(t *testing.T) {
+	input := walkHeadersInput{
+		Spec:    specInput{Content: walkHeadersTestSpec},
+		GroupBy: "status_code",
+	}
+	_, output := callWalkHeaders(t, input)
+
+	require.NotEmpty(t, output.Groups)
+	groupMap := make(map[string]int)
+	for _, g := range output.Groups {
+		groupMap[g.Key] = g.Count
+	}
+	assert.Equal(t, 3, groupMap["200"]) // GET /pets 200 (2) + GET /stores 200 (1)
+	assert.Equal(t, 2, groupMap["201"]) // POST /pets 201 (2)
+	assert.Equal(t, 1, groupMap["404"]) // GET /pets 404 (1)
+	// Component header (TraceId) has no status code -- excluded from status_code grouping.
+}
+
+func TestWalkHeaders_Pagination(t *testing.T) {
+	input := walkHeadersInput{
+		Spec:  specInput{Content: walkHeadersTestSpec},
+		Limit: 2,
+	}
+	_, output := callWalkHeaders(t, input)
+
+	assert.Equal(t, 7, output.Total)
+	assert.Equal(t, 7, output.Matched)
+	assert.Equal(t, 2, output.Returned)
+	assert.Len(t, output.Summaries, 2)
+}
+
+func TestWalkHeaders_GroupByAndDetailError(t *testing.T) {
+	input := walkHeadersInput{
+		Spec:    specInput{Content: walkHeadersTestSpec},
+		GroupBy: "name",
+		Detail:  true,
+	}
+	result, _ := callWalkHeaders(t, input)
+	require.NotNil(t, result)
+	assert.True(t, result.IsError)
+}
+
+func TestWalkHeaders_InvalidSpec(t *testing.T) {
+	input := walkHeadersInput{
+		Spec: specInput{Content: "not valid yaml: ["},
+	}
+	result, _ := callWalkHeaders(t, input)
+	require.NotNil(t, result)
+	assert.True(t, result.IsError)
+}
+
+func TestWalkHeaders_FilterByExtension(t *testing.T) {
+	spec := `openapi: "3.0.0"
+info:
+  title: Extension Test
+  version: "1.0.0"
+paths:
+  /pets:
+    get:
+      summary: List pets
+      responses:
+        "200":
+          description: OK
+          headers:
+            X-Rate-Limit:
+              description: Rate limit per hour
+              x-internal: true
+              schema:
+                type: integer
+            X-Request-Id:
+              description: Request identifier
+              schema:
+                type: string
+`
+	input := walkHeadersInput{
+		Spec:      specInput{Content: spec},
+		Extension: "x-internal=true",
+	}
+	_, output := callWalkHeaders(t, input)
+
+	assert.Equal(t, 1, output.Matched)
+	require.Len(t, output.Summaries, 1)
+	assert.Equal(t, "X-Rate-Limit", output.Summaries[0].Name)
+}
+
+func TestWalkHeaders_FilterByExtensionInvalid(t *testing.T) {
+	input := walkHeadersInput{
+		Spec:      specInput{Content: walkHeadersTestSpec},
+		Extension: "not-an-extension=true",
+	}
+	result, _ := callWalkHeaders(t, input)
+	require.NotNil(t, result)
+	assert.True(t, result.IsError)
+}

--- a/internal/mcpserver/tools_walk_paths.go
+++ b/internal/mcpserver/tools_walk_paths.go
@@ -10,9 +10,9 @@ import (
 
 type walkPathsInput struct {
 	Spec        specInput `json:"spec"                     jsonschema:"The OAS document to walk"`
-	Path        string    `json:"path,omitempty"           jsonschema:"Filter by path pattern (supports * glob)"`
+	Path        string    `json:"path,omitempty"           jsonschema:"Filter by path pattern (* = one segment\\, ** = zero or more segments\\, e.g. /users/* or /drives/**/workbook/**)"`
 	Extension   string    `json:"extension,omitempty"      jsonschema:"Filter by extension key=value (e.g. x-internal=true)"`
-	ResolveRefs bool      `json:"resolve_refs,omitempty"   jsonschema:"Resolve $ref pointers before output"`
+	ResolveRefs bool      `json:"resolve_refs,omitempty"   jsonschema:"Resolve $ref pointers in output. Inlines referenced objects instead of showing $ref strings."`
 	Detail      bool      `json:"detail,omitempty"         jsonschema:"Return full path item objects instead of summaries"`
 	Limit       int       `json:"limit,omitempty"          jsonschema:"Maximum number of results to return (default 100)"`
 	Offset      int       `json:"offset,omitempty"         jsonschema:"Skip the first N results (for pagination)"`

--- a/internal/mcpserver/tools_walk_refs.go
+++ b/internal/mcpserver/tools_walk_refs.go
@@ -1,0 +1,157 @@
+package mcpserver
+
+import (
+	"context"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/erraggy/oastools/walker"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type walkRefsInput struct {
+	Spec     specInput `json:"spec"                   jsonschema:"The OAS document to walk"`
+	Target   string    `json:"target,omitempty"        jsonschema:"Filter by ref target (supports * and ? glob, e.g. *schemas/Pet or *responses/*)"`
+	NodeType string    `json:"node_type,omitempty"     jsonschema:"Filter by ref node type: schema, parameter, response, requestBody, header, pathItem"`
+	Detail   bool      `json:"detail,omitempty"        jsonschema:"Return individual source locations instead of aggregated counts"`
+	Limit    int       `json:"limit,omitempty"         jsonschema:"Maximum number of results to return (default 100)"`
+	Offset   int       `json:"offset,omitempty"        jsonschema:"Skip the first N results (for pagination)"`
+}
+
+type refSummary struct {
+	Ref   string `json:"ref"`
+	Count int    `json:"count"`
+}
+
+type refDetail struct {
+	Ref        string `json:"ref"`
+	SourcePath string `json:"source_path"`
+	NodeType   string `json:"node_type"`
+}
+
+// walkRefsOutput holds results from walk_refs. In summary mode, Total and
+// Matched count unique ref targets. In detail mode, they count individual
+// ref occurrences (a single target referenced 3 times counts as 3).
+type walkRefsOutput struct {
+	Total     int          `json:"total"`
+	Matched   int          `json:"matched"`
+	Returned  int          `json:"returned"`
+	Summaries []refSummary `json:"refs,omitempty"`
+	Details   []refDetail  `json:"details,omitempty"`
+}
+
+func handleWalkRefs(_ context.Context, _ *mcp.CallToolRequest, input walkRefsInput) (*mcp.CallToolResult, any, error) {
+	// Validate glob pattern before expensive walk.
+	if err := validateGlobPattern(input.Target); err != nil {
+		return errResult(err), nil, nil
+	}
+
+	result, err := input.Spec.resolve()
+	if err != nil {
+		return errResult(err), nil, nil
+	}
+
+	// Collect all refs via the walker.
+	var allRefs []*walker.RefInfo
+	err = walker.Walk(result,
+		walker.WithMapRefTracking(),
+		walker.WithRefHandler(func(_ *walker.WalkContext, ref *walker.RefInfo) walker.Action {
+			allRefs = append(allRefs, ref)
+			return walker.Continue
+		}),
+	)
+	if err != nil {
+		return errResult(err), nil, nil
+	}
+
+	// Filter refs.
+	filtered := filterRefs(allRefs, input)
+
+	if input.Detail {
+		// Detail mode: return individual ref locations.
+		paged := paginate(filtered, input.Offset, input.Limit)
+		output := walkRefsOutput{
+			Total:    len(allRefs),
+			Matched:  len(filtered),
+			Returned: len(paged),
+			Details:  makeSlice[refDetail](len(paged)),
+		}
+		for _, ref := range paged {
+			output.Details = append(output.Details, refDetail{
+				Ref:        ref.Ref,
+				SourcePath: ref.SourcePath,
+				NodeType:   string(ref.NodeType),
+			})
+		}
+		return nil, output, nil
+	}
+
+	// Summary mode: aggregate by ref target, sort by count desc.
+	counts := make(map[string]int)
+	for _, ref := range filtered {
+		counts[ref.Ref]++
+	}
+
+	summaries := make([]refSummary, 0, len(counts))
+	for ref, count := range counts {
+		summaries = append(summaries, refSummary{Ref: ref, Count: count})
+	}
+	sort.Slice(summaries, func(i, j int) bool {
+		if summaries[i].Count != summaries[j].Count {
+			return summaries[i].Count > summaries[j].Count
+		}
+		return summaries[i].Ref < summaries[j].Ref
+	})
+
+	paged := paginate(summaries, input.Offset, input.Limit)
+	output := walkRefsOutput{
+		Total:     countUniqueRefs(allRefs),
+		Matched:   countUniqueRefs(filtered),
+		Returned:  len(paged),
+		Summaries: paged,
+	}
+	return nil, output, nil
+}
+
+// filterRefs applies target and node_type filters to refs.
+func filterRefs(refs []*walker.RefInfo, input walkRefsInput) []*walker.RefInfo {
+	if input.Target == "" && input.NodeType == "" {
+		return refs
+	}
+	var filtered []*walker.RefInfo
+	for _, ref := range refs {
+		if input.Target != "" && !matchRefGlob(ref.Ref, input.Target) {
+			continue
+		}
+		if input.NodeType != "" && !strings.EqualFold(string(ref.NodeType), input.NodeType) {
+			continue
+		}
+		filtered = append(filtered, ref)
+	}
+	return filtered
+}
+
+// countUniqueRefs returns the number of distinct ref targets.
+func countUniqueRefs(refs []*walker.RefInfo) int {
+	seen := make(map[string]struct{}, len(refs))
+	for _, ref := range refs {
+		seen[ref.Ref] = struct{}{}
+	}
+	return len(seen)
+}
+
+// matchRefGlob matches a $ref value against a glob pattern. Unlike matchGlobName,
+// this function allows * and ? to match across / separators in ref paths like
+// "#/components/schemas/Pet". It does this by replacing / with a non-separator
+// character before calling filepath.Match.
+func matchRefGlob(ref, pattern string) bool {
+	if !strings.ContainsAny(pattern, "*?") {
+		return strings.EqualFold(ref, pattern)
+	}
+	// Replace / with : so filepath.Match's * can cross path boundaries.
+	normalizedRef := strings.ReplaceAll(strings.ToLower(ref), "/", ":")
+	normalizedPattern := strings.ReplaceAll(strings.ToLower(pattern), "/", ":")
+	matched, err := filepath.Match(normalizedPattern, normalizedRef)
+	return err == nil && matched
+}

--- a/internal/mcpserver/tools_walk_refs_test.go
+++ b/internal/mcpserver/tools_walk_refs_test.go
@@ -1,0 +1,213 @@
+package mcpserver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const walkRefsTestSpec = `openapi: "3.0.0"
+info:
+  title: Walk Refs Test
+  version: "1.0.0"
+paths:
+  /pets:
+    get:
+      summary: List pets
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Pet"
+    post:
+      summary: Create a pet
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+      responses:
+        "201":
+          description: Created
+        "400":
+          $ref: "#/components/responses/BadRequest"
+  /pets/{petId}:
+    get:
+      summary: Get a pet
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /errors:
+    get:
+      summary: List errors
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+    Error:
+      type: object
+      properties:
+        code:
+          type: integer
+        message:
+          type: string
+  responses:
+    BadRequest:
+      description: Bad request
+    NotFound:
+      description: Not found
+`
+
+func callWalkRefs(t *testing.T, input walkRefsInput) (*mcp.CallToolResult, walkRefsOutput) {
+	t.Helper()
+	result, out, err := handleWalkRefs(context.Background(), &mcp.CallToolRequest{}, input)
+	require.NoError(t, err)
+	if out == nil {
+		return result, walkRefsOutput{}
+	}
+	wo, ok := out.(walkRefsOutput)
+	require.True(t, ok, "expected walkRefsOutput, got %T", out)
+	return result, wo
+}
+
+func TestWalkRefs_SummaryMode(t *testing.T) {
+	input := walkRefsInput{
+		Spec: specInput{Content: walkRefsTestSpec},
+	}
+	_, output := callWalkRefs(t, input)
+
+	assert.Greater(t, output.Total, 0)
+	assert.Greater(t, output.Matched, 0)
+	require.NotEmpty(t, output.Summaries)
+
+	// Pet should be the most-referenced schema (3 refs).
+	assert.Equal(t, "#/components/schemas/Pet", output.Summaries[0].Ref)
+	assert.Equal(t, 3, output.Summaries[0].Count)
+
+	// Verify sorted descending by count.
+	for i := 1; i < len(output.Summaries); i++ {
+		assert.GreaterOrEqual(t, output.Summaries[i-1].Count, output.Summaries[i].Count)
+	}
+}
+
+func TestWalkRefs_FilterByTarget(t *testing.T) {
+	input := walkRefsInput{
+		Spec:   specInput{Content: walkRefsTestSpec},
+		Target: "*schemas/Pet",
+	}
+	_, output := callWalkRefs(t, input)
+
+	assert.Equal(t, 1, output.Matched)
+	require.Len(t, output.Summaries, 1)
+	assert.Equal(t, "#/components/schemas/Pet", output.Summaries[0].Ref)
+	assert.Equal(t, 3, output.Summaries[0].Count)
+}
+
+func TestWalkRefs_FilterByNodeType(t *testing.T) {
+	input := walkRefsInput{
+		Spec:     specInput{Content: walkRefsTestSpec},
+		NodeType: "response",
+	}
+	_, output := callWalkRefs(t, input)
+
+	// Only response refs: BadRequest and NotFound.
+	assert.Equal(t, 2, output.Matched)
+	for _, s := range output.Summaries {
+		assert.Contains(t, s.Ref, "#/components/responses/")
+	}
+}
+
+func TestWalkRefs_DetailMode(t *testing.T) {
+	input := walkRefsInput{
+		Spec:   specInput{Content: walkRefsTestSpec},
+		Target: "*schemas/Pet",
+		Detail: true,
+	}
+	_, output := callWalkRefs(t, input)
+
+	assert.Nil(t, output.Summaries)
+	require.Len(t, output.Details, 3)
+	for _, d := range output.Details {
+		assert.Equal(t, "#/components/schemas/Pet", d.Ref)
+		assert.NotEmpty(t, d.SourcePath)
+		assert.Equal(t, "schema", d.NodeType)
+	}
+}
+
+func TestWalkRefs_Pagination(t *testing.T) {
+	input := walkRefsInput{
+		Spec:  specInput{Content: walkRefsTestSpec},
+		Limit: 2,
+	}
+	_, output := callWalkRefs(t, input)
+
+	assert.Equal(t, 2, output.Returned)
+	require.Len(t, output.Summaries, 2)
+}
+
+func TestWalkRefs_TargetGlob(t *testing.T) {
+	input := walkRefsInput{
+		Spec:   specInput{Content: walkRefsTestSpec},
+		Target: "*schemas/*",
+	}
+	_, output := callWalkRefs(t, input)
+
+	// Should match Pet and Error schemas.
+	assert.Equal(t, 2, output.Matched)
+}
+
+func TestMatchRefGlob(t *testing.T) {
+	// Glob * crosses / boundaries in ref targets.
+	assert.True(t, matchRefGlob("#/components/schemas/Pet", "*schemas/Pet"))
+	assert.True(t, matchRefGlob("#/components/schemas/Pet", "*Pet"))
+	assert.True(t, matchRefGlob("#/components/responses/NotFound", "*responses/*"))
+
+	// Case-insensitive.
+	assert.True(t, matchRefGlob("#/components/schemas/Pet", "*SCHEMAS/PET"))
+
+	// ? matches single character.
+	assert.True(t, matchRefGlob("#/components/schemas/Pet", "*schemas/P?t"))
+	assert.False(t, matchRefGlob("#/components/schemas/Pet", "*schemas/P?"))
+
+	// Exact match without glob chars (case-insensitive).
+	assert.True(t, matchRefGlob("#/components/schemas/Pet", "#/components/schemas/Pet"))
+	assert.True(t, matchRefGlob("#/components/schemas/Pet", "#/components/schemas/pet"))
+	assert.False(t, matchRefGlob("#/components/schemas/Pet", "#/components/schemas/Error"))
+
+	// No match.
+	assert.False(t, matchRefGlob("#/components/schemas/Pet", "*responses/*"))
+}
+
+func TestWalkRefs_InvalidSpec(t *testing.T) {
+	input := walkRefsInput{
+		Spec: specInput{Content: "not valid yaml: ["},
+	}
+	result, _ := callWalkRefs(t, input)
+	require.NotNil(t, result)
+	assert.True(t, result.IsError)
+}

--- a/internal/mcpserver/tools_walk_security.go
+++ b/internal/mcpserver/tools_walk_security.go
@@ -14,7 +14,7 @@ type walkSecurityInput struct {
 	Name        string    `json:"name,omitempty"           jsonschema:"Filter by security scheme name"`
 	Type        string    `json:"type,omitempty"           jsonschema:"Filter by security scheme type (apiKey\\, http\\, oauth2\\, openIdConnect)"`
 	Extension   string    `json:"extension,omitempty"      jsonschema:"Filter by extension key=value (e.g. x-internal=true)"`
-	ResolveRefs bool      `json:"resolve_refs,omitempty"   jsonschema:"Resolve $ref pointers before output"`
+	ResolveRefs bool      `json:"resolve_refs,omitempty"   jsonschema:"Resolve $ref pointers in output. Inlines referenced objects instead of showing $ref strings."`
 	Detail      bool      `json:"detail,omitempty"         jsonschema:"Return full security scheme objects instead of summaries"`
 	Limit       int       `json:"limit,omitempty"          jsonschema:"Maximum number of results to return (default 100)"`
 	Offset      int       `json:"offset,omitempty"         jsonschema:"Skip the first N results (for pagination)"`

--- a/plugin/CLAUDE.md
+++ b/plugin/CLAUDE.md
@@ -1,6 +1,6 @@
 # oastools MCP Plugin
 
-You have access to the oastools MCP server, which provides 15 tools for working with OpenAPI Specification (OAS 2.0-3.2) documents.
+You have access to the oastools MCP server, which provides 17 tools for working with OpenAPI Specification (OAS 2.0-3.2) documents.
 
 ## Prerequisites
 
@@ -24,7 +24,7 @@ If MCP tools are unavailable or returning errors, verify the binary is installed
 
 **Core (9):** `validate`, `parse`, `fix`, `convert`, `diff`, `join`, `overlay_apply`, `overlay_validate`, `generate`
 
-**Walk (6):** `walk_operations`, `walk_schemas`, `walk_parameters`, `walk_responses`, `walk_security`, `walk_paths`
+**Walk (8):** `walk_operations`, `walk_schemas`, `walk_parameters`, `walk_responses`, `walk_headers`, `walk_security`, `walk_paths`, `walk_refs`
 
 ## Input Model
 
@@ -54,6 +54,7 @@ Special cases:
    - Use `detail: true` only after filtering to specific items — full objects can be very large
 6. **Check breaking changes.** When diffing specs, use `breaking_only: true` to focus on changes that will break API consumers.
 7. 📄 **Page through large results.** Tools that return arrays (`validate`, `fix`, `diff`, `walk_*`) support `offset` and `limit` params (default limit: 100). When `returned` is less than the total count, use `offset` to page through. Prefer filtering over paging when possible.
+8. 📊 **Aggregate with `group_by`.** The walk tools (`walk_operations`, `walk_schemas`, `walk_parameters`, `walk_responses`, `walk_headers`) support a `group_by` parameter that returns `{key, count}` groups instead of individual items. Use this for distribution questions ("how many operations per tag?") instead of paging through all results.
 
 ## 💾 Persisting Results
 
@@ -113,7 +114,9 @@ Use a temp directory for intermediate files (e.g., `/tmp/`) and copy the final r
 
 **Explore a large API (100+ operations):**
 1. 📊 `parse` to get counts and tag list
-2. 🏷️ `walk_operations` with `tag` filter — work through one tag at a time
-3. 📋 `walk_schemas` with `component: true` — named schemas only (skip inline)
-4. 🔍 Drill into specifics with `operation_id` or `path` + `detail: true`
-5. ✅ Use `validate` with `no_warnings: true` for error-focused triage
+2. 📊 `walk_operations` with `group_by: "tag"` — operation count per tag at a glance
+3. 🏷️ `walk_operations` with `tag` filter — work through one tag at a time
+4. 📋 `walk_schemas` with `component: true` — named schemas only (skip inline)
+5. 🔗 `walk_refs` to find most-referenced schemas and trace usage patterns
+6. 🔍 Drill into specifics with `operation_id` or `path` + `detail: true`
+7. ✅ Use `validate` with `no_warnings: true` for error-focused triage

--- a/plugin/skills/explore-api/SKILL.md
+++ b/plugin/skills/explore-api/SKILL.md
@@ -39,6 +39,20 @@ Call `walk_operations` to list all API endpoints:
 
 Present them grouped by tag or by path prefix. For each operation show the method, path, and summary.
 
+For a quick overview of a large API, use `group_by` first:
+
+```json
+{"spec": {"file": "<path>"}, "group_by": "tag"}
+```
+
+This returns operation counts per tag — the fastest way to understand API scope.
+
+```json
+{"spec": {"file": "<path>"}, "group_by": "method"}
+```
+
+This shows the HTTP method distribution (e.g., 60% GET, 25% POST, etc.).
+
 ⚠️ If the API is large (more endpoints than the default page of 100), prefer **filtering** over paging:
 
 ```json
@@ -47,6 +61,12 @@ Present them grouped by tag or by path prefix. For each operation show the metho
 
 ```json
 {"spec": {"file": "<path>"}, "path": "/users/*"}
+```
+
+For deeply nested APIs, use `**` to match across path depths:
+
+```json
+{"spec": {"file": "<path>"}, "path": "/drives/**/workbook/**"}
 ```
 
 ✅ When `returned < matched`, use `offset` to page through remaining results:
@@ -67,6 +87,12 @@ Call `walk_schemas` to list the API's data models:
 
 ```json
 {"spec": {"file": "<path>"}, "component": true}
+```
+
+Get schema type distribution:
+
+```json
+{"spec": {"file": "<path>"}, "group_by": "type", "component": true}
 ```
 
 ⚠️ Omit `component` only when you need to find inline schemas (e.g., hunting for unnamed request body schemas).
@@ -105,7 +131,49 @@ Based on what the user is interested in, drill deeper:
 
 (using `walk_security`)
 
-## Step 5: Summarize findings
+**Response headers:**
+
+```json
+{"spec": {"file": "<path>"}, "group_by": "name"}
+```
+
+(using `walk_headers` — shows which headers are most common across the API)
+
+**Headers for a specific endpoint:**
+
+```json
+{"spec": {"file": "<path>"}, "path": "/users", "method": "get"}
+```
+
+(using `walk_headers`)
+
+## Step 5: Analyze references
+
+Call `walk_refs` to understand which schemas and responses are most referenced:
+
+```json
+{"spec": {"file": "<path>"}}
+```
+
+This returns unique `$ref` targets ranked by count (most-referenced first). Use this to identify the API's core data models.
+
+**Trace a specific schema's usage:**
+
+```json
+{"spec": {"file": "<path>"}, "target": "*schemas/User*", "detail": true}
+```
+
+This shows every location that references the schema — useful for understanding impact before modifying a schema.
+
+**Filter by ref type:**
+
+```json
+{"spec": {"file": "<path>"}, "node_type": "response"}
+```
+
+Narrow to schema, parameter, response, requestBody, header, or pathItem refs.
+
+## Step 6: Summarize findings
 
 Provide a structured summary of the API:
 - Purpose and scope (from title/description)


### PR DESCRIPTION
## Summary

- Add `group_by` aggregation to 5 walk tools — returns `{key, count}` groups sorted by count for distribution questions without paging through all results
  - `walk_operations`: group by `tag`, `method`
  - `walk_schemas`: group by `type`, `location`
  - `walk_parameters`: group by `location`, `name`
  - `walk_responses`: group by `status_code`, `method`
  - `walk_headers` (new): group by `name`, `status_code`
- Add `walk_headers` tool — traverse response headers with name/path/method/status/component/extension filters, detail mode, and glob name matching
- Add `walk_refs` tool — count and cross-reference `$ref` targets with `node_type` filter, detail mode showing source locations, and glob target matching
- Add `**` glob support for deep path matching across all walk tools
- Add glob pattern matching for schema name filter
- Audit and improve all tool descriptions for AI agent usability
- Validate glob patterns upfront (surface `filepath.ErrBadPattern` instead of silently returning no matches)

### Shared infrastructure

- `groupCount` type, generic `groupAndSort[T any]` helper, `validateGroupBy`, `validateGlobPattern` in `server.go`
- Filter-before-group semantics (WHERE then GROUP BY)
- Pagination applied to grouped results

## Test plan

- [x] 8140 tests pass (`make check`)
- [x] Smoke tested all `group_by` modes against MS Graph corpus (16,098 operations, 36MB)
- [x] New tests: 40+ covering group_by (positive, negative, invalid, with filters), walk_headers (15 tests), walk_refs (8 tests), glob validation
- [x] CodeRabbit review — addressed `require.Len` guard and glob pattern validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)