### PR TITLE
fix(converter): convert exclusiveMaximum/exclusiveMinimum to numeric semantics for OAS 3.1 targets

### DIFF
--- a/converter/helpers.go
+++ b/converter/helpers.go
@@ -49,7 +49,7 @@ func (c *Converter) convertOAS2ParameterToOAS3(param *parser.Parameter, result *
 
 	// Handle schema
 	if param.Schema != nil {
-		converted.Schema = c.convertOAS2SchemaToOAS3(param.Schema)
+		converted.Schema = c.convertOAS2SchemaToOAS3(param.Schema, result.TargetOASVersion, result, path+".schema")
 	} else if param.Type != "" {
 		// Convert type/format to schema, transferring all OAS 2.0 validation keywords
 		converted.Schema = &parser.Schema{
@@ -68,13 +68,35 @@ func (c *Converter) convertOAS2ParameterToOAS3(param *parser.Parameter, result *
 			MultipleOf:  param.MultipleOf,
 		}
 		if param.ExclusiveMaximum {
-			converted.Schema.ExclusiveMaximum = true
+			if c.isOAS31OrLater(result.TargetOASVersion) {
+				if param.Maximum != nil {
+					converted.Schema.ExclusiveMaximum = *param.Maximum
+					converted.Schema.Maximum = nil
+				} else {
+					c.addIssueWithContext(result, path,
+						"Parameter has 'exclusiveMaximum: true' but no 'maximum' value; constraint dropped in OAS 3.1 conversion",
+						"Add a 'maximum' value to preserve this exclusive boundary in OAS 3.1")
+				}
+			} else {
+				converted.Schema.ExclusiveMaximum = true
+			}
 		}
 		if param.ExclusiveMinimum {
-			converted.Schema.ExclusiveMinimum = true
+			if c.isOAS31OrLater(result.TargetOASVersion) {
+				if param.Minimum != nil {
+					converted.Schema.ExclusiveMinimum = *param.Minimum
+					converted.Schema.Minimum = nil
+				} else {
+					c.addIssueWithContext(result, path,
+						"Parameter has 'exclusiveMinimum: true' but no 'minimum' value; constraint dropped in OAS 3.1 conversion",
+						"Add a 'minimum' value to preserve this exclusive boundary in OAS 3.1")
+				}
+			} else {
+				converted.Schema.ExclusiveMinimum = true
+			}
 		}
 		if param.Items != nil {
-			converted.Schema.Items = convertOAS2ItemsToSchema(param.Items)
+			converted.Schema.Items = convertOAS2ItemsToSchema(c, param.Items, result, path+".items")
 			if param.Items.CollectionFormat != "" && param.Items.CollectionFormat != "csv" {
 				c.addIssueWithContext(result, path,
 					fmt.Sprintf("Parameter items uses collectionFormat '%s'", param.Items.CollectionFormat),
@@ -206,7 +228,7 @@ func (c *Converter) resolveHeaderRef(ref string, result *ConversionResult, path 
 }
 
 // convertOAS2ResponseToOAS3Old converts an OAS 2.0 response to OAS 3.x format
-func (c *Converter) convertOAS2ResponseToOAS3Old(response *parser.Response, produces []string) *parser.Response {
+func (c *Converter) convertOAS2ResponseToOAS3Old(response *parser.Response, produces []string, targetVersion parser.OASVersion, result *ConversionResult, path string) *parser.Response {
 	if response == nil {
 		return nil
 	}
@@ -226,9 +248,11 @@ func (c *Converter) convertOAS2ResponseToOAS3Old(response *parser.Response, prod
 			mediaTypes = []string{getDefaultMediaType()}
 		}
 
+		// Convert schema once; deep-copy per media type to avoid shared mutation.
+		convertedSchema := c.convertOAS2SchemaToOAS3(response.Schema, targetVersion, result, path+".schema")
 		for _, mediaType := range mediaTypes {
 			converted.Content[mediaType] = &parser.MediaType{
-				Schema: c.convertOAS2SchemaToOAS3(response.Schema),
+				Schema: convertedSchema.DeepCopy(),
 			}
 		}
 	}

--- a/converter/helpers_test.go
+++ b/converter/helpers_test.go
@@ -760,6 +760,410 @@ func TestConvertOAS2ParameterToOAS3_ArrayWithoutItems(t *testing.T) {
 	assert.Nil(t, converted.Schema.Items, "Schema.Items should be nil when source has no Items")
 }
 
+// TestConvertOAS2ParameterToOAS3_ExclusiveKeywordsOAS31 verifies that for OAS 3.1+
+// targets, boolean ExclusiveMaximum/ExclusiveMinimum are converted to numeric form.
+func TestConvertOAS2ParameterToOAS3_ExclusiveKeywordsOAS31(t *testing.T) {
+	t.Run("OAS 3.1 target converts boolean to numeric", func(t *testing.T) {
+		c := newConverter()
+		result := &ConversionResult{TargetOASVersion: parser.OASVersion310}
+
+		min := float64(0)
+		max := float64(100)
+		param := &parser.Parameter{
+			Name:             "count",
+			In:               "query",
+			Type:             "integer",
+			Minimum:          &min,
+			Maximum:          &max,
+			ExclusiveMinimum: true,
+			ExclusiveMaximum: true,
+		}
+
+		converted := c.convertOAS2ParameterToOAS3(param, result, "test")
+		require.NotNil(t, converted.Schema)
+		assert.Equal(t, float64(100), converted.Schema.ExclusiveMaximum, "ExclusiveMaximum should be numeric 100")
+		assert.Nil(t, converted.Schema.Maximum, "Maximum should be nil after conversion")
+		assert.Equal(t, float64(0), converted.Schema.ExclusiveMinimum, "ExclusiveMinimum should be numeric 0")
+		assert.Nil(t, converted.Schema.Minimum, "Minimum should be nil after conversion")
+	})
+
+	t.Run("OAS 3.0 target preserves boolean form", func(t *testing.T) {
+		c := newConverter()
+		result := &ConversionResult{TargetOASVersion: parser.OASVersion303}
+
+		min := float64(0)
+		max := float64(100)
+		param := &parser.Parameter{
+			Name:             "count",
+			In:               "query",
+			Type:             "integer",
+			Minimum:          &min,
+			Maximum:          &max,
+			ExclusiveMinimum: true,
+			ExclusiveMaximum: true,
+		}
+
+		converted := c.convertOAS2ParameterToOAS3(param, result, "test")
+		require.NotNil(t, converted.Schema)
+		assert.Equal(t, true, converted.Schema.ExclusiveMaximum, "ExclusiveMaximum should be boolean for OAS 3.0")
+		assert.Equal(t, &max, converted.Schema.Maximum, "Maximum should be preserved for OAS 3.0")
+		assert.Equal(t, true, converted.Schema.ExclusiveMinimum, "ExclusiveMinimum should be boolean for OAS 3.0")
+		assert.Equal(t, &min, converted.Schema.Minimum, "Minimum should be preserved for OAS 3.0")
+	})
+
+	t.Run("OAS 3.1 target with no maximum emits warning", func(t *testing.T) {
+		c := newConverter()
+		result := &ConversionResult{TargetOASVersion: parser.OASVersion310}
+
+		param := &parser.Parameter{
+			Name:             "count",
+			In:               "query",
+			Type:             "integer",
+			ExclusiveMaximum: true,
+			// Maximum intentionally nil — malformed OAS 2.0
+		}
+
+		converted := c.convertOAS2ParameterToOAS3(param, result, "test")
+		require.NotNil(t, converted.Schema)
+		assert.Nil(t, converted.Schema.ExclusiveMaximum, "ExclusiveMaximum should be nil when no Maximum present")
+		assert.Nil(t, converted.Schema.Maximum, "Maximum should remain nil")
+		assert.Greater(t, countIssuesContaining(result.Issues, "exclusiveMaximum: true"), 0,
+			"should emit warning about dropped exclusiveMaximum constraint")
+	})
+}
+
+// TestConvertOAS2ItemsToSchema_ExclusiveOAS31 verifies that Items conversion
+// handles exclusiveMaximum/exclusiveMinimum correctly for different target versions.
+func TestConvertOAS2ItemsToSchema_ExclusiveOAS31(t *testing.T) {
+	t.Run("OAS 3.1 target converts boolean to numeric in items", func(t *testing.T) {
+		c := newConverter()
+		result := &ConversionResult{TargetOASVersion: parser.OASVersion310}
+		max := float64(50)
+		min := float64(5)
+		items := &parser.Items{
+			Type:             "integer",
+			Maximum:          &max,
+			Minimum:          &min,
+			ExclusiveMaximum: true,
+			ExclusiveMinimum: true,
+		}
+
+		s := convertOAS2ItemsToSchema(c, items, result, "test.items")
+		require.NotNil(t, s)
+		assert.Equal(t, float64(50), s.ExclusiveMaximum, "ExclusiveMaximum should be numeric 50")
+		assert.Nil(t, s.Maximum, "Maximum should be nil after conversion")
+		assert.Equal(t, float64(5), s.ExclusiveMinimum, "ExclusiveMinimum should be numeric 5")
+		assert.Nil(t, s.Minimum, "Minimum should be nil after conversion")
+	})
+
+	t.Run("OAS 3.0 target preserves boolean in items", func(t *testing.T) {
+		c := newConverter()
+		result := &ConversionResult{TargetOASVersion: parser.OASVersion303}
+		max := float64(50)
+		min := float64(5)
+		items := &parser.Items{
+			Type:             "integer",
+			Maximum:          &max,
+			Minimum:          &min,
+			ExclusiveMaximum: true,
+			ExclusiveMinimum: true,
+		}
+
+		s := convertOAS2ItemsToSchema(c, items, result, "test.items")
+		require.NotNil(t, s)
+		assert.Equal(t, true, s.ExclusiveMaximum, "ExclusiveMaximum should be boolean for OAS 3.0")
+		assert.Equal(t, &max, s.Maximum, "Maximum should be preserved for OAS 3.0")
+		assert.Equal(t, true, s.ExclusiveMinimum, "ExclusiveMinimum should be boolean for OAS 3.0")
+		assert.Equal(t, &min, s.Minimum, "Minimum should be preserved for OAS 3.0")
+	})
+
+	t.Run("nested items inherit target version", func(t *testing.T) {
+		c := newConverter()
+		result := &ConversionResult{TargetOASVersion: parser.OASVersion310}
+		innerMax := float64(25)
+		items := &parser.Items{
+			Type: "array",
+			Items: &parser.Items{
+				Type:             "integer",
+				Maximum:          &innerMax,
+				ExclusiveMaximum: true,
+			},
+		}
+
+		s := convertOAS2ItemsToSchema(c, items, result, "test.items")
+		require.NotNil(t, s)
+		inner, ok := s.Items.(*parser.Schema)
+		require.True(t, ok, "nested Items should be *parser.Schema")
+		assert.Equal(t, float64(25), inner.ExclusiveMaximum, "nested ExclusiveMaximum should be numeric")
+		assert.Nil(t, inner.Maximum, "nested Maximum should be nil after conversion")
+	})
+
+	t.Run("OAS 3.1 items with no maximum emits warning", func(t *testing.T) {
+		c := newConverter()
+		result := &ConversionResult{TargetOASVersion: parser.OASVersion310}
+		items := &parser.Items{
+			Type:             "integer",
+			ExclusiveMaximum: true,
+			// Maximum intentionally nil
+		}
+
+		s := convertOAS2ItemsToSchema(c, items, result, "test.items")
+		require.NotNil(t, s)
+		assert.Nil(t, s.ExclusiveMaximum, "ExclusiveMaximum should remain nil")
+		assert.Greater(t, countIssuesContaining(result.Issues, "exclusiveMaximum: true"), 0,
+			"should emit warning about dropped exclusiveMaximum constraint")
+	})
+}
+
+// TestConvertOAS2SchemaToOAS3_ExclusiveOAS31 verifies that convertOAS2SchemaToOAS3
+// fixes boolean exclusive min/max in schemas when targeting OAS 3.1+.
+func TestConvertOAS2SchemaToOAS3_ExclusiveOAS31(t *testing.T) {
+	t.Run("OAS 3.1 target converts boolean exclusive in schema", func(t *testing.T) {
+		c := newConverter()
+		result := &ConversionResult{TargetOASVersion: parser.OASVersion310}
+		max := float64(200)
+		min := float64(10)
+		schema := &parser.Schema{
+			Type:             "integer",
+			Maximum:          &max,
+			Minimum:          &min,
+			ExclusiveMaximum: true,
+			ExclusiveMinimum: true,
+		}
+
+		converted := c.convertOAS2SchemaToOAS3(schema, parser.OASVersion310, result, "test")
+		require.NotNil(t, converted)
+		assert.Equal(t, float64(200), converted.ExclusiveMaximum, "ExclusiveMaximum should be numeric 200")
+		assert.Nil(t, converted.Maximum, "Maximum should be nil after conversion")
+		assert.Equal(t, float64(10), converted.ExclusiveMinimum, "ExclusiveMinimum should be numeric 10")
+		assert.Nil(t, converted.Minimum, "Minimum should be nil after conversion")
+	})
+
+	t.Run("OAS 3.0 target preserves boolean in schema", func(t *testing.T) {
+		c := newConverter()
+		result := &ConversionResult{TargetOASVersion: parser.OASVersion303}
+		max := float64(200)
+		min := float64(10)
+		schema := &parser.Schema{
+			Type:             "integer",
+			Maximum:          &max,
+			Minimum:          &min,
+			ExclusiveMaximum: true,
+			ExclusiveMinimum: true,
+		}
+
+		converted := c.convertOAS2SchemaToOAS3(schema, parser.OASVersion303, result, "test")
+		require.NotNil(t, converted)
+		assert.Equal(t, true, converted.ExclusiveMaximum, "ExclusiveMaximum should be boolean for OAS 3.0")
+		assert.NotNil(t, converted.Maximum, "Maximum should be preserved for OAS 3.0")
+		assert.Equal(t, true, converted.ExclusiveMinimum, "ExclusiveMinimum should be boolean for OAS 3.0")
+		assert.NotNil(t, converted.Minimum, "Minimum should be preserved for OAS 3.0")
+	})
+
+	t.Run("OAS 3.1 converts nested property exclusive", func(t *testing.T) {
+		c := newConverter()
+		result := &ConversionResult{TargetOASVersion: parser.OASVersion311}
+		propMax := float64(99)
+		schema := &parser.Schema{
+			Type: "object",
+			Properties: map[string]*parser.Schema{
+				"score": {
+					Type:             "number",
+					Maximum:          &propMax,
+					ExclusiveMaximum: true,
+				},
+			},
+		}
+
+		converted := c.convertOAS2SchemaToOAS3(schema, parser.OASVersion311, result, "test")
+		require.NotNil(t, converted)
+		scoreProp, ok := converted.Properties["score"]
+		require.True(t, ok, "score property should exist")
+		assert.Equal(t, float64(99), scoreProp.ExclusiveMaximum, "nested ExclusiveMaximum should be numeric")
+		assert.Nil(t, scoreProp.Maximum, "nested Maximum should be nil after conversion")
+	})
+
+	t.Run("OAS 3.1 boolean exclusive with no maximum emits warning", func(t *testing.T) {
+		c := newConverter()
+		result := &ConversionResult{TargetOASVersion: parser.OASVersion310}
+		schema := &parser.Schema{
+			Type:             "integer",
+			ExclusiveMaximum: true,
+			// Maximum intentionally nil
+		}
+
+		converted := c.convertOAS2SchemaToOAS3(schema, parser.OASVersion310, result, "test")
+		require.NotNil(t, converted)
+		assert.Nil(t, converted.ExclusiveMaximum, "ExclusiveMaximum should be nil when no Maximum present")
+		assert.Greater(t, countIssuesContaining(result.Issues, "exclusiveMaximum: true"), 0,
+			"should emit warning about dropped exclusiveMaximum constraint")
+	})
+
+	t.Run("nil schema returns nil", func(t *testing.T) {
+		c := newConverter()
+		assert.Nil(t, c.convertOAS2SchemaToOAS3(nil, parser.OASVersion310, nil, ""))
+	})
+
+	t.Run("does not mutate original schema", func(t *testing.T) {
+		c := newConverter()
+		result := &ConversionResult{TargetOASVersion: parser.OASVersion310}
+		max := float64(100)
+		original := &parser.Schema{
+			Type:             "integer",
+			Maximum:          &max,
+			ExclusiveMaximum: true,
+		}
+
+		_ = c.convertOAS2SchemaToOAS3(original, parser.OASVersion310, result, "test")
+		assert.Equal(t, true, original.ExclusiveMaximum, "original should not be mutated")
+		assert.NotNil(t, original.Maximum, "original Maximum should not be mutated")
+	})
+
+	t.Run("false boolean exclusiveMaximum becomes nil in OAS 3.1", func(t *testing.T) {
+		c := newConverter()
+		result := &ConversionResult{TargetOASVersion: parser.OASVersion310}
+		max := float64(100)
+		schema := &parser.Schema{
+			Type:             "integer",
+			Maximum:          &max,
+			ExclusiveMaximum: false, // boolean false
+		}
+
+		converted := c.convertOAS2SchemaToOAS3(schema, parser.OASVersion310, result, "test")
+		require.NotNil(t, converted)
+		assert.Nil(t, converted.ExclusiveMaximum, "false ExclusiveMaximum should become nil in OAS 3.1")
+		assert.NotNil(t, converted.Maximum, "Maximum should be preserved when ExclusiveMaximum was false")
+	})
+
+	t.Run("allOf traversal converts exclusive in OAS 3.1", func(t *testing.T) {
+		c := newConverter()
+		result := &ConversionResult{TargetOASVersion: parser.OASVersion310}
+		val := float64(42)
+		schema := &parser.Schema{
+			AllOf: []*parser.Schema{
+				{
+					Type:             "integer",
+					Maximum:          &val,
+					ExclusiveMaximum: true,
+				},
+			},
+		}
+
+		converted := c.convertOAS2SchemaToOAS3(schema, parser.OASVersion310, result, "test")
+		require.NotNil(t, converted)
+		require.Len(t, converted.AllOf, 1)
+		assert.Equal(t, float64(42), converted.AllOf[0].ExclusiveMaximum, "allOf member ExclusiveMaximum should be numeric")
+		assert.Nil(t, converted.AllOf[0].Maximum, "allOf member Maximum should be nil after conversion")
+	})
+
+	t.Run("nil result is safe for schema conversion", func(t *testing.T) {
+		c := newConverter()
+		schema := &parser.Schema{
+			Type:             "integer",
+			ExclusiveMaximum: true,
+			// Maximum intentionally nil -- would emit warning but result is nil
+		}
+
+		converted := c.convertOAS2SchemaToOAS3(schema, parser.OASVersion310, nil, "")
+		require.NotNil(t, converted)
+		assert.Nil(t, converted.ExclusiveMaximum, "ExclusiveMaximum should be nil even with nil result")
+	})
+}
+
+// TestConvertOAS2FormDataToRequestBody_ExclusiveOAS31 verifies that formData parameter
+// conversion handles exclusiveMaximum/exclusiveMinimum correctly for different target versions.
+func TestConvertOAS2FormDataToRequestBody_ExclusiveOAS31(t *testing.T) {
+	t.Run("OAS 3.1 target converts boolean to numeric in formData", func(t *testing.T) {
+		c := newConverter()
+		result := &ConversionResult{TargetOASVersion: parser.OASVersion310}
+		max := float64(100)
+		min := float64(1)
+		src := &parser.Operation{
+			Parameters: []*parser.Parameter{
+				{
+					Name:             "score",
+					In:               "formData",
+					Type:             "integer",
+					Maximum:          &max,
+					Minimum:          &min,
+					ExclusiveMaximum: true,
+					ExclusiveMinimum: true,
+				},
+			},
+		}
+
+		rb := c.convertOAS2FormDataToRequestBody(src, &parser.OAS2Document{}, result)
+		require.NotNil(t, rb)
+		require.NotEmpty(t, rb.Content, "Content should have at least one media type")
+		// Find the schema in the content
+		for _, mt := range rb.Content {
+			require.NotNil(t, mt.Schema)
+			scoreProp, ok := mt.Schema.Properties["score"]
+			require.True(t, ok, "score property should exist")
+			assert.Equal(t, float64(100), scoreProp.ExclusiveMaximum, "ExclusiveMaximum should be numeric 100")
+			assert.Nil(t, scoreProp.Maximum, "Maximum should be nil after conversion")
+			assert.Equal(t, float64(1), scoreProp.ExclusiveMinimum, "ExclusiveMinimum should be numeric 1")
+			assert.Nil(t, scoreProp.Minimum, "Minimum should be nil after conversion")
+			break
+		}
+	})
+
+	t.Run("OAS 3.0 target preserves boolean in formData", func(t *testing.T) {
+		c := newConverter()
+		result := &ConversionResult{TargetOASVersion: parser.OASVersion303}
+		max := float64(100)
+		min := float64(1)
+		src := &parser.Operation{
+			Parameters: []*parser.Parameter{
+				{
+					Name:             "score",
+					In:               "formData",
+					Type:             "integer",
+					Maximum:          &max,
+					Minimum:          &min,
+					ExclusiveMaximum: true,
+					ExclusiveMinimum: true,
+				},
+			},
+		}
+
+		rb := c.convertOAS2FormDataToRequestBody(src, &parser.OAS2Document{}, result)
+		require.NotNil(t, rb)
+		require.NotEmpty(t, rb.Content, "Content should have at least one media type")
+		for _, mt := range rb.Content {
+			require.NotNil(t, mt.Schema)
+			scoreProp, ok := mt.Schema.Properties["score"]
+			require.True(t, ok, "score property should exist")
+			assert.Equal(t, true, scoreProp.ExclusiveMaximum, "ExclusiveMaximum should be boolean for OAS 3.0")
+			assert.Equal(t, &max, scoreProp.Maximum, "Maximum should be preserved for OAS 3.0")
+			assert.Equal(t, true, scoreProp.ExclusiveMinimum, "ExclusiveMinimum should be boolean for OAS 3.0")
+			assert.Equal(t, &min, scoreProp.Minimum, "Minimum should be preserved for OAS 3.0")
+			break
+		}
+	})
+
+	t.Run("OAS 3.1 target with no maximum emits warning in formData", func(t *testing.T) {
+		c := newConverter()
+		result := &ConversionResult{TargetOASVersion: parser.OASVersion310}
+		src := &parser.Operation{
+			Parameters: []*parser.Parameter{
+				{
+					Name:             "score",
+					In:               "formData",
+					Type:             "integer",
+					ExclusiveMaximum: true,
+					// Maximum intentionally nil
+				},
+			},
+		}
+
+		rb := c.convertOAS2FormDataToRequestBody(src, &parser.OAS2Document{}, result)
+		require.NotNil(t, rb)
+		assert.Greater(t, countIssuesContaining(result.Issues, "exclusiveMaximum: true"), 0,
+			"should emit warning about dropped exclusiveMaximum constraint in formData")
+	})
+}
+
 // newConverter creates a Converter for unit testing helpers using the same
 // initialization path as production code.
 func newConverter() *Converter {

--- a/converter/oas2_to_oas3.go
+++ b/converter/oas2_to_oas3.go
@@ -35,7 +35,7 @@ func (c *Converter) convertOAS2ToOAS3(parseResult parser.ParseResult, targetVers
 
 		// Convert definitions to schemas
 		for name, schema := range src.Definitions {
-			dst.Components.Schemas[name] = c.convertOAS2SchemaToOAS3(schema)
+			dst.Components.Schemas[name] = c.convertOAS2SchemaToOAS3(schema, targetVersion, result, fmt.Sprintf("components.schemas.%s", name))
 		}
 
 		// Convert parameters
@@ -46,7 +46,7 @@ func (c *Converter) convertOAS2ToOAS3(parseResult parser.ParseResult, targetVers
 
 		// Convert responses
 		for name, response := range src.Responses {
-			dst.Components.Responses[name] = c.convertOAS2ResponseToOAS3Old(response, src.Produces)
+			dst.Components.Responses[name] = c.convertOAS2ResponseToOAS3Old(response, src.Produces, targetVersion, result, fmt.Sprintf("components.responses.%s", name))
 		}
 
 		// Convert security definitions
@@ -144,13 +144,22 @@ func (c *Converter) convertOAS2PathItemToOAS3(src *parser.PathItem, doc *parser.
 
 // convertOAS2OperationToOAS3 converts an OAS 2.0 operation to OAS 3.x
 func (c *Converter) convertOAS2OperationToOAS3(src *parser.Operation, doc *parser.OAS2Document, result *ConversionResult, opPath string) *parser.Operation {
+	// Exclude body and formData parameters before conversion — they are remapped
+	// to requestBody separately and must not be converted twice (which would
+	// emit duplicate warnings and produce unused converted parameters).
+	var nonBodyParams []*parser.Parameter
+	for _, p := range src.Parameters {
+		if p != nil && p.In != "body" && p.In != "formData" {
+			nonBodyParams = append(nonBodyParams, p)
+		}
+	}
 	dst := &parser.Operation{
 		Tags:         src.Tags,
 		Summary:      src.Summary,
 		Description:  src.Description,
 		ExternalDocs: src.ExternalDocs,
 		OperationID:  src.OperationID,
-		Parameters:   c.convertParameters(src.Parameters, result, fmt.Sprintf("%s.parameters", opPath)),
+		Parameters:   c.convertParameters(nonBodyParams, result, fmt.Sprintf("%s.parameters", opPath)),
 		Deprecated:   src.Deprecated,
 		Security:     src.Security,
 	}
@@ -158,12 +167,12 @@ func (c *Converter) convertOAS2OperationToOAS3(src *parser.Operation, doc *parse
 	// Convert responses
 	if src.Responses != nil {
 		dst.Responses = &parser.Responses{
-			Default: c.convertOAS2ResponseToOAS3Old(src.Responses.Default, c.getProduces(src, doc)),
+			Default: c.convertOAS2ResponseToOAS3Old(src.Responses.Default, c.getProduces(src, doc), result.TargetOASVersion, result, opPath+".responses.default"),
 			Codes:   make(map[string]*parser.Response),
 		}
 
 		for code, response := range src.Responses.Codes {
-			dst.Responses.Codes[code] = c.convertOAS2ResponseToOAS3Old(response, c.getProduces(src, doc))
+			dst.Responses.Codes[code] = c.convertOAS2ResponseToOAS3Old(response, c.getProduces(src, doc), result.TargetOASVersion, result, fmt.Sprintf("%s.responses.%s", opPath, code))
 		}
 	}
 
@@ -177,15 +186,7 @@ func (c *Converter) convertOAS2OperationToOAS3(src *parser.Operation, doc *parse
 	}
 
 	if hasBodyParam {
-		dst.RequestBody = c.convertOAS2RequestBody(src, doc)
-		// Remove body parameters from the parameters list in dst
-		filteredParams := make([]*parser.Parameter, 0)
-		for _, param := range dst.Parameters {
-			if param != nil && param.In != "body" {
-				filteredParams = append(filteredParams, param)
-			}
-		}
-		dst.Parameters = filteredParams
+		dst.RequestBody = c.convertOAS2RequestBody(src, doc, result)
 	}
 
 	// Convert formData parameters to requestBody
@@ -203,14 +204,7 @@ func (c *Converter) convertOAS2OperationToOAS3(src *parser.Operation, doc *parse
 				"Operation has both body and formData parameters",
 				"OAS 2.0 spec forbids this; formData parameters ignored")
 		} else {
-			dst.RequestBody = c.convertOAS2FormDataToRequestBody(src, doc)
-			filteredParams := make([]*parser.Parameter, 0, len(dst.Parameters))
-			for _, param := range dst.Parameters {
-				if param != nil && param.In != "formData" {
-					filteredParams = append(filteredParams, param)
-				}
-			}
-			dst.Parameters = filteredParams
+			dst.RequestBody = c.convertOAS2FormDataToRequestBody(src, doc, result)
 		}
 	}
 
@@ -218,7 +212,7 @@ func (c *Converter) convertOAS2OperationToOAS3(src *parser.Operation, doc *parse
 }
 
 // convertOAS2RequestBody converts OAS 2.0 body parameters and consumes to OAS 3.x requestBody
-func (c *Converter) convertOAS2RequestBody(src *parser.Operation, doc *parser.OAS2Document) *parser.RequestBody {
+func (c *Converter) convertOAS2RequestBody(src *parser.Operation, doc *parser.OAS2Document, result *ConversionResult) *parser.RequestBody {
 	// Find body parameter
 	var bodyParam *parser.Parameter
 	for _, param := range src.Parameters {
@@ -244,10 +238,11 @@ func (c *Converter) convertOAS2RequestBody(src *parser.Operation, doc *parser.OA
 		consumes = []string{getDefaultMediaType()}
 	}
 
-	// Create content for each media type
+	// Convert schema once; deep-copy per media type to avoid shared mutation.
+	convertedSchema := c.convertOAS2SchemaToOAS3(bodyParam.Schema, result.TargetOASVersion, result, "requestBody")
 	for _, mediaType := range consumes {
 		requestBody.Content[mediaType] = &parser.MediaType{
-			Schema: c.convertOAS2SchemaToOAS3(bodyParam.Schema),
+			Schema: convertedSchema.DeepCopy(),
 		}
 	}
 
@@ -255,7 +250,7 @@ func (c *Converter) convertOAS2RequestBody(src *parser.Operation, doc *parser.OA
 }
 
 // convertOAS2FormDataToRequestBody converts OAS 2.0 formData parameters to OAS 3.x requestBody.
-func (c *Converter) convertOAS2FormDataToRequestBody(src *parser.Operation, doc *parser.OAS2Document) *parser.RequestBody {
+func (c *Converter) convertOAS2FormDataToRequestBody(src *parser.Operation, doc *parser.OAS2Document, result *ConversionResult) *parser.RequestBody {
 	var formDataParams []*parser.Parameter
 	hasFile := false
 	for _, param := range src.Parameters {
@@ -285,7 +280,7 @@ func (c *Converter) convertOAS2FormDataToRequestBody(src *parser.Operation, doc 
 			propSchema.Type = "array"
 			propSchema.Format = param.Format
 			if param.Items != nil {
-				propSchema.Items = convertOAS2ItemsToSchema(param.Items)
+				propSchema.Items = convertOAS2ItemsToSchema(c, param.Items, result, fmt.Sprintf("requestBody.properties.%s.items", param.Name))
 			}
 		default:
 			propSchema.Type = param.Type
@@ -304,10 +299,32 @@ func (c *Converter) convertOAS2FormDataToRequestBody(src *parser.Operation, doc 
 		propSchema.UniqueItems = param.UniqueItems
 		propSchema.MultipleOf = param.MultipleOf
 		if param.ExclusiveMaximum {
-			propSchema.ExclusiveMaximum = true
+			if c.isOAS31OrLater(result.TargetOASVersion) {
+				if param.Maximum != nil {
+					propSchema.ExclusiveMaximum = *param.Maximum
+					propSchema.Maximum = nil
+				} else {
+					c.addIssueWithContext(result, fmt.Sprintf("requestBody.properties.%s", param.Name),
+						"FormData parameter has 'exclusiveMaximum: true' but no 'maximum' value; constraint dropped in OAS 3.1 conversion",
+						"Add a 'maximum' value to preserve this exclusive boundary in OAS 3.1")
+				}
+			} else {
+				propSchema.ExclusiveMaximum = true
+			}
 		}
 		if param.ExclusiveMinimum {
-			propSchema.ExclusiveMinimum = true
+			if c.isOAS31OrLater(result.TargetOASVersion) {
+				if param.Minimum != nil {
+					propSchema.ExclusiveMinimum = *param.Minimum
+					propSchema.Minimum = nil
+				} else {
+					c.addIssueWithContext(result, fmt.Sprintf("requestBody.properties.%s", param.Name),
+						"FormData parameter has 'exclusiveMinimum: true' but no 'minimum' value; constraint dropped in OAS 3.1 conversion",
+						"Add a 'minimum' value to preserve this exclusive boundary in OAS 3.1")
+				}
+			} else {
+				propSchema.ExclusiveMinimum = true
+			}
 		}
 		if param.Description != "" {
 			propSchema.Description = param.Description
@@ -343,7 +360,7 @@ func (c *Converter) convertOAS2FormDataToRequestBody(src *parser.Operation, doc 
 }
 
 // convertOAS2ItemsToSchema converts an OAS 2.0 Items object to an OAS 3.x Schema.
-func convertOAS2ItemsToSchema(items *parser.Items) *parser.Schema {
+func convertOAS2ItemsToSchema(c *Converter, items *parser.Items, result *ConversionResult, path string) *parser.Schema {
 	if items == nil {
 		return nil
 	}
@@ -363,13 +380,35 @@ func convertOAS2ItemsToSchema(items *parser.Items) *parser.Schema {
 		MultipleOf:  items.MultipleOf,
 	}
 	if items.ExclusiveMaximum {
-		s.ExclusiveMaximum = true
+		if c.isOAS31OrLater(result.TargetOASVersion) {
+			if items.Maximum != nil {
+				s.ExclusiveMaximum = *items.Maximum
+				s.Maximum = nil
+			} else {
+				c.addIssueWithContext(result, path,
+					"Items has 'exclusiveMaximum: true' but no 'maximum' value; constraint dropped in OAS 3.1 conversion",
+					"Add a 'maximum' value to preserve this exclusive boundary in OAS 3.1")
+			}
+		} else {
+			s.ExclusiveMaximum = true
+		}
 	}
 	if items.ExclusiveMinimum {
-		s.ExclusiveMinimum = true
+		if c.isOAS31OrLater(result.TargetOASVersion) {
+			if items.Minimum != nil {
+				s.ExclusiveMinimum = *items.Minimum
+				s.Minimum = nil
+			} else {
+				c.addIssueWithContext(result, path,
+					"Items has 'exclusiveMinimum: true' but no 'minimum' value; constraint dropped in OAS 3.1 conversion",
+					"Add a 'minimum' value to preserve this exclusive boundary in OAS 3.1")
+			}
+		} else {
+			s.ExclusiveMinimum = true
+		}
 	}
 	if items.Items != nil {
-		s.Items = convertOAS2ItemsToSchema(items.Items)
+		s.Items = convertOAS2ItemsToSchema(c, items.Items, result, path+".items")
 	}
 	return s
 }

--- a/converter/schema_convert.go
+++ b/converter/schema_convert.go
@@ -9,7 +9,7 @@ import (
 )
 
 // convertOAS2SchemaToOAS3 converts an OAS 2.0 schema to OAS 3.x format
-func (c *Converter) convertOAS2SchemaToOAS3(schema *parser.Schema) *parser.Schema {
+func (c *Converter) convertOAS2SchemaToOAS3(schema *parser.Schema, targetVersion parser.OASVersion, result *ConversionResult, path string) *parser.Schema {
 	if schema == nil {
 		return nil
 	}
@@ -20,7 +20,102 @@ func (c *Converter) convertOAS2SchemaToOAS3(schema *parser.Schema) *parser.Schem
 	// Rewrite all $ref paths from OAS 2.0 to OAS 3.x format
 	rewriteSchemaRefsOAS2ToOAS3(converted)
 
+	// For OAS 3.1+, convert boolean exclusiveMaximum/exclusiveMinimum to numeric form
+	if c.isOAS31OrLater(targetVersion) {
+		fixSchemaExclusiveMinMaxForOAS31(c, converted, result, path, make(map[*parser.Schema]bool))
+	}
+
 	return converted
+}
+
+// fixSchemaExclusiveMinMaxForOAS31 recursively converts boolean exclusiveMaximum/exclusiveMinimum
+// to OAS 3.1+ numeric semantics (number replaces boolean+maximum pair).
+// Schemas with a $ref are skipped -- they are resolved separately.
+// When result is non-nil, warnings are emitted for malformed constraints (true with no bound).
+func fixSchemaExclusiveMinMaxForOAS31(c *Converter, schema *parser.Schema, result *ConversionResult, path string, visited map[*parser.Schema]bool) {
+	if schema == nil || visited[schema] || schema.Ref != "" {
+		return
+	}
+	visited[schema] = true
+
+	if v, ok := schema.ExclusiveMaximum.(bool); ok {
+		if v && schema.Maximum != nil {
+			schema.ExclusiveMaximum = *schema.Maximum
+			schema.Maximum = nil
+		} else if v {
+			if result != nil {
+				c.addIssueWithContext(result, path,
+					"Schema has 'exclusiveMaximum: true' but no 'maximum' value; constraint dropped in OAS 3.1 conversion",
+					"Add a 'maximum' value to preserve this exclusive boundary in OAS 3.1")
+			}
+			schema.ExclusiveMaximum = nil
+		} else {
+			// false -- remove the no-op keyword
+			schema.ExclusiveMaximum = nil
+		}
+	}
+	if v, ok := schema.ExclusiveMinimum.(bool); ok {
+		if v && schema.Minimum != nil {
+			schema.ExclusiveMinimum = *schema.Minimum
+			schema.Minimum = nil
+		} else if v {
+			if result != nil {
+				c.addIssueWithContext(result, path,
+					"Schema has 'exclusiveMinimum: true' but no 'minimum' value; constraint dropped in OAS 3.1 conversion",
+					"Add a 'minimum' value to preserve this exclusive boundary in OAS 3.1")
+			}
+			schema.ExclusiveMinimum = nil
+		} else {
+			schema.ExclusiveMinimum = nil
+		}
+	}
+
+	for name, s := range schema.Properties {
+		fixSchemaExclusiveMinMaxForOAS31(c, s, result, fmt.Sprintf("%s.properties.%s", path, name), visited)
+	}
+	for pattern, s := range schema.PatternProperties {
+		fixSchemaExclusiveMinMaxForOAS31(c, s, result, fmt.Sprintf("%s.patternProperties.%s", path, pattern), visited)
+	}
+	if s, ok := schema.AdditionalProperties.(*parser.Schema); ok {
+		fixSchemaExclusiveMinMaxForOAS31(c, s, result, path+".additionalProperties", visited)
+	}
+	if s, ok := schema.Items.(*parser.Schema); ok {
+		fixSchemaExclusiveMinMaxForOAS31(c, s, result, path+".items", visited)
+	}
+	for i, s := range schema.AllOf {
+		fixSchemaExclusiveMinMaxForOAS31(c, s, result, fmt.Sprintf("%s.allOf[%d]", path, i), visited)
+	}
+	for i, s := range schema.AnyOf {
+		fixSchemaExclusiveMinMaxForOAS31(c, s, result, fmt.Sprintf("%s.anyOf[%d]", path, i), visited)
+	}
+	for i, s := range schema.OneOf {
+		fixSchemaExclusiveMinMaxForOAS31(c, s, result, fmt.Sprintf("%s.oneOf[%d]", path, i), visited)
+	}
+	fixSchemaExclusiveMinMaxForOAS31(c, schema.Not, result, path+".not", visited)
+	if s, ok := schema.AdditionalItems.(*parser.Schema); ok {
+		fixSchemaExclusiveMinMaxForOAS31(c, s, result, path+".additionalItems", visited)
+	}
+	for i, s := range schema.PrefixItems {
+		fixSchemaExclusiveMinMaxForOAS31(c, s, result, fmt.Sprintf("%s.prefixItems[%d]", path, i), visited)
+	}
+	fixSchemaExclusiveMinMaxForOAS31(c, schema.Contains, result, path+".contains", visited)
+	fixSchemaExclusiveMinMaxForOAS31(c, schema.PropertyNames, result, path+".propertyNames", visited)
+	for name, s := range schema.DependentSchemas {
+		fixSchemaExclusiveMinMaxForOAS31(c, s, result, fmt.Sprintf("%s.dependentSchemas.%s", path, name), visited)
+	}
+	if s, ok := schema.UnevaluatedProperties.(*parser.Schema); ok {
+		fixSchemaExclusiveMinMaxForOAS31(c, s, result, path+".unevaluatedProperties", visited)
+	}
+	if s, ok := schema.UnevaluatedItems.(*parser.Schema); ok {
+		fixSchemaExclusiveMinMaxForOAS31(c, s, result, path+".unevaluatedItems", visited)
+	}
+	fixSchemaExclusiveMinMaxForOAS31(c, schema.ContentSchema, result, path+".contentSchema", visited)
+	fixSchemaExclusiveMinMaxForOAS31(c, schema.If, result, path+".if", visited)
+	fixSchemaExclusiveMinMaxForOAS31(c, schema.Then, result, path+".then", visited)
+	fixSchemaExclusiveMinMaxForOAS31(c, schema.Else, result, path+".else", visited)
+	for name, s := range schema.Defs {
+		fixSchemaExclusiveMinMaxForOAS31(c, s, result, fmt.Sprintf("%s.$defs.%s", path, name), visited)
+	}
 }
 
 // convertOAS3SchemaToOAS2 converts an OAS 3.x schema to OAS 2.0 format


### PR DESCRIPTION
## Summary

Fixes #358

OAS 2.0/3.0 use `exclusiveMaximum`/`exclusiveMinimum` as **booleans** that modify an adjacent `maximum`/`minimum` bound. OAS 3.1 (JSON Schema 2020-12) changed these to **standalone numeric values**, dropping `maximum`/`minimum` entirely. The converter previously copied the boolean form regardless of target version, producing invalid OAS 3.1 output.

- When targeting OAS 3.1+: sets `exclusiveMaximum` to `*maximum` and clears `maximum` (same for min)
- When targeting OAS 3.0: boolean form is preserved (no change in behaviour)
- Edge case: `exclusiveMaximum: true` with no `maximum` (malformed OAS 2.0) now emits a `SeverityWarning` to `ConversionResult` instead of silently dropping the constraint

## Scope

All four conversion sites updated:

| Site | File |
|---|---|
| `convertOAS2ParameterToOAS3` — inline parameter type/format schema | `helpers.go` |
| `convertOAS2ResponseToOAS3Old` — response schemas (component + per-operation) | `helpers.go` |
| `convertOAS2FormDataToRequestBody` — formData parameter properties | `oas2_to_oas3.go` |
| `convertOAS2ItemsToSchema` — nested items arrays | `oas2_to_oas3.go` |
| `convertOAS2SchemaToOAS3` — component definitions via `fixSchemaExclusiveMinMaxForOAS31` | `schema_convert.go` |

`fixSchemaExclusiveMinMaxForOAS31` is a new recursive schema walker that mirrors the structure of `walkSchemaFeatures`, visiting all nested schema locations (properties, allOf/anyOf/oneOf, items, patternProperties, $defs, if/then/else, etc.) with cycle detection via a visited map.

`convertOAS2ItemsToSchema` gained `c *Converter, result *ConversionResult, path string` parameters — consistent with every other conversion helper in this package.

## Test plan

- [x] OAS 3.1 target: `exclusiveMaximum: true + maximum: 100` → `exclusiveMaximum: 100`, `maximum` removed
- [x] OAS 3.0 target: boolean form preserved, `maximum` unchanged
- [x] OAS 3.1 target: `exclusiveMaximum: true` with nil `maximum` → warning emitted, no panic
- [x] Nested items: `targetVersion` threaded recursively
- [x] Nested schema properties: recursive walker converts deeply nested fields
- [x] `allOf` traversal: composition schemas converted correctly
- [x] `false` boolean → clears to `nil` (valid OAS 3.1 no-op removal)
- [x] formData parameters: OAS 3.1 numeric and OAS 3.0 boolean paths
- [x] No mutation of original schema input

🤖 Generated with [Claude Code](https://claude.com/claude-code)