### PR TITLE
chore: resolve SA5011 staticcheck warnings in test files

### DIFF
--- a/differ/differ_test.go
+++ b/differ/differ_test.go
@@ -10,9 +10,7 @@ import (
 
 func TestDifferNew(t *testing.T) {
 	d := New()
-	if d == nil {
-		t.Fatal("Expected non-nil Differ")
-	}
+	require.NotNil(t, d, "Expected non-nil Differ")
 
 	if d.Mode != ModeSimple {
 		t.Errorf("Expected default mode to be ModeSimple, got %d", d.Mode)

--- a/validator/refs_test.go
+++ b/validator/refs_test.go
@@ -281,9 +281,7 @@ components:
 				t.Fatalf("Validate failed: %v", err)
 			}
 
-			if result == nil {
-				t.Fatal("Expected result, got nil")
-			}
+			require.NotNil(t, result, "Expected result, got nil")
 
 			hasRefError := false
 			for _, validationErr := range result.Errors {

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -15,9 +15,7 @@ import (
 // TestValidatorNew tests the New constructor
 func TestValidatorNew(t *testing.T) {
 	v := New()
-	if v == nil {
-		t.Fatal("New() returned nil")
-	}
+	require.NotNil(t, v, "New() returned nil")
 	if !v.IncludeWarnings {
 		t.Error("Expected IncludeWarnings to be true by default")
 	}
@@ -374,9 +372,7 @@ func TestCircularSchemaReferences(t *testing.T) {
 	}
 
 	// Validation should not crash on circular schemas
-	if result == nil {
-		t.Fatal("Expected result, got nil")
-	}
+	require.NotNil(t, result, "Expected result, got nil")
 
 	t.Logf("Circular schema validation completed with %d errors, %d warnings", result.ErrorCount, result.WarningCount)
 }
@@ -394,9 +390,7 @@ func TestDeeplyNestedSchemas(t *testing.T) {
 	}
 
 	// Validation should complete without stack overflow
-	if result == nil {
-		t.Fatal("Expected result, got nil")
-	}
+	require.NotNil(t, result, "Expected result, got nil")
 
 	t.Logf("Deeply nested schema validation completed with %d errors, %d warnings", result.ErrorCount, result.WarningCount)
 }


### PR DESCRIPTION
## Summary

Replaces the `if x == nil { t.Fatal(...) }` guard pattern with `require.NotNil(t, x, ...)` in 5 sites across 3 test files. Clears 11 pre-existing `SA5011` (possible nil pointer dereference) staticcheck warnings.

## Why

Newer staticcheck (ships with golangci-lint built against Go 1.26+) no longer auto-recognizes `testing.T.Fatal` as noreturn in all call sites, so it flags subsequent dereferences as possible nil dereferences. `testify/require.NotNil` is annotated and properly understood — same runtime behavior (both ultimately call `t.FailNow`), but the linter's CFG analysis treats them differently.

These warnings don't fail CI today (CI uses Go 1.25), but tooling updates beneath us — better to resolve them proactively than surface on the next Go version bump.

## Files changed

- `differ/differ_test.go` — 1 site
- `validator/refs_test.go` — 1 site
- `validator/validator_test.go` — 3 sites

All three files already import `github.com/stretchr/testify/require`; no new dependencies.

## Test plan

- [x] `make check` passes locally (lint: 0 issues; 8560 tests pass)
- [x] No behavior change — `require.NotNil` calls `t.FailNow()` under the hood, identical to `t.Fatal`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)