### PR TITLE
fix(parser,validator,pathutil): correct $ref round-trips, OAS2 required, and RFC 6901 escaping

### DIFF
--- a/fixer/prune.go
+++ b/fixer/prune.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/erraggy/oastools/internal/pathutil"
 	"github.com/erraggy/oastools/parser"
 )
 
@@ -77,17 +78,23 @@ func buildReferencedSchemaSet(collector *RefCollector, schemas map[string]*parse
 
 // extractSchemaName extracts the schema name from a reference path.
 // Handles both URL-encoded and non-encoded refs.
+//
+// The JSON Pointer escaping is reversed so the name matches the key it was
+// built from. Without it, a schema named "pet/summary" is referenced as
+// "#/definitions/pet~1summary", the recovered name never matches the schemas
+// map, and pruning deletes a schema that is in fact referenced.
 func extractSchemaName(ref, prefix string) string {
 	// Try direct prefix match first
 	if name, found := strings.CutPrefix(ref, prefix); found {
-		return name
+		return pathutil.UnescapeRefToken(name)
 	}
 
-	// Try URL-decoded version
+	// Try URL-decoded version. This is a different escaping from the JSON
+	// Pointer form above, handled because some tools emit percent-encoded refs.
 	decoded, err := url.PathUnescape(ref)
 	if err == nil {
 		if name, found := strings.CutPrefix(decoded, prefix); found {
-			return name
+			return pathutil.UnescapeRefToken(name)
 		}
 	}
 

--- a/fixer/prune_ref_escaping_test.go
+++ b/fixer/prune_ref_escaping_test.go
@@ -1,0 +1,113 @@
+package fixer
+
+import (
+	"testing"
+
+	"github.com/erraggy/oastools/parser"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPruneKeepsEscapedNameSchema covers the highest-consequence half of issue
+// #379.
+//
+// Pruning recovers a schema name from each collected ref to decide what is
+// referenced. Without reversing the RFC 6901 escaping, the recovered name is
+// "pet~1summary", which never matches the "pet/summary" key, so a schema that IS
+// referenced gets deleted. That is silent data loss rather than the false
+// positive the validator side of the issue produced, which is why it is pinned
+// separately.
+//
+// OAS 2.0 places no charset constraint on definition keys, so this document is
+// legitimate.
+func TestPruneKeepsEscapedNameSchema(t *testing.T) {
+	tests := []struct {
+		name       string
+		spec       string
+		schemaName string
+	}{
+		{
+			name:       "escaped slash",
+			schemaName: "pet/summary",
+			spec: `
+swagger: "2.0"
+info: {title: T, version: "1.0"}
+definitions:
+  pet/summary: {type: object, properties: {id: {type: string}}}
+paths:
+  /pets:
+    get:
+      responses:
+        "200":
+          description: OK
+          schema: {$ref: '#/definitions/pet~1summary'}
+`,
+		},
+		{
+			name:       "escaped tilde",
+			schemaName: "pet~summary",
+			spec: `
+swagger: "2.0"
+info: {title: T, version: "1.0"}
+definitions:
+  pet~summary: {type: object, properties: {id: {type: string}}}
+paths:
+  /pets:
+    get:
+      responses:
+        "200":
+          description: OK
+          schema: {$ref: '#/definitions/pet~0summary'}
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parseResult, err := parser.ParseWithOptions(parser.WithBytes([]byte(tt.spec)))
+			require.NoError(t, err)
+
+			f := New()
+			f.EnabledFixes = []FixType{FixTypePrunedUnusedSchema}
+			result, err := f.FixParsed(*parseResult)
+			require.NoError(t, err)
+
+			doc := result.Document.(*parser.OAS2Document)
+			assert.Contains(t, doc.Definitions, tt.schemaName,
+				"a referenced schema must survive pruning even when its name needs escaping")
+			assert.Zero(t, result.FixCount, "nothing should have been pruned")
+		})
+	}
+}
+
+// TestPruneStillRemovesUnreferencedEscapedNameSchema is the control for the test
+// above: unescaping must not make every escaped-name schema look referenced.
+func TestPruneStillRemovesUnreferencedEscapedNameSchema(t *testing.T) {
+	spec := `
+swagger: "2.0"
+info: {title: T, version: "1.0"}
+definitions:
+  pet/summary: {type: object, properties: {id: {type: string}}}
+  pet/orphan: {type: string}
+paths:
+  /pets:
+    get:
+      responses:
+        "200":
+          description: OK
+          schema: {$ref: '#/definitions/pet~1summary'}
+`
+
+	parseResult, err := parser.ParseWithOptions(parser.WithBytes([]byte(spec)))
+	require.NoError(t, err)
+
+	f := New()
+	f.EnabledFixes = []FixType{FixTypePrunedUnusedSchema}
+	result, err := f.FixParsed(*parseResult)
+	require.NoError(t, err)
+
+	doc := result.Document.(*parser.OAS2Document)
+	assert.Contains(t, doc.Definitions, "pet/summary")
+	assert.NotContains(t, doc.Definitions, "pet/orphan")
+	assert.Equal(t, 1, result.FixCount)
+}

--- a/fixer/refs.go
+++ b/fixer/refs.go
@@ -948,7 +948,7 @@ func ExtractSchemaNameFromRef(ref string, version parser.OASVersion) string {
 	}
 
 	if name, found := strings.CutPrefix(ref, prefix); found {
-		return name
+		return pathutil.UnescapeRefToken(name)
 	}
 	return ""
 }
@@ -981,14 +981,14 @@ func ExtractComponentNameFromRef(ref string) (componentType, name string) {
 	// Try OAS 3.x patterns first (more specific)
 	for prefix, compType := range oas3Prefixes {
 		if n, found := strings.CutPrefix(ref, prefix); found {
-			return compType, n
+			return compType, pathutil.UnescapeRefToken(n)
 		}
 	}
 
 	// Try OAS 2.0 patterns
 	for prefix, compType := range oas2Prefixes {
 		if n, found := strings.CutPrefix(ref, prefix); found {
-			return compType, n
+			return compType, pathutil.UnescapeRefToken(n)
 		}
 	}
 

--- a/fixer/stub_missing_refs.go
+++ b/fixer/stub_missing_refs.go
@@ -45,7 +45,7 @@ func extractResponseNameFromRef(ref string, version parser.OASVersion) string {
 	}
 
 	if name, found := strings.CutPrefix(ref, prefix); found {
-		return name
+		return pathutil.UnescapeRefToken(name)
 	}
 	return ""
 }

--- a/fixer/version_helpers.go
+++ b/fixer/version_helpers.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 
 	"github.com/erraggy/oastools/internal/paramutil"
+	"github.com/erraggy/oastools/internal/pathutil"
 	"github.com/erraggy/oastools/parser"
 )
 
@@ -26,11 +27,16 @@ func buildRefRenameMap(renames map[string]string, accessor parser.DocumentAccess
 	refRenames := make(map[string]string, len(renames)*2)
 
 	for oldName, newName := range renames {
-		oldRef := prefix + oldName
-		newRef := prefix + newName
+		// Names are escaped per RFC 6901 so a name containing "/" or "~" builds
+		// the pointer a document actually carries, and so the renamed component
+		// stays reachable afterwards.
+		oldRef := prefix + pathutil.EscapeRefToken(oldName)
+		newRef := prefix + pathutil.EscapeRefToken(newName)
 		refRenames[oldRef] = newRef
 
-		// Add URL-encoded version for refs that might be encoded
+		// Add URL-encoded version for refs that might be encoded. This is a
+		// different escaping from the JSON Pointer form above, kept because
+		// some tools emit percent-encoded refs.
 		encodedOldRef := prefix + url.PathEscape(oldName)
 		if encodedOldRef != oldRef {
 			refRenames[encodedOldRef] = newRef

--- a/generator/oas2_generator.go
+++ b/generator/oas2_generator.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/erraggy/oastools/internal/httputil"
 	"github.com/erraggy/oastools/internal/maputil"
+	"github.com/erraggy/oastools/internal/pathutil"
 	"github.com/erraggy/oastools/parser"
 )
 
@@ -74,7 +75,7 @@ func (cg *oas2CodeGenerator) collectSchemas() []oas2SchemaEntry {
 			cg.generatedTypes[typeName] = true
 
 			schemas = append(schemas, oas2SchemaEntry{name: name, schema: schema})
-			cg.schemaNames["#/definitions/"+name] = typeName
+			cg.schemaNames[pathutil.DefinitionRef(name)] = typeName
 		}
 	}
 

--- a/generator/oas3_generator.go
+++ b/generator/oas3_generator.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/erraggy/oastools/internal/httputil"
 	"github.com/erraggy/oastools/internal/maputil"
+	"github.com/erraggy/oastools/internal/pathutil"
 	"github.com/erraggy/oastools/internal/schemautil"
 	"github.com/erraggy/oastools/parser"
 )
@@ -206,7 +207,7 @@ func (cg *oas3CodeGenerator) collectSchemas() []schemaEntry {
 		cg.generatedTypes[typeName] = true
 
 		schemas = append(schemas, schemaEntry{name: name, schema: schema})
-		cg.schemaNames["#/components/schemas/"+name] = typeName
+		cg.schemaNames[pathutil.SchemaRef(name)] = typeName
 	}
 
 	// Sort for deterministic output

--- a/internal/pathutil/refs.go
+++ b/internal/pathutil/refs.go
@@ -3,6 +3,47 @@
 
 package pathutil
 
+import "strings"
+
+// EscapeRefToken escapes a component name for use as a single JSON Pointer
+// token, per RFC 6901: "~" becomes "~0" and "/" becomes "~1".
+//
+// Order matters — "~" must be escaped first, or the "~" introduced by escaping
+// "/" would itself be escaped and produce "~01".
+//
+// OAS 2.0 places no charset constraint on the keys of the root-level
+// parameters, definitions, and responses objects, so a name containing either
+// character is legitimate and must be escaped for a document to reference it.
+// Building a reference by raw concatenation instead produces a pointer that
+// names a different location and therefore never matches.
+func EscapeRefToken(name string) string {
+	// Fast path: the overwhelming majority of component names need no escaping.
+	if !strings.ContainsAny(name, "~/") {
+		return name
+	}
+	name = strings.ReplaceAll(name, "~", "~0")
+	return strings.ReplaceAll(name, "/", "~1")
+}
+
+// UnescapeRefToken reverses [EscapeRefToken], recovering a component name from
+// a single JSON Pointer token.
+//
+// Use it anywhere a reference is split back into a name — renaming, pruning, or
+// resolving a ref to its definition — or names containing "/" or "~" are
+// corrupted. Order is the inverse of escaping: "~1" must be unescaped before
+// "~0", or the "~" recovered from "~0" could combine with a following "1".
+//
+// Mirrors unescapeJSONPointer in the parser's resolver, which has always
+// implemented this for reference resolution.
+func UnescapeRefToken(token string) string {
+	// Fast path: a token with no "~" cannot carry an escape sequence.
+	if !strings.Contains(token, "~") {
+		return token
+	}
+	token = strings.ReplaceAll(token, "~1", "/")
+	return strings.ReplaceAll(token, "~0", "~")
+}
+
 // OAS 2.0 reference prefixes
 const (
 	RefPrefixDefinitions         = "#/definitions/"
@@ -27,67 +68,67 @@ const (
 
 // SchemaRef builds "#/components/schemas/{name}" (OAS 3.x).
 func SchemaRef(name string) string {
-	return RefPrefixSchemas + name
+	return RefPrefixSchemas + EscapeRefToken(name)
 }
 
 // DefinitionRef builds "#/definitions/{name}" (OAS 2.0).
 func DefinitionRef(name string) string {
-	return RefPrefixDefinitions + name
+	return RefPrefixDefinitions + EscapeRefToken(name)
 }
 
 // ParameterRef builds the appropriate parameter ref.
 // If oas2 is true, returns "#/parameters/{name}", otherwise "#/components/parameters/{name}".
 func ParameterRef(name string, oas2 bool) string {
 	if oas2 {
-		return RefPrefixParameters + name
+		return RefPrefixParameters + EscapeRefToken(name)
 	}
-	return RefPrefixParameters3 + name
+	return RefPrefixParameters3 + EscapeRefToken(name)
 }
 
 // ResponseRef builds the appropriate response ref.
 // If oas2 is true, returns "#/responses/{name}", otherwise "#/components/responses/{name}".
 func ResponseRef(name string, oas2 bool) string {
 	if oas2 {
-		return RefPrefixResponses + name
+		return RefPrefixResponses + EscapeRefToken(name)
 	}
-	return RefPrefixResponses3 + name
+	return RefPrefixResponses3 + EscapeRefToken(name)
 }
 
 // SecuritySchemeRef builds the appropriate security scheme ref.
 // If oas2 is true, returns "#/securityDefinitions/{name}", otherwise "#/components/securitySchemes/{name}".
 func SecuritySchemeRef(name string, oas2 bool) string {
 	if oas2 {
-		return RefPrefixSecurityDefinitions + name
+		return RefPrefixSecurityDefinitions + EscapeRefToken(name)
 	}
-	return RefPrefixSecuritySchemes + name
+	return RefPrefixSecuritySchemes + EscapeRefToken(name)
 }
 
 // HeaderRef builds "#/components/headers/{name}" (OAS 3.x only).
 func HeaderRef(name string) string {
-	return RefPrefixHeaders + name
+	return RefPrefixHeaders + EscapeRefToken(name)
 }
 
 // RequestBodyRef builds "#/components/requestBodies/{name}" (OAS 3.x only).
 func RequestBodyRef(name string) string {
-	return RefPrefixRequestBodies + name
+	return RefPrefixRequestBodies + EscapeRefToken(name)
 }
 
 // ExampleRef builds "#/components/examples/{name}" (OAS 3.x only).
 func ExampleRef(name string) string {
-	return RefPrefixExamples + name
+	return RefPrefixExamples + EscapeRefToken(name)
 }
 
 // LinkRef builds "#/components/links/{name}" (OAS 3.x only).
 func LinkRef(name string) string {
-	return RefPrefixLinks + name
+	return RefPrefixLinks + EscapeRefToken(name)
 }
 
 // CallbackRef builds "#/components/callbacks/{name}" (OAS 3.x only).
 func CallbackRef(name string) string {
-	return RefPrefixCallbacks + name
+	return RefPrefixCallbacks + EscapeRefToken(name)
 }
 
 // PathItemRef builds "#/components/pathItems/{name}" (OAS 3.1+ only).
 func PathItemRef(name string) string {
-	return RefPrefixPathItems + name
+	return RefPrefixPathItems + EscapeRefToken(name)
 }

--- a/internal/pathutil/refs_test.go
+++ b/internal/pathutil/refs_test.go
@@ -1,0 +1,122 @@
+// Copyright 2024 Erraggy
+// SPDX-License-Identifier: MIT
+
+package pathutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEscapeRefToken(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "no escaping needed", input: "Pet", want: "Pet"},
+		{name: "empty", input: "", want: ""},
+		{name: "slash", input: "pet/id", want: "pet~1id"},
+		{name: "tilde", input: "pet~id", want: "pet~0id"},
+		{
+			// Escaping "/" first would leave "~1", which escaping "~" would then
+			// turn into "~01" — a token that unescapes to "~1", not "~/".
+			name:  "tilde before slash",
+			input: "pet~/id",
+			want:  "pet~0~1id",
+		},
+		{
+			// The literal text "~1" must survive as a name, distinct from an
+			// escaped "/".
+			name:  "literal escape sequence is itself escaped",
+			input: "pet~1id",
+			want:  "pet~01id",
+		},
+		{name: "multiple of each", input: "a/b~c/d", want: "a~1b~0c~1d"},
+		{name: "only separators", input: "/~", want: "~1~0"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, EscapeRefToken(tt.input))
+		})
+	}
+}
+
+func TestUnescapeRefToken(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "no escaping present", input: "Pet", want: "Pet"},
+		{name: "empty", input: "", want: ""},
+		{name: "escaped slash", input: "pet~1id", want: "pet/id"},
+		{name: "escaped tilde", input: "pet~0id", want: "pet~id"},
+		{name: "both", input: "pet~0~1id", want: "pet~/id"},
+		{
+			// "~01" must decode to the literal "~1" rather than to "/", which is
+			// what unescaping "~0" first would produce.
+			name:  "escaped tilde followed by one",
+			input: "pet~01id",
+			want:  "pet~1id",
+		},
+		{name: "only separators", input: "~1~0", want: "/~"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, UnescapeRefToken(tt.input))
+		})
+	}
+}
+
+// TestEscapeUnescapeRoundTrip is the property that matters: every name must
+// survive being turned into a pointer token and back, or renaming and pruning
+// silently corrupt it.
+func TestEscapeUnescapeRoundTrip(t *testing.T) {
+	names := []string{
+		"Pet",
+		"",
+		"pet/id",
+		"pet~id",
+		"pet~/id",
+		"pet~1id",
+		"pet~0id",
+		"~",
+		"/",
+		"a/b~c/d",
+		"microsoft.graph.user",
+		"Pet-Summary_v2",
+	}
+
+	for _, name := range names {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, name, UnescapeRefToken(EscapeRefToken(name)))
+		})
+	}
+}
+
+// TestRefBuildersEscape checks that the builders produce the pointer a document
+// legitimately carries, rather than one assembled by raw concatenation.
+func TestRefBuildersEscape(t *testing.T) {
+	assert.Equal(t, "#/components/schemas/pet~1summary", SchemaRef("pet/summary"))
+	assert.Equal(t, "#/definitions/pet~1summary", DefinitionRef("pet/summary"))
+	assert.Equal(t, "#/parameters/pet~1id", ParameterRef("pet/id", true))
+	assert.Equal(t, "#/components/parameters/pet~1id", ParameterRef("pet/id", false))
+	assert.Equal(t, "#/responses/not~1found", ResponseRef("not/found", true))
+	assert.Equal(t, "#/components/responses/not~1found", ResponseRef("not/found", false))
+	assert.Equal(t, "#/securityDefinitions/o~1auth", SecuritySchemeRef("o/auth", true))
+	assert.Equal(t, "#/components/securitySchemes/o~1auth", SecuritySchemeRef("o/auth", false))
+	assert.Equal(t, "#/components/headers/x~1rate", HeaderRef("x/rate"))
+	assert.Equal(t, "#/components/requestBodies/pet~1body", RequestBodyRef("pet/body"))
+	assert.Equal(t, "#/components/examples/pet~1example", ExampleRef("pet/example"))
+	assert.Equal(t, "#/components/links/pet~1link", LinkRef("pet/link"))
+	assert.Equal(t, "#/components/callbacks/pet~1cb", CallbackRef("pet/cb"))
+	assert.Equal(t, "#/components/pathItems/pet~1item", PathItemRef("pet/item"))
+
+	// Names needing no escaping are unchanged, so ordinary specs are unaffected.
+	assert.Equal(t, "#/components/schemas/Pet", SchemaRef("Pet"))
+	assert.Equal(t, "#/definitions/Pet", DefinitionRef("Pet"))
+}

--- a/joiner/rewriter.go
+++ b/joiner/rewriter.go
@@ -404,11 +404,11 @@ func (r *SchemaRewriter) rewriteOperation(op *parser.Operation) {
 func extractSchemaName(ref string) string {
 	// Handle "#/components/schemas/Name"
 	if name, found := strings.CutPrefix(ref, pathutil.RefPrefixSchemas); found {
-		return name
+		return pathutil.UnescapeRefToken(name)
 	}
 	// Handle "#/definitions/Name"
 	if name, found := strings.CutPrefix(ref, pathutil.RefPrefixDefinitions); found {
-		return name
+		return pathutil.UnescapeRefToken(name)
 	}
 	return ""
 }

--- a/parser/parameters.go
+++ b/parser/parameters.go
@@ -1,10 +1,17 @@
 package parser
 
-// Parameter describes a single operation parameter
+// Parameter describes a single operation parameter.
+//
+// Name and In are required by the specification but are still tagged omitempty:
+// a $ref parameter arrives from the parser with every sibling field empty, and
+// emitting name: "" and in: "" alongside the $ref corrupts the object on every
+// round trip. An inline parameter that genuinely lacks them is invalid either
+// way, and the validator reports it — the serializer is not the right place to
+// surface that defect.
 type Parameter struct {
 	Ref         string `yaml:"$ref,omitempty" json:"$ref,omitempty"`
-	Name        string `yaml:"name" json:"name"`
-	In          string `yaml:"in" json:"in"` // "query", "header", "path", "cookie" (OAS 3.0+), "formData", "body" (OAS 2.0)
+	Name        string `yaml:"name,omitempty" json:"name,omitempty"`
+	In          string `yaml:"in,omitempty" json:"in,omitempty"` // "query", "header", "path", "cookie" (OAS 3.0+), "formData", "body" (OAS 2.0)
 	Description string `yaml:"description,omitempty" json:"description,omitempty"`
 	Required    bool   `yaml:"required,omitempty" json:"required,omitempty"`
 	Deprecated  bool   `yaml:"deprecated,omitempty" json:"deprecated,omitempty"` // OAS 3.0+
@@ -64,11 +71,14 @@ type Items struct {
 	Extra            map[string]any `yaml:",inline" json:"-"`
 }
 
-// RequestBody describes a single request body (OAS 3.0+)
+// RequestBody describes a single request body (OAS 3.0+).
+//
+// Content is tagged omitempty for the same reason as [Parameter.Name]: a $ref
+// request body would otherwise serialize with a null content sibling.
 type RequestBody struct {
 	Ref         string                `yaml:"$ref,omitempty" json:"$ref,omitempty"`
 	Description string                `yaml:"description,omitempty" json:"description,omitempty"`
-	Content     map[string]*MediaType `yaml:"content" json:"content"`
+	Content     map[string]*MediaType `yaml:"content,omitempty" json:"content,omitempty"`
 	Required    bool                  `yaml:"required,omitempty" json:"required,omitempty"`
 	Extra       map[string]any        `yaml:",inline" json:"-"`
 }

--- a/parser/parameters_json.go
+++ b/parser/parameters_json.go
@@ -17,11 +17,13 @@ func (p *Parameter) MarshalJSON() ([]byte, error) {
 		return marshalToJSON((*Alias)(p))
 	}
 
-	// Build map with known fields
-	m := map[string]any{
-		jsonKeyName: p.Name, // Required field, always include
-		"in":        p.In,   // Required field, always include
-	}
+	// Build map with known fields. Every field is emitted conditionally so this
+	// path agrees with the struct tags used by the fast path above — otherwise
+	// the serialized shape of a parameter would depend on whether it happens to
+	// carry an x- extension. See [Parameter] for why name and in are omitempty.
+	m := make(map[string]any, 24+len(p.Extra))
+	jsonhelpers.SetIfNotEmpty(m, jsonKeyName, p.Name)
+	jsonhelpers.SetIfNotEmpty(m, "in", p.In)
 	jsonhelpers.SetIfNotEmpty(m, jsonKeyRef, p.Ref)
 	jsonhelpers.SetIfNotEmpty(m, jsonKeyDescription, p.Description)
 	jsonhelpers.SetIfTrue(m, "required", p.Required)
@@ -114,10 +116,11 @@ func (rb *RequestBody) MarshalJSON() ([]byte, error) {
 		return marshalToJSON((*Alias)(rb))
 	}
 
-	// Build map with known fields
-	m := map[string]any{
-		"content": rb.Content, // Required field, always include
-	}
+	// Build map with known fields conditionally so this path agrees with the
+	// struct tags used by the fast path above. See [RequestBody] for why content
+	// is omitempty.
+	m := make(map[string]any, 4+len(rb.Extra))
+	jsonhelpers.SetIfMapNotEmpty(m, "content", rb.Content)
 	jsonhelpers.SetIfNotEmpty(m, jsonKeyRef, rb.Ref)
 	jsonhelpers.SetIfNotEmpty(m, jsonKeyDescription, rb.Description)
 	jsonhelpers.SetIfTrue(m, "required", rb.Required)

--- a/parser/paths.go
+++ b/parser/paths.go
@@ -106,10 +106,13 @@ func (r *Responses) UnmarshalYAML(unmarshal func(any) error) error {
 	return nil
 }
 
-// Response describes a single response from an API Operation
+// Response describes a single response from an API Operation.
+//
+// Description is tagged omitempty for the same reason as [Parameter.Name]: a
+// $ref response would otherwise serialize with an empty description sibling.
 type Response struct {
 	Ref         string                `yaml:"$ref,omitempty" json:"$ref,omitempty"`
-	Description string                `yaml:"description" json:"description"`
+	Description string                `yaml:"description,omitempty" json:"description,omitempty"`
 	Headers     map[string]*Header    `yaml:"headers,omitempty" json:"headers,omitempty"`
 	Content     map[string]*MediaType `yaml:"content,omitempty" json:"content,omitempty"` // OAS 3.0+
 	Links       map[string]*Link      `yaml:"links,omitempty" json:"links,omitempty"`     // OAS 3.0+

--- a/parser/paths_json.go
+++ b/parser/paths_json.go
@@ -108,10 +108,11 @@ func (r *Response) MarshalJSON() ([]byte, error) {
 		return marshalToJSON((*Alias)(r))
 	}
 
-	// Build map with known fields
-	m := map[string]any{
-		jsonKeyDescription: r.Description, // Required field, always include
-	}
+	// Build map with known fields conditionally so this path agrees with the
+	// struct tags used by the fast path above. See [Response] for why
+	// description is omitempty.
+	m := make(map[string]any, 7+len(r.Extra))
+	jsonhelpers.SetIfNotEmpty(m, jsonKeyDescription, r.Description)
 	jsonhelpers.SetIfNotEmpty(m, jsonKeyRef, r.Ref)
 	jsonhelpers.SetIfMapNotEmpty(m, "headers", r.Headers)
 	jsonhelpers.SetIfMapNotEmpty(m, "content", r.Content)

--- a/parser/ref_siblings_test.go
+++ b/parser/ref_siblings_test.go
@@ -1,0 +1,226 @@
+package parser
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v4"
+)
+
+// leakedSiblings are the keys that a $ref object used to emit alongside its
+// $ref: name and in from Parameter, description from Response, and content from
+// RequestBody. Each was a required field tagged without omitempty, so it was
+// written even when empty, corrupting the object on every round trip.
+var leakedSiblings = []string{"name", "in", "description", "content"}
+
+// TestRefObjectsSerializeWithoutEmptySiblings pins that a $ref object round
+// trips as $ref alone.
+//
+// Both encodings and both marshaling paths are covered deliberately. YAML goes
+// through the struct tags while JSON has custom marshalers, and those marshalers
+// take a fast path via the struct tags only when Extra is empty — so an x-
+// extension on the object selects an entirely different code path. Before this
+// was fixed the two paths disagreed, which meant the serialized shape of a $ref
+// depended on whether it happened to carry an extension.
+func TestRefObjectsSerializeWithoutEmptySiblings(t *testing.T) {
+	tests := []struct {
+		name  string
+		value any
+	}{
+		{
+			name:  "parameter",
+			value: &Parameter{Ref: "#/components/parameters/petIdParam"},
+		},
+		{
+			name: "parameter with extension",
+			value: &Parameter{
+				Ref:   "#/components/parameters/petIdParam",
+				Extra: map[string]any{"x-note": "hi"},
+			},
+		},
+		{
+			name:  "response",
+			value: &Response{Ref: "#/components/responses/NotFound"},
+		},
+		{
+			name: "response with extension",
+			value: &Response{
+				Ref:   "#/components/responses/NotFound",
+				Extra: map[string]any{"x-note": "hi"},
+			},
+		},
+		{
+			name:  "request body",
+			value: &RequestBody{Ref: "#/components/requestBodies/PetBody"},
+		},
+		{
+			name: "request body with extension",
+			value: &RequestBody{
+				Ref:   "#/components/requestBodies/PetBody",
+				Extra: map[string]any{"x-note": "hi"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name+"/json", func(t *testing.T) {
+			data, err := json.Marshal(tt.value)
+			require.NoError(t, err)
+
+			var got map[string]any
+			require.NoError(t, json.Unmarshal(data, &got))
+			assertOnlyRefAndExtensions(t, got, string(data))
+		})
+
+		t.Run(tt.name+"/yaml", func(t *testing.T) {
+			data, err := yaml.Marshal(tt.value)
+			require.NoError(t, err)
+
+			var got map[string]any
+			require.NoError(t, yaml.Unmarshal(data, &got))
+			assertOnlyRefAndExtensions(t, got, string(data))
+		})
+	}
+}
+
+// assertOnlyRefAndExtensions checks that the serialized object carries its $ref
+// and any x- extensions, and nothing else.
+func assertOnlyRefAndExtensions(t *testing.T, got map[string]any, encoded string) {
+	t.Helper()
+
+	assert.Contains(t, got, "$ref", "encoded: %s", encoded)
+	for _, key := range leakedSiblings {
+		assert.NotContains(t, got, key, "$ref object leaked empty %q sibling; encoded: %s", key, encoded)
+	}
+}
+
+// TestInlineObjectsStillSerializeRequiredFields guards the other direction: the
+// omitempty tags added for $ref objects must not drop fields that an inline
+// object genuinely sets.
+func TestInlineObjectsStillSerializeRequiredFields(t *testing.T) {
+	param := &Parameter{Name: "petId", In: ParamInPath, Required: true, Schema: &Schema{Type: "string"}}
+	response := &Response{Description: "Not found"}
+	requestBody := &RequestBody{Content: map[string]*MediaType{"application/json": {}}}
+
+	tests := []struct {
+		name  string
+		value any
+		want  []string
+	}{
+		{name: "parameter", value: param, want: []string{"name", "in", "required"}},
+		{name: "parameter with extension", value: withExtra(param, "x-note"), want: []string{"name", "in", "required"}},
+		{name: "response", value: response, want: []string{"description"}},
+		{name: "response with extension", value: withExtra(response, "x-note"), want: []string{"description"}},
+		{name: "request body", value: requestBody, want: []string{"content"}},
+		{name: "request body with extension", value: withExtra(requestBody, "x-note"), want: []string{"content"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name+"/json", func(t *testing.T) {
+			data, err := json.Marshal(tt.value)
+			require.NoError(t, err)
+
+			var got map[string]any
+			require.NoError(t, json.Unmarshal(data, &got))
+			for _, key := range tt.want {
+				assert.Contains(t, got, key, "encoded: %s", data)
+			}
+		})
+
+		t.Run(tt.name+"/yaml", func(t *testing.T) {
+			data, err := yaml.Marshal(tt.value)
+			require.NoError(t, err)
+
+			var got map[string]any
+			require.NoError(t, yaml.Unmarshal(data, &got))
+			for _, key := range tt.want {
+				assert.Contains(t, got, key, "encoded: %s", data)
+			}
+		})
+	}
+}
+
+// withExtra returns a deep copy of value carrying a single specification
+// extension, so the JSON marshalers take their Extra-fields path.
+func withExtra(value any, key string) any {
+	switch v := value.(type) {
+	case *Parameter:
+		cp := v.DeepCopy()
+		cp.Extra = map[string]any{key: "set"}
+		return cp
+	case *Response:
+		cp := v.DeepCopy()
+		cp.Extra = map[string]any{key: "set"}
+		return cp
+	case *RequestBody:
+		cp := v.DeepCopy()
+		cp.Extra = map[string]any{key: "set"}
+		return cp
+	}
+	return value
+}
+
+// TestRefDocumentRoundTrip exercises the fix end to end: a document whose path
+// item, request body, and response are all $ref objects must survive a parse and
+// re-serialize unchanged, in both encodings.
+func TestRefDocumentRoundTrip(t *testing.T) {
+	const spec = `openapi: 3.0.3
+info:
+  title: Repro
+  version: "1.0.0"
+components:
+  parameters:
+    petIdParam: {name: petId, in: path, required: true, schema: {type: string}}
+  responses:
+    NotFound: {description: Not found}
+  requestBodies:
+    PetBody: {content: {application/json: {schema: {type: object}}}}
+paths:
+  /pets/{petId}:
+    parameters:
+      - $ref: '#/components/parameters/petIdParam'
+    post:
+      requestBody: {$ref: '#/components/requestBodies/PetBody'}
+      responses:
+        "404": {$ref: '#/components/responses/NotFound'}
+`
+
+	result, err := New().ParseBytes([]byte(spec))
+	require.NoError(t, err)
+
+	doc, ok := result.OAS3Document()
+	require.True(t, ok)
+	require.NotNil(t, doc)
+
+	pathItem := doc.Paths["/pets/{petId}"]
+	require.NotNil(t, pathItem)
+	require.Len(t, pathItem.Parameters, 1)
+
+	refObjects := map[string]any{
+		"parameter":    pathItem.Parameters[0],
+		"request body": pathItem.Post.RequestBody,
+		"response":     pathItem.Post.Responses.Codes["404"],
+	}
+
+	for name, obj := range refObjects {
+		t.Run(name+"/json", func(t *testing.T) {
+			data, err := json.Marshal(obj)
+			require.NoError(t, err)
+
+			var got map[string]any
+			require.NoError(t, json.Unmarshal(data, &got))
+			assertOnlyRefAndExtensions(t, got, string(data))
+		})
+
+		t.Run(name+"/yaml", func(t *testing.T) {
+			data, err := yaml.Marshal(obj)
+			require.NoError(t, err)
+
+			var got map[string]any
+			require.NoError(t, yaml.Unmarshal(data, &got))
+			assertOnlyRefAndExtensions(t, got, string(data))
+		})
+	}
+}

--- a/parser/ref_siblings_test.go
+++ b/parser/ref_siblings_test.go
@@ -2,18 +2,14 @@ package parser
 
 import (
 	"encoding/json"
+	"maps"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.yaml.in/yaml/v4"
 )
-
-// leakedSiblings are the keys that a $ref object used to emit alongside its
-// $ref: name and in from Parameter, description from Response, and content from
-// RequestBody. Each was a required field tagged without omitempty, so it was
-// written even when empty, corrupting the object on every round trip.
-var leakedSiblings = []string{"name", "in", "description", "content"}
 
 // TestRefObjectsSerializeWithoutEmptySiblings pins that a $ref object round
 // trips as $ref alone.
@@ -25,16 +21,22 @@ var leakedSiblings = []string{"name", "in", "description", "content"}
 // was fixed the two paths disagreed, which meant the serialized shape of a $ref
 // depended on whether it happened to carry an extension.
 func TestRefObjectsSerializeWithoutEmptySiblings(t *testing.T) {
+	extras := map[string]any{"x-note": "hi"}
+
 	tests := []struct {
-		name  string
-		value any
+		name string
+		// wantExtras is the extension set the object carries, and so the only
+		// keys permitted alongside its $ref.
+		wantExtras map[string]any
+		value      any
 	}{
 		{
 			name:  "parameter",
 			value: &Parameter{Ref: "#/components/parameters/petIdParam"},
 		},
 		{
-			name: "parameter with extension",
+			name:       "parameter with extension",
+			wantExtras: extras,
 			value: &Parameter{
 				Ref:   "#/components/parameters/petIdParam",
 				Extra: map[string]any{"x-note": "hi"},
@@ -45,7 +47,8 @@ func TestRefObjectsSerializeWithoutEmptySiblings(t *testing.T) {
 			value: &Response{Ref: "#/components/responses/NotFound"},
 		},
 		{
-			name: "response with extension",
+			name:       "response with extension",
+			wantExtras: extras,
 			value: &Response{
 				Ref:   "#/components/responses/NotFound",
 				Extra: map[string]any{"x-note": "hi"},
@@ -56,7 +59,8 @@ func TestRefObjectsSerializeWithoutEmptySiblings(t *testing.T) {
 			value: &RequestBody{Ref: "#/components/requestBodies/PetBody"},
 		},
 		{
-			name: "request body with extension",
+			name:       "request body with extension",
+			wantExtras: extras,
 			value: &RequestBody{
 				Ref:   "#/components/requestBodies/PetBody",
 				Extra: map[string]any{"x-note": "hi"},
@@ -71,7 +75,7 @@ func TestRefObjectsSerializeWithoutEmptySiblings(t *testing.T) {
 
 			var got map[string]any
 			require.NoError(t, json.Unmarshal(data, &got))
-			assertOnlyRefAndExtensions(t, got, string(data))
+			assertOnlyRefAndExtensions(t, got, tt.wantExtras, string(data))
 		})
 
 		t.Run(tt.name+"/yaml", func(t *testing.T) {
@@ -80,20 +84,36 @@ func TestRefObjectsSerializeWithoutEmptySiblings(t *testing.T) {
 
 			var got map[string]any
 			require.NoError(t, yaml.Unmarshal(data, &got))
-			assertOnlyRefAndExtensions(t, got, string(data))
+			assertOnlyRefAndExtensions(t, got, tt.wantExtras, string(data))
 		})
 	}
 }
 
 // assertOnlyRefAndExtensions checks that the serialized object carries its $ref
-// and any x- extensions, and nothing else.
-func assertOnlyRefAndExtensions(t *testing.T, got map[string]any, encoded string) {
+// and exactly wantExtras, and nothing else.
+//
+// The key set is asserted whole rather than by denying a list of known-bad keys.
+// The four that used to leak — name and in from Parameter, description from
+// Response, content from RequestBody, each a required field tagged without
+// omitempty and so written even when empty — are what prompted this test, but a
+// field added later without omitempty would leak identically, and denying only
+// today's four would not notice.
+//
+// Extension values are compared, not merely counted: the marshalers reach their
+// Extra-fields path precisely when an extension is present, so a regression that
+// dropped extensions would otherwise satisfy every remaining assertion here.
+func assertOnlyRefAndExtensions(t *testing.T, got, wantExtras map[string]any, encoded string) {
 	t.Helper()
 
-	assert.Contains(t, got, "$ref", "encoded: %s", encoded)
-	for _, key := range leakedSiblings {
-		assert.NotContains(t, got, key, "$ref object leaked empty %q sibling; encoded: %s", key, encoded)
+	wantKeys := make([]string, 0, len(wantExtras)+1)
+	wantKeys = append(wantKeys, jsonKeyRef)
+	for key, want := range wantExtras {
+		wantKeys = append(wantKeys, key)
+		assert.Equal(t, want, got[key], "extension %q must survive serialization; encoded: %s", key, encoded)
 	}
+
+	assert.ElementsMatch(t, wantKeys, slices.Collect(maps.Keys(got)),
+		"a $ref object must serialize with only its $ref and its extensions; encoded: %s", encoded)
 }
 
 // TestInlineObjectsStillSerializeRequiredFields guards the other direction: the
@@ -211,7 +231,7 @@ paths:
 
 			var got map[string]any
 			require.NoError(t, json.Unmarshal(data, &got))
-			assertOnlyRefAndExtensions(t, got, string(data))
+			assertOnlyRefAndExtensions(t, got, nil, string(data))
 		})
 
 		t.Run(name+"/yaml", func(t *testing.T) {
@@ -220,7 +240,7 @@ paths:
 
 			var got map[string]any
 			require.NoError(t, yaml.Unmarshal(data, &got))
-			assertOnlyRefAndExtensions(t, got, string(data))
+			assertOnlyRefAndExtensions(t, got, nil, string(data))
 		})
 	}
 }

--- a/validator/oas2.go
+++ b/validator/oas2.go
@@ -183,7 +183,28 @@ func (v *Validator) validateOAS2Parameters(doc *parser.OAS2Document, result *Val
 		if param == nil {
 			continue
 		}
+		// A pure $ref alias to another parameter definition is valid OAS, and
+		// arrives from the parser with every sibling field empty because
+		// references are preserved verbatim for lossless round-trips. Checking
+		// the fields below would read those empties as missing content. The
+		// referenced definition is validated in its own right, so nothing is
+		// lost. Mirrors validateOAS3RequestBody, which returns early for the
+		// same reason.
+		if param.Ref != "" {
+			continue
+		}
+
 		path := "parameters." + name
+
+		// Path parameters must have required: true. Swagger 2.0 states the
+		// property is required and its value MUST be true for in: path.
+		if param.In == parser.ParamInPath && !param.Required {
+			v.addError(result, path,
+				"Path parameters must have required: true",
+				withSpecRef(fmt.Sprintf("%s#parameter-object", baseURL)),
+				withField("required"),
+			)
+		}
 
 		// Body parameters must have a schema
 		if param.In == "body" && param.Schema == nil {
@@ -337,6 +358,7 @@ func (v *Validator) validateOAS2PathParameterConsistency(doc *parser.OAS2Documen
 
 		// Path-level parameters apply to every operation in the item, so they
 		// are checked once here rather than once per operation.
+		v.validatePathParamsRequired(pathItem.Parameters, pathPrefix, result, baseURL)
 		v.validateParameterRefs(pathItem.Parameters, pathPrefix, resolver, validRefs, result, baseURL)
 
 		// A path-item parameter is declared once, so an unused one is warned
@@ -352,6 +374,7 @@ func (v *Validator) validateOAS2PathParameterConsistency(doc *parser.OAS2Documen
 			}
 
 			opPath := pathPrefix + "." + method
+			v.validatePathParamsRequired(op.Parameters, opPath, result, baseURL)
 			v.validateParameterRefs(op.Parameters, opPath, resolver, validRefs, result, baseURL)
 
 			decls := declaresPathParams(resolver, itemDeclared, itemComplete, op.Parameters)

--- a/validator/oas3.go
+++ b/validator/oas3.go
@@ -299,6 +299,17 @@ func (v *Validator) validateOAS3Components(doc *parser.OAS3Document, result *Val
 		if param == nil {
 			continue
 		}
+		// A pure $ref alias to another parameter definition is valid OAS, and
+		// arrives from the parser with every sibling field empty because
+		// references are preserved verbatim for lossless round-trips. Checking
+		// the fields below would read those empties as missing content. The
+		// referenced definition is validated in its own right, so nothing is
+		// lost. Mirrors validateOAS3RequestBody, which returns early for the
+		// same reason.
+		if param.Ref != "" {
+			continue
+		}
+
 		path := "components.parameters." + name
 
 		// Parameters must have either schema or content (but not both)
@@ -532,7 +543,7 @@ func (v *Validator) validateOAS3PathParameterConsistency(doc *parser.OAS3Documen
 
 		// Path-level parameters apply to every operation in the item, so they
 		// are checked once here rather than once per operation.
-		v.validateOAS3PathParamsRequired(pathItem.Parameters, pathPrefix, result, baseURL)
+		v.validatePathParamsRequired(pathItem.Parameters, pathPrefix, result, baseURL)
 		v.validateParameterRefs(pathItem.Parameters, pathPrefix, resolver, validRefs, result, baseURL)
 
 		// A path-item parameter is declared once, so an unused one is warned
@@ -548,7 +559,7 @@ func (v *Validator) validateOAS3PathParameterConsistency(doc *parser.OAS3Documen
 			}
 
 			opPath := pathPrefix + "." + method
-			v.validateOAS3PathParamsRequired(op.Parameters, opPath, result, baseURL)
+			v.validatePathParamsRequired(op.Parameters, opPath, result, baseURL)
 			v.validateParameterRefs(op.Parameters, opPath, resolver, validRefs, result, baseURL)
 
 			decls := declaresPathParams(resolver, itemDeclared, itemComplete, op.Parameters)
@@ -581,29 +592,6 @@ func (v *Validator) warnUnusedPathParams(
 				withValue(paramName),
 			)
 		}
-	}
-}
-
-// validateOAS3PathParamsRequired reports inline path parameters that omit
-// required: true. Referenced parameters are deliberately skipped: a ref into
-// components.parameters has its definition checked once by
-// validateOAS3Components, so checking it again at each use site would report the
-// same defect repeatedly.
-//
-// The skip is unconditional, so a ref that does not land in components.parameters
-// — external, or dangling — has its required field checked nowhere. Those refs
-// are reported as unresolvable in their own right, which is the more useful
-// diagnostic anyway.
-func (v *Validator) validateOAS3PathParamsRequired(params []*parser.Parameter, prefix string, result *ValidationResult, baseURL string) {
-	for i, param := range params {
-		if param == nil || param.Ref != "" || param.In != parser.ParamInPath || param.Required {
-			continue
-		}
-		v.addError(result, prefix+".parameters["+strconv.Itoa(i)+"]",
-			"Path parameters must have required: true",
-			withSpecRef(fmt.Sprintf("%s#parameter-object", baseURL)),
-			withField("required"),
-		)
 	}
 }
 

--- a/validator/path_parameter_refs_test.go
+++ b/validator/path_parameter_refs_test.go
@@ -174,13 +174,10 @@ paths:
 `,
 		},
 		{
-			// A reusable definition may itself be a $ref; the chain is followed.
-			//
-			// The expected error is NOT about path parameters: validateOAS3Components
-			// does not skip `$ref` parameters, so a pure-alias definition is
-			// wrongly told it needs a schema or content. Pre-existing on main and
-			// tracked separately — asserted here rather than filtered away, so
-			// that fixing it shows up as a test change instead of passing silently.
+			// A reusable definition may itself be a $ref; the chain is followed,
+			// and the alias itself is clean. validateOAS3Components skips $ref
+			// entries rather than telling a pure alias it needs a schema or
+			// content — a reference carries neither by design.
 			name: "chained $ref between component parameters",
 			spec: `
 openapi: 3.0.3
@@ -196,7 +193,7 @@ paths:
         - $ref: '#/components/parameters/aliasParam'
       responses: {"200": {description: OK}}
 `,
-			wantErrors: []string{"components.parameters.aliasParam: Parameter must have either a schema or content"},
+			wantErrors: nil,
 		},
 		{
 			// An unresolvable $ref is unknown, not empty: it may well declare
@@ -456,9 +453,11 @@ paths:
         - $ref: '#/components/parameters/aliasParam'
       responses: {"200": {description: OK}}
 `,
+			// Only the dangling ref is reported. The alias is not additionally
+			// told it needs a schema or content: that check now skips $ref
+			// entries, so a broken chain is named once rather than twice.
 			wantErrors: []string{
 				"components.parameters.aliasParam: $ref '#/components/parameters/goneParam' does not resolve to a valid component",
-				"components.parameters.aliasParam: Parameter must have either a schema or content",
 			},
 		},
 	}
@@ -536,17 +535,15 @@ paths:
 	}
 }
 
-// TestPathParameterConsistency_OAS2HasNoRequiredCheck documents why the
-// required-reported-once tests below are OAS 3 only: OAS 2.0 has no
-// "required: true" check for path parameters at all, so there is no per-path-item
-// error for the OAS 2.0 path to report more than once.
+// TestPathParameterConsistency_OAS2RequiredReportedOncePerPathItem is the OAS
+// 2.0 counterpart of TestPathParameterConsistency_RequiredReportedOncePerPathItem.
 //
-// OAS 2.0 does mandate required: true on path parameters, so this is a real gap
-// — but a pre-existing one, unrelated to $ref resolution. It is tracked in
-// issue #378. This test pins the current behavior so that adding the check is a
-// deliberate, visible change rather than a silent one: it fails once the check
-// lands, at which point it should be replaced with the positive assertions.
-func TestPathParameterConsistency_OAS2HasNoRequiredCheck(t *testing.T) {
+// Swagger 2.0 mandates required: true on path parameters just as OAS 3.x does,
+// and both versions run the same check, so both must dedup a path-item
+// parameter to a single error rather than repeating it per operation. Three
+// operations are declared so a regression to the per-operation placement shows
+// up as three errors.
+func TestPathParameterConsistency_OAS2RequiredReportedOncePerPathItem(t *testing.T) {
 	spec := `
 swagger: "2.0"
 info: {title: Test, version: "1.0.0"}
@@ -564,6 +561,63 @@ paths:
       responses: {"204": {description: No Content}}
 `
 
+	assert.Equal(t, []string{"paths./pets/{petId}.parameters[0]"}, requiredErrorPaths(t, spec),
+		"a path-item parameter defect should be reported once, not once per operation")
+}
+
+// TestPathParameterConsistency_OAS2RequiredSkippedForRefs is the OAS 2.0
+// counterpart of TestPathParameterConsistency_RequiredSkippedForRefs: a
+// referenced parameter is reported at its definition in the root-level
+// parameters, not at every use site.
+func TestPathParameterConsistency_OAS2RequiredSkippedForRefs(t *testing.T) {
+	spec := `
+swagger: "2.0"
+info: {title: Test, version: "1.0.0"}
+parameters:
+  petIdParam: {name: petId, in: path, type: string}
+paths:
+  /pets/{petId}:
+    parameters:
+      - $ref: '#/parameters/petIdParam'
+    get:
+      responses: {"200": {description: OK}}
+    put:
+      responses: {"200": {description: OK}}
+`
+
+	assert.Equal(t, []string{"parameters.petIdParam"}, requiredErrorPaths(t, spec),
+		"the defect belongs to the definition, not to each use site")
+}
+
+// TestPathParameterConsistency_OAS2AliasNotRequiredChecked pins the interaction
+// between the two halves of issue #378: the definition-site required check must
+// not fire on a pure $ref alias. An alias carries no In, so it cannot match
+// in: path — this asserts that rather than assuming it.
+func TestPathParameterConsistency_OAS2AliasNotRequiredChecked(t *testing.T) {
+	spec := `
+swagger: "2.0"
+info: {title: Test, version: "1.0.0"}
+parameters:
+  aliasParam: {$ref: '#/parameters/petIdParam'}
+  petIdParam: {name: petId, in: path, required: true, type: string}
+paths:
+  /pets/{petId}:
+    get:
+      parameters:
+        - $ref: '#/parameters/aliasParam'
+      responses: {"200": {description: OK}}
+`
+
+	assert.Empty(t, requiredErrorPaths(t, spec),
+		"a pure $ref alias has no In and must not be treated as a path parameter")
+}
+
+// requiredErrorPaths collects the paths of every "required: true" error the
+// validator reports for spec, so a test can assert both how many were reported
+// and where.
+func requiredErrorPaths(t *testing.T, spec string) []string {
+	t.Helper()
+
 	p := parser.New()
 	p.ValidateStructure = false
 	parseResult, err := p.ParseBytes([]byte(spec))
@@ -572,17 +626,18 @@ paths:
 	result, err := New().ValidateParsed(*parseResult)
 	require.NoError(t, err)
 
+	var paths []string
 	for _, e := range result.Errors {
-		assert.NotContains(t, e.Message, "Path parameters must have required: true",
-			"OAS 2.0 does not implement this check; update this test if that changes")
+		if strings.Contains(e.Message, "Path parameters must have required: true") {
+			paths = append(paths, e.Path)
+		}
 	}
+	return paths
 }
 
 // TestPathParameterConsistency_RequiredReportedOncePerPathItem guards against
 // path-item level parameters being re-validated for every operation in the
 // item, which produced one identical error per operation.
-//
-// OAS 3 only, per TestPathParameterConsistency_OAS2HasNoRequiredCheck.
 func TestPathParameterConsistency_RequiredReportedOncePerPathItem(t *testing.T) {
 	spec := `
 openapi: 3.0.3
@@ -601,22 +656,7 @@ paths:
       responses: {"204": {description: No Content}}
 `
 
-	p := parser.New()
-	p.ValidateStructure = false
-	parseResult, err := p.ParseBytes([]byte(spec))
-	require.NoError(t, err)
-
-	result, err := New().ValidateParsed(*parseResult)
-	require.NoError(t, err)
-
-	var requiredErrors []string
-	for _, e := range result.Errors {
-		if strings.Contains(e.Message, "Path parameters must have required: true") {
-			requiredErrors = append(requiredErrors, e.Path)
-		}
-	}
-
-	assert.Equal(t, []string{"paths./pets/{petId}.parameters[0]"}, requiredErrors,
+	assert.Equal(t, []string{"paths./pets/{petId}.parameters[0]"}, requiredErrorPaths(t, spec),
 		"a path-item parameter defect should be reported once, not once per operation")
 }
 
@@ -652,8 +692,6 @@ paths:
 // TestPathParameterConsistency_RequiredSkippedForRefs checks that a referenced
 // parameter missing required: true is reported at its definition rather than
 // at every place it is used.
-//
-// OAS 3 only, per TestPathParameterConsistency_OAS2HasNoRequiredCheck.
 func TestPathParameterConsistency_RequiredSkippedForRefs(t *testing.T) {
 	spec := `
 openapi: 3.0.3
@@ -671,21 +709,6 @@ paths:
       responses: {"200": {description: OK}}
 `
 
-	p := parser.New()
-	p.ValidateStructure = false
-	parseResult, err := p.ParseBytes([]byte(spec))
-	require.NoError(t, err)
-
-	result, err := New().ValidateParsed(*parseResult)
-	require.NoError(t, err)
-
-	var requiredErrors []string
-	for _, e := range result.Errors {
-		if strings.Contains(e.Message, "Path parameters must have required: true") {
-			requiredErrors = append(requiredErrors, e.Path)
-		}
-	}
-
-	assert.Equal(t, []string{"components.parameters.petIdParam"}, requiredErrors,
+	assert.Equal(t, []string{"components.parameters.petIdParam"}, requiredErrorPaths(t, spec),
 		"the defect belongs to the definition, not to each use site")
 }

--- a/validator/path_validation.go
+++ b/validator/path_validation.go
@@ -198,6 +198,36 @@ func (v *Validator) validateParameterDefinitionRefs(
 	}
 }
 
+// validatePathParamsRequired reports inline path parameters that omit
+// required: true. The rule is identical in OAS 2.0 and 3.x — Swagger 2.0 states
+// that required "MUST be true" for in: path — and the check reads only fields
+// both versions share, so both validators call this.
+//
+// Referenced parameters are deliberately skipped: a ref into the reusable
+// definitions has its definition checked once by validateOAS2Parameters or
+// validateOAS3Components, so checking it again at each use site would report the
+// same defect repeatedly.
+//
+// The skip is unconditional, so a ref that does not land in those definitions
+// — external, or dangling — has its required field checked nowhere. Those refs
+// are reported as unresolvable in their own right, which is the more useful
+// diagnostic anyway.
+//
+// Callers must invoke this once per path item rather than inside their
+// operation loop, or a path-item parameter is reported once per operation.
+func (v *Validator) validatePathParamsRequired(params []*parser.Parameter, prefix string, result *ValidationResult, baseURL string) {
+	for i, param := range params {
+		if param == nil || param.Ref != "" || param.In != parser.ParamInPath || param.Required {
+			continue
+		}
+		v.addError(result, prefix+".parameters["+strconv.Itoa(i)+"]",
+			"Path parameters must have required: true",
+			withSpecRef(fmt.Sprintf("%s#parameter-object", baseURL)),
+			withField("required"),
+		)
+	}
+}
+
 // pathParamDeclarations records the path parameters a path item declares and
 // those one of its operations declares, kept apart so each is reported where it
 // is declared while the template check still sees their union.

--- a/validator/ref_escaping_test.go
+++ b/validator/ref_escaping_test.go
@@ -1,0 +1,150 @@
+package validator
+
+import (
+	"testing"
+)
+
+// TestEscapedRefsResolve covers issue #379: reference lookups built pointers by
+// raw concatenation while the parser's resolver correctly unescaped them per RFC
+// 6901, so a component whose name contains "/" or "~" was unreachable to every
+// check that resolves references and a valid document was reported as broken.
+//
+// OAS 2.0 places no charset constraint on the keys of the root-level
+// parameters, definitions, and responses objects, so these documents are all
+// legitimate.
+func TestEscapedRefsResolve(t *testing.T) {
+	tests := []struct {
+		name string
+		spec string
+	}{
+		{
+			// The parameter case from the issue. It failed as a false positive:
+			// paramutil missed the escaped ref so Classify returned
+			// ReasonNotAParameter, validRefs missed it identically, and
+			// validateRef finally reported it as unresolvable.
+			name: "escaped slash in OAS 2.0 parameter name",
+			spec: `
+swagger: "2.0"
+info: {title: T, version: "1.0.0"}
+parameters:
+  pet/id: {name: petId, in: path, required: true, type: string}
+paths:
+  /pets/{petId}:
+    get:
+      summary: Get a pet
+      parameters:
+        - $ref: '#/parameters/pet~1id'
+      responses: {"200": {description: OK}}
+`,
+		},
+		{
+			// Same failure for definitions, which is what showed the defect was
+			// not parameter-specific.
+			name: "escaped slash in OAS 2.0 definition name",
+			spec: `
+swagger: "2.0"
+info: {title: T, version: "1.0.0"}
+definitions:
+  pet/summary: {type: object, properties: {id: {type: string}}}
+paths:
+  /pets:
+    get:
+      summary: List
+      responses:
+        "200":
+          description: OK
+          schema: {$ref: '#/definitions/pet~1summary'}
+`,
+		},
+		{
+			name: "escaped tilde in OAS 2.0 definition name",
+			spec: `
+swagger: "2.0"
+info: {title: T, version: "1.0.0"}
+definitions:
+  pet~summary: {type: object, properties: {id: {type: string}}}
+paths:
+  /pets:
+    get:
+      summary: List
+      responses:
+        "200":
+          description: OK
+          schema: {$ref: '#/definitions/pet~0summary'}
+`,
+		},
+		{
+			name: "escaped slash in OAS 2.0 response name",
+			spec: `
+swagger: "2.0"
+info: {title: T, version: "1.0.0"}
+responses:
+  not/found: {description: Not found}
+paths:
+  /pets:
+    get:
+      summary: List
+      responses:
+        "404": {$ref: '#/responses/not~1found'}
+`,
+		},
+		{
+			// OAS 3.x constrains component keys to a charset that excludes both
+			// characters, so this document is not strictly legal — but the
+			// validator does not enforce that charset, and until it does such a
+			// name must hit the same escaping path rather than a misleading
+			// "does not resolve" error.
+			name: "escaped slash in OAS 3.x schema name",
+			spec: `
+openapi: 3.0.3
+info: {title: T, version: "1.0.0"}
+components:
+  schemas:
+    pet/summary: {type: object, properties: {id: {type: string}}}
+paths:
+  /pets:
+    get:
+      summary: List
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/pet~1summary'}
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertErrorsMatch(t, validationErrors(t, tt.spec), nil)
+		})
+	}
+}
+
+// TestUnescapedRefDoesNotResolveEscapedName pins the tightening that came with
+// the fix. "#/definitions/pet/summary" is a pointer naming definitions → "pet" →
+// "summary", not the definition named "pet/summary", so it must not match.
+//
+// Raw concatenation used to make it match by accident. Asserting the new,
+// stricter behavior keeps that from being reintroduced as a leniency.
+func TestUnescapedRefDoesNotResolveEscapedName(t *testing.T) {
+	spec := `
+swagger: "2.0"
+info: {title: T, version: "1.0.0"}
+definitions:
+  pet/summary: {type: object, properties: {id: {type: string}}}
+paths:
+  /pets:
+    get:
+      summary: List
+      responses:
+        "200":
+          description: OK
+          schema: {$ref: '#/definitions/pet/summary'}
+`
+
+	assertErrorsMatch(t, validationErrors(t, spec), []string{
+		"$ref '#/definitions/pet/summary' does not resolve to a valid component",
+	})
+}

--- a/validator/ref_tracker.go
+++ b/validator/ref_tracker.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/erraggy/oastools/internal/issues"
+	"github.com/erraggy/oastools/internal/pathutil"
 	"github.com/erraggy/oastools/parser"
 )
 
@@ -275,8 +276,8 @@ func (rt *refTracker) trackSchemaRefs(schema *parser.Schema, opRef operationRef,
 		rt.addRef(schema.Ref, opRef)
 
 		// Follow the ref to track transitive dependencies
-		if components != nil && strings.HasPrefix(schema.Ref, "#/components/schemas/") {
-			name := strings.TrimPrefix(schema.Ref, "#/components/schemas/")
+		if components != nil && strings.HasPrefix(schema.Ref, pathutil.RefPrefixSchemas) {
+			name := pathutil.UnescapeRefToken(strings.TrimPrefix(schema.Ref, pathutil.RefPrefixSchemas))
 			if resolved, ok := components.Schemas[name]; ok {
 				rt.trackSchemaRefs(resolved, opRef, components, visited)
 			}


### PR DESCRIPTION
Three $ref-handling defects found in production use, all pre-existing.

#376 - Adds omitempty to Parameter.Name/In, Response.Description, and RequestBody.Content so a $ref object serializes as $ref alone.

The custom JSON marshalers needed the same handling as the struct tags: they take a fast path via the tags only when Extra is empty and built a map by hand otherwise, so the shape of a $ref depended on whether it carried an `x-...` extension. Both paths are now conditional and match, and the tests run every case with and without an extension to keep them that way.

#378 - `validateOAS3PathParamsRequired` read only Ref, In, and Required, which both OAS versions share, so it moves to path_validation.go as validatePathParamsRequired and gains two OAS 2.0 call sites rather than being reimplemented. The OAS versions can no longer drift on what counts as a defect.

Both validators now skip $ref entries before checking fields a reference does not carry (as done in `validateOAS3RequestBody`). A broken alias chain is reported once as a dangling ref instead of twice.

#379 - Adds `EscapeRefToken`/`UnescapeRefToken` to `internal/pathutil`. Escaping inside the 14 builders fixes every lookup site, `validator/refs.go` and `internal/paramutil` included, with no call-site changes. Eight sites that split a reference back into a name now unescape it.

One of those eight was silent data loss rather than a false positive: `fixer/prune.go` recovered a name that never matched its key, so `oastools fix --prune-schemas` deleted a referenced schema with no error or warning.

Deliberate tightening: `#/definitions/pet/summary` no longer matches a component named `"pet/summary"`, since per RFC 6901 that pointer means definitions → pet → summary. Raw concatenation made it match by accident.

Corpus impact: none. No corpus component name contains / or ~, and Petstore's 9
path parameters already declare required: true, so ExpectedErrors does not move.

Test count 8716 → 8760. Every new test was verified to fail without its fix.

Deferred, filed off-milestone: #380 (OAS 3.x component-name charset is still unenforced — this change makes such a document validate clean rather than fail confusingly, so the gap is now more visible) and #381 (no FixType for the required: true defect this makes reportable in OAS 2.0).

Fixes #376
Fixes #378
Fixes #379