### PR TITLE
docs(mcp): add troubleshooting guidance and missing env vars

### DIFF
--- a/internal/mcpserver/config.go
+++ b/internal/mcpserver/config.go
@@ -3,7 +3,9 @@ package mcpserver
 import (
 	"log/slog"
 	"os"
+	"sort"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -110,6 +112,17 @@ var validJoinStrategies = map[string]bool{
 	"rename-left": true, "rename-right": true,
 	"deduplicate": true,
 }
+
+// validJoinStrategyList is a sorted, comma-separated list of valid strategy
+// values for use in error messages.
+var validJoinStrategyList = func() string {
+	keys := make([]string, 0, len(validJoinStrategies))
+	for k := range validJoinStrategies {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return strings.Join(keys, ", ")
+}()
 
 func envStrategy(key string) string {
 	v := os.Getenv(key)

--- a/internal/mcpserver/input.go
+++ b/internal/mcpserver/input.go
@@ -199,7 +199,7 @@ func (s specInput) resolve(extraOpts ...parser.Option) (*parser.ParseResult, err
 
 	// Enforce inline content size limit.
 	if s.Content != "" && int64(len(s.Content)) > cfg.MaxInlineSize {
-		return nil, fmt.Errorf("inline content size %d bytes exceeds maximum %d bytes",
+		return nil, fmt.Errorf("inline content size %d bytes exceeds maximum %d bytes; use file input instead, or set OASTOOLS_MAX_INLINE_SIZE to increase",
 			len(s.Content), cfg.MaxInlineSize)
 	}
 

--- a/internal/mcpserver/safeclient.go
+++ b/internal/mcpserver/safeclient.go
@@ -33,7 +33,7 @@ func newSafeHTTPClient() *http.Client {
 				}
 				for _, ipAddr := range ips {
 					if isBlockedIP(ipAddr.IP) {
-						return nil, fmt.Errorf("blocked request to private/loopback IP: %s (%s)", host, ipAddr.IP)
+						return nil, fmt.Errorf("blocked request to private/loopback IP: %s (%s); set OASTOOLS_ALLOW_PRIVATE_IPS=true to allow", host, ipAddr.IP)
 					}
 				}
 				if len(ips) == 0 {
@@ -55,7 +55,7 @@ func newSafeHTTPClient() *http.Client {
 			}
 			for _, ipAddr := range ips {
 				if isBlockedIP(ipAddr.IP) {
-					return fmt.Errorf("redirect to private/loopback IP blocked: %s (%s)", host, ipAddr.IP)
+					return fmt.Errorf("redirect to private/loopback IP blocked: %s (%s); set OASTOOLS_ALLOW_PRIVATE_IPS=true to allow", host, ipAddr.IP)
 				}
 			}
 			return nil

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -28,8 +28,17 @@ Key settings:
 - OASTOOLS_VALIDATE_NO_WARNINGS (default: false) — suppress warnings by default
 - OASTOOLS_JOIN_PATH_STRATEGY — default path collision strategy for join
 - OASTOOLS_JOIN_SCHEMA_STRATEGY — default schema collision strategy for join
+- OASTOOLS_ALLOW_PRIVATE_IPS (default: false) — allow URL resolution to private/loopback/link-local IPs (for internal APIs)
+- OASTOOLS_MAX_INLINE_SIZE (default: 10485760) — max inline content size in bytes (10 MiB)
+- OASTOOLS_MAX_LIMIT (default: 1000) — max pagination limit for walk tools
+- OASTOOLS_MAX_JOIN_SPECS (default: 20) — max number of specs in a join operation
 
-Caching: Parsed specs are cached per session. File entries use path+mtime as key (auto-invalidated on change). URL entries are cached with a shorter TTL. A background sweeper removes expired entries every 60s.`
+Caching: Parsed specs are cached per session. File entries use path+mtime as key (auto-invalidated on change). URL entries are cached with a shorter TTL. A background sweeper removes expired entries every 60s.
+
+Troubleshooting:
+- "blocked request to private/loopback IP: <host> (<ip>); set OASTOOLS_ALLOW_PRIVATE_IPS=true to allow" or "redirect to private/loopback IP blocked: <host> (<ip>); set OASTOOLS_ALLOW_PRIVATE_IPS=true to allow" — the spec URL resolved to a private, loopback, or link-local IP address. Guide the user to set OASTOOLS_ALLOW_PRIVATE_IPS=true in their MCP client's env config. Do NOT work around this by downloading the file with curl or other tools.
+- "inline content size <actual> bytes exceeds maximum <limit> bytes; use file input instead, or set OASTOOLS_MAX_INLINE_SIZE to increase" — the spec content is too large for inline input. Use file input instead of content, or guide the user to increase OASTOOLS_MAX_INLINE_SIZE in their MCP client's env config.
+- Env var changes require restarting the MCP server (reconnecting the client).`
 
 // Run starts the MCP server over stdio and blocks until the client disconnects
 // or the context is cancelled.

--- a/internal/mcpserver/tools_join.go
+++ b/internal/mcpserver/tools_join.go
@@ -50,14 +50,14 @@ func handleJoin(_ context.Context, _ *mcp.CallToolRequest, input joinInput) (*mc
 		return errResult(fmt.Errorf("at least 2 specs are required for joining, got %d", len(input.Specs))), joinOutput{}, nil
 	}
 	if len(input.Specs) > cfg.MaxJoinSpecs {
-		return errResult(fmt.Errorf("too many specs: got %d, maximum is %d",
+		return errResult(fmt.Errorf("too many specs: got %d, maximum is %d; set OASTOOLS_MAX_JOIN_SPECS to increase",
 			len(input.Specs), cfg.MaxJoinSpecs)), joinOutput{}, nil
 	}
 	if input.PathStrategy != "" && !validJoinStrategies[input.PathStrategy] {
-		return errResult(fmt.Errorf("invalid path_strategy: %q", input.PathStrategy)), joinOutput{}, nil
+		return errResult(fmt.Errorf("invalid path_strategy: %q; valid values: %s", input.PathStrategy, validJoinStrategyList)), joinOutput{}, nil
 	}
 	if input.SchemaStrategy != "" && !validJoinStrategies[input.SchemaStrategy] {
-		return errResult(fmt.Errorf("invalid schema_strategy: %q", input.SchemaStrategy)), joinOutput{}, nil
+		return errResult(fmt.Errorf("invalid schema_strategy: %q; valid values: %s", input.SchemaStrategy, validJoinStrategyList)), joinOutput{}, nil
 	}
 
 	// Resolve all specs.


### PR DESCRIPTION
## Summary

- ✨ Add 4 missing env vars (`OASTOOLS_ALLOW_PRIVATE_IPS`, `OASTOOLS_MAX_INLINE_SIZE`, `OASTOOLS_MAX_LIMIT`, `OASTOOLS_MAX_JOIN_SPECS`) to both the MCP protocol-level `serverInstructions` and `plugin/CLAUDE.md` config table
- 🔧 Add troubleshooting sections to both files covering SSRF blocks (initial request + redirect variant), inline content size limits, and env var restart requirements
- Error message text matches actual code output (verified against `safeclient.go` and `input.go`)
- SSRF scope correctly documented as private/loopback/link-local (matching `isBlockedIP()`)

## Motivation

When an LLM agent uses `spec.url` to fetch a spec from a private/internal host, the SSRF protection blocks it with `"blocked request to private/loopback IP: <host> (<ip>)"`. Without guidance, agents fall back to workarounds like `curl` — bypassing the MCP tools entirely. The troubleshooting sections explicitly guide agents to the proper env var fix.

## Test plan

- [x] `go build ./cmd/oastools` — compiles clean
- [x] `make check` — all 8498 tests pass, 0 lint errors, 0 markdown lint errors
- [x] MCP `initialize` response verified: built from source, sent JSON-RPC initialize request over stdio, confirmed `instructions` field contains the new env vars and troubleshooting section
- [x] Error message text verified against `safeclient.go:36,58` and `input.go:202`
- [x] Env var defaults verified against `config.go:59-62`
- [x] Cross-file consistency confirmed between `server.go`, `plugin/CLAUDE.md`, and `docs/mcp-server.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)