### PR TITLE
chore: address new lints

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -67,6 +67,13 @@ linters:
       - path: _test\.go
         linters:
           - goconst
+      # Allow string literals in generated files
+      - path: zz_generated_
+        linters:
+          - goconst
+      - path: internal/codegen/
+        linters:
+          - goconst
 
 issues:
   max-issues-per-linter: 0

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -15,6 +15,14 @@ import (
 	"go.yaml.in/yaml/v4"
 )
 
+const (
+	strBuilder     = "builder"
+	pascal         = "pascal"
+	binary         = "binary"
+	defaultKeyword = "default"
+	minimumKeyword = "minimum"
+)
+
 // Builder is the main entry point for constructing OAS documents.
 // It maintains internal state for accumulated components and reflection cache.
 //
@@ -580,7 +588,7 @@ func (b *Builder) BuildResult() (*parser.ParseResult, error) {
 	}
 
 	return &parser.ParseResult{
-		SourcePath:   "builder",
+		SourcePath:   strBuilder,
 		SourceFormat: parser.SourceFormatYAML,
 		Version:      b.version.String(),
 		OASVersion:   b.version,

--- a/builder/builder_bench_test.go
+++ b/builder/builder_bench_test.go
@@ -149,7 +149,7 @@ func BenchmarkBuilderAddOperation(b *testing.B) {
 				SetVersion("1.0.0").
 				AddOperation(http.MethodPost, "/orders",
 					WithOperationID("createOrder"),
-					WithRequestBody("application/json", BenchmarkOrder{},
+					WithRequestBody(contentTypeJSON, BenchmarkOrder{},
 						WithRequired(true),
 					),
 					WithResponse(http.StatusCreated, BenchmarkOrder{}),
@@ -187,7 +187,7 @@ func BenchmarkBuilderBuild(b *testing.B) {
 			AddOperation(http.MethodPost, "/users",
 				WithOperationID("createUser"),
 				WithTags("users"),
-				WithRequestBody("application/json", BenchmarkUser{},
+				WithRequestBody(contentTypeJSON, BenchmarkUser{},
 					WithRequired(true),
 				),
 				WithResponse(http.StatusCreated, BenchmarkUser{}),

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -278,7 +278,7 @@ func TestBuilder_BuildResult(t *testing.T) {
 
 	result, err := b.BuildResult()
 	require.NoError(t, err)
-	assert.Equal(t, "builder", result.SourcePath)
+	assert.Equal(t, strBuilder, result.SourcePath)
 	assert.Equal(t, parser.SourceFormatYAML, result.SourceFormat)
 	assert.Equal(t, "3.2.0", result.Version)
 	assert.Equal(t, parser.OASVersion320, result.OASVersion)
@@ -507,7 +507,7 @@ func TestBuilder_AddOperation_WithRequestBody(t *testing.T) {
 		SetVersion("1.0.0").
 		AddOperation(http.MethodPost, "/users",
 			WithOperationID("createUser"),
-			WithRequestBody("application/json", CreateUser{},
+			WithRequestBody(contentTypeJSON, CreateUser{},
 				WithRequired(true),
 				WithRequestDescription("User to create"),
 			),
@@ -651,8 +651,8 @@ func TestBuilder_AddResponse(t *testing.T) {
 	assert.Contains(t, doc.Components.Responses, "Error")
 	resp := doc.Components.Responses["Error"]
 	assert.Equal(t, "Error response", resp.Description)
-	require.Contains(t, resp.Content, "application/json")
-	require.NotNil(t, resp.Content["application/json"].Schema)
+	require.Contains(t, resp.Content, contentTypeJSON)
+	require.NotNil(t, resp.Content[contentTypeJSON].Schema)
 }
 
 func TestBuilder_AddResponse_WithContentType(t *testing.T) {
@@ -1084,7 +1084,7 @@ func TestBuilder_AddWebhook(t *testing.T) {
 			SetVersion("1.0.0").
 			AddWebhook("newUser", http.MethodPost,
 				WithOperationID("userCreatedWebhook"),
-				WithRequestBody("application/json", WebhookPayload{}),
+				WithRequestBody(contentTypeJSON, WebhookPayload{}),
 				WithResponse(http.StatusOK, struct{}{}),
 			)
 
@@ -1247,7 +1247,7 @@ func TestBuilder_FileUpload_OAS3_Integration(t *testing.T) {
 	require.Contains(t, schema.Properties, "file")
 	fileSchema := schema.Properties["file"]
 	assert.Equal(t, "string", fileSchema.Type)
-	assert.Equal(t, "binary", fileSchema.Format)
+	assert.Equal(t, binary, fileSchema.Format)
 	assert.Equal(t, "File to upload", fileSchema.Description)
 
 	// Verify description property
@@ -1263,7 +1263,7 @@ func TestBuilder_FileUpload_OAS3_Integration(t *testing.T) {
 func TestBuilder_RawSchema_BinaryDownload_Integration(t *testing.T) {
 	schema := &parser.Schema{
 		Type:   "string",
-		Format: "binary",
+		Format: binary,
 	}
 
 	b := New(parser.OASVersion320).
@@ -1299,7 +1299,7 @@ func TestBuilder_RawSchema_BinaryDownload_Integration(t *testing.T) {
 	mediaType := resp.Content["application/octet-stream"]
 	require.NotNil(t, mediaType.Schema)
 	assert.Equal(t, "string", mediaType.Schema.Type)
-	assert.Equal(t, "binary", mediaType.Schema.Format)
+	assert.Equal(t, binary, mediaType.Schema.Format)
 
 	// Verify header
 	require.Contains(t, resp.Headers, "Content-Disposition")
@@ -1313,7 +1313,7 @@ func TestBuilder_RawSchema_ComplexUpload_Integration(t *testing.T) {
 		Properties: map[string]*parser.Schema{
 			"file": {
 				Type:        "string",
-				Format:      "binary",
+				Format:      binary,
 				Description: "The file data",
 			},
 			"metadata": {
@@ -1365,7 +1365,7 @@ func TestBuilder_RawSchema_ComplexUpload_Integration(t *testing.T) {
 	require.Contains(t, reqSchema.Properties, "file")
 	fileSchema := reqSchema.Properties["file"]
 	assert.Equal(t, "string", fileSchema.Type)
-	assert.Equal(t, "binary", fileSchema.Format)
+	assert.Equal(t, binary, fileSchema.Format)
 
 	// Verify metadata property
 	require.Contains(t, reqSchema.Properties, "metadata")

--- a/builder/errors.go
+++ b/builder/errors.go
@@ -71,7 +71,7 @@ type BuilderError struct {
 // Error implements the error interface with a detailed, formatted message.
 func (e *BuilderError) Error() string {
 	var sb strings.Builder
-	sb.WriteString("builder")
+	sb.WriteString(strBuilder)
 
 	// Add component context
 	if e.Component != "" {

--- a/builder/errors_test.go
+++ b/builder/errors_test.go
@@ -19,43 +19,43 @@ func TestBuilderError_Error(t *testing.T) {
 			name: "duplicate operationID with first occurrence",
 			err: NewDuplicateOperationIDError("getUser", "POST", "/users/{id}",
 				&operationLocation{Method: "GET", Path: "/users/{id}"}),
-			contains: []string{"builder", "operation", "POST /users/{id}", "duplicate", "getUser", "GET /users/{id}"},
+			contains: []string{strBuilder, "operation", "POST /users/{id}", "duplicate", "getUser", "GET /users/{id}"},
 		},
 		{
 			name:     "duplicate operationID without first occurrence",
 			err:      NewDuplicateOperationIDError("getUser", "POST", "/users/{id}", nil),
-			contains: []string{"builder", "operation", "POST /users/{id}", "duplicate", "getUser"},
+			contains: []string{strBuilder, "operation", "POST /users/{id}", "duplicate", "getUser"},
 		},
 		{
 			name:     "unsupported method TRACE",
 			err:      NewUnsupportedMethodError("TRACE", "/debug", "3.0.0"),
-			contains: []string{"builder", "operation", "TRACE", "/debug", "3.0.0"},
+			contains: []string{strBuilder, "operation", "TRACE", "/debug", "3.0.0"},
 		},
 		{
 			name:     "unsupported method QUERY",
 			err:      NewUnsupportedMethodError("QUERY", "/search", "3.2.0"),
-			contains: []string{"builder", "operation", "QUERY", "/search", "3.2.0"},
+			contains: []string{strBuilder, "operation", "QUERY", "/search", "3.2.0"},
 		},
 		{
 			name:     "invalid method",
 			err:      NewInvalidMethodError("INVALID", "/path"),
-			contains: []string{"builder", "operation", "INVALID", "/path", "unsupported"},
+			contains: []string{strBuilder, "operation", "INVALID", "/path", "unsupported"},
 		},
 		{
 			name: "webhook duplicate operationID",
 			err: NewDuplicateWebhookOperationIDError("createUser", "myWebhook", "POST",
 				&operationLocation{Method: "POST", Path: "/users", IsWebhook: false}),
-			contains: []string{"builder", "webhook", "myWebhook", "duplicate", "createUser", "POST /users"},
+			contains: []string{strBuilder, "webhook", "myWebhook", "duplicate", "createUser", "POST /users"},
 		},
 		{
 			name:     "schema error with cause",
 			err:      NewSchemaError("UserSchema", "deduplication failed", errors.New("hash collision")),
-			contains: []string{"builder", "schema", "UserSchema", "deduplication failed", "hash collision"},
+			contains: []string{strBuilder, "schema", "UserSchema", "deduplication failed", "hash collision"},
 		},
 		{
 			name:     "parameter constraint error",
 			err:      NewParameterConstraintError("age", "POST /users", "minimum", "minimum (100) cannot exceed maximum (1)"),
-			contains: []string{"builder", "parameter", "POST /users", "age", "minimum"},
+			contains: []string{strBuilder, "parameter", "POST /users", "age", "minimum"},
 		},
 	}
 

--- a/builder/example_test.go
+++ b/builder/example_test.go
@@ -14,6 +14,11 @@ import (
 	"github.com/erraggy/oastools/parser"
 )
 
+const (
+	contentTypeJSON = "application/json"
+	binary          = "binary"
+)
+
 // Pet represents a pet in the store.
 type Pet struct {
 	ID        int64     `json:"id" oas:"description=Unique pet identifier"`
@@ -90,7 +95,7 @@ func Example_withRequestBody() {
 		SetVersion("1.0.0").
 		AddOperation(http.MethodPost, "/pets",
 			builder.WithOperationID("createPet"),
-			builder.WithRequestBody("application/json", CreatePetRequest{},
+			builder.WithRequestBody(contentTypeJSON, CreatePetRequest{},
 				builder.WithRequired(true),
 				builder.WithRequestDescription("Pet to create"),
 			),
@@ -525,7 +530,7 @@ func Example_withRawSchema() {
 	// Binary file download response
 	binarySchema := &parser.Schema{
 		Type:   "string",
-		Format: "binary",
+		Format: binary,
 	}
 
 	spec.AddOperation(http.MethodGet, "/download/{id}",
@@ -572,7 +577,7 @@ func Example_withComplexRawSchema() {
 		Properties: map[string]*parser.Schema{
 			"file": {
 				Type:        "string",
-				Format:      "binary",
+				Format:      binary,
 				Description: "The file data",
 			},
 			"metadata": {
@@ -866,7 +871,7 @@ func Example_serverBuilderCRUD() {
 
 	srv.AddOperation(http.MethodPost, "/pets",
 		builder.WithOperationID("createPet"),
-		builder.WithRequestBody("application/json", Pet{}),
+		builder.WithRequestBody(contentTypeJSON, Pet{}),
 		builder.WithResponse(http.StatusCreated, Pet{}),
 	)
 
@@ -1116,7 +1121,7 @@ func Example_serverBuilderWithValidation() {
 
 	srv.AddOperation(http.MethodPost, "/pets",
 		builder.WithOperationID("createPet"),
-		builder.WithRequestBody("application/json", Pet{}),
+		builder.WithRequestBody(contentTypeJSON, Pet{}),
 		builder.WithResponse(http.StatusCreated, Pet{}),
 	)
 

--- a/builder/integration_oas2_test.go
+++ b/builder/integration_oas2_test.go
@@ -32,7 +32,7 @@ func TestOAS2Integration_RequestBodyAndResponse(t *testing.T) {
 		AddOperation("POST", "/users",
 			WithOperationID("createUser"),
 			WithSummary("Create a new user"),
-			WithRequestBody("application/json", CreateUserRequest{},
+			WithRequestBody(contentTypeJSON, CreateUserRequest{},
 				WithRequired(true),
 				WithRequestDescription("User creation data"),
 			),
@@ -140,12 +140,12 @@ func TestOAS2Integration_RequestBodyAndResponse(t *testing.T) {
 func TestOAS2Integration_RawSchema(t *testing.T) {
 	uploadSchema := &parser.Schema{
 		Type:   "string",
-		Format: "binary",
+		Format: binary,
 	}
 
 	downloadSchema := &parser.Schema{
 		Type:   "string",
-		Format: "binary",
+		Format: binary,
 	}
 
 	b := New(parser.OASVersion20).
@@ -177,7 +177,7 @@ func TestOAS2Integration_RawSchema(t *testing.T) {
 	assert.Equal(t, "Binary file data", uploadOp.Parameters[0].Description)
 	require.NotNil(t, uploadOp.Parameters[0].Schema)
 	assert.Equal(t, "string", uploadOp.Parameters[0].Schema.Type)
-	assert.Equal(t, "binary", uploadOp.Parameters[0].Schema.Format)
+	assert.Equal(t, binary, uploadOp.Parameters[0].Schema.Format)
 
 	// Verify download operation
 	downloadOp := doc.Paths["/download"].Get
@@ -186,7 +186,7 @@ func TestOAS2Integration_RawSchema(t *testing.T) {
 	assert.Nil(t, downloadResp.Content)
 	require.NotNil(t, downloadResp.Schema)
 	assert.Equal(t, "string", downloadResp.Schema.Type)
-	assert.Equal(t, "binary", downloadResp.Schema.Format)
+	assert.Equal(t, binary, downloadResp.Schema.Format)
 }
 
 // TestOAS2ServerBuilder_EndToEnd verifies the complete OAS 2.0 server builder flow
@@ -263,7 +263,7 @@ func TestOAS2ServerBuilder_EndToEnd(t *testing.T) {
 	// Create pet operation
 	srv.AddOperation(http.MethodPost, "/pets",
 		WithOperationID("createPet"),
-		WithRequestBody("application/json", Pet{}),
+		WithRequestBody(contentTypeJSON, Pet{}),
 		WithResponse(http.StatusCreated, Pet{}),
 	)
 	srv.Handle(http.MethodPost, "/pets", func(_ context.Context, req *Request) Response {
@@ -297,7 +297,7 @@ func TestOAS2ServerBuilder_EndToEnd(t *testing.T) {
 		result.Handler.ServeHTTP(rec, req)
 
 		assert.Equal(t, http.StatusOK, rec.Code)
-		assert.Contains(t, rec.Header().Get("Content-Type"), "application/json")
+		assert.Contains(t, rec.Header().Get("Content-Type"), contentTypeJSON)
 
 		var petsList []Pet
 		err := json.NewDecoder(rec.Body).Decode(&petsList)

--- a/builder/naming.go
+++ b/builder/naming.go
@@ -523,7 +523,7 @@ func templateFuncs() template.FuncMap {
 	titleCaser := cases.Title(language.English)
 
 	return template.FuncMap{
-		"pascal":     toPascalCase,
+		pascal:       toPascalCase,
 		"camel":      toCamelCase,
 		"snake":      toSnakeCase,
 		"kebab":      toKebabCase,

--- a/builder/naming_bench_test.go
+++ b/builder/naming_bench_test.go
@@ -38,7 +38,7 @@ func BenchmarkSchemaNaming(b *testing.B) {
 		strategy SchemaNamingStrategy
 	}{
 		{"default", SchemaNamingDefault},
-		{"pascal", SchemaNamingPascalCase},
+		{pascal, SchemaNamingPascalCase},
 		{"camel", SchemaNamingCamelCase},
 		{"snake", SchemaNamingSnakeCase},
 		{"kebab", SchemaNamingKebabCase},
@@ -100,7 +100,7 @@ func BenchmarkSchemaNameTemplate(b *testing.B) {
 		tmpl string
 	}{
 		{"simple", `{{.Type}}`},
-		{"pascal", `{{pascal .Package}}{{pascal .Type}}`},
+		{pascal, `{{pascal .Package}}{{pascal .Type}}`},
 		{"complex", `{{if .IsGeneric}}Generic_{{end}}{{snake .Package}}_{{pascal .Type}}`},
 		{"generic_aware", `{{.TypeBase}}{{if .IsGeneric}}Of{{range .GenericParamsSanitized}}{{pascal .}}{{end}}{{end}}`},
 	}
@@ -577,7 +577,7 @@ func BenchmarkTemplateParsing(b *testing.B) {
 		tmpl string
 	}{
 		{"simple", `{{.Type}}`},
-		{"pascal", `{{pascal .Package}}{{pascal .Type}}`},
+		{pascal, `{{pascal .Package}}{{pascal .Type}}`},
 		{"complex", `{{if .IsGeneric}}Generic_{{end}}{{snake .Package}}_{{pascal .Type}}`},
 		{"full", `{{.TypeBase}}{{if .IsGeneric}}Of{{range .GenericParamsSanitized}}{{pascal .}}{{end}}{{end}}`},
 	}

--- a/builder/naming_test.go
+++ b/builder/naming_test.go
@@ -233,7 +233,7 @@ func TestSchemaNamerBuildContext(t *testing.T) {
 		assert.Equal(t, "testUser", ctx.Type)
 		assert.Equal(t, "testUser", ctx.TypeBase)
 		assert.Equal(t, "testUser", ctx.TypeSanitized)
-		assert.Equal(t, "builder", ctx.Package)
+		assert.Equal(t, strBuilder, ctx.Package)
 		assert.False(t, ctx.IsGeneric)
 		assert.False(t, ctx.IsAnonymous)
 		assert.False(t, ctx.IsPointer)
@@ -279,7 +279,7 @@ func TestSchemaNamerStrategies(t *testing.T) {
 		want     string
 	}{
 		{"default", SchemaNamingDefault, "builder.testUser"},
-		{"pascal", SchemaNamingPascalCase, "BuilderTestUser"},
+		{pascal, SchemaNamingPascalCase, "BuilderTestUser"},
 		{"camel", SchemaNamingCamelCase, "builderTestUser"},
 		{"snake", SchemaNamingSnakeCase, "builder_test_user"},
 		{"kebab", SchemaNamingKebabCase, "builder-test-user"},
@@ -531,7 +531,7 @@ func (s SchemaNamingStrategy) String() string {
 	case SchemaNamingDefault:
 		return "default"
 	case SchemaNamingPascalCase:
-		return "pascal"
+		return pascal
 	case SchemaNamingCamelCase:
 		return "camel"
 	case SchemaNamingSnakeCase:
@@ -552,7 +552,7 @@ func TestTemplateFuncs(t *testing.T) {
 	funcs := templateFuncs()
 
 	expectedFuncs := []string{
-		"pascal", "camel", "snake", "kebab",
+		pascal, "camel", "snake", "kebab",
 		"upper", "lower", "title", "sanitize",
 		"trimPrefix", "trimSuffix", "replace", "join",
 	}
@@ -609,7 +609,7 @@ func TestSchemaNamerApplyStrategyFullPath(t *testing.T) {
 	name := namer.name(reflect.TypeOf(testUser{}))
 
 	// Should include full package path
-	assert.Contains(t, name, "builder")
+	assert.Contains(t, name, strBuilder)
 	assert.Contains(t, name, "testUser")
 }
 

--- a/builder/operation.go
+++ b/builder/operation.go
@@ -370,7 +370,7 @@ func WithResponse(statusCode int, responseType any, opts ...ResponseOption) Oper
 	return func(cfg *operationConfig) {
 		rCfg := &responseConfig{
 			description: fmt.Sprintf("%d response", statusCode),
-			contentType: "application/json", // Default content type
+			contentType: contentTypeJSON, // Default content type
 		}
 		for _, opt := range opts {
 			opt(rCfg)
@@ -452,13 +452,13 @@ func WithDefaultResponse(responseType any, opts ...ResponseOption) OperationOpti
 	return func(cfg *operationConfig) {
 		rCfg := &responseConfig{
 			description: "Default response",
-			contentType: "application/json", // Default content type
+			contentType: contentTypeJSON, // Default content type
 		}
 		for _, opt := range opts {
 			opt(rCfg)
 		}
 
-		cfg.responses["default"] = &responseBuilder{
+		cfg.responses[defaultKeyword] = &responseBuilder{
 			response: &parser.Response{
 				Description: rCfg.description,
 				Headers:     rCfg.headers,
@@ -955,7 +955,7 @@ func (b *Builder) buildFormParamSchema(formParams []*formParamBuilder) *parser.S
 			// For OAS 3.x, file uploads use type="string" with format="binary"
 			propSchema = &parser.Schema{
 				Type:   "string",
-				Format: "binary",
+				Format: binary,
 			}
 		} else {
 			// Generate schema from type

--- a/builder/operation_test.go
+++ b/builder/operation_test.go
@@ -135,7 +135,7 @@ func TestWithRequestBody(t *testing.T) {
 		SetTitle("Test").
 		SetVersion("1.0.0").
 		AddOperation(http.MethodPost, "/test",
-			WithRequestBody("application/json", Body{},
+			WithRequestBody(contentTypeJSON, Body{},
 				WithRequired(true),
 				WithRequestDescription("Test body"),
 			),
@@ -146,8 +146,8 @@ func TestWithRequestBody(t *testing.T) {
 	rb := b.paths["/test"].Post.RequestBody
 	assert.True(t, rb.Required)
 	assert.Equal(t, "Test body", rb.Description)
-	require.Contains(t, rb.Content, "application/json")
-	require.NotNil(t, rb.Content["application/json"].Schema)
+	require.Contains(t, rb.Content, contentTypeJSON)
+	require.NotNil(t, rb.Content[contentTypeJSON].Schema)
 }
 
 func TestWithResponse(t *testing.T) {
@@ -168,7 +168,7 @@ func TestWithResponse(t *testing.T) {
 	require.Contains(t, b.paths["/test"].Get.Responses.Codes, "200")
 	resp := b.paths["/test"].Get.Responses.Codes["200"]
 	assert.Equal(t, "Success response", resp.Description)
-	require.Contains(t, resp.Content, "application/json")
+	require.Contains(t, resp.Content, contentTypeJSON)
 }
 
 func TestWithResponseRef(t *testing.T) {
@@ -224,7 +224,7 @@ func TestWithResponseRawSchema_OAS20(t *testing.T) {
 	// Test that OAS 2.0 converts response content to direct schema with raw schema
 	schema := &parser.Schema{
 		Type:   "string",
-		Format: "binary",
+		Format: binary,
 	}
 
 	b := New(parser.OASVersion20).
@@ -247,7 +247,7 @@ func TestWithResponseRawSchema_OAS20(t *testing.T) {
 	// OAS 2.0 should have direct Schema field
 	require.NotNil(t, resp.Schema)
 	assert.Equal(t, "string", resp.Schema.Type)
-	assert.Equal(t, "binary", resp.Schema.Format)
+	assert.Equal(t, binary, resp.Schema.Format)
 }
 
 func TestWithDefaultResponse(t *testing.T) {
@@ -471,7 +471,7 @@ func TestBuilder_AddOperation_MultipleOnSamePath(t *testing.T) {
 func TestWithRequestBodyRawSchema(t *testing.T) {
 	schema := &parser.Schema{
 		Type:   "string",
-		Format: "binary",
+		Format: binary,
 	}
 
 	b := New(parser.OASVersion320).
@@ -492,13 +492,13 @@ func TestWithRequestBodyRawSchema(t *testing.T) {
 	require.Contains(t, rb.Content, "application/octet-stream")
 	require.NotNil(t, rb.Content["application/octet-stream"].Schema)
 	assert.Equal(t, "string", rb.Content["application/octet-stream"].Schema.Type)
-	assert.Equal(t, "binary", rb.Content["application/octet-stream"].Schema.Format)
+	assert.Equal(t, binary, rb.Content["application/octet-stream"].Schema.Format)
 }
 
 func TestWithResponseRawSchema(t *testing.T) {
 	schema := &parser.Schema{
 		Type:   "string",
-		Format: "binary",
+		Format: binary,
 	}
 
 	b := New(parser.OASVersion320).
@@ -517,7 +517,7 @@ func TestWithResponseRawSchema(t *testing.T) {
 	require.Contains(t, resp.Content, "application/octet-stream")
 	require.NotNil(t, resp.Content["application/octet-stream"].Schema)
 	assert.Equal(t, "string", resp.Content["application/octet-stream"].Schema.Type)
-	assert.Equal(t, "binary", resp.Content["application/octet-stream"].Schema.Format)
+	assert.Equal(t, binary, resp.Content["application/octet-stream"].Schema.Format)
 }
 
 func TestWithFileParam_OAS20(t *testing.T) {
@@ -562,7 +562,7 @@ func TestWithFileParam_OAS3(t *testing.T) {
 	require.Contains(t, schema.Properties, "file")
 	fileSchema := schema.Properties["file"]
 	assert.Equal(t, "string", fileSchema.Type)
-	assert.Equal(t, "binary", fileSchema.Format)
+	assert.Equal(t, binary, fileSchema.Format)
 	assert.Equal(t, "File to upload", fileSchema.Description)
 	require.Contains(t, schema.Required, "file")
 }
@@ -637,7 +637,7 @@ func TestWithRequestBodyRawSchema_WithExample(t *testing.T) {
 		SetTitle("Test").
 		SetVersion("1.0.0").
 		AddOperation(http.MethodPost, "/test",
-			WithRequestBodyRawSchema("application/json", schema,
+			WithRequestBodyRawSchema(contentTypeJSON, schema,
 				WithRequestExample(example),
 			),
 			WithResponse(http.StatusOK, struct{}{}),
@@ -645,15 +645,15 @@ func TestWithRequestBodyRawSchema_WithExample(t *testing.T) {
 
 	rb := b.paths["/test"].Post.RequestBody
 	require.NotNil(t, rb)
-	require.Contains(t, rb.Content, "application/json")
-	assert.Equal(t, example, rb.Content["application/json"].Example)
+	require.Contains(t, rb.Content, contentTypeJSON)
+	assert.Equal(t, example, rb.Content[contentTypeJSON].Example)
 }
 
 func TestWithRequestBodyRawSchema_OAS20(t *testing.T) {
 	// Test that OAS 2.0 converts requestBody to body parameter
 	schema := &parser.Schema{
 		Type:   "string",
-		Format: "binary",
+		Format: binary,
 	}
 
 	b := New(parser.OASVersion20).
@@ -679,7 +679,7 @@ func TestWithRequestBodyRawSchema_OAS20(t *testing.T) {
 	assert.True(t, params[0].Required)
 	require.NotNil(t, params[0].Schema)
 	assert.Equal(t, "string", params[0].Schema.Type)
-	assert.Equal(t, "binary", params[0].Schema.Format)
+	assert.Equal(t, binary, params[0].Schema.Format)
 }
 
 func TestWithRequestBody_OAS20(t *testing.T) {
@@ -693,7 +693,7 @@ func TestWithRequestBody_OAS20(t *testing.T) {
 		SetTitle("Test").
 		SetVersion("1.0.0").
 		AddOperation(http.MethodPost, "/users",
-			WithRequestBody("application/json", RequestBody{},
+			WithRequestBody(contentTypeJSON, RequestBody{},
 				WithRequired(true),
 				WithRequestDescription("User data"),
 			),
@@ -726,7 +726,7 @@ func TestWithRequestBody_OAS20(t *testing.T) {
 func TestWithResponseRawSchema_WithHeaders(t *testing.T) {
 	schema := &parser.Schema{
 		Type:   "string",
-		Format: "binary",
+		Format: binary,
 	}
 	header := &parser.Header{
 		Description: "Content disposition",
@@ -805,7 +805,7 @@ func TestWithFileParam_IgnoresConstraints_OAS3(t *testing.T) {
 
 	fileSchema := schema.Properties["file"]
 	assert.Equal(t, "string", fileSchema.Type)
-	assert.Equal(t, "binary", fileSchema.Format)
+	assert.Equal(t, binary, fileSchema.Format)
 	assert.Equal(t, "File to upload", fileSchema.Description)
 
 	// Verify constraints are not applied to file schema
@@ -835,21 +835,21 @@ func TestWithFileParam_EmptyName(t *testing.T) {
 	require.Contains(t, schema.Properties, "")
 	fileSchema := schema.Properties[""]
 	assert.Equal(t, "string", fileSchema.Type)
-	assert.Equal(t, "binary", fileSchema.Format)
+	assert.Equal(t, binary, fileSchema.Format)
 }
 
 // Tests for WithConsumes and WithProduces
 
 func TestWithConsumes(t *testing.T) {
 	cfg := &operationConfig{}
-	WithConsumes("application/json", "application/xml")(cfg)
-	assert.Equal(t, []string{"application/json", "application/xml"}, cfg.consumes)
+	WithConsumes(contentTypeJSON, "application/xml")(cfg)
+	assert.Equal(t, []string{contentTypeJSON, "application/xml"}, cfg.consumes)
 }
 
 func TestWithProduces(t *testing.T) {
 	cfg := &operationConfig{}
-	WithProduces("application/json", "text/plain")(cfg)
-	assert.Equal(t, []string{"application/json", "text/plain"}, cfg.produces)
+	WithProduces(contentTypeJSON, "text/plain")(cfg)
+	assert.Equal(t, []string{contentTypeJSON, "text/plain"}, cfg.produces)
 }
 
 func TestWithConsumesProduces_OAS2(t *testing.T) {
@@ -861,9 +861,9 @@ func TestWithConsumesProduces_OAS2(t *testing.T) {
 		SetTitle("Test").
 		SetVersion("1.0.0").
 		AddOperation(http.MethodPost, "/users",
-			WithConsumes("application/json", "application/xml"),
-			WithProduces("application/json"),
-			WithRequestBody("application/json", User{}),
+			WithConsumes(contentTypeJSON, "application/xml"),
+			WithProduces(contentTypeJSON),
+			WithRequestBody(contentTypeJSON, User{}),
 			WithResponse(http.StatusOK, User{}),
 		)
 
@@ -871,8 +871,8 @@ func TestWithConsumesProduces_OAS2(t *testing.T) {
 	require.NoError(t, err)
 
 	op := doc.Paths["/users"].Post
-	assert.Equal(t, []string{"application/json", "application/xml"}, op.Consumes)
-	assert.Equal(t, []string{"application/json"}, op.Produces)
+	assert.Equal(t, []string{contentTypeJSON, "application/xml"}, op.Consumes)
+	assert.Equal(t, []string{contentTypeJSON}, op.Produces)
 }
 
 func TestWithConsumesProduces_IgnoredForOAS3Output(t *testing.T) {
@@ -881,9 +881,9 @@ func TestWithConsumesProduces_IgnoredForOAS3Output(t *testing.T) {
 		SetTitle("Test").
 		SetVersion("1.0.0").
 		AddOperation(http.MethodPost, "/test",
-			WithConsumes("application/json"), // Should be stored but fields are omitempty
-			WithProduces("application/json"), // Should be stored but fields are omitempty
-			WithRequestBody("application/json", struct{}{}),
+			WithConsumes(contentTypeJSON), // Should be stored but fields are omitempty
+			WithProduces(contentTypeJSON), // Should be stored but fields are omitempty
+			WithRequestBody(contentTypeJSON, struct{}{}),
 			WithResponse(http.StatusOK, struct{}{}),
 		)
 
@@ -892,8 +892,8 @@ func TestWithConsumesProduces_IgnoredForOAS3Output(t *testing.T) {
 
 	op := doc.Paths["/test"].Post
 	// Fields are set but will be empty in serialized output due to omitempty
-	assert.Equal(t, []string{"application/json"}, op.Consumes)
-	assert.Equal(t, []string{"application/json"}, op.Produces)
+	assert.Equal(t, []string{contentTypeJSON}, op.Consumes)
+	assert.Equal(t, []string{contentTypeJSON}, op.Produces)
 }
 
 // Tests for WithRequestBodyContentTypes
@@ -908,7 +908,7 @@ func TestWithRequestBodyContentTypes_OAS3(t *testing.T) {
 		SetVersion("1.0.0").
 		AddOperation(http.MethodPost, "/users",
 			WithRequestBodyContentTypes(
-				[]string{"application/json", "application/xml", "text/yaml"},
+				[]string{contentTypeJSON, "application/xml", "text/yaml"},
 				User{},
 				WithRequired(true),
 			),
@@ -923,7 +923,7 @@ func TestWithRequestBodyContentTypes_OAS3(t *testing.T) {
 	assert.True(t, rb.Required)
 
 	// All content types should be present
-	require.Contains(t, rb.Content, "application/json")
+	require.Contains(t, rb.Content, contentTypeJSON)
 	require.Contains(t, rb.Content, "application/xml")
 	require.Contains(t, rb.Content, "text/yaml")
 
@@ -961,7 +961,7 @@ func TestWithRequestBodyContentTypes_OAS2(t *testing.T) {
 		SetVersion("1.0.0").
 		AddOperation(http.MethodPost, "/users",
 			WithRequestBodyContentTypes(
-				[]string{"application/json", "application/xml"},
+				[]string{contentTypeJSON, "application/xml"},
 				User{},
 				WithRequired(true),
 				WithRequestDescription("User data"),
@@ -995,7 +995,7 @@ func TestWithResponseContentTypes_OAS3(t *testing.T) {
 			WithPathParam("id", int64(0)),
 			WithResponseContentTypes(
 				http.StatusOK,
-				[]string{"application/json", "application/xml"},
+				[]string{contentTypeJSON, "application/xml"},
 				User{},
 				WithResponseDescription("User found"),
 			),
@@ -1008,7 +1008,7 @@ func TestWithResponseContentTypes_OAS3(t *testing.T) {
 	require.NotNil(t, resp)
 	assert.Equal(t, "User found", resp.Description)
 
-	require.Contains(t, resp.Content, "application/json")
+	require.Contains(t, resp.Content, contentTypeJSON)
 	require.Contains(t, resp.Content, "application/xml")
 
 	// Both should reference the same schema
@@ -1046,7 +1046,7 @@ func TestWithResponseContentTypes_OAS2(t *testing.T) {
 			WithPathParam("id", int64(0)),
 			WithResponseContentTypes(
 				http.StatusOK,
-				[]string{"application/json", "application/xml"},
+				[]string{contentTypeJSON, "application/xml"},
 				User{},
 				WithResponseDescription("User found"),
 			),
@@ -1071,7 +1071,7 @@ func TestRequestBodyMethods_LastWins(t *testing.T) {
 		SetVersion("1.0.0").
 		AddOperation(http.MethodPost, "/test",
 			WithRequestBody("text/plain", struct{}{}),
-			WithRequestBodyContentTypes([]string{"application/json", "application/xml"}, struct{}{}),
+			WithRequestBodyContentTypes([]string{contentTypeJSON, "application/xml"}, struct{}{}),
 			WithResponse(http.StatusOK, struct{}{}),
 		)
 
@@ -1083,7 +1083,7 @@ func TestRequestBodyMethods_LastWins(t *testing.T) {
 
 	// Should have the multi-content types, not text/plain
 	assert.NotContains(t, rb.Content, "text/plain")
-	assert.Contains(t, rb.Content, "application/json")
+	assert.Contains(t, rb.Content, contentTypeJSON)
 	assert.Contains(t, rb.Content, "application/xml")
 }
 
@@ -1099,7 +1099,7 @@ func TestWithResponseContentTypes_WithHeaders(t *testing.T) {
 		AddOperation(http.MethodGet, "/test",
 			WithResponseContentTypes(
 				http.StatusOK,
-				[]string{"application/json", "application/xml"},
+				[]string{contentTypeJSON, "application/xml"},
 				struct{}{},
 				WithResponseDescription("Success"),
 				WithResponseHeader("X-Rate-Limit-Remaining", header),
@@ -1343,7 +1343,7 @@ func TestWithRequestBodyExtension_OAS3Output(t *testing.T) {
 		SetTitle("Test").
 		SetVersion("1.0.0").
 		AddOperation(http.MethodPost, "/users",
-			WithRequestBody("application/json", struct{}{},
+			WithRequestBody(contentTypeJSON, struct{}{},
 				WithRequestBodyExtension("x-codegen-request-body-name", "user"),
 			),
 			WithResponse(http.StatusCreated, struct{}{}),
@@ -1363,7 +1363,7 @@ func TestWithRequestBodyExtension_OAS2BodyParam(t *testing.T) {
 		SetTitle("Test").
 		SetVersion("1.0.0").
 		AddOperation(http.MethodPost, "/users",
-			WithRequestBody("application/json", struct{}{},
+			WithRequestBody(contentTypeJSON, struct{}{},
 				WithRequestBodyExtension("x-codegen-request-body-name", "user"),
 			),
 			WithResponse(http.StatusCreated, struct{}{}),
@@ -1388,7 +1388,7 @@ func TestWithRequestBodyExtension_OAS2BodyParam(t *testing.T) {
 func TestWithRequestBodyExtension_RawSchema(t *testing.T) {
 	schema := &parser.Schema{
 		Type:   "string",
-		Format: "binary",
+		Format: binary,
 	}
 
 	b := New(parser.OASVersion320).
@@ -1416,7 +1416,7 @@ func TestWithRequestBodyExtension_MultipleContentTypes(t *testing.T) {
 		SetVersion("1.0.0").
 		AddOperation(http.MethodPost, "/users",
 			WithRequestBodyContentTypes(
-				[]string{"application/json", "application/xml"},
+				[]string{contentTypeJSON, "application/xml"},
 				struct{}{},
 				WithRequestBodyExtension("x-supports-xml", true),
 			),
@@ -1441,7 +1441,7 @@ func TestCombinedExtensions_AllComponents(t *testing.T) {
 			WithPathParam("id", "",
 				WithParamExtension("x-param-custom", "param-value"),
 			),
-			WithRequestBody("application/json", struct{}{},
+			WithRequestBody(contentTypeJSON, struct{}{},
 				WithRequestBodyExtension("x-body-custom", "body-value"),
 			),
 			WithResponse(http.StatusOK, struct{}{},

--- a/builder/parameter_form_test.go
+++ b/builder/parameter_form_test.go
@@ -338,7 +338,7 @@ func TestWithFormParam_OAS3(t *testing.T) {
 			SetTitle("Test API").
 			SetVersion("1.0.0").
 			AddOperation(http.MethodPost, "/upload",
-				WithRequestBody("application/json", struct {
+				WithRequestBody(contentTypeJSON, struct {
 					Metadata string `json:"metadata"`
 				}{},
 					WithRequired(true),
@@ -356,7 +356,7 @@ func TestWithFormParam_OAS3(t *testing.T) {
 		require.NotNil(t, rb)
 
 		// Both content types should exist
-		require.Contains(t, rb.Content, "application/json")
+		require.Contains(t, rb.Content, contentTypeJSON)
 		require.Contains(t, rb.Content, "application/x-www-form-urlencoded")
 
 		// Check form parameters

--- a/builder/reflect.go
+++ b/builder/reflect.go
@@ -9,6 +9,12 @@ import (
 	"github.com/erraggy/oastools/parser"
 )
 
+const (
+	strUUID  = "uuid"
+	strInt32 = "int32"
+	strInt64 = "int64"
+)
+
 // generateSchema converts a Go type to an OpenAPI schema.
 func (b *Builder) generateSchema(v any) *parser.Schema {
 	if v == nil {
@@ -128,7 +134,7 @@ func (b *Builder) generateSpecialTypeSchema(t reflect.Type) *parser.Schema {
 	if t.String() == "uuid.UUID" {
 		return &parser.Schema{
 			Type:   "string",
-			Format: "uuid",
+			Format: strUUID,
 		}
 	}
 
@@ -258,16 +264,16 @@ func (b *Builder) generatePrimitiveSchema(t reflect.Type) *parser.Schema {
 		return &parser.Schema{Type: "string"}
 
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32:
-		return &parser.Schema{Type: "integer", Format: "int32"}
+		return &parser.Schema{Type: "integer", Format: strInt32}
 
 	case reflect.Int64:
-		return &parser.Schema{Type: "integer", Format: "int64"}
+		return &parser.Schema{Type: "integer", Format: strInt64}
 
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32:
-		return &parser.Schema{Type: "integer", Format: "int32"}
+		return &parser.Schema{Type: "integer", Format: strInt32}
 
 	case reflect.Uint64:
-		return &parser.Schema{Type: "integer", Format: "int64"}
+		return &parser.Schema{Type: "integer", Format: strInt64}
 
 	case reflect.Float32:
 		return &parser.Schema{Type: "number", Format: "float"}

--- a/builder/response.go
+++ b/builder/response.go
@@ -73,7 +73,7 @@ func WithResponseExtension(key string, value any) ResponseOption {
 func (b *Builder) AddResponse(name string, description string, responseType any, opts ...ResponseOption) *Builder {
 	rCfg := &responseConfig{
 		description: description,
-		contentType: "application/json", // Default content type
+		contentType: contentTypeJSON, // Default content type
 	}
 	for _, opt := range opts {
 		opt(rCfg)
@@ -114,7 +114,7 @@ func buildResponsesFromMap(responseMap map[string]*parser.Response) *parser.Resp
 		Codes: make(map[string]*parser.Response),
 	}
 	for code, resp := range responseMap {
-		if code == "default" {
+		if code == defaultKeyword {
 			responses.Default = resp
 		} else {
 			responses.Codes[code] = resp

--- a/builder/server_builder.go
+++ b/builder/server_builder.go
@@ -310,7 +310,7 @@ func (s *ServerBuilder) buildDocument() (any, error) {
 // createParseResult creates a ParseResult for compatibility with httpvalidator.
 func (s *ServerBuilder) createParseResult(doc any) *parser.ParseResult {
 	return &parser.ParseResult{
-		SourcePath:   "builder",
+		SourcePath:   strBuilder,
 		SourceFormat: parser.SourceFormatYAML,
 		Version:      s.version.String(),
 		OASVersion:   s.version,

--- a/builder/server_builder_test.go
+++ b/builder/server_builder_test.go
@@ -223,7 +223,7 @@ func TestServerBuilder_EndToEnd(t *testing.T) {
 
 	srv.AddOperation(http.MethodPost, "/pets",
 		WithOperationID("createPet"),
-		WithRequestBody("application/json", Pet{}, WithRequired(true)),
+		WithRequestBody(contentTypeJSON, Pet{}, WithRequired(true)),
 		WithResponse(http.StatusCreated, Pet{}),
 	)
 
@@ -287,7 +287,7 @@ func TestServerBuilder_EndToEnd(t *testing.T) {
 		body := `{"id": 3, "name": "Buddy"}`
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodPost, "/pets", strings.NewReader(body))
-		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Content-Type", contentTypeJSON)
 		result.Handler.ServeHTTP(rec, req)
 
 		assert.Equal(t, http.StatusCreated, rec.Code)

--- a/builder/server_dispatcher_test.go
+++ b/builder/server_dispatcher_test.go
@@ -30,7 +30,7 @@ func TestDispatcher_RouteToCorrectHandler(t *testing.T) {
 
 	srv.AddOperation(http.MethodPost, "/pets",
 		WithOperationID("createPet"),
-		WithRequestBody("application/json", struct{}{}),
+		WithRequestBody(contentTypeJSON, struct{}{}),
 		WithResponse(http.StatusCreated, struct{}{}),
 	)
 
@@ -63,7 +63,7 @@ func TestDispatcher_RouteToCorrectHandler(t *testing.T) {
 	createCalled = false
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodPost, "/pets", strings.NewReader(`{}`))
-	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Type", contentTypeJSON)
 	result.Handler.ServeHTTP(rec, req)
 
 	assert.False(t, listCalled, "listPets handler was incorrectly called for POST")
@@ -144,7 +144,7 @@ func TestDispatcher_RequestBodyParsed(t *testing.T) {
 
 	srv.AddOperation(http.MethodPost, "/data",
 		WithOperationID("postData"),
-		WithRequestBody("application/json", struct{}{}),
+		WithRequestBody(contentTypeJSON, struct{}{}),
 		WithResponse(http.StatusOK, struct{}{}),
 	)
 
@@ -162,7 +162,7 @@ func TestDispatcher_RequestBodyParsed(t *testing.T) {
 	body := `{"name": "test", "value": 42}`
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/data", strings.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Type", contentTypeJSON)
 	result.Handler.ServeHTTP(rec, req)
 
 	assert.Equal(t, body, string(capturedRawBody))
@@ -551,7 +551,7 @@ func TestDispatcher_ResponseJSON(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, rec.Code)
 
-	assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+	assert.Equal(t, contentTypeJSON, rec.Header().Get("Content-Type"))
 
 	var body map[string]string
 	err := json.NewDecoder(rec.Body).Decode(&body)

--- a/builder/server_response_test.go
+++ b/builder/server_response_test.go
@@ -34,7 +34,7 @@ func TestJSON(t *testing.T) {
 	err := resp.WriteTo(rec)
 	require.NoError(t, err)
 
-	assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+	assert.Equal(t, contentTypeJSON, rec.Header().Get("Content-Type"))
 
 	var got testData
 	err = json.NewDecoder(rec.Body).Decode(&got)
@@ -89,7 +89,7 @@ func TestError(t *testing.T) {
 	err := resp.WriteTo(rec)
 	require.NoError(t, err)
 
-	assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+	assert.Equal(t, contentTypeJSON, rec.Header().Get("Content-Type"))
 
 	var got map[string]any
 	err = json.NewDecoder(rec.Body).Decode(&got)
@@ -189,7 +189,7 @@ func TestResponseBuilder_JSON(t *testing.T) {
 	err := resp.WriteTo(rec)
 	require.NoError(t, err)
 
-	assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+	assert.Equal(t, contentTypeJSON, rec.Header().Get("Content-Type"))
 
 	var got testData
 	err = json.NewDecoder(rec.Body).Decode(&got)

--- a/builder/server_testing.go
+++ b/builder/server_testing.go
@@ -56,7 +56,7 @@ func (r *TestRequest) JSONBody(body any) *TestRequest {
 		panic(fmt.Sprintf("builder: JSONBody failed to marshal body: %v", err))
 	}
 	r.body = bytes.NewReader(data)
-	r.headers.Set("Content-Type", "application/json")
+	r.headers.Set("Content-Type", contentTypeJSON)
 	return r
 }
 

--- a/builder/server_testing_test.go
+++ b/builder/server_testing_test.go
@@ -54,7 +54,7 @@ func TestTestRequest_JSONBody(t *testing.T) {
 	req := NewTestRequest(http.MethodPost, "/test").
 		JSONBody(payload{Name: "test"})
 
-	assert.Equal(t, "application/json", req.headers.Get("Content-Type"))
+	assert.Equal(t, contentTypeJSON, req.headers.Get("Content-Type"))
 	assert.NotNil(t, req.body)
 }
 
@@ -150,14 +150,14 @@ func TestServerTest(t *testing.T) {
 
 	srv.AddOperation(http.MethodPost, "/pets",
 		WithOperationID("createPet"),
-		WithRequestBody("application/json", Pet{}),
+		WithRequestBody(contentTypeJSON, Pet{}),
 		WithResponse(http.StatusCreated, Pet{}),
 	)
 
 	srv.AddOperation(http.MethodPut, "/pets/{id}",
 		WithOperationID("updatePet"),
 		WithPathParam("id", int64(0)),
-		WithRequestBody("application/json", Pet{}),
+		WithRequestBody(contentTypeJSON, Pet{}),
 		WithResponse(http.StatusOK, Pet{}),
 	)
 
@@ -312,7 +312,7 @@ func TestTestRequest_Body(t *testing.T) {
 		JSONBody(customBody{Data: "test"})
 
 	httpReq := req.Build()
-	assert.Equal(t, "application/json", httpReq.Header.Get("Content-Type"))
+	assert.Equal(t, contentTypeJSON, httpReq.Header.Get("Content-Type"))
 
 	var decoded customBody
 	err := json.NewDecoder(httpReq.Body).Decode(&decoded)

--- a/builder/server_validation.go
+++ b/builder/server_validation.go
@@ -63,7 +63,7 @@ func validationResultFromContext(ctx context.Context) *httpvalidator.RequestVali
 // and status have already been written. Any encoding failure would result in a
 // partial/empty body, but there's no recovery path available.
 func writeValidationError(w http.ResponseWriter, status int, message string) {
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Type", contentTypeJSON)
 	w.WriteHeader(status)
 	_ = json.NewEncoder(w).Encode(map[string]string{ //nolint:errcheck // Cannot recover after headers written
 		"error": message,
@@ -75,7 +75,7 @@ func writeValidationError(w http.ResponseWriter, status int, message string) {
 // and status have already been written. Any encoding failure would result in a
 // partial/empty body, but there's no recovery path available.
 func writeValidationResult(w http.ResponseWriter, result *httpvalidator.RequestValidationResult) {
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Type", contentTypeJSON)
 	w.WriteHeader(http.StatusBadRequest)
 
 	errors := make([]map[string]string, 0, len(result.Errors))

--- a/builder/server_validation_test.go
+++ b/builder/server_validation_test.go
@@ -53,7 +53,7 @@ func TestWriteValidationError(t *testing.T) {
 
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 
-	assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+	assert.Equal(t, contentTypeJSON, rec.Header().Get("Content-Type"))
 
 	var body map[string]string
 	err := json.NewDecoder(rec.Body).Decode(&body)
@@ -77,7 +77,7 @@ func TestWriteValidationResult(t *testing.T) {
 
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 
-	assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+	assert.Equal(t, contentTypeJSON, rec.Header().Get("Content-Type"))
 
 	var body map[string]any
 	err := json.NewDecoder(rec.Body).Decode(&body)

--- a/builder/tags.go
+++ b/builder/tags.go
@@ -144,7 +144,7 @@ func applyOASTag(schema *parser.Schema, tag string) *parser.Schema {
 				result.Enum[i] = strings.TrimSpace(v)
 			}
 
-		case "minimum":
+		case minimumKeyword:
 			if f, err := strconv.ParseFloat(value, 64); err == nil {
 				result.Minimum = &f
 			}
@@ -196,7 +196,7 @@ func applyOASTag(schema *parser.Schema, tag string) *parser.Schema {
 		case "title":
 			result.Title = value
 
-		case "default":
+		case defaultKeyword:
 			// Try to parse as appropriate type based on schema type
 			result.Default = parseDefaultValue(value, result.Type)
 		}

--- a/cmd/oastools/commands/common.go
+++ b/cmd/oastools/commands/common.go
@@ -25,6 +25,31 @@ const (
 // StdinFilePath is the special file path used to indicate reading from stdin.
 const StdinFilePath = "-"
 
+const (
+	// flagHelpLong is the long-form help flag.
+	flagHelpLong = "--help"
+	// strategyFirst is the first-encountered collision strategy name.
+	strategyFirst = "first"
+	// strategyMostSpecific is the most-specific collision strategy name.
+	strategyMostSpecific = "most-specific"
+	// strategyAlphabetical is the alphabetical collision strategy name.
+	strategyAlphabetical = "alphabetical"
+	// headerName is the table header for name columns.
+	headerName = "NAME"
+	// headerMethod is the table header for HTTP method columns.
+	headerMethod = "METHOD"
+	// headerPath is the table header for path columns.
+	headerPath = "PATH"
+	// headerSummary is the table header for summary columns.
+	headerSummary = "SUMMARY"
+	// headerType is the table header for type columns.
+	headerType = "TYPE"
+	// headerExtensions is the table header for specification extensions.
+	headerExtensions = "EXTENSIONS"
+	// locationComponent labels schemas defined in the components section.
+	locationComponent = "component"
+)
+
 // ValidateOutputFormat validates an output format and returns an error if invalid.
 func ValidateOutputFormat(format string) error {
 	if format != FormatText && format != FormatJSON && format != FormatYAML {
@@ -87,7 +112,7 @@ func ValidatePrimaryOperationPolicy(policy string) error {
 	if policy == "" {
 		return nil
 	}
-	valid := []string{"first", "most-specific", "alphabetical"}
+	valid := []string{strategyFirst, strategyMostSpecific, strategyAlphabetical}
 	if slices.Contains(valid, policy) {
 		return nil
 	}
@@ -97,9 +122,9 @@ func ValidatePrimaryOperationPolicy(policy string) error {
 // MapPrimaryOperationPolicy maps a string policy to the joiner enum.
 func MapPrimaryOperationPolicy(policy string) joiner.PrimaryOperationPolicy {
 	switch policy {
-	case "most-specific":
+	case strategyMostSpecific:
 		return joiner.PolicyMostSpecific
-	case "alphabetical":
+	case strategyAlphabetical:
 		return joiner.PolicyAlphabetical
 	default:
 		return joiner.PolicyFirstEncountered

--- a/cmd/oastools/commands/overlay.go
+++ b/cmd/oastools/commands/overlay.go
@@ -114,7 +114,7 @@ func HandleOverlay(args []string) error {
 		return handleOverlayApply(args[1:])
 	case "validate":
 		return handleOverlayValidate(args[1:])
-	case "-h", "--help", "help":
+	case "-h", flagHelpLong, "help":
 		printOverlayUsage()
 		return nil
 	default:

--- a/cmd/oastools/commands/walk.go
+++ b/cmd/oastools/commands/walk.go
@@ -18,7 +18,7 @@ func HandleWalk(args []string) error {
 	subcommand := args[0]
 
 	// Handle --help at walk level
-	if subcommand == "--help" || subcommand == "-h" || subcommand == "help" {
+	if subcommand == flagHelpLong || subcommand == "-h" || subcommand == "help" {
 		printWalkUsage()
 		return nil
 	}

--- a/cmd/oastools/commands/walk_operations.go
+++ b/cmd/oastools/commands/walk_operations.go
@@ -155,7 +155,7 @@ func matchOperationTag(tags []string, filter string) bool {
 
 // renderOperationsSummary renders a summary table of operations.
 func renderOperationsSummary(ops []*walker.OperationInfo, flags WalkFlags) error {
-	headers := []string{"METHOD", "PATH", "SUMMARY", "TAGS", "EXTENSIONS"}
+	headers := []string{headerMethod, headerPath, headerSummary, "TAGS", headerExtensions}
 	rows := make([][]string, 0, len(ops))
 
 	for _, op := range ops {

--- a/cmd/oastools/commands/walk_parameters.go
+++ b/cmd/oastools/commands/walk_parameters.go
@@ -130,7 +130,7 @@ func handleWalkParameters(args []string) error {
 	}
 
 	// Summary table
-	headers := []string{"NAME", "IN", "REQUIRED", "PATH", "METHOD", "EXTENSIONS"}
+	headers := []string{headerName, "IN", "REQUIRED", headerPath, headerMethod, headerExtensions}
 	var rows [][]string
 	for _, info := range filtered {
 		rows = append(rows, []string{

--- a/cmd/oastools/commands/walk_paths.go
+++ b/cmd/oastools/commands/walk_paths.go
@@ -184,7 +184,7 @@ type pathDetailView struct {
 
 // renderPathsSummary renders a summary table of path items.
 func renderPathsSummary(paths []pathInfo, flags WalkFlags) error {
-	headers := []string{"PATH", "METHODS", "SUMMARY", "EXTENSIONS"}
+	headers := []string{headerPath, "METHODS", headerSummary, headerExtensions}
 	rows := make([][]string, 0, len(paths))
 
 	for _, p := range paths {

--- a/cmd/oastools/commands/walk_responses.go
+++ b/cmd/oastools/commands/walk_responses.go
@@ -119,7 +119,7 @@ func handleWalkResponses(args []string) error {
 		return nil
 	}
 
-	headers := []string{"STATUS", "DESCRIPTION", "PATH", "METHOD", "EXTENSIONS"}
+	headers := []string{"STATUS", "DESCRIPTION", headerPath, headerMethod, headerExtensions}
 	rows := make([][]string, 0, len(filtered))
 	for _, info := range filtered {
 		rows = append(rows, []string{

--- a/cmd/oastools/commands/walk_schemas.go
+++ b/cmd/oastools/commands/walk_schemas.go
@@ -136,7 +136,7 @@ func handleWalkSchemas(args []string) error {
 		return nil
 	}
 
-	headers := []string{"NAME", "TYPE", "PROPERTIES", "LOCATION", "EXTENSIONS"}
+	headers := []string{headerName, headerType, "PROPERTIES", "LOCATION", headerExtensions}
 	rows := make([][]string, 0, len(filtered))
 	for _, info := range filtered {
 		displayName := info.Name
@@ -153,7 +153,7 @@ func handleWalkSchemas(args []string) error {
 
 		location := "inline"
 		if info.IsComponent {
-			location = "component"
+			location = locationComponent
 		}
 
 		extensions := FormatExtensions(info.Schema.Extra)

--- a/cmd/oastools/commands/walk_security.go
+++ b/cmd/oastools/commands/walk_security.go
@@ -128,7 +128,7 @@ func filterSecuritySchemes(
 
 // renderSecuritySummary renders a summary table of security schemes.
 func renderSecuritySummary(schemes []*walker.SecuritySchemeInfo, flags WalkFlags) error {
-	headers := []string{"NAME", "TYPE", "SCHEME", "IN", "EXTENSIONS"}
+	headers := []string{headerName, headerType, "SCHEME", "IN", headerExtensions}
 	rows := make([][]string, 0, len(schemes))
 
 	for _, info := range schemes {

--- a/converter/converter.go
+++ b/converter/converter.go
@@ -25,6 +25,13 @@ const (
 	SeverityCritical = severity.SeverityCritical
 )
 
+const (
+	mediaTypeJSON      = "application/json"
+	schemeHTTPS        = "https"
+	paramInFormData    = "formData"
+	securityTypeOAuth2 = "oauth2"
+)
+
 // ConversionIssue represents a single conversion issue or limitation
 type ConversionIssue = issues.Issue
 

--- a/converter/helpers.go
+++ b/converter/helpers.go
@@ -11,7 +11,7 @@ import (
 
 // getDefaultMediaType returns a default media type if none is specified
 func getDefaultMediaType() string {
-	return "application/json"
+	return mediaTypeJSON
 }
 
 // mergeStringArrays merges multiple string arrays, removing duplicates

--- a/converter/oas2_to_oas3.go
+++ b/converter/oas2_to_oas3.go
@@ -101,7 +101,7 @@ func (c *Converter) convertServers(src *parser.OAS2Document, result *ConversionR
 
 	schemes := src.Schemes
 	if len(schemes) == 0 {
-		schemes = []string{"https"}
+		schemes = []string{schemeHTTPS}
 	}
 
 	basePath := src.BasePath
@@ -149,7 +149,7 @@ func (c *Converter) convertOAS2OperationToOAS3(src *parser.Operation, doc *parse
 	// emit duplicate warnings and produce unused converted parameters).
 	var nonBodyParams []*parser.Parameter
 	for _, p := range src.Parameters {
-		if p != nil && p.In != "body" && p.In != "formData" {
+		if p != nil && p.In != "body" && p.In != paramInFormData {
 			nonBodyParams = append(nonBodyParams, p)
 		}
 	}
@@ -192,7 +192,7 @@ func (c *Converter) convertOAS2OperationToOAS3(src *parser.Operation, doc *parse
 	// Convert formData parameters to requestBody
 	hasFormData := false
 	for _, param := range src.Parameters {
-		if param != nil && param.In == "formData" {
+		if param != nil && param.In == paramInFormData {
 			hasFormData = true
 			break
 		}
@@ -254,7 +254,7 @@ func (c *Converter) convertOAS2FormDataToRequestBody(src *parser.Operation, doc 
 	var formDataParams []*parser.Parameter
 	hasFile := false
 	for _, param := range src.Parameters {
-		if param != nil && param.In == "formData" {
+		if param != nil && param.In == paramInFormData {
 			formDataParams = append(formDataParams, param)
 			if param.Type == "file" {
 				hasFile = true
@@ -431,7 +431,7 @@ func (c *Converter) convertSecurityDefinitions(src *parser.OAS2Document, dst *pa
 		}
 
 		// Convert OAuth2 flows
-		if secDef.Type == "oauth2" {
+		if secDef.Type == securityTypeOAuth2 {
 			scheme.Flows = &parser.OAuthFlows{}
 
 			switch secDef.Flow {

--- a/converter/oas3_to_oas2.go
+++ b/converter/oas3_to_oas2.go
@@ -108,7 +108,7 @@ func (c *Converter) convertServersToHostBasePath(src *parser.OAS3Document, dst *
 		// No servers defined, use defaults
 		dst.Host = "localhost"
 		dst.BasePath = "/"
-		dst.Schemes = []string{"https"}
+		dst.Schemes = []string{schemeHTTPS}
 		c.addIssue(result, "servers", "No servers defined in OAS 3.x document, using defaults", SeverityInfo)
 		return
 	}
@@ -124,7 +124,7 @@ func (c *Converter) convertServersToHostBasePath(src *parser.OAS3Document, dst *
 			"Using default values")
 		dst.Host = "localhost"
 		dst.BasePath = "/"
-		dst.Schemes = []string{"https"}
+		dst.Schemes = []string{schemeHTTPS}
 		return
 	}
 
@@ -318,7 +318,7 @@ func (c *Converter) convertSecuritySchemes(src *parser.OAS3Document, dst *parser
 		}
 
 		// Convert OAuth2 flows
-		if scheme.Type == "oauth2" && scheme.Flows != nil {
+		if scheme.Type == securityTypeOAuth2 && scheme.Flows != nil {
 			// OAS 2.0 only supports a single flow
 			flowCount := 0
 			if scheme.Flows.Implicit != nil {

--- a/differ/differ.go
+++ b/differ/differ.go
@@ -108,15 +108,7 @@ func (c Change) String() string {
 		symbol = "·"
 	}
 
-	typeStr := ""
-	switch c.Type {
-	case ChangeTypeAdded:
-		typeStr = "added"
-	case ChangeTypeRemoved:
-		typeStr = "removed"
-	case ChangeTypeModified:
-		typeStr = "modified"
-	}
+	typeStr := string(c.Type)
 
 	return fmt.Sprintf("%s %s [%s] %s: %s", symbol, c.Path, typeStr, c.Category, c.Message)
 }

--- a/differ/rules.go
+++ b/differ/rules.go
@@ -7,6 +7,9 @@ import (
 // SubType constants for rule matching
 const (
 	subTypeDescription = "description"
+	subTypeRequired    = "required"
+	subTypeType        = "type"
+	subTypeMediaType   = "mediaType"
 )
 
 // BreakingChangeRule configures how a specific change type is treated.
@@ -445,15 +448,15 @@ func (c *BreakingRulesConfig) getParameterRule(key RuleKey) *BreakingChangeRule 
 		return c.Parameter.Added
 	case ChangeTypeModified:
 		switch key.SubType {
-		case "required":
+		case subTypeRequired:
 			return c.Parameter.RequiredChanged
-		case "type":
+		case subTypeType:
 			return c.Parameter.TypeChanged
 		case "format":
 			return c.Parameter.FormatChanged
 		case "style":
 			return c.Parameter.StyleChanged
-		case "schema":
+		case string(CategorySchema):
 			return c.Parameter.SchemaChanged
 		case subTypeDescription:
 			return c.Parameter.DescriptionModified
@@ -468,20 +471,20 @@ func (c *BreakingRulesConfig) getRequestBodyRule(key RuleKey) *BreakingChangeRul
 	}
 	switch key.ChangeType {
 	case ChangeTypeRemoved:
-		if key.SubType == "mediaType" {
+		if key.SubType == subTypeMediaType {
 			return c.RequestBody.MediaTypeRemoved
 		}
 		return c.RequestBody.Removed
 	case ChangeTypeAdded:
-		if key.SubType == "mediaType" {
+		if key.SubType == subTypeMediaType {
 			return c.RequestBody.MediaTypeAdded
 		}
 		return c.RequestBody.Added
 	case ChangeTypeModified:
 		switch key.SubType {
-		case "required":
+		case subTypeRequired:
 			return c.RequestBody.RequiredChanged
-		case "schema":
+		case string(CategorySchema):
 			return c.RequestBody.SchemaChanged
 		}
 	}
@@ -495,7 +498,7 @@ func (c *BreakingRulesConfig) getResponseRule(key RuleKey) *BreakingChangeRule {
 	switch key.ChangeType {
 	case ChangeTypeRemoved:
 		switch key.SubType {
-		case "mediaType":
+		case subTypeMediaType:
 			return c.Response.MediaTypeRemoved
 		case "header":
 			return c.Response.HeaderRemoved
@@ -504,7 +507,7 @@ func (c *BreakingRulesConfig) getResponseRule(key RuleKey) *BreakingChangeRule {
 		}
 	case ChangeTypeAdded:
 		switch key.SubType {
-		case "mediaType":
+		case subTypeMediaType:
 			return c.Response.MediaTypeAdded
 		case "header":
 			return c.Response.HeaderAdded
@@ -515,7 +518,7 @@ func (c *BreakingRulesConfig) getResponseRule(key RuleKey) *BreakingChangeRule {
 		switch key.SubType {
 		case subTypeDescription:
 			return c.Response.DescriptionModified
-		case "schema":
+		case string(CategorySchema):
 			return c.Response.SchemaChanged
 		}
 	}
@@ -531,7 +534,7 @@ func (c *BreakingRulesConfig) getSchemaRule(key RuleKey) *BreakingChangeRule {
 		switch key.SubType {
 		case "property":
 			return c.Schema.PropertyRemoved
-		case "required":
+		case subTypeRequired:
 			return c.Schema.RequiredRemoved
 		case "enum":
 			return c.Schema.EnumValueRemoved
@@ -544,7 +547,7 @@ func (c *BreakingRulesConfig) getSchemaRule(key RuleKey) *BreakingChangeRule {
 		switch key.SubType {
 		case "property":
 			return c.Schema.PropertyAdded
-		case "required":
+		case subTypeRequired:
 			return c.Schema.RequiredAdded
 		case "enum":
 			return c.Schema.EnumValueAdded
@@ -555,7 +558,7 @@ func (c *BreakingRulesConfig) getSchemaRule(key RuleKey) *BreakingChangeRule {
 		}
 	case ChangeTypeModified:
 		switch key.SubType {
-		case "type":
+		case subTypeType:
 			return c.Schema.TypeChanged
 		case "format":
 			return c.Schema.FormatChanged
@@ -594,7 +597,7 @@ func (c *BreakingRulesConfig) getSecurityRule(key RuleKey) *BreakingChangeRule {
 		}
 		return c.Security.Added
 	case ChangeTypeModified:
-		if key.SubType == "type" {
+		if key.SubType == subTypeType {
 			return c.Security.TypeChanged
 		}
 	}

--- a/fixer/refs.go
+++ b/fixer/refs.go
@@ -88,21 +88,28 @@ const (
 	RefTypePathItem
 )
 
+const (
+	refTypeNameSchema         = "schema"
+	refTypeNameParameter      = "parameter"
+	refTypeNameResponse       = "response"
+	refTypeNameSecurityScheme = "securityScheme"
+)
+
 // String returns the string representation of a RefType.
 func (rt RefType) String() string {
 	switch rt {
 	case RefTypeSchema:
-		return "schema"
+		return refTypeNameSchema
 	case RefTypeParameter:
-		return "parameter"
+		return refTypeNameParameter
 	case RefTypeResponse:
-		return "response"
+		return refTypeNameResponse
 	case RefTypeRequestBody:
 		return "requestBody"
 	case RefTypeHeader:
 		return "header"
 	case RefTypeSecurityScheme:
-		return "securityScheme"
+		return refTypeNameSecurityScheme
 	case RefTypeLink:
 		return "link"
 	case RefTypeCallback:
@@ -951,20 +958,20 @@ func ExtractSchemaNameFromRef(ref string, version parser.OASVersion) string {
 func ExtractComponentNameFromRef(ref string) (componentType, name string) {
 	// OAS 2.0 patterns
 	oas2Prefixes := map[string]string{
-		pathutil.RefPrefixDefinitions:         "schema",
-		pathutil.RefPrefixParameters:          "parameter",
-		pathutil.RefPrefixResponses:           "response",
-		pathutil.RefPrefixSecurityDefinitions: "securityScheme",
+		pathutil.RefPrefixDefinitions:         refTypeNameSchema,
+		pathutil.RefPrefixParameters:          refTypeNameParameter,
+		pathutil.RefPrefixResponses:           refTypeNameResponse,
+		pathutil.RefPrefixSecurityDefinitions: refTypeNameSecurityScheme,
 	}
 
 	// OAS 3.x patterns
 	oas3Prefixes := map[string]string{
-		pathutil.RefPrefixSchemas:         "schema",
-		pathutil.RefPrefixParameters3:     "parameter",
-		pathutil.RefPrefixResponses3:      "response",
+		pathutil.RefPrefixSchemas:         refTypeNameSchema,
+		pathutil.RefPrefixParameters3:     refTypeNameParameter,
+		pathutil.RefPrefixResponses3:      refTypeNameResponse,
 		pathutil.RefPrefixRequestBodies:   "requestBody",
 		pathutil.RefPrefixHeaders:         "header",
-		pathutil.RefPrefixSecuritySchemes: "securityScheme",
+		pathutil.RefPrefixSecuritySchemes: refTypeNameSecurityScheme,
 		pathutil.RefPrefixLinks:           "link",
 		pathutil.RefPrefixCallbacks:       "callback",
 		pathutil.RefPrefixExamples:        "example",

--- a/generator/base_code_generator.go
+++ b/generator/base_code_generator.go
@@ -184,7 +184,7 @@ func (b *baseCodeGenerator) schemaToGoTypeBase(schema *parser.Schema, required b
 	case "number":
 		goType = numberFormatToGoType(schema.Format)
 	case "boolean":
-		goType = "bool"
+		goType = goTypeBool
 	case "array":
 		goType = "[]" + b.getArrayItemType(schema, schemaToGoType)
 	case "object":

--- a/generator/constants.go
+++ b/generator/constants.go
@@ -1,0 +1,31 @@
+package generator
+
+// Generated Go type name constants.
+const (
+	goTypeBool    = "bool"
+	goTypeInt64   = "int64"
+	goTypeFloat64 = "float64"
+)
+
+// Generated file name constants.
+const (
+	fileNameTypes  = "types.go"
+	fileNameClient = "client.go"
+	fileNameServer = "server.go"
+)
+
+// OpenAPI format and value constants.
+const (
+	formatDateTime = "date-time"
+
+	httpMethodPost = "post"
+
+	defaultName = "default"
+
+	typeName = "type"
+
+	kindAlias = "alias"
+
+	oauth2FlowAccessCode = "accessCode"
+	oauth2FlowImplicit   = "implicit"
+)

--- a/generator/file_splitter.go
+++ b/generator/file_splitter.go
@@ -319,14 +319,14 @@ func (fs *FileSplitter) extractOAS3Operations(doc *parser.OAS3Document) []*Opera
 
 		// Iterate over each HTTP method
 		methodOps := map[string]*parser.Operation{
-			"get":     pathItem.Get,
-			"put":     pathItem.Put,
-			"post":    pathItem.Post,
-			"delete":  pathItem.Delete,
-			"options": pathItem.Options,
-			"head":    pathItem.Head,
-			"patch":   pathItem.Patch,
-			"trace":   pathItem.Trace,
+			"get":          pathItem.Get,
+			"put":          pathItem.Put,
+			httpMethodPost: pathItem.Post,
+			"delete":       pathItem.Delete,
+			"options":      pathItem.Options,
+			"head":         pathItem.Head,
+			"patch":        pathItem.Patch,
+			"trace":        pathItem.Trace,
 		}
 
 		for method, op := range methodOps {
@@ -375,13 +375,13 @@ func (fs *FileSplitter) extractOAS2Operations(doc *parser.OAS2Document) []*Opera
 
 		// Iterate over each HTTP method
 		methodOps := map[string]*parser.Operation{
-			"get":     pathItem.Get,
-			"put":     pathItem.Put,
-			"post":    pathItem.Post,
-			"delete":  pathItem.Delete,
-			"options": pathItem.Options,
-			"head":    pathItem.Head,
-			"patch":   pathItem.Patch,
+			"get":          pathItem.Get,
+			"put":          pathItem.Put,
+			httpMethodPost: pathItem.Post,
+			"delete":       pathItem.Delete,
+			"options":      pathItem.Options,
+			"head":         pathItem.Head,
+			"patch":        pathItem.Patch,
 		}
 
 		for method, op := range methodOps {
@@ -420,7 +420,7 @@ func (fs *FileSplitter) groupByTag(operations []*OperationInfo) map[string][]*Op
 	groups := make(map[string][]*OperationInfo)
 
 	for _, op := range operations {
-		tag := "default"
+		tag := defaultName
 		if len(op.Tags) > 0 {
 			tag = op.Tags[0]
 		}
@@ -454,12 +454,12 @@ func (fs *FileSplitter) extractPathPrefix(path string) string {
 		// Remove any path parameters
 		segment := parts[0]
 		if strings.HasPrefix(segment, "{") {
-			return "default"
+			return defaultName
 		}
 		return segment
 	}
 
-	return "default"
+	return defaultName
 }
 
 // groupAlphabetically groups operations alphabetically by operation ID.
@@ -523,7 +523,7 @@ func (fs *FileSplitter) getOperationByMethod(pathItem *parser.PathItem, method s
 		return pathItem.Get
 	case "put":
 		return pathItem.Put
-	case "post":
+	case httpMethodPost:
 		return pathItem.Post
 	case "delete":
 		return pathItem.Delete

--- a/generator/naming.go
+++ b/generator/naming.go
@@ -21,10 +21,10 @@ const maxDescriptionLength = 200
 var goReservedWords = map[string]bool{
 	// Keywords (these are truly reserved and cannot be used)
 	"break": true, "case": true, "chan": true, "const": true, "continue": true,
-	"default": true, "defer": true, "else": true, "fallthrough": true, "for": true,
+	defaultName: true, "defer": true, "else": true, "fallthrough": true, "for": true,
 	"func": true, "go": true, "goto": true, "if": true, "import": true,
 	"interface": true, "map": true, "package": true, "range": true, "return": true,
-	"select": true, "struct": true, "switch": true, "type": true, "var": true,
+	"select": true, "struct": true, "switch": true, typeName: true, "var": true,
 }
 
 // escapeReservedWord checks if a name is a Go reserved keyword and escapes it

--- a/generator/oas2_generator.go
+++ b/generator/oas2_generator.go
@@ -135,7 +135,7 @@ func (cg *oas2CodeGenerator) generateSingleTypes() error {
 	}
 
 	// Format and append the file
-	appendFormattedFile(cg.result, "types.go", &buf, cg.addIssue)
+	appendFormattedFile(cg.result, fileNameTypes, &buf, cg.addIssue)
 
 	return nil
 }
@@ -149,7 +149,7 @@ func (cg *oas2CodeGenerator) generateSplitTypes() error {
 	allSchemas := cg.collectSchemas()
 
 	// Generate shared types file (types.go)
-	if err := cg.generateOAS2TypesFile("types.go", "Shared types used across multiple operations", allSchemas, sharedTypes); err != nil {
+	if err := cg.generateOAS2TypesFile(fileNameTypes, "Shared types used across multiple operations", allSchemas, sharedTypes); err != nil {
 		return err
 	}
 
@@ -452,7 +452,7 @@ func (cg *oas2CodeGenerator) generateSingleClient() error {
 	buf.WriteString(clientHelpers)
 
 	// Format and append the file
-	appendFormattedFile(cg.result, "client.go", &buf, cg.addIssue)
+	appendFormattedFile(cg.result, fileNameClient, &buf, cg.addIssue)
 
 	return nil
 }

--- a/generator/oas3_generator.go
+++ b/generator/oas3_generator.go
@@ -62,12 +62,12 @@ func (cg *oas3CodeGenerator) generateSingleTypes() error {
 	// Execute template
 	formatted, err := executeTemplate("types.go.tmpl", data)
 	if err != nil {
-		cg.addIssue("types.go", fmt.Sprintf("failed to execute template: %v", err), SeverityWarning)
+		cg.addIssue(fileNameTypes, fmt.Sprintf("failed to execute template: %v", err), SeverityWarning)
 		return err
 	}
 
 	cg.result.Files = append(cg.result.Files, GeneratedFile{
-		Name:    "types.go",
+		Name:    fileNameTypes,
 		Content: formatted,
 	})
 
@@ -83,7 +83,7 @@ func (cg *oas3CodeGenerator) generateSplitTypes() error {
 	allSchemas := cg.collectSchemas()
 
 	// Generate shared types file (types.go)
-	if err := cg.generateTypesFile("types.go", "Shared types used across multiple operations", allSchemas, sharedTypes); err != nil {
+	if err := cg.generateTypesFile(fileNameTypes, "Shared types used across multiple operations", allSchemas, sharedTypes); err != nil {
 		return err
 	}
 
@@ -383,7 +383,7 @@ func (cg *oas3CodeGenerator) generateSingleClient() error {
 	buf.WriteString(clientHelpers)
 
 	// Format and append the file
-	appendFormattedFile(cg.result, "client.go", &buf, cg.addIssue)
+	appendFormattedFile(cg.result, fileNameClient, &buf, cg.addIssue)
 
 	return nil
 }
@@ -444,7 +444,7 @@ func (cg *oas3CodeGenerator) generateClientGroupFile(group FileGroup, opToPathMe
 		// Check if any parameters need time
 		for _, param := range op.Parameters {
 			if param != nil && param.Schema != nil {
-				if param.Schema.Format == "date-time" || param.Schema.Format == "date" {
+				if param.Schema.Format == formatDateTime || param.Schema.Format == "date" {
 					needsTime = true
 				}
 			}
@@ -954,11 +954,11 @@ func (cg *oas3CodeGenerator) generateReadmeFile(schemes map[string]*parser.Secur
 // getFileDescription returns a description for a generated file
 func getFileDescription(name string) string {
 	switch name {
-	case "types.go":
+	case fileNameTypes:
 		return "Data types and models"
-	case "client.go":
+	case fileNameClient:
 		return "HTTP client implementation"
-	case "server.go":
+	case fileNameServer:
 		return "Server interface"
 	case "security_helpers.go":
 		return "Security authentication helpers"

--- a/generator/oauth2_flows.go
+++ b/generator/oauth2_flows.go
@@ -31,7 +31,7 @@ type OAuth2Generator struct {
 
 // NewOAuth2Generator creates a new OAuth2Generator from a security scheme.
 func NewOAuth2Generator(name string, scheme *parser.SecurityScheme) *OAuth2Generator {
-	if scheme == nil || scheme.Type != "oauth2" {
+	if scheme == nil || scheme.Type != schemeTypeOAuth2 {
 		return nil
 	}
 
@@ -391,7 +391,7 @@ func (g *OAuth2Generator) hasAuthorizationCodeFlow() bool {
 	if g.Flows != nil && g.Flows.AuthorizationCode != nil {
 		return true
 	}
-	return g.OAS2Flow == "accessCode" || g.OAS2Flow == "authorizationCode"
+	return g.OAS2Flow == oauth2FlowAccessCode || g.OAS2Flow == "authorizationCode"
 }
 
 func (g *OAuth2Generator) hasClientCredentialsFlow() bool {
@@ -412,7 +412,7 @@ func (g *OAuth2Generator) hasImplicitFlow() bool {
 	if g.Flows != nil && g.Flows.Implicit != nil {
 		return true
 	}
-	return g.OAS2Flow == "implicit"
+	return g.OAS2Flow == oauth2FlowImplicit
 }
 
 // HasAnyFlow returns true if any OAuth2 flow is configured.

--- a/generator/readme_generator.go
+++ b/generator/readme_generator.go
@@ -524,21 +524,21 @@ func extractOAuth2FlowNames(flows *OAuthFlows, legacyFlow string) []string {
 			names = append(names, "password")
 		}
 		if flows.Implicit != nil {
-			names = append(names, "implicit")
+			names = append(names, oauth2FlowImplicit)
 		}
 	}
 
 	// OAS 2.0 style
 	if len(names) == 0 && legacyFlow != "" {
 		switch legacyFlow {
-		case "accessCode", "authorizationCode":
+		case oauth2FlowAccessCode, "authorizationCode":
 			names = append(names, "authorization_code")
 		case "application", "clientCredentials":
 			names = append(names, "client_credentials")
 		case "password":
 			names = append(names, "password")
-		case "implicit":
-			names = append(names, "implicit")
+		case oauth2FlowImplicit:
+			names = append(names, oauth2FlowImplicit)
 		}
 	}
 

--- a/generator/security_enforce.go
+++ b/generator/security_enforce.go
@@ -323,14 +323,14 @@ func ExtractOperationSecurityOAS3(doc *parser.OAS3Document) OperationSecurityReq
 		}
 
 		methodOps := map[string]*parser.Operation{
-			"get":     pathItem.Get,
-			"put":     pathItem.Put,
-			"post":    pathItem.Post,
-			"delete":  pathItem.Delete,
-			"options": pathItem.Options,
-			"head":    pathItem.Head,
-			"patch":   pathItem.Patch,
-			"trace":   pathItem.Trace,
+			"get":          pathItem.Get,
+			"put":          pathItem.Put,
+			httpMethodPost: pathItem.Post,
+			"delete":       pathItem.Delete,
+			"options":      pathItem.Options,
+			"head":         pathItem.Head,
+			"patch":        pathItem.Patch,
+			"trace":        pathItem.Trace,
 		}
 
 		for method, op := range methodOps {
@@ -368,13 +368,13 @@ func ExtractOperationSecurityOAS2(doc *parser.OAS2Document) OperationSecurityReq
 		}
 
 		methodOps := map[string]*parser.Operation{
-			"get":     pathItem.Get,
-			"put":     pathItem.Put,
-			"post":    pathItem.Post,
-			"delete":  pathItem.Delete,
-			"options": pathItem.Options,
-			"head":    pathItem.Head,
-			"patch":   pathItem.Patch,
+			"get":          pathItem.Get,
+			"put":          pathItem.Put,
+			httpMethodPost: pathItem.Post,
+			"delete":       pathItem.Delete,
+			"options":      pathItem.Options,
+			"head":         pathItem.Head,
+			"patch":        pathItem.Patch,
 		}
 
 		for method, op := range methodOps {

--- a/generator/security_gen_shared.go
+++ b/generator/security_gen_shared.go
@@ -107,7 +107,7 @@ func isSecureURL(urlStr string) bool {
 	if u.Scheme == "https" {
 		return true
 	}
-	if u.Scheme == "http" && (u.Hostname() == "localhost" || u.Hostname() == "127.0.0.1" || u.Hostname() == "::1") {
+	if u.Scheme == schemeTypeHTTP && (u.Hostname() == "localhost" || u.Hostname() == "127.0.0.1" || u.Hostname() == "::1") {
 		return true
 	}
 	return false
@@ -357,7 +357,7 @@ func buildReadmeContextShared(b *readmeContextBuilder, secSummaries []SecuritySc
 			WasSplit:        true,
 			Strategy:        strategy,
 			Groups:          groups,
-			SharedTypesFile: "types.go",
+			SharedTypesFile: fileNameTypes,
 		}
 	}
 
@@ -459,13 +459,13 @@ func buildSecuritySchemeSummariesOAS3(schemes map[string]*parser.SecurityScheme)
 		}
 
 		switch scheme.Type {
-		case "apiKey":
+		case schemeTypeAPIKey:
 			summary.Location = scheme.In
-		case "http":
+		case schemeTypeHTTP:
 			summary.Scheme = scheme.Scheme
-		case "oauth2":
+		case schemeTypeOAuth2:
 			summary.Flows = extractOAuth2FlowNames(convertFlows(scheme.Flows), scheme.Flow)
-		case "openIdConnect":
+		case schemeTypeOpenIDConnect:
 			summary.OpenIDConnectURL = scheme.OpenIDConnectURL
 		}
 
@@ -492,7 +492,7 @@ func parseStatusCodeMetadata(code string) StatusCodeData {
 	data := StatusCodeData{Code: code}
 
 	switch {
-	case code == "default":
+	case code == defaultName:
 		data.MethodName = "StatusDefault"
 		data.StatusCodeInt = 500
 		data.IsDefault = true
@@ -620,7 +620,7 @@ func buildStatusCodesShared(op *parser.Operation, buildData statusCodeDataBuilde
 
 	// Process default response first
 	if op.Responses.Default != nil {
-		statusData := buildData("default", op.Responses.Default)
+		statusData := buildData(defaultName, op.Responses.Default)
 		codes = append(codes, statusData)
 	}
 

--- a/generator/security_helpers.go
+++ b/generator/security_helpers.go
@@ -451,7 +451,7 @@ func getOAuth2FlowTypes(scheme *parser.SecurityScheme) []string {
 	// OAS 3.0+ style
 	if scheme.Flows != nil {
 		if scheme.Flows.Implicit != nil {
-			flows = append(flows, "implicit")
+			flows = append(flows, oauth2FlowImplicit)
 		}
 		if scheme.Flows.Password != nil {
 			flows = append(flows, "password")

--- a/generator/server_gen_shared.go
+++ b/generator/server_gen_shared.go
@@ -420,7 +420,7 @@ func generateBaseServerShared(ctx *baseServerContext) (map[string]bool, error) {
 	writeNotImplementedError(&buf)
 
 	// Format and append the file
-	appendFormattedFile(ctx.result, "server.go", &buf, ctx.addIssue)
+	appendFormattedFile(ctx.result, fileNameServer, &buf, ctx.addIssue)
 
 	return generatedMethods, nil
 }
@@ -561,7 +561,7 @@ func generateBaseClientShared(packageName string, info *parser.Info, result *Gen
 	buf.WriteString(clientHelpers)
 
 	// Format and append the file
-	appendFormattedFile(result, "client.go", &buf, addIssue)
+	appendFormattedFile(result, fileNameClient, &buf, addIssue)
 
 	return nil
 }

--- a/generator/template_builders.go
+++ b/generator/template_builders.go
@@ -274,7 +274,7 @@ func (cg *oas3CodeGenerator) buildAliasTypeDefinition(typeName string, schema *p
 	}
 
 	return TypeDefinition{
-		Kind:  "alias",
+		Kind:  kindAlias,
 		Alias: aliasData,
 	}
 }
@@ -294,7 +294,7 @@ func (cg *oas3CodeGenerator) buildArrayAliasTypeDefinition(typeName string, sche
 	}
 
 	return TypeDefinition{
-		Kind:  "alias",
+		Kind:  kindAlias,
 		Alias: aliasData,
 	}
 }
@@ -314,7 +314,7 @@ func (cg *oas3CodeGenerator) buildStringAliasTypeDefinition(typeName string, sch
 	}
 
 	return TypeDefinition{
-		Kind:  "alias",
+		Kind:  kindAlias,
 		Alias: aliasData,
 	}
 }
@@ -334,7 +334,7 @@ func (cg *oas3CodeGenerator) buildIntegerAliasTypeDefinition(typeName string, sc
 	}
 
 	return TypeDefinition{
-		Kind:  "alias",
+		Kind:  kindAlias,
 		Alias: aliasData,
 	}
 }
@@ -354,7 +354,7 @@ func (cg *oas3CodeGenerator) buildNumberAliasTypeDefinition(typeName string, sch
 	}
 
 	return TypeDefinition{
-		Kind:  "alias",
+		Kind:  kindAlias,
 		Alias: aliasData,
 	}
 }
@@ -363,7 +363,7 @@ func (cg *oas3CodeGenerator) buildNumberAliasTypeDefinition(typeName string, sch
 func (cg *oas3CodeGenerator) buildBooleanAliasTypeDefinition(typeName string, schema *parser.Schema) TypeDefinition {
 	aliasData := &AliasData{
 		TypeName:   typeName,
-		TargetType: "bool",
+		TargetType: goTypeBool,
 		IsDefined:  false,
 	}
 
@@ -372,7 +372,7 @@ func (cg *oas3CodeGenerator) buildBooleanAliasTypeDefinition(typeName string, sc
 	}
 
 	return TypeDefinition{
-		Kind:  "alias",
+		Kind:  kindAlias,
 		Alias: aliasData,
 	}
 }
@@ -386,7 +386,7 @@ func (cg *oas3CodeGenerator) buildAnyAliasTypeDefinition(typeName string) TypeDe
 	}
 
 	return TypeDefinition{
-		Kind:  "alias",
+		Kind:  kindAlias,
 		Alias: aliasData,
 	}
 }

--- a/generator/type_mapping.go
+++ b/generator/type_mapping.go
@@ -41,7 +41,7 @@ func getSchemaType(schema *parser.Schema) string {
 // stringFormatToGoType maps OpenAPI string formats to Go types.
 func stringFormatToGoType(format string) string {
 	switch format {
-	case "date-time":
+	case formatDateTime:
 		return "time.Time"
 	case "date":
 		return "string" // Could use time.Time with custom parsing
@@ -61,10 +61,10 @@ func integerFormatToGoType(format string) string {
 	switch format {
 	case "int32":
 		return "int32"
-	case "int64":
-		return "int64"
+	case goTypeInt64:
+		return goTypeInt64
 	default:
-		return "int64"
+		return goTypeInt64
 	}
 }
 
@@ -74,9 +74,9 @@ func numberFormatToGoType(format string) string {
 	case "float":
 		return "float32"
 	case "double":
-		return "float64"
+		return goTypeFloat64
 	default:
-		return "float64"
+		return goTypeFloat64
 	}
 }
 
@@ -91,7 +91,7 @@ func paramTypeToGoType(paramType, format string) string {
 	case "number":
 		return numberFormatToGoType(format)
 	case "boolean":
-		return "bool"
+		return goTypeBool
 	case "array":
 		return "[]string"
 	default:
@@ -106,7 +106,7 @@ func needsTimeImport(schema *parser.Schema) bool {
 	}
 
 	schemaType := getSchemaType(schema)
-	if schemaType == "string" && schema.Format == "date-time" {
+	if schemaType == "string" && schema.Format == formatDateTime {
 		return true
 	}
 
@@ -138,11 +138,11 @@ func zeroValue(t string) string {
 	switch t {
 	case "string":
 		return `""`
-	case "bool":
+	case goTypeBool:
 		return "false"
-	case "int", "int8", "int16", "int32", "int64",
+	case "int", "int8", "int16", "int32", goTypeInt64,
 		"uint", "uint8", "uint16", "uint32", "uint64",
-		"float32", "float64":
+		"float32", goTypeFloat64:
 		return "0"
 	case "any":
 		return "nil"
@@ -155,7 +155,7 @@ func zeroValue(t string) string {
 // This handles cases where the parser returns additionalProperties or items as a
 // map[string]any rather than a *parser.Schema.
 func schemaTypeFromMap(m map[string]any) string {
-	if typeVal, ok := m["type"]; ok {
+	if typeVal, ok := m[typeName]; ok {
 		if typeStr, ok := typeVal.(string); ok {
 			switch typeStr {
 			case "string":
@@ -167,14 +167,14 @@ func schemaTypeFromMap(m map[string]any) string {
 				if format, ok := m["format"].(string); ok {
 					return integerFormatToGoType(format)
 				}
-				return "int64"
+				return goTypeInt64
 			case "number":
 				if format, ok := m["format"].(string); ok {
 					return numberFormatToGoType(format)
 				}
-				return "float64"
+				return goTypeFloat64
 			case "boolean":
-				return "bool"
+				return goTypeBool
 			case "array":
 				return "[]any"
 			case "object":

--- a/httpvalidator/params.go
+++ b/httpvalidator/params.go
@@ -8,6 +8,12 @@ import (
 	"github.com/erraggy/oastools/parser"
 )
 
+// Parameter serialization style constants.
+const (
+	styleLabel  = "label"
+	styleMatrix = "matrix"
+)
+
 // ParamDeserializer handles deserialization of HTTP parameters according to
 // OpenAPI serialization styles. Each parameter location has default styles:
 //
@@ -48,9 +54,9 @@ func (d *ParamDeserializer) DeserializePathParam(value string, param *parser.Par
 	switch style {
 	case "simple":
 		return d.deserializeSimple(value, schema, explode)
-	case "label":
+	case styleLabel:
 		return d.deserializeLabel(value, schema, explode)
-	case "matrix":
+	case styleMatrix:
 		return d.deserializeMatrix(value, param.Name, schema, explode)
 	default:
 		// Unknown style, return raw value

--- a/internal/corpusutil/corpus.go
+++ b/internal/corpusutil/corpus.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 )
 
+const formatJSON = "json"
+
 // SpecInfo contains metadata about a corpus specification.
 type SpecInfo struct {
 	Name             string // Human-readable name (e.g., "Stripe")
@@ -40,7 +42,7 @@ var Corpus = []SpecInfo{
 		Filename:       "petstore-swagger.json",
 		URL:            "https://petstore.swagger.io/v2/swagger.json",
 		OASVersion:     "2.0",
-		Format:         "json",
+		Format:         formatJSON,
 		ExpectedValid:  true,
 		ExpectedErrors: 0,
 		IsLarge:        false,
@@ -75,7 +77,7 @@ var Corpus = []SpecInfo{
 		Filename:       "google-maps-platform.json",
 		URL:            "https://raw.githubusercontent.com/googlemaps/openapi-specification/main/dist/google-maps-platform-openapi3.json",
 		OASVersion:     "3.0.3",
-		Format:         "json",
+		Format:         formatJSON,
 		ExpectedValid:  true, // Now valid after fixing $ref parameter validation (was 228 false positives)
 		ExpectedErrors: 0,
 		IsLarge:        false,
@@ -86,7 +88,7 @@ var Corpus = []SpecInfo{
 		Filename:       "nws-openapi.json",
 		URL:            "https://api.weather.gov/openapi.json",
 		OASVersion:     "3.0.3",
-		Format:         "json",
+		Format:         formatJSON,
 		ExpectedValid:  false,
 		ExpectedErrors: 44, // Reduced from 156 after fixing $ref parameter validation
 		IsLarge:        false,
@@ -108,7 +110,7 @@ var Corpus = []SpecInfo{
 		Filename:       "discord-openapi.json",
 		URL:            "https://raw.githubusercontent.com/discord/discord-api-spec/main/specs/openapi.json",
 		OASVersion:     "3.1.0",
-		Format:         "json",
+		Format:         formatJSON,
 		ExpectedValid:  true,
 		ExpectedErrors: 0,
 		IsLarge:        false,
@@ -119,7 +121,7 @@ var Corpus = []SpecInfo{
 		Filename:       "github-api.json",
 		URL:            "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json",
 		OASVersion:     "3.0.3",
-		Format:         "json",
+		Format:         formatJSON,
 		ExpectedValid:  false,
 		ExpectedErrors: 2224, // Reduced from 8000 after fixing $ref parameter/requestBody validation
 		IsLarge:        false,
@@ -130,7 +132,7 @@ var Corpus = []SpecInfo{
 		Filename:       "stripe-spec3.json",
 		URL:            "https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json",
 		OASVersion:     "3.0.0",
-		Format:         "json",
+		Format:         formatJSON,
 		ExpectedValid:  true,
 		ExpectedErrors: 0,
 		IsLarge:        true,

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -14,6 +14,13 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
+const (
+	groupByName       = "name"
+	groupByMethod     = "method"
+	groupByLocation   = "location"
+	groupByStatusCode = "status_code"
+)
+
 const serverInstructions = `oastools MCP server — validates, fixes, converts, diffs, joins, walks, and generates OpenAPI specs.
 
 Configuration: All defaults are configurable via OASTOOLS_* environment variables set in your MCP client config. The Go MCP SDK does not support initializationOptions; use env vars instead.

--- a/internal/mcpserver/tools_walk_headers.go
+++ b/internal/mcpserver/tools_walk_headers.go
@@ -72,7 +72,7 @@ func handleWalkHeaders(_ context.Context, _ *mcp.CallToolRequest, input walkHead
 		return errResult(err), nil, nil
 	}
 
-	if err := validateGroupBy(input.GroupBy, input.Detail, []string{"name", "status_code"}); err != nil {
+	if err := validateGroupBy(input.GroupBy, input.Detail, []string{groupByName, groupByStatusCode}); err != nil {
 		return errResult(err), nil, nil
 	}
 
@@ -105,9 +105,9 @@ func handleWalkHeaders(_ context.Context, _ *mcp.CallToolRequest, input walkHead
 	if input.GroupBy != "" {
 		groups := groupAndSort(matched, func(info *headerInfo) []string {
 			switch strings.ToLower(input.GroupBy) {
-			case "name":
+			case groupByName:
 				return []string{info.Name}
-			case "status_code":
+			case groupByStatusCode:
 				if info.StatusCode == "" {
 					return nil
 				}

--- a/internal/mcpserver/tools_walk_operations.go
+++ b/internal/mcpserver/tools_walk_operations.go
@@ -61,7 +61,7 @@ func handleWalkOperations(_ context.Context, _ *mcp.CallToolRequest, input walkO
 		return errResult(err), nil, nil
 	}
 
-	if err := validateGroupBy(input.GroupBy, input.Detail, []string{"tag", "method"}); err != nil {
+	if err := validateGroupBy(input.GroupBy, input.Detail, []string{"tag", groupByMethod}); err != nil {
 		return errResult(err), nil, nil
 	}
 
@@ -85,7 +85,7 @@ func handleWalkOperations(_ context.Context, _ *mcp.CallToolRequest, input walkO
 					return nil
 				}
 				return op.Operation.Tags
-			case "method":
+			case groupByMethod:
 				return []string{strings.ToUpper(op.Method)}
 			default:
 				return nil

--- a/internal/mcpserver/tools_walk_parameters.go
+++ b/internal/mcpserver/tools_walk_parameters.go
@@ -60,7 +60,7 @@ func handleWalkParameters(_ context.Context, _ *mcp.CallToolRequest, input walkP
 		return errResult(err), nil, nil
 	}
 
-	if err := validateGroupBy(input.GroupBy, input.Detail, []string{"location", "name"}); err != nil {
+	if err := validateGroupBy(input.GroupBy, input.Detail, []string{groupByLocation, groupByName}); err != nil {
 		return errResult(err), nil, nil
 	}
 
@@ -79,12 +79,12 @@ func handleWalkParameters(_ context.Context, _ *mcp.CallToolRequest, input walkP
 	if input.GroupBy != "" {
 		groups := groupAndSort(matched, func(info *walker.ParameterInfo) []string {
 			switch strings.ToLower(input.GroupBy) {
-			case "location":
+			case groupByLocation:
 				if info.In == "" {
 					return []string{"(ref)"}
 				}
 				return []string{info.In}
-			case "name":
+			case groupByName:
 				return []string{info.Name}
 			default:
 				return nil

--- a/internal/mcpserver/tools_walk_responses.go
+++ b/internal/mcpserver/tools_walk_responses.go
@@ -56,7 +56,7 @@ func handleWalkResponses(_ context.Context, _ *mcp.CallToolRequest, input walkRe
 		return errResult(err), nil, nil
 	}
 
-	if err := validateGroupBy(input.GroupBy, input.Detail, []string{"status_code", "method"}); err != nil {
+	if err := validateGroupBy(input.GroupBy, input.Detail, []string{groupByStatusCode, groupByMethod}); err != nil {
 		return errResult(err), nil, nil
 	}
 
@@ -75,12 +75,12 @@ func handleWalkResponses(_ context.Context, _ *mcp.CallToolRequest, input walkRe
 	if input.GroupBy != "" {
 		groups := groupAndSort(matched, func(info *walker.ResponseInfo) []string {
 			switch strings.ToLower(input.GroupBy) {
-			case "status_code":
+			case groupByStatusCode:
 				if info.StatusCode == "" {
 					return []string{"(component)"}
 				}
 				return []string{info.StatusCode}
-			case "method":
+			case groupByMethod:
 				if info.Method == "" {
 					return []string{"(component)"}
 				}

--- a/internal/mcpserver/tools_walk_schemas.go
+++ b/internal/mcpserver/tools_walk_schemas.go
@@ -54,7 +54,7 @@ func handleWalkSchemas(_ context.Context, _ *mcp.CallToolRequest, input walkSche
 		return errResult(fmt.Errorf("cannot use both component and inline filters")), nil, nil
 	}
 
-	if err := validateGroupBy(input.GroupBy, input.Detail, []string{"type", "location"}); err != nil {
+	if err := validateGroupBy(input.GroupBy, input.Detail, []string{"type", groupByLocation}); err != nil {
 		return errResult(err), nil, nil
 	}
 
@@ -97,7 +97,7 @@ func handleWalkSchemas(_ context.Context, _ *mcp.CallToolRequest, input walkSche
 					return []string{"(untyped)"}
 				}
 				return []string{t}
-			case "location":
+			case groupByLocation:
 				return []string{schemaLocation(info.IsComponent)}
 			default:
 				return nil

--- a/joiner/collision.go
+++ b/joiner/collision.go
@@ -2,6 +2,18 @@ package joiner
 
 import "github.com/erraggy/oastools/internal/severity"
 
+// Collision resolution outcome labels recorded on CollisionEvent.Resolution.
+const (
+	resolutionRenamed      = "renamed"
+	resolutionDeduplicated = "deduplicated"
+	resolutionKeptLeft     = "kept-left"
+	resolutionKeptRight    = "kept-right"
+	resolutionFailed       = "failed"
+)
+
+// defaultKey is the OpenAPI "default" key used for responses and template helpers.
+const defaultKey = "default"
+
 // CollisionReport provides detailed analysis of collisions encountered during join operations
 type CollisionReport struct {
 	TotalCollisions  int
@@ -53,13 +65,13 @@ func (r *CollisionReport) AddEvent(event CollisionEvent) {
 	r.TotalCollisions++
 
 	switch event.Resolution {
-	case "renamed":
+	case resolutionRenamed:
 		r.ResolvedByRename++
-	case "deduplicated":
+	case resolutionDeduplicated:
 		r.ResolvedByDedup++
-	case "kept-left", "kept-right":
+	case resolutionKeptLeft, resolutionKeptRight:
 		r.ResolvedByAccept++
-	case "failed":
+	case resolutionFailed:
 		r.FailedCollisions++
 	}
 }

--- a/joiner/collision_handler.go
+++ b/joiner/collision_handler.go
@@ -274,13 +274,13 @@ func (j *Joiner) applySchemaResolution(p schemaResolutionParams) (bool, error) {
 
 	case ResolutionAcceptLeft:
 		// Keep existing (left), discard incoming (right)
-		j.recordCollisionEvent(p.result, p.collision.Name, p.collision.LeftSource, p.collision.RightSource, p.collision.ConfiguredStrategy, "kept-left", "")
+		j.recordCollisionEvent(p.result, p.collision.Name, p.collision.LeftSource, p.collision.RightSource, p.collision.ConfiguredStrategy, resolutionKeptLeft, "")
 		return true, nil
 
 	case ResolutionAcceptRight:
 		// Replace with incoming (right)
 		p.target[p.collision.Name] = schema
-		j.recordCollisionEvent(p.result, p.collision.Name, p.collision.LeftSource, p.collision.RightSource, p.collision.ConfiguredStrategy, "kept-right", "")
+		j.recordCollisionEvent(p.result, p.collision.Name, p.collision.LeftSource, p.collision.RightSource, p.collision.ConfiguredStrategy, resolutionKeptRight, "")
 		return true, nil
 
 	case ResolutionRename:
@@ -293,14 +293,14 @@ func (j *Joiner) applySchemaResolution(p schemaResolutionParams) (bool, error) {
 		p.result.rewriter.RegisterRename(p.collision.Name, newName, p.result.OASVersion)
 		line, col := j.getLocation(p.ctx.filePath, p.collision.JSONPath)
 		p.result.AddWarning(NewSchemaRenamedWarning(p.collision.Name, newName, p.label, p.ctx.filePath, line, col, false))
-		j.recordCollisionEvent(p.result, p.collision.Name, p.collision.LeftSource, p.collision.RightSource, p.collision.ConfiguredStrategy, "renamed", newName)
+		j.recordCollisionEvent(p.result, p.collision.Name, p.collision.LeftSource, p.collision.RightSource, p.collision.ConfiguredStrategy, resolutionRenamed, newName)
 		return true, nil
 
 	case ResolutionDeduplicate:
 		// Keep left, discard right (treat as equivalent)
 		line, col := j.getLocation(p.ctx.filePath, p.collision.JSONPath)
 		p.result.AddWarning(NewSchemaDedupWarning(p.collision.Name, p.label, p.ctx.filePath, line, col))
-		j.recordCollisionEvent(p.result, p.collision.Name, p.collision.LeftSource, p.collision.RightSource, p.collision.ConfiguredStrategy, "deduplicated", "")
+		j.recordCollisionEvent(p.result, p.collision.Name, p.collision.LeftSource, p.collision.RightSource, p.collision.ConfiguredStrategy, resolutionDeduplicated, "")
 		return true, nil
 
 	case ResolutionFail:
@@ -357,19 +357,19 @@ func (j *Joiner) applyComponentResolution(p componentResolutionParams) (handled 
 
 	case ResolutionAcceptLeft:
 		// Keep existing (left), discard incoming (right)
-		j.recordCollisionEvent(p.result, p.collision.Name, p.collision.LeftSource, p.collision.RightSource, p.collision.ConfiguredStrategy, "kept-left", "")
+		j.recordCollisionEvent(p.result, p.collision.Name, p.collision.LeftSource, p.collision.RightSource, p.collision.ConfiguredStrategy, resolutionKeptLeft, "")
 		return true, false, nil
 
 	case ResolutionAcceptRight:
 		// Replace with incoming (right)
-		j.recordCollisionEvent(p.result, p.collision.Name, p.collision.LeftSource, p.collision.RightSource, p.collision.ConfiguredStrategy, "kept-right", "")
+		j.recordCollisionEvent(p.result, p.collision.Name, p.collision.LeftSource, p.collision.RightSource, p.collision.ConfiguredStrategy, resolutionKeptRight, "")
 		return true, true, nil
 
 	case ResolutionDeduplicate:
 		// Keep left, discard right (treat as equivalent)
 		line, col := j.getLocation(p.ctx.filePath, p.collision.JSONPath)
 		p.result.AddWarning(NewSchemaDedupWarning(p.collision.Name, string(p.collision.Type), p.ctx.filePath, line, col))
-		j.recordCollisionEvent(p.result, p.collision.Name, p.collision.LeftSource, p.collision.RightSource, p.collision.ConfiguredStrategy, "deduplicated", "")
+		j.recordCollisionEvent(p.result, p.collision.Name, p.collision.LeftSource, p.collision.RightSource, p.collision.ConfiguredStrategy, resolutionDeduplicated, "")
 		return true, false, nil
 
 	case ResolutionFail:

--- a/joiner/helpers.go
+++ b/joiner/helpers.go
@@ -241,7 +241,7 @@ func (j *Joiner) applyPathResolution(
 
 	case ResolutionAcceptLeft:
 		// Keep existing (left), discard incoming (right) - no action needed
-		j.recordCollisionEventWithPath(result, collision.Name, collision.JSONPath, collision.LeftSource, collision.RightSource, collision.ConfiguredStrategy, "kept-left")
+		j.recordCollisionEventWithPath(result, collision.Name, collision.JSONPath, collision.LeftSource, collision.RightSource, collision.ConfiguredStrategy, resolutionKeptLeft)
 		line, col := j.getLocation(ctx.filePath, collision.JSONPath)
 		result.AddWarning(NewPathCollisionWarning(collision.Name, "kept from first document", collision.LeftSource, ctx.filePath, line, col))
 		return true, nil
@@ -249,7 +249,7 @@ func (j *Joiner) applyPathResolution(
 	case ResolutionAcceptRight:
 		// Replace with incoming (right)
 		target[collision.Name] = pathItem
-		j.recordCollisionEventWithPath(result, collision.Name, collision.JSONPath, collision.LeftSource, collision.RightSource, collision.ConfiguredStrategy, "kept-right")
+		j.recordCollisionEventWithPath(result, collision.Name, collision.JSONPath, collision.LeftSource, collision.RightSource, collision.ConfiguredStrategy, resolutionKeptRight)
 		line, col := j.getLocation(ctx.filePath, collision.JSONPath)
 		result.AddWarning(NewPathCollisionWarning(collision.Name, "overwritten", collision.LeftSource, ctx.filePath, line, col))
 		return true, nil
@@ -260,7 +260,7 @@ func (j *Joiner) applyPathResolution(
 
 	case ResolutionDeduplicate:
 		// Keep left, discard right (treat as equivalent)
-		j.recordCollisionEventWithPath(result, collision.Name, collision.JSONPath, collision.LeftSource, collision.RightSource, collision.ConfiguredStrategy, "deduplicated")
+		j.recordCollisionEventWithPath(result, collision.Name, collision.JSONPath, collision.LeftSource, collision.RightSource, collision.ConfiguredStrategy, resolutionDeduplicated)
 		line, col := j.getLocation(ctx.filePath, collision.JSONPath)
 		result.AddWarning(NewPathCollisionWarning(collision.Name, "deduplicated (kept from first document)", collision.LeftSource, ctx.filePath, line, col))
 		return true, nil

--- a/joiner/oas2.go
+++ b/joiner/oas2.go
@@ -237,7 +237,7 @@ func (j *Joiner) mergeOAS2Definitions(joined, source *parser.OAS2Document, ctx d
 						// Schemas are equivalent, keep existing and skip
 						line, col := j.getLocation(ctx.filePath, fmt.Sprintf("$.definitions.%s", effectiveName))
 						result.AddWarning(NewSchemaDedupWarning(effectiveName, "definition", ctx.filePath, line, col))
-						j.recordCollisionEvent(result, effectiveName, result.firstFilePath, ctx.filePath, schemaStrategy, "deduplicated", "")
+						j.recordCollisionEvent(result, effectiveName, result.firstFilePath, ctx.filePath, schemaStrategy, resolutionDeduplicated, "")
 						continue
 					}
 					// Not equivalent, fall back to fail
@@ -270,7 +270,7 @@ func (j *Joiner) mergeOAS2Definitions(joined, source *parser.OAS2Document, ctx d
 
 				line, col := j.getLocation(ctx.filePath, fmt.Sprintf("$.definitions.%s", effectiveName))
 				result.AddWarning(NewSchemaRenamedWarning(effectiveName, newName, "definition", ctx.filePath, line, col, true))
-				j.recordCollisionEvent(result, effectiveName, result.firstFilePath, ctx.filePath, schemaStrategy, "renamed", newName)
+				j.recordCollisionEvent(result, effectiveName, result.firstFilePath, ctx.filePath, schemaStrategy, resolutionRenamed, newName)
 
 			case StrategyRenameRight:
 				// Rename the new (right) definition and keep existing (left) definition under original name
@@ -296,7 +296,7 @@ func (j *Joiner) mergeOAS2Definitions(joined, source *parser.OAS2Document, ctx d
 
 				line, col := j.getLocation(ctx.filePath, fmt.Sprintf("$.definitions.%s", effectiveName))
 				result.AddWarning(NewSchemaRenamedWarning(effectiveName, newName, "definition", ctx.filePath, line, col, false))
-				j.recordCollisionEvent(result, effectiveName, result.firstFilePath, ctx.filePath, schemaStrategy, "renamed", newName)
+				j.recordCollisionEvent(result, effectiveName, result.firstFilePath, ctx.filePath, schemaStrategy, resolutionRenamed, newName)
 
 			default:
 				// Handle existing strategies
@@ -307,10 +307,10 @@ func (j *Joiner) mergeOAS2Definitions(joined, source *parser.OAS2Document, ctx d
 				if j.shouldOverwrite(schemaStrategy) {
 					joined.Definitions[effectiveName] = schema
 					result.AddWarning(NewSchemaCollisionWarning(effectiveName, "overwritten", "definitions", result.firstFilePath, ctx.filePath, line, col))
-					j.recordCollisionEvent(result, effectiveName, result.firstFilePath, ctx.filePath, schemaStrategy, "kept-right", "")
+					j.recordCollisionEvent(result, effectiveName, result.firstFilePath, ctx.filePath, schemaStrategy, resolutionKeptRight, "")
 				} else {
 					result.AddWarning(NewSchemaCollisionWarning(effectiveName, "kept from first document", "definitions", result.firstFilePath, ctx.filePath, line, col))
-					j.recordCollisionEvent(result, effectiveName, result.firstFilePath, ctx.filePath, schemaStrategy, "kept-left", "")
+					j.recordCollisionEvent(result, effectiveName, result.firstFilePath, ctx.filePath, schemaStrategy, resolutionKeptLeft, "")
 				}
 			}
 		} else {

--- a/joiner/oas3.go
+++ b/joiner/oas3.go
@@ -354,7 +354,7 @@ func (j *Joiner) mergeSchemas(target, source map[string]*parser.Schema, strategy
 						// Schemas are equivalent, keep existing and skip
 						line, col := j.getLocation(ctx.filePath, fmt.Sprintf("$.components.schemas.%s", effectiveName))
 						result.AddWarning(NewSchemaDedupWarning(effectiveName, "schema", ctx.filePath, line, col))
-						j.recordCollisionEvent(result, effectiveName, result.firstFilePath, ctx.filePath, strategy, "deduplicated", "")
+						j.recordCollisionEvent(result, effectiveName, result.firstFilePath, ctx.filePath, strategy, resolutionDeduplicated, "")
 						continue
 					}
 					// Not equivalent, fall back to default strategy or fail
@@ -388,7 +388,7 @@ func (j *Joiner) mergeSchemas(target, source map[string]*parser.Schema, strategy
 
 				line, col := j.getLocation(ctx.filePath, fmt.Sprintf("$.components.schemas.%s", effectiveName))
 				result.AddWarning(NewSchemaRenamedWarning(effectiveName, newName, "schema", ctx.filePath, line, col, true))
-				j.recordCollisionEvent(result, effectiveName, result.firstFilePath, ctx.filePath, strategy, "renamed", newName)
+				j.recordCollisionEvent(result, effectiveName, result.firstFilePath, ctx.filePath, strategy, resolutionRenamed, newName)
 
 			case StrategyRenameRight:
 				// Rename the new (right) schema and keep existing (left) schema under original name
@@ -415,7 +415,7 @@ func (j *Joiner) mergeSchemas(target, source map[string]*parser.Schema, strategy
 
 				line, col := j.getLocation(ctx.filePath, fmt.Sprintf("$.components.schemas.%s", effectiveName))
 				result.AddWarning(NewSchemaRenamedWarning(effectiveName, newName, "schema", ctx.filePath, line, col, false))
-				j.recordCollisionEvent(result, effectiveName, result.firstFilePath, ctx.filePath, strategy, "renamed", newName)
+				j.recordCollisionEvent(result, effectiveName, result.firstFilePath, ctx.filePath, strategy, resolutionRenamed, newName)
 
 			default:
 				// Handle existing strategies (accept-left, accept-right, fail, fail-on-paths)
@@ -426,11 +426,11 @@ func (j *Joiner) mergeSchemas(target, source map[string]*parser.Schema, strategy
 					target[effectiveName] = schema
 					line, col := j.getLocation(ctx.filePath, fmt.Sprintf("$.components.schemas.%s", effectiveName))
 					result.AddWarning(NewSchemaCollisionWarning(effectiveName, "overwritten", "components.schemas", result.firstFilePath, ctx.filePath, line, col))
-					j.recordCollisionEvent(result, effectiveName, result.firstFilePath, ctx.filePath, strategy, "kept-right", "")
+					j.recordCollisionEvent(result, effectiveName, result.firstFilePath, ctx.filePath, strategy, resolutionKeptRight, "")
 				} else {
 					line, col := j.getLocation(ctx.filePath, fmt.Sprintf("$.components.schemas.%s", effectiveName))
 					result.AddWarning(NewSchemaCollisionWarning(effectiveName, "kept from first document", "components.schemas", result.firstFilePath, ctx.filePath, line, col))
-					j.recordCollisionEvent(result, effectiveName, result.firstFilePath, ctx.filePath, strategy, "kept-left", "")
+					j.recordCollisionEvent(result, effectiveName, result.firstFilePath, ctx.filePath, strategy, resolutionKeptLeft, "")
 				}
 			}
 		} else {

--- a/joiner/refgraph.go
+++ b/joiner/refgraph.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/erraggy/oastools/internal/httputil"
 	"github.com/erraggy/oastools/parser"
 )
 
@@ -81,7 +82,7 @@ func (g *RefGraph) recordPathItemOAS3(path string, pathItem *parser.PathItem, ve
 		if op.Responses != nil {
 			// Default response
 			if op.Responses.Default != nil {
-				g.recordResponseSchemaRefs(op.Responses.Default, baseRef, "default")
+				g.recordResponseSchemaRefs(op.Responses.Default, baseRef, defaultKey)
 			}
 			// Status code responses
 			for statusCode, response := range op.Responses.Codes {
@@ -161,7 +162,7 @@ func (g *RefGraph) recordPathItemCallbackOAS3(pathItem *parser.PathItem, baseRef
 		// Record responses
 		if op.Responses != nil {
 			if op.Responses.Default != nil {
-				g.recordResponseSchemaRefs(op.Responses.Default, callbackRef, "default")
+				g.recordResponseSchemaRefs(op.Responses.Default, callbackRef, defaultKey)
 			}
 			for statusCode, response := range op.Responses.Codes {
 				if response != nil {
@@ -240,13 +241,13 @@ func buildRefGraphOAS2(doc *parser.OAS2Document) *RefGraph {
 func (g *RefGraph) recordPathItemOAS2(path string, pathItem *parser.PathItem) {
 	// OAS 2.0 operations
 	operations := map[string]*parser.Operation{
-		"get":     pathItem.Get,
-		"put":     pathItem.Put,
-		"post":    pathItem.Post,
-		"delete":  pathItem.Delete,
-		"options": pathItem.Options,
-		"head":    pathItem.Head,
-		"patch":   pathItem.Patch,
+		"get":               pathItem.Get,
+		"put":               pathItem.Put,
+		httputil.MethodPost: pathItem.Post,
+		"delete":            pathItem.Delete,
+		"options":           pathItem.Options,
+		"head":              pathItem.Head,
+		"patch":             pathItem.Patch,
 	}
 
 	for method, op := range operations {
@@ -279,7 +280,7 @@ func (g *RefGraph) recordPathItemOAS2(path string, pathItem *parser.PathItem) {
 		if op.Responses != nil {
 			// Default response
 			if op.Responses.Default != nil && op.Responses.Default.Schema != nil {
-				g.recordOperationSchemaRef(op.Responses.Default.Schema, baseRef, UsageTypeResponse, "default", "", "")
+				g.recordOperationSchemaRef(op.Responses.Default.Schema, baseRef, UsageTypeResponse, defaultKey, "", "")
 			}
 			// Status code responses
 			for statusCode, response := range op.Responses.Codes {

--- a/joiner/rename_context.go
+++ b/joiner/rename_context.go
@@ -165,7 +165,7 @@ func renameFuncs() template.FuncMap {
 		"kebabCase":  naming.ToKebabCase,
 
 		// Conditional helpers
-		"default":  defaultValue,
+		defaultKey: defaultValue,
 		"coalesce": coalesce,
 	}
 }

--- a/parser/common_json.go
+++ b/parser/common_json.go
@@ -19,10 +19,10 @@ func (i *Info) MarshalJSON() ([]byte, error) {
 
 	// Build map with known fields
 	m := map[string]any{
-		"title":   i.Title,   // Required field, always include
-		"version": i.Version, // Required field, always include
+		jsonKeyTitle:   i.Title,   // Required field, always include
+		jsonKeyVersion: i.Version, // Required field, always include
 	}
-	jsonhelpers.SetIfNotEmpty(m, "description", i.Description)
+	jsonhelpers.SetIfNotEmpty(m, jsonKeyDescription, i.Description)
 	jsonhelpers.SetIfNotEmpty(m, "termsOfService", i.TermsOfService)
 	jsonhelpers.SetIfNotNil(m, "contact", i.Contact)
 	jsonhelpers.SetIfNotNil(m, "license", i.License)
@@ -56,7 +56,7 @@ func (c *Contact) MarshalJSON() ([]byte, error) {
 
 	// Build map with known fields
 	m := make(map[string]any, 3+len(c.Extra))
-	jsonhelpers.SetIfNotEmpty(m, "name", c.Name)
+	jsonhelpers.SetIfNotEmpty(m, jsonKeyName, c.Name)
 	jsonhelpers.SetIfNotEmpty(m, "url", c.URL)
 	jsonhelpers.SetIfNotEmpty(m, "email", c.Email)
 
@@ -88,7 +88,7 @@ func (l *License) MarshalJSON() ([]byte, error) {
 
 	// Build map with known fields
 	m := make(map[string]any, 3+len(l.Extra))
-	jsonhelpers.SetIfNotEmpty(m, "name", l.Name)
+	jsonhelpers.SetIfNotEmpty(m, jsonKeyName, l.Name)
 	jsonhelpers.SetIfNotEmpty(m, "url", l.URL)
 	jsonhelpers.SetIfNotEmpty(m, "identifier", l.Identifier)
 
@@ -122,7 +122,7 @@ func (e *ExternalDocs) MarshalJSON() ([]byte, error) {
 	m := map[string]any{
 		"url": e.URL, // Required field, always include
 	}
-	jsonhelpers.SetIfNotEmpty(m, "description", e.Description)
+	jsonhelpers.SetIfNotEmpty(m, jsonKeyDescription, e.Description)
 
 	// Merge in Extra fields and marshal
 	return jsonhelpers.MarshalWithExtras(m, e.Extra)
@@ -152,9 +152,9 @@ func (t *Tag) MarshalJSON() ([]byte, error) {
 
 	// Build map with known fields
 	m := map[string]any{
-		"name": t.Name, // Required field, always include
+		jsonKeyName: t.Name, // Required field, always include
 	}
-	jsonhelpers.SetIfNotEmpty(m, "description", t.Description)
+	jsonhelpers.SetIfNotEmpty(m, jsonKeyDescription, t.Description)
 	jsonhelpers.SetIfNotNil(m, "externalDocs", t.ExternalDocs)
 
 	// Merge in Extra fields and marshal
@@ -187,7 +187,7 @@ func (s *Server) MarshalJSON() ([]byte, error) {
 	m := map[string]any{
 		"url": s.URL, // Required field, always include
 	}
-	jsonhelpers.SetIfNotEmpty(m, "description", s.Description)
+	jsonhelpers.SetIfNotEmpty(m, jsonKeyDescription, s.Description)
 	jsonhelpers.SetIfMapNotEmpty(m, "variables", s.Variables)
 
 	// Merge in Extra fields and marshal
@@ -218,10 +218,10 @@ func (sv *ServerVariable) MarshalJSON() ([]byte, error) {
 
 	// Build map with known fields
 	m := map[string]any{
-		"default": sv.Default, // Required field, always include
+		jsonKeyDefault: sv.Default, // Required field, always include
 	}
 	jsonhelpers.SetIfNotNil(m, "enum", sv.Enum)
-	jsonhelpers.SetIfNotEmpty(m, "description", sv.Description)
+	jsonhelpers.SetIfNotEmpty(m, jsonKeyDescription, sv.Description)
 
 	// Merge in Extra fields and marshal
 	return jsonhelpers.MarshalWithExtras(m, sv.Extra)
@@ -251,10 +251,10 @@ func (r *Reference) MarshalJSON() ([]byte, error) {
 
 	// Build map with known fields
 	m := map[string]any{
-		"$ref": r.Ref, // Required field, always include
+		jsonKeyRef: r.Ref, // Required field, always include
 	}
 	jsonhelpers.SetIfNotEmpty(m, "summary", r.Summary)
-	jsonhelpers.SetIfNotEmpty(m, "description", r.Description)
+	jsonhelpers.SetIfNotEmpty(m, jsonKeyDescription, r.Description)
 
 	// Merge in Extra fields and marshal
 	return jsonhelpers.MarshalWithExtras(m, r.Extra)

--- a/parser/constants.go
+++ b/parser/constants.go
@@ -15,3 +15,35 @@ const (
 	// ParamInBody indicates the parameter is in the request body (OAS 2.0 only)
 	ParamInBody = "body"
 )
+
+// JSON field key constants used across the parser package.
+const (
+	jsonKeyTitle       = "title"
+	jsonKeyVersion     = "version"
+	jsonKeyName        = "name"
+	jsonKeyDefault     = "default"
+	jsonKeyRef         = "$ref"
+	jsonKeyType        = "type"
+	jsonKeyDescription = "description"
+)
+
+// Reference type constants (used in Ref.RefType field).
+const (
+	refTypeFile = "file"
+	refTypeHTTP = "http"
+)
+
+// MIME type constants used for content-type detection.
+const (
+	mimeApplicationJSON = "application/json"
+	mimeApplicationYAML = "application/yaml"
+)
+
+// OAS version string constants.
+const (
+	oas300 = "3.0.0"
+	oas301 = "3.0.1"
+	oas303 = "3.0.3"
+	oas310 = "3.1.0"
+	oas320 = "3.2.0"
+)

--- a/parser/internal/jsonhelpers/helpers.go
+++ b/parser/internal/jsonhelpers/helpers.go
@@ -183,7 +183,7 @@ func SetIfNotNil(m map[string]any, key string, value any) {
 	// We must use reflection to detect these cases
 	v := reflect.ValueOf(value)
 	switch v.Kind() {
-	case reflect.Ptr, reflect.Slice, reflect.Map, reflect.Chan, reflect.Func, reflect.Interface:
+	case reflect.Pointer, reflect.Slice, reflect.Map, reflect.Chan, reflect.Func, reflect.Interface:
 		if v.IsNil() {
 			return
 		}

--- a/parser/parameters_json.go
+++ b/parser/parameters_json.go
@@ -19,11 +19,11 @@ func (p *Parameter) MarshalJSON() ([]byte, error) {
 
 	// Build map with known fields
 	m := map[string]any{
-		"name": p.Name, // Required field, always include
-		"in":   p.In,   // Required field, always include
+		jsonKeyName: p.Name, // Required field, always include
+		"in":        p.In,   // Required field, always include
 	}
-	jsonhelpers.SetIfNotEmpty(m, "$ref", p.Ref)
-	jsonhelpers.SetIfNotEmpty(m, "description", p.Description)
+	jsonhelpers.SetIfNotEmpty(m, jsonKeyRef, p.Ref)
+	jsonhelpers.SetIfNotEmpty(m, jsonKeyDescription, p.Description)
 	jsonhelpers.SetIfTrue(m, "required", p.Required)
 	jsonhelpers.SetIfTrue(m, "deprecated", p.Deprecated)
 	jsonhelpers.SetIfNotEmpty(m, "style", p.Style)
@@ -74,7 +74,7 @@ func (i *Items) MarshalJSON() ([]byte, error) {
 
 	// Build map with known fields
 	m := map[string]any{
-		"type": i.Type, // Required field, always include
+		jsonKeyType: i.Type, // Required field, always include
 	}
 	jsonhelpers.SetOAS2PrimitiveFields(m, jsonhelpers.OAS2PrimitiveFields{
 		Format: i.Format, Items: i.Items,
@@ -118,8 +118,8 @@ func (rb *RequestBody) MarshalJSON() ([]byte, error) {
 	m := map[string]any{
 		"content": rb.Content, // Required field, always include
 	}
-	jsonhelpers.SetIfNotEmpty(m, "$ref", rb.Ref)
-	jsonhelpers.SetIfNotEmpty(m, "description", rb.Description)
+	jsonhelpers.SetIfNotEmpty(m, jsonKeyRef, rb.Ref)
+	jsonhelpers.SetIfNotEmpty(m, jsonKeyDescription, rb.Description)
 	jsonhelpers.SetIfTrue(m, "required", rb.Required)
 
 	// Merge in Extra fields and marshal
@@ -150,8 +150,8 @@ func (h *Header) MarshalJSON() ([]byte, error) {
 
 	// Build map with known fields
 	m := make(map[string]any, 27+len(h.Extra))
-	jsonhelpers.SetIfNotEmpty(m, "$ref", h.Ref)
-	jsonhelpers.SetIfNotEmpty(m, "description", h.Description)
+	jsonhelpers.SetIfNotEmpty(m, jsonKeyRef, h.Ref)
+	jsonhelpers.SetIfNotEmpty(m, jsonKeyDescription, h.Description)
 	jsonhelpers.SetIfTrue(m, "required", h.Required)
 	jsonhelpers.SetIfTrue(m, "deprecated", h.Deprecated)
 	jsonhelpers.SetIfNotEmpty(m, "style", h.Style)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -940,7 +940,7 @@ func (p *Parser) validateOAS3(doc *OAS3Document) []error {
 	// Validate openapi version field
 	if doc.OpenAPI == "" {
 		errors = append(errors, fmt.Errorf("oas 3.x: missing required root field 'openapi': must be set to a valid 3.x version (e.g., \"3.0.3\", \"3.1.0\")"))
-	} else if !versionInRangeExclusive(doc.OpenAPI, "3.0.0", "4.0.0") {
+	} else if !versionInRangeExclusive(doc.OpenAPI, oas300, "4.0.0") {
 		errors = append(errors, fmt.Errorf("oas %s: invalid 'openapi' field value: \"%s\" is not a valid 3.x version", version, doc.OpenAPI))
 	}
 
@@ -957,7 +957,7 @@ func (p *Parser) validateOAS3(doc *OAS3Document) []error {
 
 	// Validate webhooks if present (OAS 3.1+)
 	if len(doc.Webhooks) > 0 {
-		if versionInRangeExclusive(doc.OpenAPI, "0.0.0", "3.1.0") {
+		if versionInRangeExclusive(doc.OpenAPI, "0.0.0", oas310) {
 			errors = append(errors, fmt.Errorf("oas %s: 'webhooks' field is only supported in OAS 3.1.0 and later, not in version %s", version, doc.OpenAPI))
 		} else {
 			// Validate webhook structure (webhooks are PathItems like paths)
@@ -985,11 +985,11 @@ func (p *Parser) validateOAS3Info(info *Info, version string) []error {
 
 func (p *Parser) validateOAS3PathsRequirement(doc *OAS3Document, version string) []error {
 	errors := make([]error, 0)
-	if versionInRangeExclusive(doc.OpenAPI, "3.0.0", "3.1.0") {
+	if versionInRangeExclusive(doc.OpenAPI, oas300, oas310) {
 		if doc.Paths == nil {
 			errors = append(errors, fmt.Errorf("oas %s: missing required root field 'paths': Paths object is required in OAS 3.0.x (https://spec.openapis.org/oas/v3.0.0.html#paths-object)", version))
 		}
-	} else if versionInRangeExclusive(doc.OpenAPI, "3.1.0", "") {
+	} else if versionInRangeExclusive(doc.OpenAPI, oas310, "") {
 		// In OAS 3.1+, either paths or webhooks must be present
 		if doc.Paths == nil && len(doc.Webhooks) == 0 {
 			errors = append(errors, fmt.Errorf("oas %s: document must have either 'paths' or 'webhooks': at least one is required in OAS 3.1+", version))

--- a/parser/parser_format.go
+++ b/parser/parser_format.go
@@ -168,9 +168,9 @@ func detectFormatFromURL(urlStr string, contentType string) SourceFormat {
 		contentType = strings.TrimSpace(contentType)
 
 		switch contentType {
-		case "application/json":
+		case mimeApplicationJSON:
 			return SourceFormatJSON
-		case "application/yaml", "application/x-yaml", "text/yaml", "text/x-yaml":
+		case mimeApplicationYAML, "application/x-yaml", "text/yaml", "text/x-yaml":
 			return SourceFormatYAML
 		}
 	}

--- a/parser/paths.go
+++ b/parser/paths.go
@@ -75,7 +75,7 @@ func (r *Responses) UnmarshalYAML(unmarshal func(any) error) error {
 
 	// Process each field
 	for key, value := range raw {
-		if key == "default" {
+		if key == jsonKeyDefault {
 			// Handle the default response
 			valueBytes, err := yamlMarshalValue(value)
 			if err != nil {

--- a/parser/paths_json.go
+++ b/parser/paths_json.go
@@ -21,9 +21,9 @@ func (p *PathItem) MarshalJSON() ([]byte, error) {
 
 	// Build map with known fields
 	m := make(map[string]any, 12+len(p.Extra))
-	jsonhelpers.SetIfNotEmpty(m, "$ref", p.Ref)
+	jsonhelpers.SetIfNotEmpty(m, jsonKeyRef, p.Ref)
 	jsonhelpers.SetIfNotEmpty(m, "summary", p.Summary)
-	jsonhelpers.SetIfNotEmpty(m, "description", p.Description)
+	jsonhelpers.SetIfNotEmpty(m, jsonKeyDescription, p.Description)
 	jsonhelpers.SetIfNotNil(m, "get", p.Get)
 	jsonhelpers.SetIfNotNil(m, "put", p.Put)
 	jsonhelpers.SetIfNotNil(m, "post", p.Post)
@@ -69,7 +69,7 @@ func (o *Operation) MarshalJSON() ([]byte, error) {
 	}
 	jsonhelpers.SetIfSliceNotEmpty(m, "tags", o.Tags)
 	jsonhelpers.SetIfNotEmpty(m, "summary", o.Summary)
-	jsonhelpers.SetIfNotEmpty(m, "description", o.Description)
+	jsonhelpers.SetIfNotEmpty(m, jsonKeyDescription, o.Description)
 	jsonhelpers.SetIfNotNil(m, "externalDocs", o.ExternalDocs)
 	jsonhelpers.SetIfNotEmpty(m, "operationId", o.OperationID)
 	jsonhelpers.SetIfSliceNotEmpty(m, "parameters", o.Parameters)
@@ -110,9 +110,9 @@ func (r *Response) MarshalJSON() ([]byte, error) {
 
 	// Build map with known fields
 	m := map[string]any{
-		"description": r.Description, // Required field, always include
+		jsonKeyDescription: r.Description, // Required field, always include
 	}
-	jsonhelpers.SetIfNotEmpty(m, "$ref", r.Ref)
+	jsonhelpers.SetIfNotEmpty(m, jsonKeyRef, r.Ref)
 	jsonhelpers.SetIfMapNotEmpty(m, "headers", r.Headers)
 	jsonhelpers.SetIfMapNotEmpty(m, "content", r.Content)
 	jsonhelpers.SetIfMapNotEmpty(m, "links", r.Links)
@@ -147,12 +147,12 @@ func (l *Link) MarshalJSON() ([]byte, error) {
 
 	// Build map with known fields
 	m := make(map[string]any, 7+len(l.Extra))
-	jsonhelpers.SetIfNotEmpty(m, "$ref", l.Ref)
+	jsonhelpers.SetIfNotEmpty(m, jsonKeyRef, l.Ref)
 	jsonhelpers.SetIfNotEmpty(m, "operationRef", l.OperationRef)
 	jsonhelpers.SetIfNotEmpty(m, "operationId", l.OperationID)
 	jsonhelpers.SetIfMapNotEmpty(m, "parameters", l.Parameters)
 	jsonhelpers.SetIfNotNil(m, "requestBody", l.RequestBody)
-	jsonhelpers.SetIfNotEmpty(m, "description", l.Description)
+	jsonhelpers.SetIfNotEmpty(m, jsonKeyDescription, l.Description)
 	jsonhelpers.SetIfNotNil(m, "server", l.Server)
 
 	// Merge in Extra fields and marshal
@@ -216,9 +216,9 @@ func (e *Example) MarshalJSON() ([]byte, error) {
 
 	// Build map with known fields
 	m := make(map[string]any, 5+len(e.Extra))
-	jsonhelpers.SetIfNotEmpty(m, "$ref", e.Ref)
+	jsonhelpers.SetIfNotEmpty(m, jsonKeyRef, e.Ref)
 	jsonhelpers.SetIfNotEmpty(m, "summary", e.Summary)
-	jsonhelpers.SetIfNotEmpty(m, "description", e.Description)
+	jsonhelpers.SetIfNotEmpty(m, jsonKeyDescription, e.Description)
 	jsonhelpers.SetIfNotNil(m, "value", e.Value)
 	jsonhelpers.SetIfNotEmpty(m, "externalValue", e.ExternalValue)
 
@@ -281,7 +281,7 @@ func (r *Responses) MarshalJSON() ([]byte, error) {
 
 	// Add default if present
 	if r.Default != nil {
-		m["default"] = r.Default
+		m[jsonKeyDefault] = r.Default
 	}
 
 	// Add status code responses
@@ -306,7 +306,7 @@ func (r *Responses) UnmarshalJSON(data []byte) error {
 	r.Codes = make(map[string]*Response)
 
 	for key, value := range m {
-		if key == "default" {
+		if key == jsonKeyDefault {
 			var defaultResp Response
 			if err := json.Unmarshal(value, &defaultResp); err != nil {
 				return err

--- a/parser/resolver.go
+++ b/parser/resolver.go
@@ -204,7 +204,7 @@ func (r *RefResolver) ResolveExternal(ref string) (any, error) {
 	if r.visited[ref] {
 		return nil, &oaserrors.ReferenceError{
 			Ref:        ref,
-			RefType:    "file",
+			RefType:    refTypeFile,
 			IsCircular: true,
 		}
 	}
@@ -241,7 +241,7 @@ func (r *RefResolver) ResolveExternal(ref string) (any, error) {
 	if err != nil || strings.HasPrefix(relPath, "..") {
 		return nil, &oaserrors.ReferenceError{
 			Ref:             ref,
-			RefType:         "file",
+			RefType:         refTypeFile,
 			IsPathTraversal: true,
 		}
 	}
@@ -302,7 +302,7 @@ func (r *RefResolver) ResolveHTTP(ref string) (any, error) {
 	if r.visited[ref] {
 		return nil, &oaserrors.ReferenceError{
 			Ref:        ref,
-			RefType:    "http",
+			RefType:    refTypeHTTP,
 			IsCircular: true,
 		}
 	}
@@ -464,7 +464,7 @@ func (r *RefResolver) resolveRefsRecursive(root, current any, depth int) error {
 	switch v := current.(type) {
 	case map[string]any:
 		// Check if this object has a $ref field
-		if ref, ok := v["$ref"].(string); ok {
+		if ref, ok := v[jsonKeyRef].(string); ok {
 			// Check for $ref pointing to document root (always circular)
 			if ref == "#" || ref == "#/" {
 				// Leave the $ref in place - resolving it would create infinite recursion
@@ -496,7 +496,7 @@ func (r *RefResolver) resolveRefsRecursive(root, current any, depth int) error {
 			// Replace the current object with the resolved content
 			// Note: This modifies the map in place
 			for k := range v {
-				if k != "$ref" {
+				if k != jsonKeyRef {
 					delete(v, k)
 				}
 			}
@@ -517,7 +517,7 @@ func (r *RefResolver) resolveRefsRecursive(root, current any, depth int) error {
 					v[k] = deepCopyJSONValue(val)
 				}
 			}
-			delete(v, "$ref")
+			delete(v, jsonKeyRef)
 
 			// Continue resolving in the newly resolved content
 			// Keep ref in resolving map during this recursive call to detect self-references

--- a/parser/schema_json.go
+++ b/parser/schema_json.go
@@ -22,13 +22,13 @@ func (s *Schema) MarshalJSON() ([]byte, error) {
 	m := make(map[string]any, 50+len(s.Extra))
 
 	// Add known fields (using helpers to omit zero values)
-	jsonhelpers.SetIfNotEmpty(m, "$ref", s.Ref)
+	jsonhelpers.SetIfNotEmpty(m, jsonKeyRef, s.Ref)
 	jsonhelpers.SetIfNotEmpty(m, "$schema", s.Schema)
-	jsonhelpers.SetIfNotEmpty(m, "title", s.Title)
-	jsonhelpers.SetIfNotEmpty(m, "description", s.Description)
-	jsonhelpers.SetIfNotNil(m, "default", s.Default)
+	jsonhelpers.SetIfNotEmpty(m, jsonKeyTitle, s.Title)
+	jsonhelpers.SetIfNotEmpty(m, jsonKeyDescription, s.Description)
+	jsonhelpers.SetIfNotNil(m, jsonKeyDefault, s.Default)
 	jsonhelpers.SetIfSliceNotEmpty(m, "examples", s.Examples)
-	jsonhelpers.SetIfNotNil(m, "type", s.Type)
+	jsonhelpers.SetIfNotNil(m, jsonKeyType, s.Type)
 	jsonhelpers.SetIfNotNil(m, "enum", s.Enum)
 	jsonhelpers.SetIfNotNil(m, "const", s.Const)
 	jsonhelpers.SetIfNotNil(m, "multipleOf", s.MultipleOf)
@@ -197,7 +197,7 @@ func (x *XML) MarshalJSON() ([]byte, error) {
 
 	// Build map with known fields
 	m := make(map[string]any, 5+len(x.Extra))
-	jsonhelpers.SetIfNotEmpty(m, "name", x.Name)
+	jsonhelpers.SetIfNotEmpty(m, jsonKeyName, x.Name)
 	jsonhelpers.SetIfNotEmpty(m, "namespace", x.Namespace)
 	jsonhelpers.SetIfNotEmpty(m, "prefix", x.Prefix)
 	jsonhelpers.SetIfTrue(m, "attribute", x.Attribute)

--- a/parser/security_json.go
+++ b/parser/security_json.go
@@ -22,15 +22,15 @@ func (ss *SecurityScheme) MarshalJSON() ([]byte, error) {
 
 	// Add known fields (omit zero values to match json:",omitempty" behavior)
 	if ss.Ref != "" {
-		m["$ref"] = ss.Ref
+		m[jsonKeyRef] = ss.Ref
 	}
 	// Type is required, always include
-	m["type"] = ss.Type
+	m[jsonKeyType] = ss.Type
 	if ss.Description != "" {
-		m["description"] = ss.Description
+		m[jsonKeyDescription] = ss.Description
 	}
 	if ss.Name != "" {
-		m["name"] = ss.Name
+		m[jsonKeyName] = ss.Name
 	}
 	if ss.In != "" {
 		m["in"] = ss.In

--- a/parser/sourcemap.go
+++ b/parser/sourcemap.go
@@ -266,7 +266,7 @@ func walkNode(node *yaml.Node, path string, sm *SourceMap, file string) {
 			})
 
 			// Track $ref specially
-			if key == "$ref" && valNode.Kind == yaml.ScalarNode {
+			if key == jsonKeyRef && valNode.Kind == yaml.ScalarNode {
 				sm.setRef(path, RefLocation{
 					Origin: SourceLocation{
 						Line:   valNode.Line,

--- a/parser/versions.go
+++ b/parser/versions.go
@@ -41,15 +41,15 @@ type seriesInfo struct {
 var (
 	versionToString = map[OASVersion]string{
 		OASVersion20:  "2.0",
-		OASVersion300: "3.0.0",
-		OASVersion301: "3.0.1",
+		OASVersion300: oas300,
+		OASVersion301: oas301,
 		OASVersion302: "3.0.2",
-		OASVersion303: "3.0.3",
+		OASVersion303: oas303,
 		OASVersion304: "3.0.4",
-		OASVersion310: "3.1.0",
+		OASVersion310: oas310,
 		OASVersion311: "3.1.1",
 		OASVersion312: "3.1.2",
-		OASVersion320: "3.2.0",
+		OASVersion320: oas320,
 	}
 
 	stringToVersion = func() map[string]OASVersion {

--- a/validator/oas2.go
+++ b/validator/oas2.go
@@ -250,7 +250,7 @@ func (v *Validator) validateOAS2Security(doc *parser.OAS2Document, result *Valid
 
 		// Validate type-specific requirements
 		switch secDef.Type {
-		case "apiKey":
+		case securitySchemeTypeAPIKey:
 			if secDef.Name == "" {
 				v.addError(result, path,
 					"API key security scheme must have a name",
@@ -265,7 +265,7 @@ func (v *Validator) validateOAS2Security(doc *parser.OAS2Document, result *Valid
 					withField("in"),
 				)
 			}
-		case "oauth2":
+		case securitySchemeTypeOAuth2:
 			if secDef.Flow == "" {
 				v.addError(result, path,
 					"OAuth2 security scheme must have a flow",

--- a/validator/oas3.go
+++ b/validator/oas3.go
@@ -345,7 +345,7 @@ func (v *Validator) validateOAS3SecurityScheme(scheme *parser.SecurityScheme, pa
 	}
 
 	switch scheme.Type {
-	case "apiKey":
+	case securitySchemeTypeAPIKey:
 		if scheme.Name == "" {
 			v.addError(result, path, "API key security scheme must have a name",
 				withSpecRef(fmt.Sprintf("%s#security-scheme-object", baseURL)),
@@ -365,7 +365,7 @@ func (v *Validator) validateOAS3SecurityScheme(scheme *parser.SecurityScheme, pa
 				withField("scheme"),
 			)
 		}
-	case "oauth2":
+	case securitySchemeTypeOAuth2:
 		if scheme.Flows == nil {
 			v.addError(result, path, "OAuth2 security scheme must have flows",
 				withSpecRef(fmt.Sprintf("%s#security-scheme-object", baseURL)),

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -33,6 +33,12 @@ const (
 	maxSchemaNestingDepth = 100 // Maximum depth for nested schemas to prevent stack overflow
 )
 
+// Security scheme type constants.
+const (
+	securitySchemeTypeAPIKey = "apiKey"
+	securitySchemeTypeOAuth2 = "oauth2"
+)
+
 // ValidationError represents a single validation issue
 type ValidationError = issues.Issue
 


### PR DESCRIPTION
Since my last committed code changes, there have been
changes to linters, and now the unchanged code in main
has new lint errors.

This PR extracts string literals to package constants for 
commonly repeated string literals across multiple packages 
(parser, converter, builder, generator, mcpserver). 
Now excludes generated code from lints.