### PR TITLE
feat(mcp): add spec cache, group_by expansions, and UX improvements

### DIFF
--- a/docs/mcp-ux-findings.md
+++ b/docs/mcp-ux-findings.md
@@ -1,0 +1,208 @@
+# MCP Server UX Findings
+
+> Observations from using the oastools MCP server tools as a Claude Code client to analyze the `testdata/corpus/` specs. Focus is on what a fresh-install user would encounter without codebase knowledge.
+>
+> Generated 2026-02-15 from corpus analysis session.
+
+## Resolution Status
+
+| Finding | Status | Resolution |
+|---------|--------|------------|
+| `group_by` on `walk_refs` | Addressed | Added `group_by=node_type` |
+| `group_by` on `walk_paths` | Addressed | Added `group_by=segment` (first path segment) |
+| `group_by` on `walk_security` | Deferred | Low priority -- most specs have 0-3 schemes |
+| Cross-spec aggregation | Out of scope | Would require multi-spec input; not planned |
+| `walk_headers` `component` filter | Deferred | Low usage -- headers rarely exceed component count |
+| Header name casing normalization | Deferred | Spec quality issue; may add as option later |
+| Empty location for $ref parameters | Addressed | Labeled as `(ref)` in group_by results |
+| Schema type "" ambiguity | Addressed | Labeled as `(untyped)` in group_by results |
+| Component response "" status | Addressed | Labeled as `(component)` in group_by results |
+| Parse description truncation | Addressed | Truncated to 200 chars in summary mode |
+| Plugin rebuild after update | Addressed | SessionStart hook checks binary vs plugin version |
+| `group_by` enum constraints | Deferred | Works via description; enum would be stricter |
+| `walk_refs` total semantics | Addressed | Documented in MCP server docs |
+| `walk_headers`/`walk_refs` missing from docs | Addressed | Added to MCP server documentation |
+| Operation-level security overrides | Deferred | Would need new walk_security features |
+| Spec re-parsing on every call | Addressed | Session-scoped LRU cache (max 10 entries) |
+
+> **Note:** The sections below reflect findings as observed during the original corpus analysis session. The Resolution Status table above shows which items have since been addressed. Sections describing addressed items are preserved as historical context for the design decisions.
+
+---
+
+## Setup & Discovery
+
+### Plugin rebuild required after code changes
+
+After PR #321 merged (adding `group_by`, `walk_headers`, `walk_refs`), the **running MCP server plugin didn't expose the new tools or parameters** until the plugin binary was rebuilt. The MCP tool schema is generated at runtime from Go struct tags, so a stale binary means stale schemas.
+
+**Impact**: A user who updates oastools via `go install` or git pull won't get new MCP features until they also rebuild the plugin. There's no version mismatch warning.
+
+**Suggestion**: The plugin could expose its version (from `plugin.json`) in tool responses or as a resource, so clients can detect staleness. Alternatively, document the rebuild step prominently in plugin setup docs.
+
+### Tool parameter discoverability
+
+The `group_by` parameter's allowed values are documented in the JSON Schema `description` field (e.g., "Values: tag, method"). This works well -- Claude Code picks them up automatically from the schema. However, the allowed values are buried in prose rather than using `enum` constraints.
+
+**Suggestion**: Consider adding `enum` to `group_by` fields so clients can validate locally and offer autocompletion. The current approach works but relies on the client reading the description text.
+
+---
+
+## `group_by` Aggregation
+
+### What works well
+
+- **Massive efficiency gain**: analyzing method distribution across 10 specs took 10 parallel calls instead of 50+ (5 methods x 10 specs). Each `group_by` call replaces N filter-and-count calls.
+- **Output shape is clean**: `{"groups": [{"key": "GET", "count": 568}]}` is immediately usable. The `total` and `matched` counts alongside groups provide context.
+- **Sorted by count descending**: groups come back largest-first, which is the natural reading order for analysis.
+- **Composable with filters**: `group_by=method` combined with `tag=repos` works correctly to show method distribution within a specific tag.
+
+### What could be improved
+
+- **No `group_by` on `walk_paths`**: paths are the only walk tool without aggregation. A `group_by=depth` or `group_by=segment` (first path segment) would be valuable for understanding API structure. For example, GitHub's paths could be grouped by `/repos/**`, `/orgs/**`, `/users/**`.
+- **No `group_by` on `walk_refs`**: refs already return counts by default (which is great), but there's no way to group by ref *type* (schema vs response vs parameter vs header). You can filter by `node_type`, but you can't get a single "how many schema refs vs response refs vs parameter refs" summary.
+- **No `group_by` on `walk_security`**: low priority since most specs have 0-3 security schemes, but `group_by=type` would show the auth type distribution across a spec.
+
+### Missing: cross-spec aggregation
+
+The most labor-intensive part of the analysis was running the same `group_by` call across all 10 specs and manually assembling the results into a table. A hypothetical `walk_operations` that accepts multiple specs and returns per-spec groups would eliminate this entirely. This may be out of scope for the MCP server, but it's the dominant workflow pain point.
+
+---
+
+## `walk_headers` (New)
+
+### What works well
+
+- **Fills a genuine gap**: before this tool, finding response headers required `walk_responses` with `detail=true` and manually inspecting each response object. Now it's a single call.
+- **`group_by=name` is the killer feature**: immediately reveals rate-limit patterns (Discord: 5 headers x 240 operations = 1,200 total) and HATEOAS patterns (GitHub: `Link` header on 193 responses).
+- **Correctly handles both inline and `$ref`-based headers**: Discord's headers are all `$ref`s to `#/components/headers/X-RateLimit-*`, and the tool resolves them for counting.
+
+### What could be improved
+
+- **No `component` filter like `walk_schemas` has**: `walk_schemas` has `component=true` to show only `components/schemas/` entries. An analogous `component=true` for `walk_headers` would show only `components/headers/` definitions, useful for understanding the reusable header vocabulary.
+- **Header name casing**: GitHub's spec has both `Link` and `link`, `Location` and `location` as separate header entries. Since HTTP headers are case-insensitive, `group_by=name` could optionally normalize casing (or at least note duplicates). This is arguably a spec quality issue rather than a tool issue, but the tool is in a position to surface it.
+
+---
+
+## `walk_refs` (New)
+
+### What works well
+
+- **Default behavior is perfect**: returns unique ref targets ranked by reference count, most-referenced first. This immediately shows the "gravity centers" of a spec.
+- **Ref counts reveal API structure**: Discord's `SnowflakeType` (554 refs) tells you more about the API's design than any other single data point. GitHub's `owner`/`repo` parameters (480/479 refs) reveal the repo-centric architecture.
+- **Mixed ref types in one view**: seeing schemas, responses, parameters, and headers ranked together shows which component *category* dominates. For Discord, 5 of the top 8 refs are headers. For GitHub, 3 of the top 10 are parameters.
+
+### What could be improved
+
+- **No `group_by=node_type`**: as noted above, a single call to get "schema refs: 500, response refs: 300, parameter refs: 200, header refs: 100" would be a useful overview. Currently you'd need 4 separate calls with `node_type` filter.
+- **`total` count semantics**: for `walk_refs`, `total` returns the number of *unique ref targets* (e.g., 1,349 for GitHub), not the total number of `$ref` occurrences across the document. This is the right default, but the distinction isn't documented. A user might expect `total` to mean "total $ref usages" (which would be the sum of all `count` values).
+
+---
+
+## `walk_parameters`
+
+### Empty location for `$ref` parameters
+
+Parameters that use `$ref` (e.g., `$ref: '#/components/parameters/owner'`) show up with an **empty string location `""`** in `group_by=location` results. This is technically correct (the `in` field isn't on the `$ref` object itself), but it's confusing.
+
+For GitHub, 2,832 of 3,303 parameters (86%) show empty location. The workaround is `resolve_refs=true`, but that's expensive on large specs and changes the output format.
+
+**Suggestion**: Consider resolving just the `in` field for `$ref` parameters during grouping, or label the empty group as `"$ref (unresolved)"` instead of `""`.
+
+---
+
+## `walk_schemas`
+
+### `total` vs `matched` distinction
+
+The `total` field counts *all* schemas (inline + component), while `matched` reflects filters. With `component=true`:
+
+| Spec | total (all) | matched (component only) | Inline % |
+|------|----------:|------------------------:|---------:|
+| Petstore | 49 | 33 | 33% |
+| GitHub | 34,847 | 31,959 | 8% |
+| Stripe | 23,286 | 8,860 | 62% |
+| MS Graph | 89,434 | 29,665 | 67% |
+
+This reveals that **Stripe and MS Graph have more inline schemas than component schemas** -- a surprising finding that `group_by=location` would surface directly.
+
+### Schema type "(none)" ambiguity
+
+Schemas without an explicit `type` field show as `""` in `group_by=type`. These are composition schemas (`allOf`, `anyOf`, `oneOf`), pure `$ref` wrappers, or `enum`-only schemas. The empty string is accurate but unlabeled.
+
+**Suggestion**: Consider labeling these as `"(composition)"` or `"(untyped)"` to make the output self-documenting. Alternatively, the docs could explain what `""` means in this context.
+
+---
+
+## `walk_responses`
+
+### Wildcard status codes
+
+Discord uses `4XX` and MS Graph uses `2XX`/`4XX`/`5XX` (OAS 3.0 range wildcards). These appear correctly in `group_by=status_code` as their literal values (`"4XX"`, `"5XX"`). The `status` filter also handles them with its own wildcard syntax (`status=2xx` matches `2XX` range codes).
+
+This works well. The only gap is that there's no way to distinguish between a spec that declares `4XX` (range wildcard) and one that declares individual `400`, `401`, `403`, `404` codes. Both are valid OAS patterns but imply different levels of client guidance.
+
+---
+
+## `walk_security`
+
+### Works perfectly for its scope
+
+Security schemes are simple enough that the current tool covers the use case completely. No `group_by` is needed since specs rarely have more than 3 schemes.
+
+### Missing: operation-level security overrides
+
+`walk_security` only shows schemes *defined* in `components/securitySchemes`. It doesn't show which operations *use* which schemes, or which operations override the global security. A `walk_operations` filter like `security_scheme=OAuth2` would be useful for understanding auth coverage.
+
+---
+
+## `parse` Tool
+
+### Description field can be enormous
+
+DigitalOcean's `description` field in the parse output is ~8,000 characters -- it contains their entire API introduction including rate limiting docs, curl examples, and CORS documentation. This makes the parse response very large for what's meant to be a summary.
+
+**Suggestion**: Truncate the `description` field in parse output (e.g., first 200 chars with `...`) or move it behind a `full=true` flag. The current behavior means parsing DigitalOcean returns ~10x more text than parsing Stripe, even though both are similar in structural complexity.
+
+---
+
+## Cross-Tool Patterns
+
+### Consistent output shape
+
+All walk tools follow the same pattern: `{"total": N, "matched": N, "returned": N, "summaries|groups|refs": [...]}`. This consistency is excellent for tooling -- once you learn one walk tool, you know the shape of all of them.
+
+### Pagination works but is rarely needed
+
+`limit` and `offset` are available on all walk tools. In practice, `group_by` eliminates the need for pagination in analysis workflows since aggregated results are always small. Pagination is most useful for `detail=true` queries on large specs.
+
+### `resolve_refs` is a power-user feature
+
+Most analysis workflows don't need `resolve_refs=true`. The one exception is `walk_parameters` where unresolved refs hide the parameter location. For all other tools, the default (no resolution) is the right choice because it's faster and the output is more compact.
+
+---
+
+## Documentation Gaps
+
+1. **`group_by` allowed values**: documented in schema descriptions but not in the MCP server docs (`docs/mcp-server.md`). A table of "tool -> group_by values" would help.
+2. **`walk_refs` total semantics**: the `total` field means "unique ref targets", not "total $ref occurrences". This should be documented.
+3. **Empty string in group keys**: `""` appears in `group_by` results for schemas without `type`, parameters without `in` (due to `$ref`), and responses without explicit status codes. What `""` means varies by context and should be explained.
+4. **`walk_headers` and `walk_refs` aren't in the MCP server docs yet**: they were added in PR #321 but the documentation page hasn't been updated.
+5. **Plugin rebuild after update**: the docs don't mention that updating oastools source requires rebuilding the plugin to get new MCP features.
+
+---
+
+## Summary of Actionable Suggestions
+
+| Priority | Suggestion |
+|----------|-----------|
+| High | Add `walk_headers` and `walk_refs` to MCP server documentation |
+| High | Document `group_by` values in a table in MCP docs |
+| High | Document what `""` means in each group_by context |
+| Medium | Add `group_by=node_type` to `walk_refs` |
+| Medium | ~~Label empty parameter locations~~ — resolved: labeled as `(ref)` |
+| Medium | Truncate `description` in `parse` output |
+| Medium | Add `group_by` to `walk_paths` (e.g., by first segment or depth) |
+| Low | Add `component` filter to `walk_headers` |
+| Low | Add `enum` constraints to `group_by` fields in JSON Schema |
+| Low | Add version/build info to plugin for staleness detection |
+| Low | Consider case-insensitive header name grouping option |

--- a/internal/mcpserver/input.go
+++ b/internal/mcpserver/input.go
@@ -1,8 +1,14 @@
 package mcpserver
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/erraggy/oastools/parser"
 )
@@ -15,8 +21,111 @@ type specInput struct {
 	Content string `json:"content,omitempty" jsonschema:"Inline OAS document content (JSON or YAML)"`
 }
 
-// resolve parses the spec from whichever input was provided.
-// Additional parser options can be passed to customize parsing behavior.
+// cacheEntry holds a cached parse result with its insertion order for LRU eviction.
+type cacheEntry struct {
+	result   *parser.ParseResult
+	insertAt time.Time
+}
+
+// specCacheStore provides a session-scoped cache for parsed specs.
+// File inputs are keyed by (absolutePath, modTime). Content inputs are keyed
+// by a SHA-256 hash. URL inputs are never cached (the remote may change).
+type specCacheStore struct {
+	mu      sync.Mutex
+	entries map[string]*cacheEntry
+	maxSize int
+}
+
+var specCache = &specCacheStore{
+	entries: make(map[string]*cacheEntry),
+	maxSize: 10,
+}
+
+// get returns a cached result or nil.
+func (c *specCacheStore) get(key string) *parser.ParseResult {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if e, ok := c.entries[key]; ok {
+		// Touch entry for LRU.
+		e.insertAt = time.Now()
+		return e.result
+	}
+	return nil
+}
+
+// put stores a result in the cache, evicting the oldest entry if at capacity.
+func (c *specCacheStore) put(key string, result *parser.ParseResult) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// If already cached, just update.
+	if _, ok := c.entries[key]; ok {
+		c.entries[key] = &cacheEntry{result: result, insertAt: time.Now()}
+		return
+	}
+
+	// Evict oldest if at capacity.
+	if len(c.entries) >= c.maxSize {
+		var oldestKey string
+		var oldestTime time.Time
+		for k, e := range c.entries {
+			if oldestKey == "" || e.insertAt.Before(oldestTime) {
+				oldestKey = k
+				oldestTime = e.insertAt
+			}
+		}
+		if oldestKey != "" {
+			delete(c.entries, oldestKey)
+		}
+	}
+
+	c.entries[key] = &cacheEntry{result: result, insertAt: time.Now()}
+}
+
+// reset clears all cached entries. Used in tests.
+func (c *specCacheStore) reset() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries = make(map[string]*cacheEntry)
+}
+
+// size returns the number of cached entries.
+func (c *specCacheStore) size() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.entries)
+}
+
+// makeCacheKey creates a cache key for the given spec input.
+// Returns empty string if the input should not be cached (URLs, or when
+// extra parser options are provided since we cannot distinguish option sets).
+func makeCacheKey(s specInput, extraOpts []parser.Option) string {
+	if len(extraOpts) > 0 {
+		return ""
+	}
+
+	switch {
+	case s.File != "":
+		absPath, err := filepath.Abs(s.File)
+		if err != nil {
+			return ""
+		}
+		info, err := os.Stat(absPath)
+		if err != nil {
+			return "" // Can't stat, don't cache.
+		}
+		return fmt.Sprintf("file:%s:%d", absPath, info.ModTime().UnixNano())
+	case s.Content != "":
+		h := sha256.Sum256([]byte(s.Content))
+		return fmt.Sprintf("content:%s", hex.EncodeToString(h[:]))
+	default:
+		return "" // URL inputs are not cached.
+	}
+}
+
+// resolve parses the spec from whichever input was provided, using the cache
+// for file and content inputs. Additional parser options can be passed to
+// customize parsing behavior.
 func (s specInput) resolve(extraOpts ...parser.Option) (*parser.ParseResult, error) {
 	count := 0
 	if s.File != "" {
@@ -32,6 +141,14 @@ func (s specInput) resolve(extraOpts ...parser.Option) (*parser.ParseResult, err
 		return nil, fmt.Errorf("exactly one of file, url, or content must be provided (got %d)", count)
 	}
 
+	// Check cache for file and content inputs.
+	key := makeCacheKey(s, extraOpts)
+	if key != "" {
+		if cached := specCache.get(key); cached != nil {
+			return cached, nil
+		}
+	}
+
 	var opts []parser.Option
 	switch {
 	case s.File != "":
@@ -43,5 +160,15 @@ func (s specInput) resolve(extraOpts ...parser.Option) (*parser.ParseResult, err
 	}
 	opts = append(opts, extraOpts...)
 
-	return parser.ParseWithOptions(opts...)
+	result, err := parser.ParseWithOptions(opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Cache the result for future calls.
+	if key != "" {
+		specCache.put(key, result)
+	}
+
+	return result, nil
 }

--- a/internal/mcpserver/input_test.go
+++ b/internal/mcpserver/input_test.go
@@ -1,13 +1,17 @@
 package mcpserver
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestSpecInput_ResolveFile(t *testing.T) {
+	specCache.reset()
 	// Use an existing testdata file from the repo
 	input := specInput{File: "../../testdata/petstore-3.0.yaml"}
 	result, err := input.resolve()
@@ -17,6 +21,7 @@ func TestSpecInput_ResolveFile(t *testing.T) {
 }
 
 func TestSpecInput_ResolveContent(t *testing.T) {
+	specCache.reset()
 	content := `openapi: "3.0.0"
 info:
   title: Test
@@ -45,7 +50,113 @@ func TestSpecInput_ResolveMultipleProvided(t *testing.T) {
 }
 
 func TestSpecInput_ResolveFileNotFound(t *testing.T) {
+	specCache.reset()
 	input := specInput{File: "/nonexistent/path.yaml"}
 	_, err := input.resolve()
 	assert.Error(t, err)
+}
+
+func TestSpecCache_HitOnSameFile(t *testing.T) {
+	specCache.reset()
+	input := specInput{File: "../../testdata/petstore-3.0.yaml"}
+
+	// First call populates cache.
+	result1, err := input.resolve()
+	require.NoError(t, err)
+	assert.Equal(t, 1, specCache.size())
+
+	// Second call should return the same pointer (cache hit).
+	result2, err := input.resolve()
+	require.NoError(t, err)
+	assert.Same(t, result1, result2, "expected same pointer from cache hit")
+}
+
+func TestSpecCache_MissOnModifiedFile(t *testing.T) {
+	specCache.reset()
+
+	// Create a temp file.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "spec.yaml")
+	content1 := []byte(`openapi: "3.0.0"
+info:
+  title: Test V1
+  version: "1.0"
+paths: {}
+`)
+	require.NoError(t, os.WriteFile(path, content1, 0644))
+
+	input := specInput{File: path}
+	result1, err := input.resolve()
+	require.NoError(t, err)
+	accessor1 := result1.AsAccessor()
+	require.NotNil(t, accessor1)
+	assert.Equal(t, "Test V1", accessor1.GetInfo().Title)
+
+	// Modify the file (change mtime).
+	content2 := []byte(`openapi: "3.0.0"
+info:
+  title: Test V2
+  version: "2.0"
+paths: {}
+`)
+	require.NoError(t, os.WriteFile(path, content2, 0644))
+
+	// Ensure mtime differs from the first write on coarse-grained filesystems.
+	future := time.Now().Add(2 * time.Second)
+	require.NoError(t, os.Chtimes(path, future, future))
+
+	result2, err := input.resolve()
+	require.NoError(t, err)
+	// Should be a different result since mtime changed.
+	assert.NotSame(t, result1, result2)
+	accessor2 := result2.AsAccessor()
+	require.NotNil(t, accessor2)
+	assert.Equal(t, "Test V2", accessor2.GetInfo().Title)
+}
+
+func TestSpecCache_ContentHash(t *testing.T) {
+	specCache.reset()
+	content := `openapi: "3.0.0"
+info:
+  title: Hash Test
+  version: "1.0"
+paths: {}
+`
+	input := specInput{Content: content}
+
+	result1, err := input.resolve()
+	require.NoError(t, err)
+
+	// Same content should hit cache.
+	result2, err := input.resolve()
+	require.NoError(t, err)
+	assert.Same(t, result1, result2)
+}
+
+func TestSpecCache_LRUEviction(t *testing.T) {
+	specCache.reset()
+
+	// Insert 11 specs into a cache of size 10.
+	// Track the first content's cache key to verify it is evicted.
+	var firstKey string
+	for i := range 11 {
+		content := `openapi: "3.0.0"
+info:
+  title: "Spec ` + string(rune('A'+i)) + `"
+  version: "1.0"
+paths: {}
+`
+		if i == 0 {
+			firstKey = makeCacheKey(specInput{Content: content}, nil)
+		}
+		input := specInput{Content: content}
+		_, err := input.resolve()
+		require.NoError(t, err)
+	}
+
+	// Cache should not exceed max size.
+	assert.Equal(t, 10, specCache.size())
+
+	// The first entry (oldest) should have been evicted.
+	assert.Nil(t, specCache.get(firstKey), "expected oldest entry to be evicted")
 }

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -97,12 +97,12 @@ func registerAllTools(server *mcp.Server) {
 
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "walk_paths",
-		Description: "Walk and query path items in an OpenAPI Specification document. Filter by path pattern or extension. Returns summaries (path, method count) by default or full path item objects with detail=true. Path patterns support * (one segment) and ** (zero or more segments), e.g. /users/** matches all paths under /users.",
+		Description: "Walk and query path items in an OpenAPI Specification document. Filter by path pattern or extension. Returns summaries (path, method count) by default or full path item objects with detail=true. Path patterns support * (one segment) and ** (zero or more segments), e.g. /users/** matches all paths under /users. Use group_by=segment to group paths by their first URL segment.",
 	}, handleWalkPaths)
 
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "walk_refs",
-		Description: "Walk and count $ref references in an OpenAPI Specification document. By default, returns unique ref targets ranked by reference count (most-referenced first). Use target to filter to a specific ref (supports * glob, e.g. *schemas/microsoft.graph.*). Use detail=true to see individual source locations instead of counts. Filter by node_type to narrow to schema, parameter, response, requestBody, header, or pathItem refs.",
+		Description: "Walk and count $ref references in an OpenAPI Specification document. By default, returns unique ref targets ranked by reference count (most-referenced first). Use target to filter to a specific ref (supports * glob, e.g. *schemas/microsoft.graph.*). Use detail=true to see individual source locations instead of counts. Filter by node_type to narrow to schema, parameter, response, requestBody, header, or pathItem refs. Use group_by=node_type to get distribution counts by ref type.",
 	}, handleWalkRefs)
 
 	mcp.AddTool(server, &mcp.Tool{

--- a/internal/mcpserver/tools_parse.go
+++ b/internal/mcpserver/tools_parse.go
@@ -75,6 +75,15 @@ func handleParse(_ context.Context, _ *mcp.CallToolRequest, input parseInput) (*
 		}
 	}
 
+	// In summary mode, truncate long text fields to reduce token usage.
+	const summaryMaxDescriptionLen = 200
+	if !input.Full {
+		output.Description = truncateText(output.Description, summaryMaxDescriptionLen)
+		for i := range output.Servers {
+			output.Servers[i].Description = truncateText(output.Servers[i].Description, summaryMaxDescriptionLen)
+		}
+	}
+
 	if input.Full {
 		var data []byte
 		switch result.SourceFormat {
@@ -90,4 +99,16 @@ func handleParse(_ context.Context, _ *mcp.CallToolRequest, input parseInput) (*
 	}
 
 	return nil, output, nil
+}
+
+// truncateText truncates a string to maxLen runes, appending "..." if truncated.
+func truncateText(s string, maxLen int) string {
+	if maxLen < 0 {
+		maxLen = 0
+	}
+	runes := []rune(s)
+	if len(runes) <= maxLen {
+		return s
+	}
+	return string(runes[:maxLen]) + "..."
 }

--- a/internal/mcpserver/tools_walk_parameters.go
+++ b/internal/mcpserver/tools_walk_parameters.go
@@ -80,6 +80,9 @@ func handleWalkParameters(_ context.Context, _ *mcp.CallToolRequest, input walkP
 		groups := groupAndSort(matched, func(info *walker.ParameterInfo) []string {
 			switch strings.ToLower(input.GroupBy) {
 			case "location":
+				if info.In == "" {
+					return []string{"(ref)"}
+				}
 				return []string{info.In}
 			case "name":
 				return []string{info.Name}

--- a/internal/mcpserver/tools_walk_responses.go
+++ b/internal/mcpserver/tools_walk_responses.go
@@ -76,6 +76,9 @@ func handleWalkResponses(_ context.Context, _ *mcp.CallToolRequest, input walkRe
 		groups := groupAndSort(matched, func(info *walker.ResponseInfo) []string {
 			switch strings.ToLower(input.GroupBy) {
 			case "status_code":
+				if info.StatusCode == "" {
+					return []string{"(component)"}
+				}
 				return []string{info.StatusCode}
 			case "method":
 				return []string{strings.ToUpper(info.Method)}

--- a/internal/mcpserver/tools_walk_schemas.go
+++ b/internal/mcpserver/tools_walk_schemas.go
@@ -94,7 +94,7 @@ func handleWalkSchemas(_ context.Context, _ *mcp.CallToolRequest, input walkSche
 			case "type":
 				t := schemaTypeString(info.Schema.Type)
 				if t == "" {
-					return []string{""}
+					return []string{"(untyped)"}
 				}
 				return []string{t}
 			case "location":

--- a/plugin/CLAUDE.md
+++ b/plugin/CLAUDE.md
@@ -22,6 +22,8 @@ go install github.com/erraggy/oastools/cmd/oastools@latest
 
 If MCP tools are unavailable or returning errors, verify the binary is installed and up to date. New tool parameters (like `output` on `fix`) require the corresponding binary version.
 
+**Version mismatch detection:** On session start, the plugin checks whether the installed `oastools` binary version matches the plugin version. If a mismatch is detected, a warning is surfaced so you can update accordingly. Dev and unknown builds skip this check.
+
 ## Available Tools
 
 **Core (9):** `validate`, `parse`, `fix`, `convert`, `diff`, `join`, `overlay_apply`, `overlay_validate`, `generate`
@@ -57,7 +59,7 @@ Special cases:
    - Use `detail: true` only after filtering to specific items — full objects can be very large
 6. **Check breaking changes.** When diffing specs, use `breaking_only: true` to focus on changes that will break API consumers.
 7. 📄 **Page through large results.** Tools that return arrays (`validate`, `fix`, `diff`, `walk_*`) support `offset` and `limit` params (default limit: 100). When `returned` is less than the total count, use `offset` to page through. Prefer filtering over paging when possible.
-8. 📊 **Aggregate with `group_by`.** The walk tools (`walk_operations`, `walk_schemas`, `walk_parameters`, `walk_responses`, `walk_headers`) support a `group_by` parameter that returns `{key, count}` groups instead of individual items. Use this for distribution questions ("how many operations per tag?") instead of paging through all results.
+8. 📊 **Aggregate with `group_by`.** Most walk tools (`walk_operations`, `walk_schemas`, `walk_parameters`, `walk_responses`, `walk_headers`, `walk_paths`, `walk_refs`) support a `group_by` parameter (`walk_security` does not, since specs rarely have more than 3 schemes) that returns `{key, count}` groups instead of individual items. `walk_paths` supports `group_by: "segment"` (group by first path segment) and `walk_refs` supports `group_by: "node_type"` (group by reference target type). Use this for distribution questions ("how many operations per tag?") instead of paging through all results.
 
 ## 💾 Persisting Results
 

--- a/plugin/hooks/scripts/check-binary.sh
+++ b/plugin/hooks/scripts/check-binary.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# check-binary.sh - Verify oastools binary is installed and report version.
+# check-binary.sh - Verify oastools binary is installed and check version alignment.
 # Used as a SessionStart hook to give agents early awareness of the
 # binary's presence and version before any MCP tool calls.
 
@@ -19,5 +19,40 @@ MSG
     exit 2
 fi
 
-VERSION=$(oastools version 2>/dev/null | head -1 || echo "unknown")
-echo "oastools $VERSION"
+# Extract binary version (e.g., "1.51.3" from "oastools v1.51.3 ...").
+RAW_VERSION=$(oastools version 2>/dev/null | head -1 | grep -oE 'v[^ ]+' | sed 's/^v//' || echo "unknown")
+if echo "$RAW_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+    BINARY_VERSION="$RAW_VERSION"
+elif [ "$RAW_VERSION" = "dev" ]; then
+    BINARY_VERSION="dev"
+else
+    BINARY_VERSION="unknown"
+fi
+
+# Extract plugin version from plugin.json (no jq dependency).
+PLUGIN_JSON="${CLAUDE_PLUGIN_ROOT:-.}/.claude-plugin/plugin.json"
+if [ -f "$PLUGIN_JSON" ]; then
+    PLUGIN_VERSION=$(grep -oE '"version"[[:space:]]*:[[:space:]]*"[^"]*"' "$PLUGIN_JSON" | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "unknown")
+else
+    PLUGIN_VERSION="unknown"
+fi
+
+# Compare versions.
+if [ "$BINARY_VERSION" = "unknown" ] || [ "$BINARY_VERSION" = "dev" ]; then
+    # Dev build or unparseable version — skip comparison.
+    echo "oastools v${BINARY_VERSION} (binary: ${BINARY_VERSION}, plugin: ${PLUGIN_VERSION}, status: ${BINARY_VERSION})"
+elif [ "$PLUGIN_VERSION" = "unknown" ]; then
+    # Plugin version not found — just report binary version.
+    echo "oastools v${BINARY_VERSION}"
+elif [ "$BINARY_VERSION" = "$PLUGIN_VERSION" ]; then
+    echo "oastools v${BINARY_VERSION} (binary: v${BINARY_VERSION}, plugin: v${PLUGIN_VERSION}, status: ok)"
+else
+    echo "oastools v${BINARY_VERSION} (binary: v${BINARY_VERSION}, plugin: v${PLUGIN_VERSION}, status: MISMATCH)"
+    echo ""
+    echo "WARNING: Binary version (v${BINARY_VERSION}) does not match plugin version (v${PLUGIN_VERSION})."
+    echo "Some MCP tool parameters may be unavailable or behave unexpectedly."
+    echo ""
+    echo "Update the binary:"
+    echo "  brew upgrade erraggy/oastools/oastools"
+    echo "  # or: go install github.com/erraggy/oastools/cmd/oastools@v${PLUGIN_VERSION}"
+fi


### PR DESCRIPTION
## Summary

Addresses all actionable findings from the [corpus analysis UX session](docs/mcp-ux-findings.md) where we analyzed 10 real-world OpenAPI specs using only the oastools MCP tools.

- 🗄️ **Session-scoped spec cache** with LRU eviction (max 10 entries) — file inputs keyed by absolute path + mtime, content by SHA-256 hash, URLs bypass cache. Read-only tools use cache; mutating tools (fix/convert/join/overlay) bypass it.
- 📊 **`group_by` expansions** — `walk_refs` gets `group_by=node_type`, `walk_paths` gets `group_by=segment` (first path segment)
- 🏷️ **Empty group key labels** — `(untyped)` for typeless schemas, `(ref)` for unresolved $ref parameters, `(component)` for component responses
- ✂️ **Parse description truncation** — rune-safe truncation to 200 chars in summary mode
- 🔍 **Plugin version staleness detection** — SessionStart hook compares binary vs plugin.json versions, warns on mismatch
- 📖 **Documentation** — MCP server docs updated with spec caching, behavioral notes, new group_by values; corpus UX findings doc added with resolution status table

## Test plan

- [x] All existing tests pass (`make check` exit 0)
- [x] New tests for walk_refs group_by, walk_paths group_by, empty key labels, parse truncation, spec cache (hit/miss/eviction/content hash)
- [x] gopls diagnostics clean
- [x] CodeRabbit review — 2 passes, critical findings addressed (UTF-8 truncation, cache key collision, path normalization)
- [ ] Manual: restart Claude Code, verify SessionStart hook version output
- [ ] Manual: run `group_by=node_type` on corpus spec via MCP tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)