### PR TITLE
fix(mcp): use correct hyphenated collision strategy names in join tool

### DIFF
--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -52,7 +52,7 @@ func registerAllTools(server *mcp.Server) {
 
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "join",
-		Description: "Join multiple OpenAPI Specification documents into a single merged document. Requires at least 2 specs via the specs array. Collision strategies: accept_left, accept_right, fail (paths/schemas), rename (schemas only). Use semantic_dedup to merge equivalent schemas.",
+		Description: "Join multiple OpenAPI Specification documents into a single merged document. Requires at least 2 specs via the specs array. Collision strategies: accept-left, accept-right, fail (paths/schemas), rename (schemas only). Use semantic_dedup to merge equivalent schemas.",
 	}, handleJoin)
 
 	mcp.AddTool(server, &mcp.Tool{

--- a/internal/mcpserver/tools_join.go
+++ b/internal/mcpserver/tools_join.go
@@ -13,8 +13,8 @@ import (
 
 type joinInput struct {
 	Specs          []specInput `json:"specs"                         jsonschema:"Array of OAS documents to join (minimum 2)"`
-	PathStrategy   string      `json:"path_strategy,omitempty"       jsonschema:"Strategy for path collisions: accept_left or accept_right or fail"`
-	SchemaStrategy string      `json:"schema_strategy,omitempty"     jsonschema:"Strategy for schema collisions: accept_left or accept_right or fail or rename"`
+	PathStrategy   string      `json:"path_strategy,omitempty"       jsonschema:"Strategy for path collisions: accept-left or accept-right or fail"`
+	SchemaStrategy string      `json:"schema_strategy,omitempty"     jsonschema:"Strategy for schema collisions: accept-left or accept-right or fail or rename"`
 	SemanticDedup  bool        `json:"semantic_dedup,omitempty"      jsonschema:"Enable semantic deduplication of equivalent schemas"`
 	Output         string      `json:"output,omitempty"              jsonschema:"File path to write joined document. If omitted the result is returned inline."`
 }


### PR DESCRIPTION
## Summary

- Fixed `join` tool description and `jsonschema` tags to use `accept-left`/`accept-right` (matching `joiner.CollisionStrategy` constants) instead of `accept_left`/`accept_right`

The mismatch caused LLMs to always pass invalid strategy values on first attempt, getting `unknown collision strategy` errors.

## Test plan

- [x] All 178 MCP server unit tests pass
- [x] Verified end-to-end via MCP: `join` with `accept-left` strategy works correctly
- [x] Full corpus test suite passes (`make test-corpus`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)