### PR TITLE
docs: fix ~100 inaccuracies and add CI prevention checks

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,5 +36,18 @@ jobs:
       - name: Prepare Documentation
         run: ./scripts/prepare-docs.sh
 
+      - name: Restore lychee cache
+        uses: actions/cache@v4
+        with:
+          path: .lycheecache
+          key: lychee-${{ hashFiles('lychee.toml') }}
+          restore-keys: lychee-
+
+      - name: Check links
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: --no-progress docs/
+          fail: true
+
       - name: Deploy to GitHub Pages
         run: mkdocs gh-deploy --force

--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,9 @@ testdata/corpus/*.yaml
 testdata/corpus/*.yml
 !testdata/corpus/README.md
 
+# Lychee link checker cache
+.lycheecache
+
 # Generated Documentation
 site/
 .tmp/

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -304,6 +304,16 @@ go test -bench=. ./parser
 4. ✅ Verify test coverage is sufficient
 5. ✅ Update benchmarks with `make bench-save` for performance-impacting changes
 
+### Documentation Checks
+
+CI automatically verifies that documentation stays in sync with code through automated checks:
+
+- **CLI flag tables** (`TestCLIFlagsDocumented`) - CLI flags must match `docs/cli-reference.md`
+- **Option tables** (`TestDeepDiveOptionTables`) - `With*` functions must appear in respective `deep_dive.md`
+- **Link checking** (lychee) - Broken links caught in CI and via `make docs-check`
+
+If you add a CLI flag or `With*` option, the tests will tell you which doc to update.
+
 ### Commit Message Format
 
 Use conventional commit format:

--- a/Makefile
+++ b/Makefile
@@ -572,6 +572,21 @@ docs-clean:
 	@rm -f docs/CONTRIBUTORS.md docs/LICENSE.md docs/benchmarks.md
 	@rm -rf docs/packages docs/examples
 
+## lint-links: Check for broken links in assembled docs
+.PHONY: lint-links
+lint-links: docs-prepare
+	@echo "Checking links in docs/..."
+	@if command -v lychee >/dev/null 2>&1; then \
+		lychee --no-progress docs/; \
+	else \
+		echo "WARNING: lychee not found — link checking SKIPPED." >&2; \
+		echo "Install: brew install lychee (or cargo install lychee)" >&2; \
+	fi
+
+## docs-check: Full documentation validation (prepare + link check)
+.PHONY: docs-check
+docs-check: lint-links
+
 # =============================================================================
 # Help Target
 # =============================================================================

--- a/builder/deep_dive.md
+++ b/builder/deep_dive.md
@@ -1110,10 +1110,12 @@ result := srv.MustBuildServer()
 | `WithoutValidation()` | Disable request validation |
 | `WithValidationConfig(cfg)` | Configure validation behavior |
 | `WithRecovery()` | Enable panic recovery middleware |
-| `WithRequestLogger(fn)` | Add request logging |
+| `WithRequestLogging(fn)` | Enable request logging with a logger function |
 | `WithErrorHandler(fn)` | Custom error handler |
 | `WithNotFoundHandler(h)` | Custom 404 handler |
 | `WithMethodNotAllowedHandler(h)` | Custom 405 handler |
+| `WithRouter(strategy)` | Set the routing strategy |
+| `WithStdlibRouter()` | Use net/http with PathMatcherSet for routing (default) |
 
 [↑ Back to top](#top)
 

--- a/cmd/oastools/commands/cli_doc_test.go
+++ b/cmd/oastools/commands/cli_doc_test.go
@@ -1,0 +1,156 @@
+package commands
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCLIFlagsDocumented verifies that every registered CLI flag appears in
+// docs/cli-reference.md, and every documented flag corresponds to a registered flag.
+func TestCLIFlagsDocumented(t *testing.T) {
+	// Resolve docs path from this test file's location.
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(t, ok, "runtime.Caller(0) failed to retrieve file path")
+	docPath := filepath.Join(filepath.Dir(thisFile), "..", "..", "..", "docs", "cli-reference.md")
+
+	docBytes, err := os.ReadFile(docPath)
+	require.NoError(t, err, "reading cli-reference.md")
+	docContent := string(docBytes)
+
+	// Build the map of command -> FlagSet by calling every Setup*Flags function.
+	commands := map[string]*flag.FlagSet{
+		"validate":         mustFS(SetupValidateFlags()),
+		"parse":            mustFS(SetupParseFlags()),
+		"fix":              mustFS(SetupFixFlags()),
+		"convert":          mustFS(SetupConvertFlags()),
+		"diff":             mustFS(SetupDiffFlags()),
+		"join":             mustFS(SetupJoinFlags()),
+		"generate":         mustFS(SetupGenerateFlags()),
+		"overlay apply":    mustFS(SetupOverlayApplyFlags()),
+		"overlay validate": mustFS(SetupOverlayValidateFlags()),
+		"walk operations":  mustFS(SetupWalkOperationsFlags()),
+		"walk schemas":     mustFS(SetupWalkSchemasFlags()),
+		"walk parameters":  mustFS(SetupWalkParametersFlags()),
+		"walk responses":   mustFS(SetupWalkResponsesFlags()),
+		"walk security":    mustFS(SetupWalkSecurityFlags()),
+		"walk paths":       mustFS(SetupWalkPathsFlags()),
+	}
+
+	// Parse documented flags from markdown tables per command section.
+	knownCmds := make(map[string]bool, len(commands))
+	for name := range commands {
+		knownCmds[name] = true
+	}
+	docFlags := parseDocFlags(docContent, knownCmds)
+
+	for cmdName, fs := range commands {
+		t.Run(cmdName, func(t *testing.T) {
+			documented := docFlags[cmdName]
+			require.NotNil(t, documented, "no flag table found in cli-reference.md for command %q", cmdName)
+
+			// Collect registered long-form flag names (skip single-char aliases and help).
+			registeredSet := make(map[string]bool)
+			fs.VisitAll(func(f *flag.Flag) {
+				if len(f.Name) == 1 || f.Name == "help" {
+					return
+				}
+				registeredSet[f.Name] = true
+			})
+
+			// Check: every registered flag should be documented.
+			for name := range registeredSet {
+				assert.True(t, documented[name], "flag --%s is registered for %q but not documented in cli-reference.md", name, cmdName)
+			}
+
+			// Check: every documented flag should be registered.
+			for name := range documented {
+				if name == "help" {
+					continue
+				}
+				assert.True(t, registeredSet[name], "flag --%s is documented for %q in cli-reference.md but not registered", name, cmdName)
+			}
+		})
+	}
+}
+
+// mustFS extracts the *flag.FlagSet from a Setup*Flags return pair.
+func mustFS[T any](fs *flag.FlagSet, _ T) *flag.FlagSet {
+	return fs
+}
+
+// parseDocFlags parses cli-reference.md and returns a map of command name -> set of documented flag names.
+// It looks for markdown sections (## command / ### subcommand) and flag table rows (| `--flagname` |).
+// knownCmds is the authoritative set of command names to match against section headers.
+func parseDocFlags(content string, knownCmds map[string]bool) map[string]map[string]bool {
+	result := make(map[string]map[string]bool)
+
+	// Split into lines for section tracking.
+	lines := strings.Split(content, "\n")
+
+	// allFlagsRe matches all --flag-name occurrences in a table row.
+	// This handles rows like:
+	// | `--flag-name` | description |
+	// | `-s, --flag-name` | description |
+	// | `--prune-all, --prune` | description |
+	// | `-o, --flag-name string` | description |
+	allFlagsRe := regexp.MustCompile(`--([a-zA-Z][a-zA-Z0-9-]*)`)
+
+	var currentCmd string
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		// Track current section from ## and ### headers.
+		// - ## headers are top-level commands: set currentCmd if recognized, reset otherwise
+		// - ### headers are subcommands (overlay apply, walk operations, etc.): set if recognized, keep otherwise
+		// - #### headers are sub-subsections (Flags, Examples): always ignore
+		if strings.HasPrefix(trimmed, "## ") || strings.HasPrefix(trimmed, "### ") {
+			var headerText string
+			switch {
+			case strings.HasPrefix(trimmed, "### "):
+				headerText = strings.TrimPrefix(trimmed, "### ")
+			case strings.HasPrefix(trimmed, "## "):
+				headerText = strings.TrimPrefix(trimmed, "## ")
+			}
+			headerText = strings.TrimSpace(headerText)
+			headerLower := strings.ToLower(headerText)
+
+			if knownCmds[headerLower] {
+				currentCmd = headerLower
+				if result[currentCmd] == nil {
+					result[currentCmd] = make(map[string]bool)
+				}
+			} else if strings.HasPrefix(trimmed, "## ") {
+				// Reset currentCmd on unrecognized ## headers to avoid
+				// attributing flags from unrelated sections to the previous command.
+				currentCmd = ""
+			}
+			// For unrecognized ### headers (e.g., "### Flags", "### Examples"),
+			// keep currentCmd as-is — they are subsections of the current command.
+		}
+
+		// Extract flags from the first cell of table rows.
+		if currentCmd != "" && strings.HasPrefix(trimmed, "|") {
+			// Extract the first table cell (between the first and second |).
+			parts := strings.SplitN(trimmed, "|", 3)
+			if len(parts) >= 3 {
+				firstCell := parts[1]
+				for _, matches := range allFlagsRe.FindAllStringSubmatch(firstCell, -1) {
+					if len(matches) > 1 {
+						result[currentCmd][matches[1]] = true
+					}
+				}
+			}
+		}
+	}
+
+	return result
+}

--- a/differ/deep_dive.md
+++ b/differ/deep_dive.md
@@ -53,6 +53,7 @@ Changes are organized by the specification element that was modified:
 | `CategorySecurity` | Security scheme modifications |
 | `CategoryServer` | Server URL or variable changes |
 | `CategoryInfo` | Metadata changes (title, version, description) |
+| `CategoryExtension` | Specification extension (x-*) changes |
 
 ### Severity Levels
 
@@ -228,8 +229,8 @@ func main() {
         for _, change := range result.Changes {
             if change.Severity == differ.SeverityCritical || 
                change.Severity == differ.SeverityError {
-                fmt.Printf("  [%s] %s: %s\n", 
-                    change.Severity, change.Path, change.Description)
+                fmt.Printf("  [%s] %s: %s\n",
+                    change.Severity, change.Path, change.Message)
             }
         }
         os.Exit(1)
@@ -347,6 +348,7 @@ func main() {
         differ.CategorySecurity,
         differ.CategoryServer,
         differ.CategoryInfo,
+        differ.CategoryExtension,
     }
     
     for _, category := range categoryOrder {
@@ -565,10 +567,10 @@ result, _ := differ.DiffWithOptions(
 for _, change := range result.Changes {
     if change.HasLocation() {
         // IDE-friendly format: file:line:column
-        fmt.Printf("%s: %s\n", change.Location(), change.Description)
+        fmt.Printf("%s: %s\n", change.Location(), change.Message)
     } else {
         // Fallback to JSON path
-        fmt.Printf("%s: %s\n", change.Path, change.Description)
+        fmt.Printf("%s: %s\n", change.Path, change.Message)
     }
 }
 ```
@@ -705,8 +707,20 @@ result2, _ := d.Diff("api-v2.yaml", "api-v3.yaml")
 type DiffResult struct {
     // SourceVersion is the OAS version of the source document
     SourceVersion string
+    // SourceOASVersion is the enumerated source OAS version
+    SourceOASVersion parser.OASVersion
+    // SourceStats contains statistical information about the source document
+    SourceStats parser.DocumentStats
+    // SourceSize is the size of the source document in bytes
+    SourceSize int64
     // TargetVersion is the OAS version of the target document
     TargetVersion string
+    // TargetOASVersion is the enumerated target OAS version
+    TargetOASVersion parser.OASVersion
+    // TargetStats contains statistical information about the target document
+    TargetStats parser.DocumentStats
+    // TargetSize is the size of the target document in bytes
+    TargetSize int64
     // Changes contains all detected changes
     Changes []Change
     // BreakingCount is the number of breaking changes (Critical + Error)
@@ -734,7 +748,7 @@ type Change struct {
     Category    ChangeCategory // endpoint, operation, parameter, etc.
     Severity    Severity       // critical, error, warning, info
     Path        string         // JSON path to changed element
-    Description string         // Human-readable description
+    Message     string         // Human-readable description
     OldValue    any            // Previous value (for modifications)
     NewValue    any            // New value (for modifications)
 }

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -153,10 +153,10 @@ if result.HasBreakingChanges {
 
 ```bash
 # Detect breaking changes
-oastools diff --mode breaking api-v1.yaml api-v2.yaml
+oastools diff --breaking api-v1.yaml api-v2.yaml
 
 # Focus on breaking and error-level changes only
-oastools diff --mode breaking --no-info api-v1.yaml api-v2.yaml
+oastools diff --breaking --no-info api-v1.yaml api-v2.yaml
 ```
 
 ---
@@ -300,7 +300,7 @@ responses:
 # Example: Fail CI if breaking changes are detected
 
 oastools diff \
-  --mode breaking \
+  --breaking \
   current-api.yaml \
   proposed-api.yaml \
   > diff-result.txt

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -1740,13 +1740,13 @@ if err != nil {
     log.Fatal(err)
 }
 
-// Validate (30x faster than validator.Validate)
+// Validate (31x faster than validator.Validate)
 valResult, _ := validator.ValidateWithOptions(
     validator.WithParsed(*parseResult),
     validator.WithIncludeWarnings(true),
 )
 
-// Convert (9x faster than converter.Convert)
+// Convert (47x faster than converter.Convert)
 convResult, _ := converter.ConvertWithOptions(
     converter.WithParsed(*parseResult),
     converter.WithTargetVersion("3.0.3"),
@@ -2164,4 +2164,4 @@ Two documents define the same path. Choose a collision strategy:
 - **API Documentation**: [pkg.go.dev/github.com/erraggy/oastools](https://pkg.go.dev/github.com/erraggy/oastools)
 - **GitHub Issues**: [https://github.com/erraggy/oastools/issues](https://github.com/erraggy/oastools/issues)
 - **Breaking Change Semantics**: See [breaking-changes.md](breaking-changes.md)
-- **Performance Details**: See [benchmarks.md](benchmarks.md)
+- **Performance Details**: See the [whitepaper performance section](whitepaper.md#17-performance-analysis)

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@
 
 # oastools
 
-A complete, self-contained OpenAPI toolkit for Go — parse, validate, fix, convert, diff, join, generate, and build OpenAPI specs (2.0–3.2) with minimal dependencies.
+A complete, self-contained OpenAPI toolkit for Go — parse, validate, fix, convert, diff, join, walk, generate, and build OpenAPI specs (2.0–3.2) with an MCP server for AI-assisted development.
 
 [![CI: Go](https://github.com/erraggy/oastools/actions/workflows/go.yml/badge.svg)](https://github.com/erraggy/oastools/actions/workflows/go.yml)
 [![codecov](https://codecov.io/gh/erraggy/oastools/graph/badge.svg?token=T8768QXQAX)](https://codecov.io/gh/erraggy/oastools)
@@ -21,7 +21,7 @@ Import oastools packages into your Go application for parsing, validation, conve
 
 ```go
 result, _ := parser.ParseWithOptions(parser.WithFilePath("api.yaml"))
-vResult, _ := validator.ValidateWithOptions(validator.WithDocument(result))
+vResult, _ := validator.ValidateWithOptions(validator.WithParsed(*result))
 ```
 
 → **[Developer Guide](developer-guide.md)** — Complete library usage with examples for all 12 packages
@@ -93,7 +93,7 @@ All packages include comprehensive documentation with runnable examples. See ind
 
 ??? note "Performance"
 
-    Pre-parsed workflows are 11–150x faster. JSON marshaling optimized for 25-32% better performance. 340+ benchmarks track regressions. See [Benchmarks](benchmarks.md).
+    Pre-parsed workflows are 11–150x faster. JSON marshaling optimized for 25-32% better performance. 340+ benchmarks track regressions. See the [whitepaper performance section](whitepaper.md#17-performance-analysis) for detailed analysis.
 
 ??? note "Enterprise-Ready"
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -70,6 +70,10 @@ All server defaults are configurable via `OASTOOLS_*` environment variables. The
 | `OASTOOLS_VALIDATE_NO_WARNINGS` | bool | `false` | Suppress warnings by default |
 | `OASTOOLS_JOIN_PATH_STRATEGY` | string | *(none)* | Default path collision strategy for join |
 | `OASTOOLS_JOIN_SCHEMA_STRATEGY` | string | *(none)* | Default schema collision strategy for join |
+| `OASTOOLS_ALLOW_PRIVATE_IPS` | bool | `false` | Allow resolution of private/loopback IPs |
+| `OASTOOLS_MAX_INLINE_SIZE` | int | `10485760` | Maximum size of inline content (10 MiB) |
+| `OASTOOLS_MAX_LIMIT` | int | `1000` | Maximum result limit for walk tools |
+| `OASTOOLS_MAX_JOIN_SPECS` | int | `20` | Maximum number of specs in a join operation |
 
 Duration values use Go syntax: `30s`, `5m`, `1h`. Invalid values log a warning and fall back to the default.
 
@@ -205,7 +209,7 @@ Validate an OpenAPI spec against its declared version schema.
 | `version` | string | Detected OAS version |
 | `error_count` | number | Number of validation errors |
 | `warning_count` | number | Number of warnings |
-| `errors` | array | Error details (path, message, severity) |
+| `errors` | array | Error details (path, message, field) |
 | `warnings` | array | Warning details |
 
 **Example:**
@@ -357,7 +361,6 @@ Apply an Overlay document to an OAS spec.
 | `spec` | object | The OAS document |
 | `overlay` | object | The Overlay document (file/url/content) |
 | `dry_run` | boolean | Preview changes without applying |
-| `strict` | boolean | Fail if any target matches nothing |
 | `output` | string | File path to write the result |
 
 ---
@@ -370,16 +373,14 @@ Validate an Overlay document structure.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `spec` | object | The Overlay document (file/url/content) |
+| `overlay` | object | The Overlay document (file/url/content) |
 
 **Output:**
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `valid` | boolean | Whether the overlay is valid |
-| `version` | string | Overlay specification version |
-| `title` | string | Overlay title |
-| `action_count` | number | Number of actions |
+| `error_count` | number | Number of validation errors |
 | `errors` | array | Validation errors |
 
 ---

--- a/docs/why-oastools.md
+++ b/docs/why-oastools.md
@@ -38,13 +38,13 @@ Pre-parsed workflows eliminate redundant parsing when processing multiple operat
 | Method             | Speedup      |
 |--------------------|--------------|
 | `ValidateParsed()` | 31x faster   |
-| `ConvertParsed()`  | ~50x faster  |
+| `ConvertParsed()`  | 47x faster   |
 | `JoinParsed()`     | 150x faster  |
 | `DiffParsed()`     | 81x faster   |
 | `FixParsed()`      | ~60x faster  |
 | `ApplyParsed()`    | ~11x faster  |
 
-JSON marshaling is optimized for 25-32% better performance with 29-37% fewer allocations. See [Benchmarks](benchmarks.md) for detailed analysis.
+JSON marshaling is optimized for 25-32% better performance with 29-37% fewer allocations. See the [whitepaper performance section](whitepaper.md#17-performance-analysis) for detailed analysis.
 
 ## 🔒 Type-Safe Document Cloning
 

--- a/fixer/deep_dive.md
+++ b/fixer/deep_dive.md
@@ -44,10 +44,15 @@ The fixer analyzes OAS documents and applies fixes for issues that would cause v
 | `FixTypePrunedUnusedSchema` | ❌ Disabled | Removes unreferenced schema definitions |
 | `FixTypePrunedEmptyPath` | ❌ Disabled | Removes paths with no HTTP operations |
 | `FixTypeEnumCSVExpanded` | ❌ Disabled | Expands CSV enum strings to typed arrays (e.g., "1,2,3" → [1, 2, 3]) |
+| `FixTypeDuplicateOperationId` | ❌ Disabled | Renames duplicate operationId values to ensure uniqueness |
+| `FixTypeStubMissingRef` | ❌ Disabled | Creates empty stubs for unresolved `$ref` targets |
 
 **Why are some fixes disabled by default?**
 
-Schema renaming and pruning involve expensive operations (walking all references, computing unused schemas) that can significantly slow down processing of large specifications. Enable them explicitly when needed.
+Disabled fixes fall into two categories:
+
+- **Performance-sensitive**: Schema renaming (`FixTypeRenamedGenericSchema`) and pruning (`FixTypePrunedUnusedSchema`, `FixTypePrunedEmptyPath`) walk all references and compute unused schemas, which can significantly slow processing of large specifications.
+- **Behavioral impact**: `FixTypeDuplicateOperationId` renames operation IDs that clients and SDK generators may already depend on. `FixTypeStubMissingRef` injects synthetic placeholder content into the document. Both are opt-in to avoid unexpected breakage.
 
 [Back to top](#top)
 
@@ -205,6 +210,11 @@ Configure with `WithGenericNaming()` or `WithGenericNamingConfig()`.
 | `WithGenericNamingConfig(cfg)` | Custom naming configuration |
 | `WithDryRun(bool)` | Preview without applying |
 | `WithMutableInput(bool)` | Skip defensive copy when caller owns input |
+| `WithUserAgent(userAgent string)` | Custom User-Agent for HTTP requests |
+| `WithSourceMap(sm *parser.SourceMap)` | Source map for line/column info in fixes |
+| `WithOperationIdNamingConfig(config OperationIdNamingConfig)` | Configuration for duplicate operationId renaming |
+| `WithStubConfig(config StubConfig)` | Configuration for missing reference stub creation |
+| `WithStubResponseDescription(desc string)` | Default description for stubbed responses |
 
 ### Fixer Fields
 
@@ -212,7 +222,11 @@ Configure with `WithGenericNaming()` or `WithGenericNamingConfig()`.
 |-------|------|-------------|
 | `InferTypes` | `bool` | Enable type inference |
 | `EnabledFixes` | `[]FixType` | Fix types to apply (empty = all) |
-| `GenericNamingConfig` | `*GenericNamingConfig` | Custom naming rules |
+| `UserAgent` | `string` | User-Agent string for HTTP requests |
+| `SourceMap` | `*parser.SourceMap` | Source location lookup for fix issues |
+| `GenericNamingConfig` | `GenericNamingConfig` | Custom naming rules |
+| `OperationIdNamingConfig` | `OperationIdNamingConfig` | Configuration for duplicate operationId renaming |
+| `StubConfig` | `StubConfig` | Configuration for missing reference stub creation |
 | `DryRun` | `bool` | Preview mode |
 | `MutableInput` | `bool` | Skip defensive copy |
 

--- a/generator/deep_dive.md
+++ b/generator/deep_dive.md
@@ -421,7 +421,7 @@ func main() {
     
     fmt.Printf("Generated %d files\n", len(result.Files))
     for _, file := range result.Files {
-        fmt.Printf("  %s (%d lines)\n", file.Name, file.LineCount)
+        fmt.Printf("  %s (%d bytes)\n", file.Name, len(file.Content))
     }
 }
 ```
@@ -1122,8 +1122,7 @@ func main() {
     
     fmt.Printf("Generated %d files:\n", len(result.Files))
     for _, file := range result.Files {
-        fmt.Printf("  %s (%d lines, %d types)\n", 
-            file.Name, file.LineCount, file.TypeCount)
+        fmt.Printf("  %s (%d bytes)\n", file.Name, len(file.Content))
     }
 }
 ```
@@ -1376,6 +1375,7 @@ type Generator struct {
 | `WithServerMiddleware(bool)` | Generate validation middleware |
 | `WithServerRouter(string)` | Generate HTTP router ("stdlib", "chi") |
 | `WithServerStubs(bool)` | Generate stub server for testing |
+| `WithServerEmbedSpec(bool)` | Embed the OpenAPI spec in generated code |
 | `WithServerAll()` | Enable all server extensions |
 
 [↑ Back to top](#top)
@@ -1386,21 +1386,24 @@ type Generator struct {
 type GenerateResult struct {
     // Files contains all generated files
     Files []GeneratedFile
-    
+
     // Version info
-    Version    string
-    OASVersion parser.OASVersion
-    PackageName string
-    
+    SourceVersion    string
+    SourceOASVersion parser.OASVersion
+    SourceFormat     parser.SourceFormat
+    PackageName      string
+
     // Statistics
-    TypeCount      int
-    OperationCount int
-    SchemaCount    int
-    
-    // Generation info
+    GeneratedTypes      int
+    GeneratedOperations int
+
+    // Timing and size
+    LoadTime      time.Duration
     GenerateTime  time.Duration
+    SourceSize    int64
+    Stats         parser.DocumentStats
     Success       bool
-    
+
     // Issues encountered
     Issues        []GenerateIssue
     InfoCount     int
@@ -1409,10 +1412,8 @@ type GenerateResult struct {
 }
 
 type GeneratedFile struct {
-    Name      string
-    Content   []byte
-    LineCount int
-    TypeCount int
+    Name    string
+    Content []byte
 }
 ```
 

--- a/internal/doctest/doc_test.go
+++ b/internal/doctest/doc_test.go
@@ -1,0 +1,317 @@
+package doctest
+
+import (
+	"go/ast"
+	goparser "go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDeepDiveOptionTables verifies that every exported With* function in each
+// package appears in its deep_dive.md option table, and vice versa.
+func TestDeepDiveOptionTables(t *testing.T) {
+	// Resolve the repo root from this test file's location.
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(t, ok, "runtime.Caller(0) failed to retrieve file path")
+	repoRoot := filepath.Join(filepath.Dir(thisFile), "..", "..")
+
+	packages := []struct {
+		name string
+		dir  string // relative to repo root
+	}{
+		{"parser", "parser"},
+		{"validator", "validator"},
+		{"fixer", "fixer"},
+		{"converter", "converter"},
+		{"joiner", "joiner"},
+		{"differ", "differ"},
+		{"overlay", "overlay"},
+		{"httpvalidator", "httpvalidator"},
+		{"generator", "generator"},
+		{"builder", "builder"},
+		{"walker", "walker"},
+	}
+
+	// Known exceptions: With* functions intentionally not documented in deep_dive.md.
+	// Each entry maps package name -> set of function names to skip for source->doc checks.
+	sourceExceptions := map[string]map[string]bool{
+		// WithLogger is an internal debugging option, not part of the public API docs.
+		"parser": {"WithLogger": true},
+
+		// Programmatic overlay variants: file-path versions are documented instead.
+		// WithSourceMap and WithUserAgent are utility plumbing options.
+		"converter": {
+			"WithPreConversionOverlay":  true,
+			"WithPostConversionOverlay": true,
+			"WithSourceMap":             true,
+			"WithUserAgent":             true,
+		},
+
+		// Many advanced configuration options not yet in the option table.
+		// Programmatic overlay variants (file-path versions are documented).
+		"joiner": {
+			"WithDefaultStrategy":        true,
+			"WithDeduplicateTags":        true,
+			"WithMergeArrays":            true,
+			"WithRenameTemplate":         true,
+			"WithNamespacePrefix":        true,
+			"WithAlwaysApplyPrefix":      true,
+			"WithEquivalenceMode":        true,
+			"WithOperationContext":       true,
+			"WithPrimaryOperationPolicy": true,
+			"WithPreJoinOverlay":         true,
+			"WithPostJoinOverlay":        true,
+			"WithSpecOverlay":            true,
+			"WithSpecOverlayFile":        true,
+		},
+
+		// The differ deep_dive.md documents options in code examples rather than
+		// a formal option table. All With* functions appear in examples.
+		"differ": {
+			"WithSourceFilePath": true,
+			"WithTargetFilePath": true,
+			"WithSourceParsed":   true,
+			"WithTargetParsed":   true,
+			"WithMode":           true,
+			"WithIncludeInfo":    true,
+			"WithBreakingRules":  true,
+			"WithUserAgent":      true,
+		},
+
+		// Generator has long-form aliases (WithGenerate*) and utility options.
+		"generator": {
+			// Long-form aliases: WithSecurity -> WithGenerateSecurity, etc.
+			"WithGenerateSecurity":        true,
+			"WithGenerateOAuth2Flows":     true,
+			"WithGenerateCredentialMgmt":  true,
+			"WithGenerateSecurityEnforce": true,
+			"WithGenerateOIDCDiscovery":   true,
+			"WithGenerateReadme":          true,
+			// Utility and less common options.
+			"WithPointers":             true,
+			"WithValidation":           true,
+			"WithStrictMode":           true,
+			"WithIncludeInfo":          true,
+			"WithUserAgent":            true,
+			"WithSourceMap":            true,
+			"WithMaxTypesPerFile":      true,
+			"WithMaxOperationsPerFile": true,
+			"WithSplitByPathPrefix":    true,
+		},
+
+		// Builder has many specialized option types (ParamOption, TagOption,
+		// ServerOption, etc.) with fine-grained options documented in Go examples
+		// rather than the summary option table.
+		"builder": {
+			// Tag options
+			"WithTagDescription":  true,
+			"WithTagExternalDocs": true,
+			// Server options
+			"WithServerDescription":         true,
+			"WithServerVariable":            true,
+			"WithServerVariableEnum":        true,
+			"WithServerVariableDescription": true,
+			// Response detail options
+			"WithResponseContentType": true,
+			"WithResponseExample":     true,
+			"WithResponseHeader":      true,
+			"WithResponseRawSchema":   true,
+			"WithResponseRef":         true,
+			"WithDefaultResponse":     true,
+			// Request body detail options
+			"WithRequestBodyRawSchema": true,
+			"WithRequestDescription":   true,
+			"WithRequestExample":       true,
+			"WithRequired":             true,
+			// Operation detail options
+			"WithHandler":      true,
+			"WithHandlerFunc":  true,
+			"WithNoSecurity":   true,
+			"WithParameter":    true,
+			"WithParameterRef": true,
+			"WithFileParam":    true,
+			"WithFormParam":    true,
+			// Parameter validation options
+			"WithParamDefault":          true,
+			"WithParamDeprecated":       true,
+			"WithParamEnum":             true,
+			"WithParamExample":          true,
+			"WithParamExclusiveMaximum": true,
+			"WithParamExclusiveMinimum": true,
+			"WithParamMaximum":          true,
+			"WithParamMaxItems":         true,
+			"WithParamMaxLength":        true,
+			"WithParamMinimum":          true,
+			"WithParamMinItems":         true,
+			"WithParamMinLength":        true,
+			"WithParamMultipleOf":       true,
+			"WithParamPattern":          true,
+			"WithParamUniqueItems":      true,
+			// Builder-level configuration options
+			"WithGenericNaming":          true,
+			"WithGenericNamingConfig":    true,
+			"WithGenericSeparator":       true,
+			"WithGenericParamSeparator":  true,
+			"WithGenericIncludePackage":  true,
+			"WithGenericApplyBaseCasing": true,
+			"WithSchemaFieldProcessor":   true,
+			"WithoutValidation":          true,
+		},
+
+		// Walker documents handler options in prose/examples and post handlers
+		// in a table. Many individual handler registrations are not in a
+		// consolidated option table.
+		"walker": {
+			"WithDocumentHandler":       true,
+			"WithOAS2DocumentHandler":   true,
+			"WithOAS3DocumentHandler":   true,
+			"WithInfoHandler":           true,
+			"WithServerHandler":         true,
+			"WithTagHandler":            true,
+			"WithPathHandler":           true,
+			"WithPathItemHandler":       true,
+			"WithParameterHandler":      true,
+			"WithRequestBodyHandler":    true,
+			"WithResponseHandler":       true,
+			"WithSecuritySchemeHandler": true,
+			"WithHeaderHandler":         true,
+			"WithMediaTypeHandler":      true,
+			"WithLinkHandler":           true,
+			"WithCallbackHandler":       true,
+			"WithExampleHandler":        true,
+			"WithExternalDocsHandler":   true,
+			"WithFilePath":              true,
+			"WithParsed":                true,
+			"WithContext":               true,
+		},
+	}
+
+	// Known exceptions: With* names that appear in docs but don't correspond
+	// to an actual exported function in the package source.
+	docExceptions := map[string]map[string]bool{
+		// WithMessage appears in joiner docs as a helper variant pattern,
+		// not an actual exported function.
+		"joiner": {"WithMessage": true},
+
+		// The overlay deep_dive.md references converter options
+		// (WithPreConversionOverlayFile, WithPostConversionOverlayFile)
+		// that belong to the converter package, not overlay.
+		"overlay": {
+			"WithPreConversionOverlayFile":  true,
+			"WithPostConversionOverlayFile": true,
+		},
+
+		// WithErrorHandler is referenced in generator docs but is actually
+		// a builder.ServerBuilderOption, not a generator.Option.
+		"generator": {"WithErrorHandler": true},
+	}
+
+	for _, pkg := range packages {
+		t.Run(pkg.name, func(t *testing.T) {
+			pkgDir := filepath.Join(repoRoot, pkg.dir)
+			deepDivePath := filepath.Join(pkgDir, "deep_dive.md")
+
+			// Extract With* functions from Go source.
+			sourceOpts := extractWithFunctions(t, pkgDir)
+			if len(sourceOpts) == 0 {
+				t.Skipf("no With* functions found in %s", pkg.dir)
+			}
+
+			// Extract With* names from deep_dive.md.
+			docOpts := extractDocOptions(t, deepDivePath)
+
+			srcExc := sourceExceptions[pkg.name]
+			docExc := docExceptions[pkg.name]
+
+			// Check: every source With* function must appear in the doc.
+			for _, fn := range sourceOpts {
+				if srcExc[fn] {
+					continue
+				}
+				assert.True(t, docOpts[fn], "function %s() exists in %s/ source but is not referenced in deep_dive.md", fn, pkg.name)
+			}
+
+			// Check: every documented With* must exist in source.
+			sourceSet := make(map[string]bool, len(sourceOpts))
+			for _, fn := range sourceOpts {
+				sourceSet[fn] = true
+			}
+			for fn := range docOpts {
+				if docExc[fn] {
+					continue
+				}
+				assert.True(t, sourceSet[fn], "deep_dive.md references %s() but no such function exists in %s/ source", fn, pkg.name)
+			}
+
+			// Check: sourceExceptions entries are not stale.
+			for fn := range srcExc {
+				assert.True(t, sourceSet[fn], "sourceExceptions lists %s for %s/ but no such function exists in source (stale exception?)", fn, pkg.name)
+			}
+
+			// Check: docExceptions entries are not stale.
+			for fn := range docExc {
+				assert.True(t, docOpts[fn], "docExceptions lists %s for %s/ but no such reference exists in deep_dive.md (stale exception?)", fn, pkg.name)
+			}
+		})
+	}
+}
+
+// extractWithFunctions uses go/ast to find all exported With* functions
+// (not methods) in the given package directory, excluding test files.
+func extractWithFunctions(t *testing.T, dir string) []string {
+	t.Helper()
+
+	fset := token.NewFileSet()
+	pkgs, err := goparser.ParseDir(fset, dir, func(fi os.FileInfo) bool {
+		return !strings.HasSuffix(fi.Name(), "_test.go")
+	}, 0)
+	require.NoError(t, err, "parsing package dir %s", dir)
+
+	var funcs []string
+	for _, pkg := range pkgs {
+		for _, file := range pkg.Files {
+			for _, decl := range file.Decls {
+				fn, ok := decl.(*ast.FuncDecl)
+				if !ok || fn.Recv != nil {
+					continue
+				}
+				if fn.Name.IsExported() && strings.HasPrefix(fn.Name.Name, "With") {
+					funcs = append(funcs, fn.Name.Name)
+				}
+			}
+		}
+	}
+	return funcs
+}
+
+// extractDocOptions parses a deep_dive.md file and extracts With* function
+// names from backtick-wrapped references (option tables, code mentions, etc.).
+// Matches patterns like: `WithFoo(...)` or `WithFoo` in backticks.
+func extractDocOptions(t *testing.T, path string) map[string]bool {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err, "reading %s", path)
+
+	// Match backtick-wrapped With* names: `WithSomething(` or `WithSomething`
+	// NOTE: Uses With[a-zA-Z] (not With[A-Z]) to also match Without* patterns.
+	// This intentionally does NOT match With* in fenced code blocks (```go ... ```).
+	// Functions documented only in code examples must be added to sourceExceptions.
+	re := regexp.MustCompile("`(With[a-zA-Z][a-zA-Z0-9]*)(?:\\(|`)")
+
+	result := make(map[string]bool)
+	for _, match := range re.FindAllStringSubmatch(string(data), -1) {
+		if len(match) > 1 {
+			result[match[1]] = true
+		}
+	}
+	return result
+}

--- a/joiner/deep_dive.md
+++ b/joiner/deep_dive.md
@@ -84,7 +84,7 @@ Best for single merge operations with inline configuration:
 
 ```go
 result, err := joiner.JoinWithOptions(
-    joiner.WithFilePaths([]string{"base.yaml", "ext.yaml"}),
+    joiner.WithFilePaths("base.yaml", "ext.yaml"),
     joiner.WithPathStrategy(joiner.StrategyFailOnCollision),
     joiner.WithSchemaStrategy(joiner.StrategyAcceptLeft),
 )
@@ -881,7 +881,7 @@ import (
 
 func main() {
     result, err := joiner.JoinWithOptions(
-        joiner.WithFilePaths([]string{"base.yaml", "overlay.yaml"}),
+        joiner.WithFilePaths("base.yaml", "overlay.yaml"),
         joiner.WithSchemaStrategy(joiner.StrategyAcceptLeft), // Default strategy
         joiner.WithCollisionHandler(func(collision joiner.CollisionContext) (joiner.CollisionResolution, error) {
             // Log all collisions
@@ -1051,9 +1051,9 @@ joiner.WithCollisionHandlerFor(
 | Type | Description | Custom Value Support | Rename Support |
 |------|-------------|---------------------|----------------|
 | `CollisionTypeSchema` | Schema in components.schemas (OAS3) or definitions (OAS2) | ✅ Yes | ✅ Yes |
-| `CollisionTypePath` | Path in paths section | ✅ Yes | ❌ No |
+| `CollisionTypePath` | Path in paths section | ❌ No | ❌ No |
 
-Note: `Rename()` is not supported for path collisions because paths are URL endpoints that cannot be renamed without breaking API contracts. However, `UseCustomValue()` is supported for paths, allowing you to provide a merged `*parser.PathItem` that combines operations from both colliding paths.
+Note: `Rename()` and `UseCustomValue()` are not supported for path collisions because paths are URL endpoints that cannot be renamed or custom-merged without breaking API contracts. Use `AcceptLeft()`, `AcceptRight()`, `Deduplicate()`, or `Fail()` for path collisions.
 
 ### Error Handling
 
@@ -1145,11 +1145,11 @@ func governanceHandler(collision joiner.CollisionContext) (joiner.CollisionResol
 
 func main() {
     result, err := joiner.JoinWithOptions(
-        joiner.WithFilePaths([]string{
+        joiner.WithFilePaths(
             "base-api.yaml",
             "users-service.yaml",
             "orders-service.yaml",
-        }),
+        ),
         joiner.WithSchemaStrategy(joiner.StrategyFailOnCollision),
         joiner.WithCollisionHandler(governanceHandler),
     )
@@ -1235,11 +1235,11 @@ import (
 
 func main() {
     result, err := joiner.JoinWithOptions(
-        joiner.WithFilePaths([]string{
+        joiner.WithFilePaths(
             "users-api.yaml",    // Has Address schema
             "orders-api.yaml",   // Has ShippingAddress schema (identical structure)
             "billing-api.yaml",  // Has BillingAddress schema (identical structure)
-        }),
+        ),
         joiner.WithSemanticDeduplication(true),
     )
     if err != nil {
@@ -1497,8 +1497,8 @@ import (
 
 func main() {
     result, err := joiner.JoinWithOptions(
-        joiner.WithFilePaths([]string{"api1.yaml", "api2.yaml"}),
-        
+        joiner.WithFilePaths("api1.yaml", "api2.yaml"),
+
         // Apply overlay to each input before merging
         joiner.WithPreJoinOverlayFile("normalize.yaml"),
         
@@ -1610,7 +1610,7 @@ type JoinerConfig struct {
 
 | Option | Description |
 |--------|-------------|
-| `WithFilePaths([]string)` | Input file paths or URLs |
+| `WithFilePaths(paths ...string)` | Input file paths or URLs |
 | `WithParsed(docs ...ParseResult)` | Pre-parsed documents (154x faster) |
 | `WithConfig(JoinerConfig)` | Full configuration object |
 | `WithPathStrategy(CollisionStrategy)` | Strategy for path collisions |
@@ -1621,6 +1621,7 @@ type JoinerConfig struct {
 | `WithCollisionHandlerFor(handler, types...)` | Register handler for specific collision types |
 | `WithPreJoinOverlayFile(string)` | Overlay applied to each input |
 | `WithPostJoinOverlayFile(string)` | Overlay applied to merged result |
+| `WithCollisionReport(bool)` | Enable detailed collision analysis in result |
 
 [↑ Back to top](#top)
 
@@ -1717,7 +1718,7 @@ The `ToParseResult()` method enables seamless chaining with other oastools packa
 ```go
 // Join then validate
 joinResult, err := joiner.JoinWithOptions(
-    joiner.WithFilePaths([]string{"users-api.yaml", "orders-api.yaml"}),
+    joiner.WithFilePaths("users-api.yaml", "orders-api.yaml"),
 )
 if err != nil {
     log.Fatal(err)

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,15 @@
+# lychee.toml — link checker configuration
+# Used by `make lint-links` and CI docs workflow.
+
+cache = true
+max_cache_age = "1d"
+
+# Rate-limited or self-referential sites that cause flaky results.
+exclude = [
+  "localhost",
+  "127\\.0\\.0\\.1",
+  "pkg\\.go\\.dev",
+  "oastools\\.robnrob\\.com",
+]
+
+exclude_path = ["node_modules", "vendor", "site"]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: oastools
-site_description: High-performance Go library and CLI for working with OpenAPI Specifications (OAS 2.0, 3.0, 3.1).
+site_description: High-performance Go library, CLI, and MCP server for working with OpenAPI Specifications (OAS 2.0, 3.0, 3.1, 3.2).
 site_url: https://erraggy.github.io/oastools/
 repo_url: https://github.com/erraggy/oastools
 repo_name: erraggy/oastools
@@ -67,6 +67,8 @@ nav:
     - Why oastools?: why-oastools.md
     - Detecting API Breaking Changes: breaking-changes.md
     - Generator Features: generator_beyond_boilerplate.md
+    - Corpus Analysis: corpus-analysis.md
+    - MCP UX Findings: mcp-ux-findings.md
     - Benchmarks: benchmarks.md
   - Examples:
     - Overview: examples/index.md

--- a/overlay/deep_dive.md
+++ b/overlay/deep_dive.md
@@ -232,14 +232,29 @@ if errs := overlay.Validate(o); len(errs) > 0 {
 
 ### Result Fields
 
+**ApplyResult:**
+
 | Field | Type | Description |
 |-------|------|-------------|
+| `Document` | `any` | The modified document |
+| `SourceFormat` | `parser.SourceFormat` | The original document format (YAML or JSON) |
 | `ActionsApplied` | `int` | Number of actions that matched and modified nodes |
 | `ActionsSkipped` | `int` | Number of actions with no matching targets |
-| `Changes` | `[]Change` | Details of each change (for dry-run) |
+| `Changes` | `[]ChangeRecord` | Details of each applied change |
 | `Warnings` | `[]string` | Non-fatal warnings during application |
-| `Document` | `any` | The modified document |
-| `ToParseResult()` | `*parser.ParseResult` | Converts result for package chaining |
+| `StructuredWarnings` | `ApplyWarnings` | Detailed warning information with context |
+
+`ToParseResult()` converts the result to `*parser.ParseResult` for package chaining.
+
+**DryRunResult:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `WouldApply` | `int` | Number of actions that would be successfully applied |
+| `WouldSkip` | `int` | Number of actions that would be skipped |
+| `Changes` | `[]ProposedChange` | Proposed changes that would be made (different type than ApplyResult) |
+| `Warnings` | `[]string` | Non-fatal issues that would occur |
+| `StructuredWarnings` | `ApplyWarnings` | Detailed warning information with context |
 
 [Back to top](#top)
 

--- a/parser/deep_dive.md
+++ b/parser/deep_dive.md
@@ -302,12 +302,15 @@ See also: [DeepCopy example](https://pkg.go.dev/github.com/erraggy/oastools/pars
 ```go
 result, _ := parser.ParseWithOptions(parser.WithFilePath("api.yaml"))
 
+// Get the typed document
+doc, _ := result.OAS3Document()
+
 // Deep copy before mutation
-copy := result.OAS3Document.DeepCopy()
-copy.Info.Title = "Modified API"
+docCopy := doc.DeepCopy()
+docCopy.Info.Title = "Modified API"
 
 // Original unchanged
-fmt.Println(result.OAS3Document.Info.Title) // Original title
+fmt.Println(doc.Info.Title) // Original title
 ```
 
 [Back to top](#top)
@@ -321,13 +324,21 @@ fmt.Println(result.OAS3Document.Info.Title) // Original title
 | Option | Description |
 |--------|-------------|
 | `WithFilePath(path)` | File path or URL to parse |
+| `WithBytes(data []byte)` | Parse from byte slice |
+| `WithReader(r io.Reader)` | Parse from an io.Reader |
 | `WithResolveRefs(bool)` | Enable `$ref` resolution (default: true) |
 | `WithResolveHTTPRefs(bool)` | Enable HTTP/HTTPS ref resolution (default: false) |
 | `WithValidateStructure(bool)` | Validate document structure during parsing |
 | `WithInsecureSkipVerify(bool)` | Skip TLS verification for HTTPS refs |
+| `WithSourceMap(enabled bool)` | Enable source map tracking for line/column info |
+| `WithPreserveOrder(enabled bool)` | Preserve original field ordering from source |
+| `WithUserAgent(ua string)` | Custom User-Agent for HTTP requests |
+| `WithHTTPClient(client *http.Client)` | Custom HTTP client for remote refs |
 | `WithMaxRefDepth(n)` | Max nested ref depth (default: 100) |
 | `WithMaxCachedDocuments(n)` | Max cached external docs (default: 100) |
 | `WithMaxFileSize(n)` | Max file size in bytes (default: 10MB) |
+| `WithMaxInputSize(size int)` | Max input size in bytes |
+| `WithSourceName(name string)` | Override source name for bytes/reader input |
 
 ### ParseResult Fields
 
@@ -338,7 +349,7 @@ fmt.Println(result.OAS3Document.Info.Title) // Original title
 | `OASVersion` | `OASVersion` | Parsed version constant |
 | `SourceFormat` | `SourceFormat` | Detected format (JSON or YAML) |
 | `SourcePath` | `string` | Original file path |
-| `Errors` | `[]string` | Parse errors |
+| `Errors` | `[]error` | Parse errors |
 | `Warnings` | `[]string` | Non-fatal warnings |
 
 [Back to top](#top)

--- a/validator/deep_dive.md
+++ b/validator/deep_dive.md
@@ -621,6 +621,9 @@ type ValidationResult struct {
     // SourceFormat preserves the original document format for output
     SourceFormat parser.SourceFormat
 
+    // SourcePath is the original source path from the parsed document
+    SourcePath string
+
     // Errors contains all validation errors
     Errors []ValidationError
 
@@ -659,7 +662,7 @@ type ValidationError struct {
     Field string
     
     // Value is the problematic value (optional)
-    Value string
+    Value any
 
     // OperationContext provides API operation context (optional)
     OperationContext *issues.OperationContext
@@ -730,6 +733,10 @@ type Validator struct {
 
     // UserAgent for HTTP requests when fetching URLs
     UserAgent string
+
+    // SourceMap provides source location lookup for validation errors.
+    // When set, validation errors will include Line, Column, and File fields.
+    SourceMap *parser.SourceMap
 }
 ```
 
@@ -743,6 +750,7 @@ type Validator struct {
 | `WithStrictMode(bool)` | Treat warnings as errors |
 | `WithValidateStructure(bool)` | Enable/disable parser structure validation (default: true) |
 | `WithUserAgent(string)` | Custom User-Agent for HTTP requests |
+| `WithSourceMap(sm *parser.SourceMap)` | Source map for line/column info in errors |
 
 [↑ Back to top](#top)
 


### PR DESCRIPTION
## Summary

Full documentation accuracy audit across all 11 packages, whitepaper, and site pages with automated CI checks to prevent drift from recurring.

- **~100 inaccuracy fixes**: wrong types, missing fields, outdated examples, incorrect code snippets across all `deep_dive.md` files, `docs/whitepaper.md`, `docs/cli-reference.md`, and site pages
- **Lychee link checker**: integrated into docs CI workflow and `make lint-links` / `make docs-check` targets
- **`TestCLIFlagsDocumented`**: bidirectional verification that every CLI flag is documented and every documented flag exists (caught 12 pre-existing undocumented flags)
- **`TestDeepDiveOptionTables`**: AST-based verification that every exported `With*` function appears in its package's `deep_dive.md`, with staleness checks for exception lists
- **Walk subcommand refactoring**: extracted `Setup*Flags()` + typed flag structs for all 6 walk subcommands, bringing them in line with the other 9 commands
- **12 previously undocumented CLI flags** added to `docs/cli-reference.md` (validate, parse, fix, join)

## Test plan

- [x] `make check` passes (8405 tests)
- [x] `TestCLIFlagsDocumented` — 15/15 commands pass
- [x] `TestDeepDiveOptionTables` — 11/11 packages pass
- [x] `make lint-links` — 216 links, 0 errors, 50 excluded (config working)
- [x] gopls diagnostics clean
- [x] Reviewed by pr-review-toolkit (3 agents) and CodeRabbit

🤖 Generated with [Claude Code](https://claude.com/claude-code)