### PR TITLE
perf(validator,converter,schemautil,fixer): reduce allocations and eliminate regex overhead

### DIFF
--- a/internal/schemautil/hash.go
+++ b/internal/schemautil/hash.go
@@ -6,6 +6,7 @@ import (
 	"hash/fnv"
 	"reflect"
 	"sort"
+	"strconv"
 
 	"github.com/erraggy/oastools/parser"
 )
@@ -28,7 +29,7 @@ func NewSchemaHasher() *SchemaHasher {
 // Schemas with identical structural properties will have the same hash.
 // Note: Hash collisions are possible; use deep comparison to verify equivalence.
 func (h *SchemaHasher) Hash(schema *parser.Schema) uint64 {
-	h.visited = make(map[uintptr]bool) // Reset visited map
+	clear(h.visited) // Reset visited map without reallocating
 	hasher := fnv.New64a()
 	h.hashSchema(hasher, schema)
 	return hasher.Sum64()
@@ -323,10 +324,10 @@ func (h *SchemaHasher) hashSchemaOrBool(hasher hash.Hash64, v any) {
 // hashNumericConstraints hashes numeric validation fields.
 func (h *SchemaHasher) hashNumericConstraints(hasher hash.Hash64, schema *parser.Schema) {
 	if schema.Minimum != nil {
-		h.writeString(hasher, fmt.Sprintf("minimum:%v", *schema.Minimum))
+		h.writeString(hasher, "minimum:"+strconv.FormatFloat(*schema.Minimum, 'g', -1, 64))
 	}
 	if schema.Maximum != nil {
-		h.writeString(hasher, fmt.Sprintf("maximum:%v", *schema.Maximum))
+		h.writeString(hasher, "maximum:"+strconv.FormatFloat(*schema.Maximum, 'g', -1, 64))
 	}
 	if schema.ExclusiveMinimum != nil {
 		h.writeString(hasher, fmt.Sprintf("exclusiveMinimum:%v", schema.ExclusiveMinimum))
@@ -335,46 +336,46 @@ func (h *SchemaHasher) hashNumericConstraints(hasher hash.Hash64, schema *parser
 		h.writeString(hasher, fmt.Sprintf("exclusiveMaximum:%v", schema.ExclusiveMaximum))
 	}
 	if schema.MultipleOf != nil {
-		h.writeString(hasher, fmt.Sprintf("multipleOf:%v", *schema.MultipleOf))
+		h.writeString(hasher, "multipleOf:"+strconv.FormatFloat(*schema.MultipleOf, 'g', -1, 64))
 	}
 }
 
 // hashStringConstraints hashes string validation fields.
 func (h *SchemaHasher) hashStringConstraints(hasher hash.Hash64, schema *parser.Schema) {
 	if schema.MinLength != nil {
-		h.writeString(hasher, fmt.Sprintf("minLength:%d", *schema.MinLength))
+		h.writeString(hasher, "minLength:"+strconv.Itoa(*schema.MinLength))
 	}
 	if schema.MaxLength != nil {
-		h.writeString(hasher, fmt.Sprintf("maxLength:%d", *schema.MaxLength))
+		h.writeString(hasher, "maxLength:"+strconv.Itoa(*schema.MaxLength))
 	}
 }
 
 // hashArrayConstraints hashes array validation fields.
 func (h *SchemaHasher) hashArrayConstraints(hasher hash.Hash64, schema *parser.Schema) {
 	if schema.MinItems != nil {
-		h.writeString(hasher, fmt.Sprintf("minItems:%d", *schema.MinItems))
+		h.writeString(hasher, "minItems:"+strconv.Itoa(*schema.MinItems))
 	}
 	if schema.MaxItems != nil {
-		h.writeString(hasher, fmt.Sprintf("maxItems:%d", *schema.MaxItems))
+		h.writeString(hasher, "maxItems:"+strconv.Itoa(*schema.MaxItems))
 	}
 	if schema.UniqueItems {
 		h.writeString(hasher, "uniqueItems:true")
 	}
 	if schema.MinContains != nil {
-		h.writeString(hasher, fmt.Sprintf("minContains:%d", *schema.MinContains))
+		h.writeString(hasher, "minContains:"+strconv.Itoa(*schema.MinContains))
 	}
 	if schema.MaxContains != nil {
-		h.writeString(hasher, fmt.Sprintf("maxContains:%d", *schema.MaxContains))
+		h.writeString(hasher, "maxContains:"+strconv.Itoa(*schema.MaxContains))
 	}
 }
 
 // hashObjectConstraints hashes object validation fields.
 func (h *SchemaHasher) hashObjectConstraints(hasher hash.Hash64, schema *parser.Schema) {
 	if schema.MinProperties != nil {
-		h.writeString(hasher, fmt.Sprintf("minProperties:%d", *schema.MinProperties))
+		h.writeString(hasher, "minProperties:"+strconv.Itoa(*schema.MinProperties))
 	}
 	if schema.MaxProperties != nil {
-		h.writeString(hasher, fmt.Sprintf("maxProperties:%d", *schema.MaxProperties))
+		h.writeString(hasher, "maxProperties:"+strconv.Itoa(*schema.MaxProperties))
 	}
 }
 

--- a/validator/helpers.go
+++ b/validator/helpers.go
@@ -74,14 +74,14 @@ func (v *Validator) validateResponseStatusCodes(responses *parser.Responses, pat
 	for code := range responses.Codes {
 		// Validate HTTP status code format
 		if !httputil.ValidateStatusCode(code) {
-			v.addError(result, fmt.Sprintf("%s.responses.%s", path, code),
+			v.addError(result, path+".responses."+code,
 				fmt.Sprintf("Invalid HTTP status code: %s", code),
 				withSpecRef(fmt.Sprintf("%s#responses-object", baseURL)),
 				withValue(code),
 			)
 		} else if v.StrictMode && !httputil.IsStandardStatusCode(code) {
 			// In strict mode, warn about non-standard status codes
-			v.addWarning(result, fmt.Sprintf("%s.responses.%s", path, code),
+			v.addWarning(result, path+".responses."+code,
 				fmt.Sprintf("Non-standard HTTP status code: %s (not defined in HTTP RFCs)", code),
 				withSpecRef(fmt.Sprintf("%s#responses-object", baseURL)),
 				withValue(code),
@@ -93,7 +93,7 @@ func (v *Validator) validateResponseStatusCodes(responses *parser.Responses, pat
 		}
 	}
 	if !hasSuccess && v.StrictMode {
-		v.addWarning(result, fmt.Sprintf("%s.responses", path),
+		v.addWarning(result, path+".responses",
 			"Operation should define at least one successful response (2XX or default)",
 			withSpecRef(fmt.Sprintf("%s#responses-object", baseURL)),
 		)
@@ -115,7 +115,7 @@ func (v *Validator) checkDuplicateOperationIds(
 			continue
 		}
 
-		opPath := fmt.Sprintf("%s.%s.%s", pathType, pathPattern, method)
+		opPath := pathType + "." + pathPattern + "." + method
 
 		if firstSeenAt, exists := operationIds[op.OperationID]; exists {
 			// Determine the correct spec reference based on path type


### PR DESCRIPTION
## Summary

- Replace `fmt.Sprintf` with string concatenation for JSON path construction across validator, converter, and fixer
- Replace `regexp.MatchString`/`ReplaceAllString` with `strings.HasPrefix` + string slicing in converter ref rewriting
- Replace `fmt.Sprintf` with `strconv.Itoa`/`strconv.FormatFloat` for numeric formatting in validator and schemautil
- Pre-allocate maps with capacity hints in validator ref building
- Thread schema nesting depth as explicit counter instead of counting dots in path strings
- Refactor fixer ref collection from slice-return to pointer-accumulator pattern
- Use `clear()` to reuse map allocations in SchemaHasher

## Benchmark Results

`benchstat`, 10 iterations, Apple M4:

### Validator (primary target — hot path optimization)
| Benchmark | Time | Memory | Allocs |
|-----------|------|--------|--------|
| ValidateParsed/Small | **-24.0%** | **-17.7%** | **-55.4%** |
| ValidateParsed/Medium | **-28.4%** | **-22.7%** | **-53.6%** |
| ValidateParsed/Large | **-29.4%** | **-23.5%** | **-56.9%** |

### SchemaUtil (hasher)
| Benchmark | Time | Memory | Allocs |
|-----------|------|--------|--------|
| Hash/Simple | **-22.9%** | **-82.8%** | -28.6% |
| Hash/ComplexObject | **-13.7%** | **-40.4%** | -9.5% |
| GroupByHash/1000 | **-13.7%** | **-56.2%** | -14.3% |

### Converter
| Benchmark | Time | Memory | Allocs |
|-----------|------|--------|--------|
| Parsed/OAS2→OAS3/Medium | **-9.0%** | -1.6% | -10.3% |
| Parsed/OAS3→OAS2/Medium | **-5.8%** | -0.7% | -2.5% |

### Fixer
Allocation pattern improved (pointer-accumulator), but no measurable time/memory impact — ref collection is a small fraction of overall fix cost.

## Optimization Techniques

| Technique | Where | Impact |
|-----------|-------|--------|
| `fmt.Sprintf` → string concat | validator, converter | Eliminates reflect-based formatting in hot loops |
| `regexp` → `strings.HasPrefix` | converter/ref_rewrite | Removes regex engine overhead for simple prefix matching |
| `fmt.Sprintf` → `strconv` | schemautil/hash, validator | Avoids `%v`/`%d` format parsing for known types |
| Map pre-allocation | validator/refs | Reduces rehashing for known-size component maps |
| `clear(map)` vs `make(map)` | schemautil/hash | Reuses backing array instead of reallocating |
| Explicit depth counter | validator/schema | Removes `strings.Count(path, ".")` per recursion level |
| `*[]string` accumulator | fixer/prune | Avoids intermediate slice allocations and append-spread |

## Test plan

- [x] `make check` passes (8498 tests)
- [x] All benchmarks run with 10 iterations for statistical significance
- [x] All `p=0.000` confirming results are not noise
- [x] Code review: no bugs, no semantic changes (3 independent reviewers)
- [x] Schema depth guard reviewed: more permissive but semantically correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)