### PR TITLE
fix(joiner): preserve docs during semantic-dedup (strict-by-default)

### DIFF
--- a/builder/builder_dedupe_test.go
+++ b/builder/builder_dedupe_test.go
@@ -164,10 +164,13 @@ func TestBuilder_WithSemanticDeduplication_Disabled(t *testing.T) {
 	assert.Len(t, doc.Components.Schemas, 2)
 }
 
-func TestBuilder_DeduplicateSchemas_MetadataIgnored(t *testing.T) {
+func TestBuilder_DeduplicateSchemas_MetadataPreserved(t *testing.T) {
+	// Regression for issue #363: under the strict equivalence default, the
+	// builder must not consolidate schemas that differ in documentation.
+	// Doing so would replace the surviving canonical schema's docs at every
+	// reference site, producing misleading API documentation.
 	b := New(parser.OASVersion320, WithSemanticDeduplication(true))
 
-	// Schemas differ only in metadata - should still be deduplicated
 	b.addSchema("Address", &parser.Schema{
 		Type:        "object",
 		Title:       "An Address",
@@ -188,8 +191,11 @@ func TestBuilder_DeduplicateSchemas_MetadataIgnored(t *testing.T) {
 	doc, err := b.BuildOAS3()
 	require.NoError(t, err)
 
-	// Should deduplicate since structural properties are the same
-	assert.Len(t, doc.Components.Schemas, 1)
+	// Both schemas must survive because their documentation differs.
+	assert.Len(t, doc.Components.Schemas, 2,
+		"strict equivalence should preserve schemas with divergent metadata")
+	assert.Equal(t, "An Address", doc.Components.Schemas["Address"].Title)
+	assert.Equal(t, "A Location", doc.Components.Schemas["Location"].Title)
 }
 
 func TestBuilder_DeduplicateSchemas_MultipleGroups(t *testing.T) {

--- a/cmd/oastools/commands/common.go
+++ b/cmd/oastools/commands/common.go
@@ -73,6 +73,15 @@ func ValidateEquivalenceMode(value string) error {
 	return nil
 }
 
+// ValidateEquivalenceDocs validates the equivalence-docs flag and returns an
+// error if invalid. Empty values are accepted and resolved to the default.
+func ValidateEquivalenceDocs(value string) error {
+	if value != "" && !joiner.IsValidEquivalenceDocs(value) {
+		return fmt.Errorf("invalid equivalence-docs '%s'. Valid values: %v", value, joiner.ValidEquivalenceDocs())
+	}
+	return nil
+}
+
 // ValidatePrimaryOperationPolicy validates the primary operation policy flag value.
 func ValidatePrimaryOperationPolicy(policy string) error {
 	if policy == "" {

--- a/cmd/oastools/commands/common_test.go
+++ b/cmd/oastools/commands/common_test.go
@@ -89,6 +89,31 @@ func TestValidateEquivalenceMode(t *testing.T) {
 	}
 }
 
+func TestValidateEquivalenceDocs(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{"empty value", "", false},
+		{"valid include", "include", false},
+		{"valid ignore", "ignore", false},
+		{"invalid value", "strict", true},
+		{"case sensitive INCLUDE", "INCLUDE", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateEquivalenceDocs(tt.value)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestMarshalDocument(t *testing.T) {
 	doc := map[string]string{"key": "value"}
 

--- a/cmd/oastools/commands/join.go
+++ b/cmd/oastools/commands/join.go
@@ -78,6 +78,7 @@ type JoinFlags struct {
 	// Advanced collision strategies
 	RenameTemplate  string
 	EquivalenceMode string
+	EquivalenceDocs string
 	CollisionReport bool
 	SemanticDedup   bool
 	// Namespace prefix configuration
@@ -114,6 +115,8 @@ func SetupJoinFlags() (*flag.FlagSet, *JoinFlags) {
 	// Advanced collision strategies
 	fs.StringVar(&flags.RenameTemplate, "rename-template", "{{.Name}}_{{.Source}}", "template for renamed schema names")
 	fs.StringVar(&flags.EquivalenceMode, "equivalence-mode", "none", "schema comparison mode for deduplication (none, shallow, deep)")
+	fs.StringVar(&flags.EquivalenceDocs, "equivalence-docs", "include",
+		"whether title/description/example/examples participate in schema equivalence (include, ignore)")
 	fs.BoolVar(&flags.CollisionReport, "collision-report", false, "generate detailed collision analysis report")
 	fs.BoolVar(&flags.SemanticDedup, "semantic-dedup", false, "enable semantic deduplication to consolidate identical schemas")
 
@@ -243,6 +246,9 @@ func HandleJoin(args []string) error {
 	// Apply advanced collision strategy settings
 	config.RenameTemplate = flags.RenameTemplate
 	config.EquivalenceMode = flags.EquivalenceMode
+	if flags.EquivalenceDocs != "" {
+		config.EquivalenceDocs = flags.EquivalenceDocs
+	}
 	config.CollisionReport = flags.CollisionReport
 	config.SemanticDeduplication = flags.SemanticDedup
 
@@ -264,6 +270,9 @@ func HandleJoin(args []string) error {
 		return err
 	}
 	if err := ValidateEquivalenceMode(flags.EquivalenceMode); err != nil {
+		return err
+	}
+	if err := ValidateEquivalenceDocs(flags.EquivalenceDocs); err != nil {
 		return err
 	}
 	if err := ValidatePrimaryOperationPolicy(flags.PrimaryOperationPolicy); err != nil {

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -599,6 +599,7 @@ oastools join [flags] <file1> <file2> [file3...]
 | `--primary-operation-policy` | | Policy for selecting primary operation: `first`, `most-specific`, `alphabetical` (default: `first`) |
 | `--semantic-dedup` | | Enable semantic deduplication to consolidate identical schemas |
 | `--equivalence-mode` | | Schema comparison mode for deduplication: `none`, `shallow`, `deep` (default: `none`) |
+| `--equivalence-docs` | | Whether `title`, `description`, `example`, and `examples` participate in schema equivalence: `include` (default, strict), `ignore` (legacy loose) |
 | `--collision-report` | | Generate detailed collision analysis report |
 | `--namespace-prefix` | | Namespace prefix for source file (format: source=prefix, can be repeated) |
 | `--always-prefix` | | Apply namespace prefix to all schemas, not just on collision |

--- a/joiner/deep_dive.md
+++ b/joiner/deep_dive.md
@@ -1374,6 +1374,45 @@ func main() {
 }
 ```
 
+### Preserving Documentation During Deduplication
+
+Since v1.54.0, semantic equivalence is **strict by default**: two schemas that
+differ only in `title`, `description`, `example`, or `examples` are treated
+as **not equivalent** and are preserved as separate schemas. This prevents a
+subtle documentation-clobbering bug where every `$ref` site to a
+consolidated schema ended up pointing at a canonical schema whose prose
+applied to a different context (for example, a 403 response landing on a
+schema whose description said "The request is invalid").
+
+Callers that explicitly want the legacy loose behavior — where schemas with
+identical structure are merged regardless of docs — can opt in with
+`WithEquivalenceDocs`:
+
+```go
+result, err := joiner.JoinWithOptions(
+    joiner.WithFilePaths("users-api.yaml", "admin-api.yaml"),
+    joiner.WithSemanticDeduplication(true),
+    // Accept that consolidated schemas' docs will be replaced
+    // at every $ref site.
+    joiner.WithEquivalenceDocs(string(joiner.EquivalenceDocsIgnore)),
+)
+```
+
+The CLI exposes the same control via `--equivalence-docs`:
+
+```bash
+# Default: strict. Schemas with differing docs are preserved.
+oastools join --semantic-dedup -o merged.yaml api1.yaml api2.yaml
+
+# Loose: legacy behavior. Differing docs are discarded during dedup.
+oastools join --semantic-dedup --equivalence-docs ignore \
+    -o merged.yaml api1.yaml api2.yaml
+```
+
+The same `WithEquivalenceDocs` option applies to the `deduplicate` collision
+strategy (`SchemaStrategy = StrategyDeduplicateEquivalent`) and to the
+`SemanticDeduplication` post-merge pass.
+
 ### High-Performance Joining with Pre-Parsed Documents
 
 For integration with other oastools packages, use pre-parsed documents for 154x faster performance:

--- a/joiner/equivalence.go
+++ b/joiner/equivalence.go
@@ -63,6 +63,68 @@ func IsValidEquivalenceMode(mode string) bool {
 	}
 }
 
+// EquivalenceDocs controls whether documentation-oriented metadata fields
+// (title, description, example, examples) participate in schema equivalence.
+//
+// When EquivalenceDocsInclude (the default) is selected, two schemas that
+// differ only in their documentation are treated as non-equivalent. This
+// matters for semantic deduplication: merging schemas with divergent
+// descriptions causes the canonical schema's docs to replace the other
+// schemas' docs at every $ref site, which produces misleading API
+// documentation (for example, a 403 response pointing at a schema whose
+// description says "The request is invalid").
+//
+// When EquivalenceDocsIgnore is selected, title/description/example/examples
+// are ignored during comparison. Use this when you intentionally want
+// structurally identical schemas to be consolidated even if their prose
+// differs, and the docs of the surviving canonical schema are acceptable for
+// every reference site.
+type EquivalenceDocs string
+
+const (
+	// EquivalenceDocsInclude makes title, description, example, and examples
+	// part of the comparison. Default and recommended.
+	EquivalenceDocsInclude EquivalenceDocs = "include"
+	// EquivalenceDocsIgnore skips documentation metadata during comparison.
+	EquivalenceDocsIgnore EquivalenceDocs = "ignore"
+)
+
+// ValidEquivalenceDocs returns all valid equivalence docs strings
+func ValidEquivalenceDocs() []string {
+	return []string{
+		string(EquivalenceDocsInclude),
+		string(EquivalenceDocsIgnore),
+	}
+}
+
+// IsValidEquivalenceDocs checks if an equivalence docs string is valid
+func IsValidEquivalenceDocs(mode string) bool {
+	switch EquivalenceDocs(mode) {
+	case EquivalenceDocsInclude, EquivalenceDocsIgnore:
+		return true
+	default:
+		return false
+	}
+}
+
+// CompareOptions configures schema equivalence comparison behavior.
+//
+// Mode controls structural comparison depth.
+// Docs controls whether documentation metadata participates in comparison.
+type CompareOptions struct {
+	// Mode controls comparison depth: none, shallow, or deep.
+	Mode EquivalenceMode
+	// Docs controls whether title/description/example/examples participate.
+	// Empty value is treated as EquivalenceDocsInclude (strict).
+	Docs EquivalenceDocs
+}
+
+// defaultCompareOptions builds a CompareOptions with the provided mode and
+// the strict (include) documentation policy.
+func defaultCompareOptions(mode EquivalenceMode) CompareOptions {
+	return CompareOptions{Mode: mode, Docs: EquivalenceDocsInclude}
+}
+
 // EquivalenceResult contains the outcome of schema comparison
 type EquivalenceResult struct {
 	Equivalent  bool
@@ -275,12 +337,29 @@ func (r EquivalenceResult) String() string {
 	return b.String()
 }
 
-// CompareSchemas compares two schemas for structural equivalence
-// Ignores: description, title, example, deprecated, and extension fields (x-*)
+// CompareSchemas compares two schemas for structural equivalence using the
+// strict (docs-included) comparison policy. Title, description, example, and
+// examples all participate in the comparison by default; two schemas that
+// differ only in those fields will be reported as non-equivalent.
+//
+// Callers that need the legacy behavior of ignoring documentation metadata
+// can use CompareSchemasWithOptions with Docs set to EquivalenceDocsIgnore.
 func CompareSchemas(left, right *parser.Schema, mode EquivalenceMode) EquivalenceResult {
-	if mode == EquivalenceModeNone {
+	return CompareSchemasWithOptions(left, right, defaultCompareOptions(mode))
+}
+
+// CompareSchemasWithOptions compares two schemas using the provided options.
+//
+// When opts.Docs is empty, it is treated as EquivalenceDocsInclude (strict).
+// See CompareOptions and EquivalenceDocs for details.
+func CompareSchemasWithOptions(left, right *parser.Schema, opts CompareOptions) EquivalenceResult {
+	if opts.Mode == EquivalenceModeNone {
 		return EquivalenceResult{Equivalent: false}
 	}
+	if opts.Docs == "" {
+		opts.Docs = EquivalenceDocsInclude
+	}
+	compareDocs := opts.Docs == EquivalenceDocsInclude
 
 	result := EquivalenceResult{
 		Differences: make([]SchemaDifference, 0),
@@ -319,10 +398,10 @@ func CompareSchemas(left, right *parser.Schema, mode EquivalenceMode) Equivalenc
 	// Use stack-based path builder to minimize allocations
 	path := &comparePath{segments: make([]string, 0, 8)}
 
-	if mode == EquivalenceModeShallow {
-		compareShallow(left, right, path, &result)
+	if opts.Mode == EquivalenceModeShallow {
+		compareShallow(left, right, path, &result, compareDocs)
 	} else {
-		compareDeep(left, right, path, &result, visited)
+		compareDeep(left, right, path, &result, visited, compareDocs)
 	}
 
 	result.Equivalent = len(result.Differences) == 0
@@ -335,9 +414,67 @@ type pointerPair struct {
 	right uintptr
 }
 
+// compareDocFields compares documentation metadata fields (title, description,
+// example, examples) and records any differences on the result.
+//
+// Only invoked when the caller has elected to include documentation in
+// equivalence (Docs == EquivalenceDocsInclude).
+func compareDocFields(left, right *parser.Schema, path *comparePath, result *EquivalenceResult) {
+	if left.Title != right.Title {
+		path.push("title")
+		result.Differences = append(result.Differences, SchemaDifference{
+			Path:        path.String(),
+			LeftValue:   left.Title,
+			RightValue:  right.Title,
+			Description: "title mismatch",
+		})
+		path.pop()
+	}
+
+	if left.Description != right.Description {
+		path.push("description")
+		result.Differences = append(result.Differences, SchemaDifference{
+			Path:        path.String(),
+			LeftValue:   left.Description,
+			RightValue:  right.Description,
+			Description: "description mismatch",
+		})
+		path.pop()
+	}
+
+	if !reflect.DeepEqual(left.Example, right.Example) {
+		path.push("example")
+		result.Differences = append(result.Differences, SchemaDifference{
+			Path:        path.String(),
+			LeftValue:   left.Example,
+			RightValue:  right.Example,
+			Description: "example mismatch",
+		})
+		path.pop()
+	}
+
+	if !reflect.DeepEqual(left.Examples, right.Examples) {
+		path.push("examples")
+		result.Differences = append(result.Differences, SchemaDifference{
+			Path:        path.String(),
+			LeftValue:   left.Examples,
+			RightValue:  right.Examples,
+			Description: "examples mismatch",
+		})
+		path.pop()
+	}
+}
+
 // compareCommonFields compares schema fields common to both shallow and deep comparison.
 // This helper eliminates duplication between compareShallow and compareDeep.
-func compareCommonFields(left, right *parser.Schema, path *comparePath, result *EquivalenceResult) {
+//
+// When compareDocs is true, documentation metadata (title, description,
+// example, examples) is also compared.
+func compareCommonFields(left, right *parser.Schema, path *comparePath, result *EquivalenceResult, compareDocs bool) {
+	if compareDocs {
+		compareDocFields(left, right, path, result)
+	}
+
 	// Compare type
 	if !equalTypes(left.Type, right.Type) {
 		path.push("type")
@@ -400,12 +537,12 @@ func compareCommonFields(left, right *parser.Schema, path *comparePath, result *
 }
 
 // compareShallow compares only the top-level properties of schemas
-func compareShallow(left, right *parser.Schema, path *comparePath, result *EquivalenceResult) {
-	compareCommonFields(left, right, path, result)
+func compareShallow(left, right *parser.Schema, path *comparePath, result *EquivalenceResult, compareDocs bool) {
+	compareCommonFields(left, right, path, result, compareDocs)
 }
 
 // compareDeep recursively compares all schema properties
-func compareDeep(left, right *parser.Schema, path *comparePath, result *EquivalenceResult, visited map[pointerPair]bool) {
+func compareDeep(left, right *parser.Schema, path *comparePath, result *EquivalenceResult, visited map[pointerPair]bool, compareDocs bool) {
 	// Check for circular references
 	pair := pointerPair{
 		left:  reflect.ValueOf(left).Pointer(),
@@ -416,8 +553,9 @@ func compareDeep(left, right *parser.Schema, path *comparePath, result *Equivale
 	}
 	visited[pair] = true
 
-	// Compare common fields (type, format, required, enum, propertyNames)
-	compareCommonFields(left, right, path, result)
+	// Compare common fields (type, format, required, enum, propertyNames, and
+	// optionally documentation metadata).
+	compareCommonFields(left, right, path, result, compareDocs)
 
 	// Compare pattern (deep only)
 	if left.Pattern != right.Pattern {
@@ -547,27 +685,27 @@ func compareDeep(left, right *parser.Schema, path *comparePath, result *Equivale
 		for name, leftProp := range left.Properties {
 			rightProp := right.Properties[name]
 			path.push(name)
-			compareDeep(leftProp, rightProp, path, result, visited)
+			compareDeep(leftProp, rightProp, path, result, visited, compareDocs)
 			path.pop()
 		}
 		path.pop()
 	}
 
 	// Compare items (array item schema)
-	compareItemsSchemas(left.Items, right.Items, path, result, visited)
+	compareItemsSchemas(left.Items, right.Items, path, result, visited, compareDocs)
 
 	// Compare additionalProperties
-	compareAdditionalPropertiesSchemas(left.AdditionalProperties, right.AdditionalProperties, path, result, visited)
+	compareAdditionalPropertiesSchemas(left.AdditionalProperties, right.AdditionalProperties, path, result, visited, compareDocs)
 
 	// Compare composition (allOf, anyOf, oneOf)
 	path.push("allOf")
-	compareSchemaArrays(left.AllOf, right.AllOf, path, result, visited)
+	compareSchemaArrays(left.AllOf, right.AllOf, path, result, visited, compareDocs)
 	path.pop()
 	path.push("anyOf")
-	compareSchemaArrays(left.AnyOf, right.AnyOf, path, result, visited)
+	compareSchemaArrays(left.AnyOf, right.AnyOf, path, result, visited, compareDocs)
 	path.pop()
 	path.push("oneOf")
-	compareSchemaArrays(left.OneOf, right.OneOf, path, result, visited)
+	compareSchemaArrays(left.OneOf, right.OneOf, path, result, visited, compareDocs)
 	path.pop()
 
 	// Compare not
@@ -582,7 +720,7 @@ func compareDeep(left, right *parser.Schema, path *comparePath, result *Equivale
 		path.pop()
 	} else if left.Not != nil && right.Not != nil {
 		path.push("not")
-		compareDeep(left.Not, right.Not, path, result, visited)
+		compareDeep(left.Not, right.Not, path, result, visited, compareDocs)
 		path.pop()
 	}
 
@@ -590,12 +728,12 @@ func compareDeep(left, right *parser.Schema, path *comparePath, result *Equivale
 
 	// Compare unevaluatedProperties (can be bool or *Schema)
 	path.push("unevaluatedProperties")
-	comparePolymorphicSchemas(left.UnevaluatedProperties, right.UnevaluatedProperties, path, result, visited)
+	comparePolymorphicSchemas(left.UnevaluatedProperties, right.UnevaluatedProperties, path, result, visited, compareDocs)
 	path.pop()
 
 	// Compare unevaluatedItems (can be bool or *Schema)
 	path.push("unevaluatedItems")
-	comparePolymorphicSchemas(left.UnevaluatedItems, right.UnevaluatedItems, path, result, visited)
+	comparePolymorphicSchemas(left.UnevaluatedItems, right.UnevaluatedItems, path, result, visited, compareDocs)
 	path.pop()
 
 	// Compare contentEncoding
@@ -634,13 +772,13 @@ func compareDeep(left, right *parser.Schema, path *comparePath, result *Equivale
 		path.pop()
 	} else if left.ContentSchema != nil && right.ContentSchema != nil {
 		path.push("contentSchema")
-		compareDeep(left.ContentSchema, right.ContentSchema, path, result, visited)
+		compareDeep(left.ContentSchema, right.ContentSchema, path, result, visited, compareDocs)
 		path.pop()
 	}
 
 	// Compare prefixItems
 	path.push("prefixItems")
-	compareSchemaArrays(left.PrefixItems, right.PrefixItems, path, result, visited)
+	compareSchemaArrays(left.PrefixItems, right.PrefixItems, path, result, visited, compareDocs)
 	path.pop()
 
 	// Compare contains
@@ -655,7 +793,7 @@ func compareDeep(left, right *parser.Schema, path *comparePath, result *Equivale
 		path.pop()
 	} else if left.Contains != nil && right.Contains != nil {
 		path.push("contains")
-		compareDeep(left.Contains, right.Contains, path, result, visited)
+		compareDeep(left.Contains, right.Contains, path, result, visited, compareDocs)
 		path.pop()
 	}
 
@@ -671,7 +809,7 @@ func compareDeep(left, right *parser.Schema, path *comparePath, result *Equivale
 		path.pop()
 	} else if left.PropertyNames != nil && right.PropertyNames != nil {
 		path.push("propertyNames")
-		compareDeep(left.PropertyNames, right.PropertyNames, path, result, visited)
+		compareDeep(left.PropertyNames, right.PropertyNames, path, result, visited, compareDocs)
 		path.pop()
 	}
 
@@ -690,7 +828,7 @@ func compareDeep(left, right *parser.Schema, path *comparePath, result *Equivale
 		for name, leftSchema := range left.DependentSchemas {
 			rightSchema := right.DependentSchemas[name]
 			path.push(name)
-			compareDeep(leftSchema, rightSchema, path, result, visited)
+			compareDeep(leftSchema, rightSchema, path, result, visited, compareDocs)
 			path.pop()
 		}
 		path.pop()
@@ -792,7 +930,7 @@ func getPropertyNames(properties map[string]*parser.Schema) []string {
 	return names
 }
 
-func compareItemsSchemas(left, right any, path *comparePath, result *EquivalenceResult, visited map[pointerPair]bool) {
+func compareItemsSchemas(left, right any, path *comparePath, result *EquivalenceResult, visited map[pointerPair]bool, compareDocs bool) {
 	// Both nil
 	if left == nil && right == nil {
 		return
@@ -815,7 +953,7 @@ func compareItemsSchemas(left, right any, path *comparePath, result *Equivalence
 	rightSchema, rightIsSchema := right.(*parser.Schema)
 	if leftIsSchema && rightIsSchema {
 		path.push("items")
-		compareDeep(leftSchema, rightSchema, path, result, visited)
+		compareDeep(leftSchema, rightSchema, path, result, visited, compareDocs)
 		path.pop()
 		return
 	}
@@ -848,7 +986,7 @@ func compareItemsSchemas(left, right any, path *comparePath, result *Equivalence
 	path.pop()
 }
 
-func compareAdditionalPropertiesSchemas(left, right any, path *comparePath, result *EquivalenceResult, visited map[pointerPair]bool) {
+func compareAdditionalPropertiesSchemas(left, right any, path *comparePath, result *EquivalenceResult, visited map[pointerPair]bool, compareDocs bool) {
 	// Both nil
 	if left == nil && right == nil {
 		return
@@ -871,7 +1009,7 @@ func compareAdditionalPropertiesSchemas(left, right any, path *comparePath, resu
 	rightSchema, rightIsSchema := right.(*parser.Schema)
 	if leftIsSchema && rightIsSchema {
 		path.push("additionalProperties")
-		compareDeep(leftSchema, rightSchema, path, result, visited)
+		compareDeep(leftSchema, rightSchema, path, result, visited, compareDocs)
 		path.pop()
 		return
 	}
@@ -905,7 +1043,7 @@ func compareAdditionalPropertiesSchemas(left, right any, path *comparePath, resu
 }
 
 // comparePolymorphicSchemas compares schema fields that can be bool or *Schema (e.g., unevaluatedProperties, unevaluatedItems)
-func comparePolymorphicSchemas(left, right any, path *comparePath, result *EquivalenceResult, visited map[pointerPair]bool) {
+func comparePolymorphicSchemas(left, right any, path *comparePath, result *EquivalenceResult, visited map[pointerPair]bool, compareDocs bool) {
 	// Both nil
 	if left == nil && right == nil {
 		return
@@ -925,7 +1063,7 @@ func comparePolymorphicSchemas(left, right any, path *comparePath, result *Equiv
 	leftSchema, leftIsSchema := left.(*parser.Schema)
 	rightSchema, rightIsSchema := right.(*parser.Schema)
 	if leftIsSchema && rightIsSchema {
-		compareDeep(leftSchema, rightSchema, path, result, visited)
+		compareDeep(leftSchema, rightSchema, path, result, visited, compareDocs)
 		return
 	}
 
@@ -953,7 +1091,7 @@ func comparePolymorphicSchemas(left, right any, path *comparePath, result *Equiv
 	})
 }
 
-func compareSchemaArrays(left, right []*parser.Schema, path *comparePath, result *EquivalenceResult, visited map[pointerPair]bool) {
+func compareSchemaArrays(left, right []*parser.Schema, path *comparePath, result *EquivalenceResult, visited map[pointerPair]bool, compareDocs bool) {
 	if len(left) != len(right) {
 		result.Differences = append(result.Differences, SchemaDifference{
 			Path:        path.String(),
@@ -967,7 +1105,7 @@ func compareSchemaArrays(left, right []*parser.Schema, path *comparePath, result
 	for i := range left {
 		// Use strconv.Itoa instead of fmt.Sprintf for better performance
 		path.push("[" + strconv.Itoa(i) + "]")
-		compareDeep(left[i], right[i], path, result, visited)
+		compareDeep(left[i], right[i], path, result, visited, compareDocs)
 		path.pop()
 	}
 }

--- a/joiner/equivalence_test.go
+++ b/joiner/equivalence_test.go
@@ -336,26 +336,152 @@ func TestCompareSchemas_AllOfLengthMismatch(t *testing.T) {
 	assert.True(t, found)
 }
 
-func TestCompareSchemas_IgnoresMetadata(t *testing.T) {
+func TestCompareSchemas_DocsIncludedByDefault(t *testing.T) {
+	// Schemas that differ only in documentation fields are NOT equivalent
+	// under the default (strict) policy. Callers that want the old loose
+	// behavior can opt in with EquivalenceDocsIgnore.
 	left := &parser.Schema{
 		Type:        "string",
 		Title:       "User Name",
 		Description: "The name of the user",
 		Example:     "John Doe",
-		Deprecated:  false,
 	}
 	right := &parser.Schema{
 		Type:        "string",
 		Title:       "Full Name",
 		Description: "User's full name",
 		Example:     "Jane Smith",
-		Deprecated:  true,
 	}
 
+	// Default: docs included -> not equivalent
 	result := CompareSchemas(left, right, EquivalenceModeDeep)
+	assert.False(t, result.Equivalent, "schemas differing only in docs should NOT be equivalent under default")
+	assert.NotEmpty(t, result.Differences, "expected differences to be recorded")
 
-	// Should be equivalent because metadata is ignored
-	assert.True(t, result.Equivalent, "schemas should be equivalent when only metadata differs")
+	// Opt-in loose mode: docs ignored -> equivalent
+	looseResult := CompareSchemasWithOptions(left, right, CompareOptions{
+		Mode: EquivalenceModeDeep,
+		Docs: EquivalenceDocsIgnore,
+	})
+	assert.True(t, looseResult.Equivalent, "schemas should be equivalent when docs are explicitly ignored")
+}
+
+func TestCompareSchemas_TitleOnlyDifference(t *testing.T) {
+	left := &parser.Schema{Type: "string", Title: "A"}
+	right := &parser.Schema{Type: "string", Title: "B"}
+
+	// Default (strict): titles differ -> not equivalent
+	strict := CompareSchemas(left, right, EquivalenceModeDeep)
+	assert.False(t, strict.Equivalent)
+	require.NotEmpty(t, strict.Differences)
+	assert.Equal(t, "title", strict.Differences[0].Path)
+
+	// Loose mode: titles ignored -> equivalent
+	loose := CompareSchemasWithOptions(left, right, CompareOptions{
+		Mode: EquivalenceModeDeep,
+		Docs: EquivalenceDocsIgnore,
+	})
+	assert.True(t, loose.Equivalent)
+}
+
+func TestCompareSchemas_DescriptionOnlyDifference(t *testing.T) {
+	left := &parser.Schema{Type: "string", Description: "the first"}
+	right := &parser.Schema{Type: "string", Description: "the second"}
+
+	strict := CompareSchemas(left, right, EquivalenceModeDeep)
+	assert.False(t, strict.Equivalent)
+	require.NotEmpty(t, strict.Differences)
+	assert.Equal(t, "description", strict.Differences[0].Path)
+
+	loose := CompareSchemasWithOptions(left, right, CompareOptions{
+		Mode: EquivalenceModeDeep,
+		Docs: EquivalenceDocsIgnore,
+	})
+	assert.True(t, loose.Equivalent)
+}
+
+func TestCompareSchemas_ExampleOnlyDifference(t *testing.T) {
+	left := &parser.Schema{Type: "string", Example: "hello"}
+	right := &parser.Schema{Type: "string", Example: "world"}
+
+	strict := CompareSchemas(left, right, EquivalenceModeDeep)
+	assert.False(t, strict.Equivalent)
+	require.NotEmpty(t, strict.Differences)
+	assert.Equal(t, "example", strict.Differences[0].Path)
+
+	loose := CompareSchemasWithOptions(left, right, CompareOptions{
+		Mode: EquivalenceModeDeep,
+		Docs: EquivalenceDocsIgnore,
+	})
+	assert.True(t, loose.Equivalent)
+}
+
+func TestCompareSchemas_NestedDocDifference(t *testing.T) {
+	// Two object schemas, identical at the top level, but a nested property
+	// differs only in description. Default behavior: not equivalent.
+	left := &parser.Schema{
+		Type: "object",
+		Properties: map[string]*parser.Schema{
+			"id": {Type: "string", Description: "the user id"},
+		},
+	}
+	right := &parser.Schema{
+		Type: "object",
+		Properties: map[string]*parser.Schema{
+			"id": {Type: "string", Description: "the account id"},
+		},
+	}
+
+	strict := CompareSchemas(left, right, EquivalenceModeDeep)
+	assert.False(t, strict.Equivalent, "nested description differences should bubble up")
+	require.NotEmpty(t, strict.Differences)
+	assert.Equal(t, "properties.id.description", strict.Differences[0].Path)
+
+	loose := CompareSchemasWithOptions(left, right, CompareOptions{
+		Mode: EquivalenceModeDeep,
+		Docs: EquivalenceDocsIgnore,
+	})
+	assert.True(t, loose.Equivalent, "nested docs should be ignored in loose mode")
+}
+
+func TestCompareSchemas_IdenticalSchemasAlwaysEquivalent(t *testing.T) {
+	// When schemas are fully identical (structure + docs), both modes agree.
+	left := &parser.Schema{
+		Type:        "string",
+		Title:       "Name",
+		Description: "A name",
+		Example:     "Alice",
+	}
+	right := &parser.Schema{
+		Type:        "string",
+		Title:       "Name",
+		Description: "A name",
+		Example:     "Alice",
+	}
+
+	assert.True(t, CompareSchemas(left, right, EquivalenceModeDeep).Equivalent)
+	assert.True(t, CompareSchemasWithOptions(left, right, CompareOptions{
+		Mode: EquivalenceModeDeep,
+		Docs: EquivalenceDocsIgnore,
+	}).Equivalent)
+}
+
+func TestIsValidEquivalenceDocs(t *testing.T) {
+	assert.True(t, IsValidEquivalenceDocs("include"))
+	assert.True(t, IsValidEquivalenceDocs("ignore"))
+	assert.False(t, IsValidEquivalenceDocs(""))
+	assert.False(t, IsValidEquivalenceDocs("strict"))
+	assert.False(t, IsValidEquivalenceDocs("INCLUDE"))
+	assert.Equal(t, []string{"include", "ignore"}, ValidEquivalenceDocs())
+}
+
+func TestCompareSchemasWithOptions_EmptyDocsDefaultsToInclude(t *testing.T) {
+	// Empty Docs is treated as "include" (strict).
+	left := &parser.Schema{Type: "string", Description: "one"}
+	right := &parser.Schema{Type: "string", Description: "two"}
+
+	result := CompareSchemasWithOptions(left, right, CompareOptions{Mode: EquivalenceModeDeep})
+	assert.False(t, result.Equivalent, "empty Docs should default to include (strict)")
 }
 
 func TestCompareSchemas_CircularReferences(t *testing.T) {

--- a/joiner/joiner.go
+++ b/joiner/joiner.go
@@ -90,6 +90,12 @@ type JoinerConfig struct {
 	AlwaysApplyPrefix bool
 	// EquivalenceMode controls depth of schema comparison: "none", "shallow", or "deep"
 	EquivalenceMode string
+	// EquivalenceDocs controls whether documentation metadata (title, description,
+	// example, examples) participates in schema equivalence.
+	// Valid values: "include" (default, strict), "ignore" (legacy loose behavior).
+	// When "include", semantic deduplication refuses to consolidate schemas that
+	// differ only in their prose, preserving reference-site documentation.
+	EquivalenceDocs string
 	// CollisionReport enables detailed collision analysis reporting
 	CollisionReport bool
 	// SemanticDeduplication enables cross-document schema deduplication after merging.
@@ -122,6 +128,7 @@ func DefaultConfig() JoinerConfig {
 		NamespacePrefix:   make(map[string]string),
 		AlwaysApplyPrefix: false,
 		EquivalenceMode:   "none",
+		EquivalenceDocs:   string(EquivalenceDocsInclude),
 		CollisionReport:   false,
 	}
 }
@@ -147,6 +154,17 @@ func New(config JoinerConfig) *Joiner {
 	return &Joiner{
 		config: config,
 	}
+}
+
+// buildCompareOptions builds a CompareOptions for schema equivalence using
+// the joiner's configured EquivalenceDocs setting. Invalid or empty values
+// fall back to EquivalenceDocsInclude (strict).
+func (j *Joiner) buildCompareOptions(mode EquivalenceMode) CompareOptions {
+	docs := EquivalenceDocs(j.config.EquivalenceDocs)
+	if !IsValidEquivalenceDocs(string(docs)) {
+		docs = EquivalenceDocsInclude
+	}
+	return CompareOptions{Mode: mode, Docs: docs}
 }
 
 // JoinResult contains the joined OpenAPI specification and metadata

--- a/joiner/joiner_dedupe_test.go
+++ b/joiner/joiner_dedupe_test.go
@@ -588,8 +588,92 @@ func TestJoiner_WithSemanticDeduplication_Option(t *testing.T) {
 	assert.Len(t, oas3Doc.Components.Schemas, 1, "Expected 1 schema after dedup")
 }
 
-func TestJoiner_SemanticDeduplication_MetadataIgnored(t *testing.T) {
-	// Create two documents with schemas that differ only in metadata
+func TestJoiner_SemanticDeduplication_MetadataPreservedByDefault(t *testing.T) {
+	// Regression test for issue #363: schemas that differ only in metadata
+	// (title, description) MUST NOT be consolidated under the strict default.
+	// Losing per-schema docs when references get rewritten produces misleading
+	// API documentation (a 403 response pointing at a schema whose description
+	// applies to the 400 case, for example).
+	doc1, doc2 := buildMetadataOnlyDifferenceFixtures()
+
+	results := []parser.ParseResult{
+		{
+			Document:     doc1,
+			Version:      "3.0.3",
+			OASVersion:   parser.OASVersion303,
+			SourcePath:   "api1.yaml",
+			SourceFormat: "yaml",
+		},
+		{
+			Document:     doc2,
+			Version:      "3.0.3",
+			OASVersion:   parser.OASVersion303,
+			SourcePath:   "api2.yaml",
+			SourceFormat: "yaml",
+		},
+	}
+
+	// Default config -> EquivalenceDocs is "include", schemas must survive.
+	config := DefaultConfig()
+	config.SemanticDeduplication = true
+	j := New(config)
+
+	joinResult, err := j.JoinParsed(results)
+	require.NoError(t, err)
+
+	oas3Doc, ok := joinResult.Document.(*parser.OAS3Document)
+	require.True(t, ok, "Expected OAS3Document")
+
+	// Both schemas are kept because their documentation differs.
+	assert.Len(t, oas3Doc.Components.Schemas, 2,
+		"expected both schemas to survive strict equivalence (docs differ)")
+	_, hasAddress := oas3Doc.Components.Schemas["Address"]
+	_, hasLocation := oas3Doc.Components.Schemas["Location"]
+	assert.True(t, hasAddress, "Address schema should be preserved")
+	assert.True(t, hasLocation, "Location schema should be preserved")
+}
+
+func TestJoiner_SemanticDeduplication_MetadataIgnored_Loose(t *testing.T) {
+	// Opt-in loose mode: when callers explicitly request EquivalenceDocs=ignore,
+	// schemas that differ only in metadata ARE consolidated (legacy behavior).
+	doc1, doc2 := buildMetadataOnlyDifferenceFixtures()
+
+	results := []parser.ParseResult{
+		{
+			Document:     doc1,
+			Version:      "3.0.3",
+			OASVersion:   parser.OASVersion303,
+			SourcePath:   "api1.yaml",
+			SourceFormat: "yaml",
+		},
+		{
+			Document:     doc2,
+			Version:      "3.0.3",
+			OASVersion:   parser.OASVersion303,
+			SourcePath:   "api2.yaml",
+			SourceFormat: "yaml",
+		},
+	}
+
+	config := DefaultConfig()
+	config.SemanticDeduplication = true
+	config.EquivalenceDocs = string(EquivalenceDocsIgnore)
+	j := New(config)
+
+	joinResult, err := j.JoinParsed(results)
+	require.NoError(t, err)
+
+	oas3Doc, ok := joinResult.Document.(*parser.OAS3Document)
+	require.True(t, ok, "Expected OAS3Document")
+
+	assert.Len(t, oas3Doc.Components.Schemas, 1,
+		"expected 1 schema after loose equivalence deduplication")
+}
+
+// buildMetadataOnlyDifferenceFixtures returns two OAS3 documents each
+// containing a single structurally identical schema whose docs (title,
+// description) differ. Used by TestJoiner_SemanticDeduplication_*.
+func buildMetadataOnlyDifferenceFixtures() (*parser.OAS3Document, *parser.OAS3Document) {
 	doc1 := &parser.OAS3Document{
 		OpenAPI: "3.0.3",
 		Info:    &parser.Info{Title: "API 1", Version: "1.0.0"},
@@ -627,22 +711,51 @@ func TestJoiner_SemanticDeduplication_MetadataIgnored(t *testing.T) {
 		},
 		OASVersion: parser.OASVersion303,
 	}
+	return doc1, doc2
+}
+
+func TestJoiner_SemanticDeduplication_Issue363_ErrorResponses(t *testing.T) {
+	// Canonical reproduction from issue #363. Three error schemas with
+	// identical structure but distinct, response-specific descriptions.
+	// Under the strict default, all three must survive so that a 403's
+	// description doesn't end up claiming "The request is invalid".
+	makeErrorSchema := func(description string) *parser.Schema {
+		return &parser.Schema{
+			Type:        "object",
+			Description: description,
+			Required:    []string{"code", "message"},
+			Properties: map[string]*parser.Schema{
+				"code":    {Type: "string"},
+				"message": {Type: "string"},
+			},
+		}
+	}
+
+	doc1 := &parser.OAS3Document{
+		OpenAPI: "3.0.3",
+		Info:    &parser.Info{Title: "Errors API", Version: "1.0.0"},
+		Paths:   make(parser.Paths),
+		Components: &parser.Components{
+			Schemas: map[string]*parser.Schema{
+				"BadRequest": makeErrorSchema("The request is invalid."),
+				"Forbidden":  makeErrorSchema("The caller lacks permission to perform this action."),
+				"NotFound":   makeErrorSchema("The requested resource could not be located."),
+			},
+		},
+		OASVersion: parser.OASVersion303,
+	}
+
+	doc2 := &parser.OAS3Document{
+		OpenAPI:    "3.0.3",
+		Info:       &parser.Info{Title: "Other API", Version: "1.0.0"},
+		Paths:      make(parser.Paths),
+		Components: &parser.Components{Schemas: map[string]*parser.Schema{}},
+		OASVersion: parser.OASVersion303,
+	}
 
 	results := []parser.ParseResult{
-		{
-			Document:     doc1,
-			Version:      "3.0.3",
-			OASVersion:   parser.OASVersion303,
-			SourcePath:   "api1.yaml",
-			SourceFormat: "yaml",
-		},
-		{
-			Document:     doc2,
-			Version:      "3.0.3",
-			OASVersion:   parser.OASVersion303,
-			SourcePath:   "api2.yaml",
-			SourceFormat: "yaml",
-		},
+		{Document: doc1, Version: "3.0.3", OASVersion: parser.OASVersion303, SourcePath: "errors.yaml", SourceFormat: "yaml"},
+		{Document: doc2, Version: "3.0.3", OASVersion: parser.OASVersion303, SourcePath: "other.yaml", SourceFormat: "yaml"},
 	}
 
 	config := DefaultConfig()
@@ -651,12 +764,16 @@ func TestJoiner_SemanticDeduplication_MetadataIgnored(t *testing.T) {
 
 	joinResult, err := j.JoinParsed(results)
 	require.NoError(t, err)
-
 	oas3Doc, ok := joinResult.Document.(*parser.OAS3Document)
-	require.True(t, ok, "Expected OAS3Document")
+	require.True(t, ok)
 
-	// Should deduplicate since structural properties are the same
-	assert.Len(t, oas3Doc.Components.Schemas, 1, "Expected 1 schema (metadata ignored)")
+	assert.Len(t, oas3Doc.Components.Schemas, 3,
+		"each error response schema should survive: descriptions are response-specific")
+
+	// Verify docs are preserved untouched.
+	assert.Equal(t, "The request is invalid.", oas3Doc.Components.Schemas["BadRequest"].Description)
+	assert.Equal(t, "The caller lacks permission to perform this action.", oas3Doc.Components.Schemas["Forbidden"].Description)
+	assert.Equal(t, "The requested resource could not be located.", oas3Doc.Components.Schemas["NotFound"].Description)
 }
 
 func TestJoiner_SemanticDeduplication_EmptySchemasPreserved(t *testing.T) {

--- a/joiner/joiner_options.go
+++ b/joiner/joiner_options.go
@@ -30,6 +30,7 @@ type joinConfig struct {
 	namespacePrefix        map[string]string
 	alwaysApplyPrefix      *bool
 	equivalenceMode        *string
+	equivalenceDocs        *string
 	collisionReport        *bool
 	semanticDeduplication  *bool
 	operationContext       *bool
@@ -89,6 +90,7 @@ func JoinWithOptions(opts ...Option) (*JoinResult, error) {
 		NamespacePrefix:       mapValueOrDefault(cfg.namespacePrefix, defaults.NamespacePrefix),
 		AlwaysApplyPrefix:     boolValueOrDefault(cfg.alwaysApplyPrefix, defaults.AlwaysApplyPrefix),
 		EquivalenceMode:       stringValueOrDefault(cfg.equivalenceMode, defaults.EquivalenceMode),
+		EquivalenceDocs:       stringValueOrDefault(cfg.equivalenceDocs, defaults.EquivalenceDocs),
 		CollisionReport:       boolValueOrDefault(cfg.collisionReport, defaults.CollisionReport),
 		SemanticDeduplication: boolValueOrDefault(cfg.semanticDeduplication, defaults.SemanticDeduplication),
 	}
@@ -375,6 +377,7 @@ func WithConfig(config JoinerConfig) Option {
 		cfg.namespacePrefix = config.NamespacePrefix
 		cfg.alwaysApplyPrefix = &config.AlwaysApplyPrefix
 		cfg.equivalenceMode = &config.EquivalenceMode
+		cfg.equivalenceDocs = &config.EquivalenceDocs
 		cfg.collisionReport = &config.CollisionReport
 		cfg.semanticDeduplication = &config.SemanticDeduplication
 		cfg.operationContext = &config.OperationContext
@@ -475,6 +478,28 @@ func WithEquivalenceMode(mode string) Option {
 			return fmt.Errorf("invalid equivalence mode %q: valid values are none, shallow, deep", mode)
 		}
 		cfg.equivalenceMode = &mode
+		return nil
+	}
+}
+
+// WithEquivalenceDocs controls whether documentation metadata (title,
+// description, example, examples) participates in schema equivalence.
+// Valid values: "include" (default, strict), "ignore" (legacy loose).
+//
+// When "include" (strict), semantic deduplication refuses to merge schemas
+// that differ only in their prose. This preserves reference-site
+// documentation accuracy: a schema referenced from a 403 response won't be
+// consolidated with a schema whose description applies to 400 errors.
+//
+// When "ignore" (loose), documentation differences are treated as
+// inconsequential for equivalence. Use when you explicitly accept that the
+// surviving canonical schema's docs will replace docs at every $ref site.
+func WithEquivalenceDocs(mode string) Option {
+	return func(cfg *joinConfig) error {
+		if !IsValidEquivalenceDocs(mode) {
+			return fmt.Errorf("invalid equivalence docs %q: valid values are include, ignore", mode)
+		}
+		cfg.equivalenceDocs = &mode
 		return nil
 	}
 }

--- a/joiner/joiner_test.go
+++ b/joiner/joiner_test.go
@@ -984,10 +984,15 @@ func TestJoinOAS3_RenameStrategies(t *testing.T) {
 func TestJoinOAS3_DeduplicateStrategy(t *testing.T) {
 	testdataDir := filepath.Join("..", "testdata")
 
-	t.Run("deduplicate equivalent schemas", func(t *testing.T) {
+	t.Run("deduplicate equivalent schemas with loose docs", func(t *testing.T) {
+		// The Product fixtures differ only in title/description. Under the
+		// strict default these would NOT be consolidated. Opt in to the
+		// legacy loose behavior to verify dedup still works when callers
+		// explicitly accept that documentation will be discarded.
 		config := DefaultConfig()
 		config.SchemaStrategy = StrategyDeduplicateEquivalent
 		config.EquivalenceMode = "deep"
+		config.EquivalenceDocs = string(EquivalenceDocsIgnore)
 
 		j := New(config)
 		result, err := j.Join([]string{
@@ -1007,6 +1012,23 @@ func TestJoinOAS3_DeduplicateStrategy(t *testing.T) {
 
 		// Should have both paths
 		assert.Equal(t, 2, len(doc.Paths))
+	})
+
+	t.Run("deduplicate under strict docs preserves metadata-only differences", func(t *testing.T) {
+		// Same fixtures, strict default. Because the two Product schemas
+		// differ in title/description, dedup must refuse to consolidate.
+		config := DefaultConfig()
+		config.SchemaStrategy = StrategyDeduplicateEquivalent
+		config.EquivalenceMode = "deep"
+
+		j := New(config)
+		_, err := j.Join([]string{
+			filepath.Join(testdataDir, "join-equivalent-schemas-base-3.0.yaml"),
+			filepath.Join(testdataDir, "join-equivalent-schemas-ext-3.0.yaml"),
+		})
+
+		require.Error(t, err, "strict default should fail to dedup schemas with divergent docs")
+		assert.Contains(t, err.Error(), "not equivalent")
 	})
 
 	t.Run("deduplicate fails on non-equivalent schemas", func(t *testing.T) {
@@ -1140,6 +1162,9 @@ func TestJoinWithOptions_NewStrategies(t *testing.T) {
 	})
 
 	t.Run("with equivalence mode option", func(t *testing.T) {
+		// The Product fixtures differ in title/description so this scenario
+		// requires EquivalenceDocs=ignore to consolidate them. Under the
+		// strict default the joiner would refuse to dedup.
 		result, err := JoinWithOptions(
 			WithFilePaths(
 				filepath.Join(testdataDir, "join-equivalent-schemas-base-3.0.yaml"),
@@ -1147,6 +1172,7 @@ func TestJoinWithOptions_NewStrategies(t *testing.T) {
 			),
 			WithSchemaStrategy(StrategyDeduplicateEquivalent),
 			WithEquivalenceMode("deep"),
+			WithEquivalenceDocs(string(EquivalenceDocsIgnore)),
 		)
 
 		require.NoError(t, err)

--- a/joiner/oas2.go
+++ b/joiner/oas2.go
@@ -70,8 +70,9 @@ func (j *Joiner) joinOAS2Documents(docs []parser.ParseResult) (*JoinResult, erro
 
 	// Apply semantic deduplication if enabled
 	if j.config.SemanticDeduplication && len(joined.Definitions) > 1 {
+		compareOpts := j.buildCompareOptions(EquivalenceModeDeep)
 		compare := func(left, right *parser.Schema) bool {
-			res := CompareSchemas(left, right, EquivalenceModeDeep)
+			res := CompareSchemasWithOptions(left, right, compareOpts)
 			return res.Equivalent
 		}
 		config := schemautil.DefaultDeduplicationConfig()
@@ -231,7 +232,7 @@ func (j *Joiner) mergeOAS2Definitions(joined, source *parser.OAS2Document, ctx d
 				}
 
 				if mode != EquivalenceModeNone {
-					eqResult := CompareSchemas(joined.Definitions[effectiveName], schema, mode)
+					eqResult := CompareSchemasWithOptions(joined.Definitions[effectiveName], schema, j.buildCompareOptions(mode))
 					if eqResult.Equivalent {
 						// Schemas are equivalent, keep existing and skip
 						line, col := j.getLocation(ctx.filePath, fmt.Sprintf("$.definitions.%s", effectiveName))

--- a/joiner/oas2.go
+++ b/joiner/oas2.go
@@ -224,10 +224,10 @@ func (j *Joiner) mergeOAS2Definitions(joined, source *parser.OAS2Document, ctx d
 			case StrategyDeduplicateEquivalent:
 				// Use semantic equivalence to determine if schemas are identical
 				mode := EquivalenceModeNone
-				switch j.config.EquivalenceMode {
-				case "shallow":
+				switch EquivalenceMode(j.config.EquivalenceMode) {
+				case EquivalenceModeShallow:
 					mode = EquivalenceModeShallow
-				case "deep":
+				case EquivalenceModeDeep:
 					mode = EquivalenceModeDeep
 				}
 

--- a/joiner/oas3.go
+++ b/joiner/oas3.go
@@ -182,8 +182,9 @@ func (j *Joiner) joinOAS3Documents(docs []parser.ParseResult) (*JoinResult, erro
 
 	// Apply semantic deduplication if enabled
 	if j.config.SemanticDeduplication && len(joined.Components.Schemas) > 1 {
+		compareOpts := j.buildCompareOptions(EquivalenceModeDeep)
 		compare := func(left, right *parser.Schema) bool {
-			res := CompareSchemas(left, right, EquivalenceModeDeep)
+			res := CompareSchemasWithOptions(left, right, compareOpts)
 			return res.Equivalent
 		}
 		config := schemautil.DefaultDeduplicationConfig()
@@ -348,7 +349,7 @@ func (j *Joiner) mergeSchemas(target, source map[string]*parser.Schema, strategy
 				}
 
 				if mode != EquivalenceModeNone {
-					eqResult := CompareSchemas(target[effectiveName], schema, mode)
+					eqResult := CompareSchemasWithOptions(target[effectiveName], schema, j.buildCompareOptions(mode))
 					if eqResult.Equivalent {
 						// Schemas are equivalent, keep existing and skip
 						line, col := j.getLocation(ctx.filePath, fmt.Sprintf("$.components.schemas.%s", effectiveName))

--- a/joiner/oas3.go
+++ b/joiner/oas3.go
@@ -341,10 +341,10 @@ func (j *Joiner) mergeSchemas(target, source map[string]*parser.Schema, strategy
 			case StrategyDeduplicateEquivalent:
 				// Use semantic equivalence to determine if schemas are identical
 				mode := EquivalenceModeNone
-				switch j.config.EquivalenceMode {
-				case "shallow":
+				switch EquivalenceMode(j.config.EquivalenceMode) {
+				case EquivalenceModeShallow:
 					mode = EquivalenceModeShallow
-				case "deep":
+				case EquivalenceModeDeep:
 					mode = EquivalenceModeDeep
 				}
 


### PR DESCRIPTION
## Summary

- Two schemas that differ only in `title`, `description`, `example`, or `examples` are no longer treated as equivalent by the joiner's schema comparison. Previously, semantic dedup replaced the surviving canonical schema's docs at every `$ref` site — producing misleading API docs (a 403 response landing on a schema whose description said "The request is invalid").
- Behavior is now **strict by default**. Callers who need the old loose behavior can opt in via `--equivalence-docs ignore` (CLI) or `WithEquivalenceDocs("ignore")` (Go API).

Fixes #363.

## What changed

- New `EquivalenceDocs` type with values `include` (default, strict) and `ignore` (legacy loose)
- New `CompareSchemasWithOptions` accepting `CompareOptions`; existing `CompareSchemas` delegates with the strict default so most callers get the fix for free
- `compareDocs bool` threaded through `compareShallow` / `compareDeep` and all recursive helpers (properties, items, allOf/anyOf/oneOf/not)
- New `JoinerConfig.EquivalenceDocs` option, `WithEquivalenceDocs` functional option, and `--equivalence-docs` CLI flag
- Builder inherits the new default through its existing `joiner.CompareSchemas` call

## Behavior change note

This is a breaking behavior change for anyone relying on semantic-dedup to collapse metadata-different schemas. The old behavior is still available via the opt-in flag. Documentation updated in `joiner/deep_dive.md` and `docs/cli-reference.md`.

## Test plan

- [x] `TestJoiner_SemanticDeduplication_Issue363_ErrorResponses` — canonical repro from the issue (BadRequest/Forbidden/NotFound all survive with docs preserved)
- [x] Title-only, description-only, example-only, and nested-doc-difference cases
- [x] Opt-in `ignore` mode still collapses metadata-different schemas (legacy behavior preserved)
- [x] Integration `semantic-dedup.yaml` scenario passes
- [x] `make check` passes locally (lint 0 issues, 8576 tests)
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)