### PR TITLE
fix(validator): enforce OAS 3.x component name charset and resolve components by name

### DIFF
--- a/validator/component_names.go
+++ b/validator/component_names.go
@@ -1,0 +1,84 @@
+package validator
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/erraggy/oastools/internal/maputil"
+	"github.com/erraggy/oastools/parser"
+)
+
+// componentNamePattern is the key charset OAS 3.x requires of every fixed field
+// of the Components Object: "All the fixed fields declared above are objects
+// that MUST use keys that match the regular expression: ^[a-zA-Z0-9\.\-_]+$".
+//
+// See: https://spec.openapis.org/oas/v3.0.0.html#components-object
+//
+// The spec writes "." and "-" escaped inside the character class, where neither
+// needs escaping; this is the same expression written plainly.
+//
+// OAS 2.0 has no counterpart, deliberately. It places no charset constraint on
+// the keys of the root-level parameters, definitions, and responses objects, so
+// a name containing "/" or "~" is legitimate there and is escaped per RFC 6901
+// when referenced: see [pathutil.EscapeRefToken]. Applying this pattern to an
+// OAS 2.0 document would reject valid specs.
+var componentNamePattern = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
+
+// validateOAS3ComponentNames reports component names that violate the charset
+// OAS 3.x requires.
+//
+// The rule covers every fixed field of the Components Object, not just schemas.
+// Checking the names in one pass here rather than inside each section's
+// value-validation loop keeps the rule in a single readable place, and means a
+// nil value cannot cause its name to go unchecked.
+func (v *Validator) validateOAS3ComponentNames(components *parser.Components, result *ValidationResult, baseURL string) {
+	if components == nil {
+		return
+	}
+
+	checkComponentNames(v, components.Schemas, "schemas", result, baseURL)
+	checkComponentNames(v, components.Responses, "responses", result, baseURL)
+	checkComponentNames(v, components.Parameters, "parameters", result, baseURL)
+	checkComponentNames(v, components.Examples, "examples", result, baseURL)
+	checkComponentNames(v, components.RequestBodies, "requestBodies", result, baseURL)
+	checkComponentNames(v, components.Headers, "headers", result, baseURL)
+	checkComponentNames(v, components.SecuritySchemes, "securitySchemes", result, baseURL)
+	checkComponentNames(v, components.Links, "links", result, baseURL)
+	checkComponentNames(v, components.Callbacks, "callbacks", result, baseURL)
+	checkComponentNames(v, components.PathItems, "pathItems", result, baseURL)
+	checkComponentNames(v, components.MediaTypes, "mediaTypes", result, baseURL)
+}
+
+// checkComponentNames reports every key of one Components section that falls
+// outside [componentNamePattern].
+//
+// A free function rather than a method because Go does not permit type
+// parameters on methods, and the sections hold eleven different value types.
+//
+// Empty and whitespace-only names are skipped: those are a missing name rather
+// than a malformed one, and validateSchemaName already reports them for schemas
+// with a message that says so. Reporting them here as a charset violation would
+// double up on that and describe the defect less clearly.
+//
+// Keys are visited in sorted order so a document with several offending names
+// reports them the same way on every run.
+func checkComponentNames[V any](
+	v *Validator,
+	section map[string]V,
+	field string,
+	result *ValidationResult,
+	baseURL string,
+) {
+	for _, name := range maputil.SortedKeys(section) {
+		if strings.TrimSpace(name) == "" || componentNamePattern.MatchString(name) {
+			continue
+		}
+		v.addError(result, "components."+field+"."+name,
+			fmt.Sprintf("Component name %q must match %s", name, componentNamePattern),
+			withSpecRef(fmt.Sprintf("%s#components-object", baseURL)),
+			withField("name"),
+			withValue(name),
+		)
+	}
+}

--- a/validator/component_names.go
+++ b/validator/component_names.go
@@ -37,7 +37,7 @@ func (v *Validator) validateOAS3ComponentNames(components *parser.Components, re
 		return
 	}
 
-	checkComponentNames(v, components.Schemas, "schemas", result, baseURL)
+	checkComponentNames(v, components.Schemas, componentSchemasName, result, baseURL)
 	checkComponentNames(v, components.Responses, "responses", result, baseURL)
 	checkComponentNames(v, components.Parameters, "parameters", result, baseURL)
 	checkComponentNames(v, components.Examples, "examples", result, baseURL)
@@ -50,16 +50,19 @@ func (v *Validator) validateOAS3ComponentNames(components *parser.Components, re
 	checkComponentNames(v, components.MediaTypes, "mediaTypes", result, baseURL)
 }
 
+// componentSchemasName is a special case
+const componentSchemasName = "schemas"
+
 // checkComponentNames reports every key of one Components section that falls
 // outside [componentNamePattern].
 //
 // A free function rather than a method because Go does not permit type
 // parameters on methods, and the sections hold eleven different value types.
 //
-// Empty and whitespace-only names are skipped: those are a missing name rather
-// than a malformed one, and validateSchemaName already reports them for schemas
-// with a message that says so. Reporting them here as a charset violation would
-// double up on that and describe the defect less clearly.
+// An empty or whitespace-only name is reported as a missing name rather than a
+// charset violation, because that is the more accurate description and the more
+// actionable message. Schemas are the exception: validateSchemaName already says
+// exactly that for them, so blankNamesReportedElsewhere suppresses the duplicate.
 //
 // Keys are visited in sorted order so a document with several offending names
 // reports them the same way on every run.
@@ -70,15 +73,33 @@ func checkComponentNames[V any](
 	result *ValidationResult,
 	baseURL string,
 ) {
+	prefix := "components." + field
+	specRef := withSpecRef(fmt.Sprintf("%s#components-object", baseURL))
+
+	// if this is schemas, then know it is reported elsewhere
+	blankNamesReportedElsewhere := field == componentSchemasName
+
 	for _, name := range maputil.SortedKeys(section) {
-		if strings.TrimSpace(name) == "" || componentNamePattern.MatchString(name) {
+		switch {
+		case blankNamesReportedElsewhere && strings.TrimSpace(name) == "":
 			continue
+
+		case name == "":
+			v.addError(result, prefix, "Component name cannot be empty",
+				specRef, withField("name"), withValue(""),
+			)
+
+		case strings.TrimSpace(name) == "":
+			v.addError(result, prefix+"."+name,
+				fmt.Sprintf("Component name cannot be whitespace-only: %q", name),
+				specRef, withField("name"), withValue(name),
+			)
+
+		case !componentNamePattern.MatchString(name):
+			v.addError(result, prefix+"."+name,
+				fmt.Sprintf("Component name %q must match %s", name, componentNamePattern),
+				specRef, withField("name"), withValue(name),
+			)
 		}
-		v.addError(result, "components."+field+"."+name,
-			fmt.Sprintf("Component name %q must match %s", name, componentNamePattern),
-			withSpecRef(fmt.Sprintf("%s#components-object", baseURL)),
-			withField("name"),
-			withValue(name),
-		)
 	}
 }

--- a/validator/component_names_test.go
+++ b/validator/component_names_test.go
@@ -8,19 +8,27 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// oas3WithComponentSection builds a minimal OAS 3.1 document declaring one
-// component of the given kind under the given name. 3.1 is used so pathItems is
-// legal; every other section exists in 3.0 as well.
-func oas3WithComponentSection(t *testing.T, field, name, body string) string {
+// Component sections were not all introduced at once, so each case declares the
+// earliest version in which its section is a legal Components field. Using one
+// blanket version would test some sections against a document that may not
+// legally carry them.
+const (
+	oas31 = "3.1.0" // pathItems
+	oas32 = "3.2.0" // mediaTypes
+)
+
+// oas3WithComponentSection builds a minimal OAS 3.x document declaring one
+// component of the given kind under the given name.
+func oas3WithComponentSection(t *testing.T, version, field, name, body string) string {
 	t.Helper()
 
-	return fmt.Sprintf(`openapi: 3.1.0
+	return fmt.Sprintf(`openapi: %s
 info: {title: T, version: "1.0.0"}
 components:
   %s:
     %q: %s
 paths: {}
-`, field, name, body)
+`, version, field, name, body)
 }
 
 // TestComponentNameCharset covers issue #380: OAS 3.x requires every fixed field
@@ -30,34 +38,37 @@ paths: {}
 // Every section is exercised rather than schemas alone, because the previous gap
 // was precisely that only schemas had any name validation at all.
 func TestComponentNameCharset(t *testing.T) {
-	// bodies are the minimal valid value for each section, so the only error a
-	// case can produce is the name one.
-	bodies := map[string]string{
-		"schemas":         `{type: object}`,
-		"responses":       `{description: OK}`,
-		"parameters":      `{name: q, in: query, schema: {type: string}}`,
-		"examples":        `{value: 1}`,
-		"requestBodies":   `{content: {application/json: {schema: {type: object}}}}`,
-		"headers":         `{schema: {type: string}}`,
-		"securitySchemes": `{type: apiKey, name: k, in: header}`,
-		"links":           `{operationId: getPet}`,
-		"callbacks":       `{}`,
-		"pathItems":       `{}`,
-		"mediaTypes":      `{schema: {type: object}}`,
-	}
-
-	for field, body := range bodies {
+	for field, section := range componentSections() {
 		t.Run(field+"/rejects slash", func(t *testing.T) {
-			spec := oas3WithComponentSection(t, field, "pet/summary", body)
+			spec := oas3WithComponentSection(t, section.version, field, "pet/summary", section.body)
 			assertErrorsMatch(t, validationErrors(t, spec), []string{
 				fmt.Sprintf(`components.%s.pet/summary: Component name "pet/summary" must match`, field),
 			})
 		})
 
 		t.Run(field+"/accepts legal name", func(t *testing.T) {
-			spec := oas3WithComponentSection(t, field, "Pet.Summary-v2_1", body)
+			spec := oas3WithComponentSection(t, section.version, field, "Pet.Summary-v2_1", section.body)
 			assertErrorsMatch(t, validationErrors(t, spec), nil)
 		})
+	}
+}
+
+// componentSections pairs each Components field with the earliest OAS version
+// that accepts it and a minimal valid value, so the only error a case can
+// produce is the name one.
+func componentSections() map[string]struct{ version, body string } {
+	return map[string]struct{ version, body string }{
+		"schemas":         {oas31, `{type: object}`},
+		"responses":       {oas31, `{description: OK}`},
+		"parameters":      {oas31, `{name: q, in: query, schema: {type: string}}`},
+		"examples":        {oas31, `{value: 1}`},
+		"requestBodies":   {oas31, `{content: {application/json: {schema: {type: object}}}}`},
+		"headers":         {oas31, `{schema: {type: string}}`},
+		"securitySchemes": {oas31, `{type: apiKey, name: k, in: header}`},
+		"links":           {oas31, `{operationId: getPet}`},
+		"callbacks":       {oas31, `{}`},
+		"pathItems":       {oas31, `{}`},                       // OAS 3.1+
+		"mediaTypes":      {oas32, `{schema: {type: object}}`}, // OAS 3.2+
 	}
 }
 
@@ -79,7 +90,7 @@ func TestComponentNameCharsetRejectedCharacters(t *testing.T) {
 
 	for _, name := range rejected {
 		t.Run(name, func(t *testing.T) {
-			spec := oas3WithComponentSection(t, "schemas", name, `{type: object}`)
+			spec := oas3WithComponentSection(t, oas31, "schemas", name, `{type: object}`)
 			errs := validationErrors(t, spec)
 			assert.Len(t, errs, 1, "expected exactly the name error; got: %v", errs)
 			assert.Contains(t, strings.Join(errs, "\n"), "must match",
@@ -108,7 +119,7 @@ func TestComponentNameCharsetAcceptedCharacters(t *testing.T) {
 
 	for _, name := range accepted {
 		t.Run(name, func(t *testing.T) {
-			spec := oas3WithComponentSection(t, "schemas", name, `{type: object}`)
+			spec := oas3WithComponentSection(t, oas31, "schemas", name, `{type: object}`)
 			assertErrorsMatch(t, validationErrors(t, spec), nil)
 		})
 	}
@@ -196,4 +207,32 @@ paths: {}
 	errs := validationErrors(t, spec)
 	assert.Len(t, errs, 1, "the blank name should be reported once, not also as a charset violation; got: %v", errs)
 	assert.Contains(t, strings.Join(errs, "\n"), "schema name cannot be empty")
+}
+
+// TestComponentBlankNames covers the sections validateSchemaName does not reach.
+//
+// Only schemas had any name validation before this check, so a blank key
+// anywhere else went unreported entirely. It is reported as a missing name
+// rather than as a charset violation, because that describes the defect and
+// says what to do about it.
+func TestComponentBlankNames(t *testing.T) {
+	for field, section := range componentSections() {
+		if field == componentSchemasName {
+			continue // validateSchemaName owns these; see the test above
+		}
+
+		t.Run(field+"/empty", func(t *testing.T) {
+			spec := oas3WithComponentSection(t, section.version, field, "", section.body)
+			assertErrorsMatch(t, validationErrors(t, spec), []string{
+				fmt.Sprintf("components.%s: Component name cannot be empty", field),
+			})
+		})
+
+		t.Run(field+"/whitespace only", func(t *testing.T) {
+			spec := oas3WithComponentSection(t, section.version, field, "   ", section.body)
+			assertErrorsMatch(t, validationErrors(t, spec), []string{
+				fmt.Sprintf("components.%s.   : Component name cannot be whitespace-only", field),
+			})
+		})
+	}
 }

--- a/validator/component_names_test.go
+++ b/validator/component_names_test.go
@@ -194,19 +194,29 @@ paths:
 // TestComponentNameCharsetSkipsBlankNames keeps this check from double-reporting
 // a defect validateSchemaName already owns. An empty or whitespace-only name is
 // a missing name rather than a malformed one, and is reported as such.
+//
+// Both blank forms are covered because they are separate branches: a
+// whitespace-only name also fails the charset pattern, so suppressing it takes
+// its own guard, whereas an empty name would be caught by either check.
 func TestComponentNameCharsetSkipsBlankNames(t *testing.T) {
-	spec := `
-openapi: 3.0.3
-info: {title: T, version: "1.0.0"}
-components:
-  schemas:
-    "": {type: object}
-paths: {}
-`
+	tests := []struct {
+		name string
+		want string
+	}{
+		{name: "", want: "schema name cannot be empty"},
+		{name: "   ", want: "schema name cannot be whitespace-only"},
+	}
 
-	errs := validationErrors(t, spec)
-	assert.Len(t, errs, 1, "the blank name should be reported once, not also as a charset violation; got: %v", errs)
-	assert.Contains(t, strings.Join(errs, "\n"), "schema name cannot be empty")
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%q", tt.name), func(t *testing.T) {
+			spec := oas3WithComponentSection(t, oas31, "schemas", tt.name, `{type: object}`)
+
+			errs := validationErrors(t, spec)
+			assert.Len(t, errs, 1,
+				"the blank name should be reported once, not also as a charset violation; got: %v", errs)
+			assert.Contains(t, strings.Join(errs, "\n"), tt.want)
+		})
+	}
 }
 
 // TestComponentBlankNames covers the sections validateSchemaName does not reach.

--- a/validator/component_names_test.go
+++ b/validator/component_names_test.go
@@ -1,0 +1,199 @@
+package validator
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// oas3WithComponentSection builds a minimal OAS 3.1 document declaring one
+// component of the given kind under the given name. 3.1 is used so pathItems is
+// legal; every other section exists in 3.0 as well.
+func oas3WithComponentSection(t *testing.T, field, name, body string) string {
+	t.Helper()
+
+	return fmt.Sprintf(`openapi: 3.1.0
+info: {title: T, version: "1.0.0"}
+components:
+  %s:
+    %q: %s
+paths: {}
+`, field, name, body)
+}
+
+// TestComponentNameCharset covers issue #380: OAS 3.x requires every fixed field
+// of the Components Object to use keys matching ^[a-zA-Z0-9\.\-_]+$, and the
+// validator enforced this nowhere.
+//
+// Every section is exercised rather than schemas alone, because the previous gap
+// was precisely that only schemas had any name validation at all.
+func TestComponentNameCharset(t *testing.T) {
+	// bodies are the minimal valid value for each section, so the only error a
+	// case can produce is the name one.
+	bodies := map[string]string{
+		"schemas":         `{type: object}`,
+		"responses":       `{description: OK}`,
+		"parameters":      `{name: q, in: query, schema: {type: string}}`,
+		"examples":        `{value: 1}`,
+		"requestBodies":   `{content: {application/json: {schema: {type: object}}}}`,
+		"headers":         `{schema: {type: string}}`,
+		"securitySchemes": `{type: apiKey, name: k, in: header}`,
+		"links":           `{operationId: getPet}`,
+		"callbacks":       `{}`,
+		"pathItems":       `{}`,
+		"mediaTypes":      `{schema: {type: object}}`,
+	}
+
+	for field, body := range bodies {
+		t.Run(field+"/rejects slash", func(t *testing.T) {
+			spec := oas3WithComponentSection(t, field, "pet/summary", body)
+			assertErrorsMatch(t, validationErrors(t, spec), []string{
+				fmt.Sprintf(`components.%s.pet/summary: Component name "pet/summary" must match`, field),
+			})
+		})
+
+		t.Run(field+"/accepts legal name", func(t *testing.T) {
+			spec := oas3WithComponentSection(t, field, "Pet.Summary-v2_1", body)
+			assertErrorsMatch(t, validationErrors(t, spec), nil)
+		})
+	}
+}
+
+// TestComponentNameCharsetRejectedCharacters pins the boundary of the pattern
+// rather than a single representative violation.
+func TestComponentNameCharsetRejectedCharacters(t *testing.T) {
+	rejected := []string{
+		"pet/summary",
+		"pet~summary",
+		"pet summary",
+		"pet:summary",
+		"pet+summary",
+		"pet#summary",
+		"pet@summary",
+		"pet%summary",
+		"pet[0]",
+		"pét",
+	}
+
+	for _, name := range rejected {
+		t.Run(name, func(t *testing.T) {
+			spec := oas3WithComponentSection(t, "schemas", name, `{type: object}`)
+			errs := validationErrors(t, spec)
+			assert.Len(t, errs, 1, "expected exactly the name error; got: %v", errs)
+			assert.Contains(t, strings.Join(errs, "\n"), "must match",
+				"name %q should be rejected by the charset rule", name)
+		})
+	}
+}
+
+// TestComponentNameCharsetAcceptedCharacters is the control: the pattern permits
+// letters, digits, dot, hyphen, and underscore, and real specs lean on all of
+// them. msgraph alone contributes thousands of dotted names like
+// microsoft.graph.user.
+func TestComponentNameCharsetAcceptedCharacters(t *testing.T) {
+	accepted := []string{
+		"Pet",
+		"pet",
+		"Pet2",
+		"microsoft.graph.user",
+		"Pet-Summary",
+		"Pet_Summary",
+		"_leading",
+		"-leading",
+		".leading",
+		"9",
+	}
+
+	for _, name := range accepted {
+		t.Run(name, func(t *testing.T) {
+			spec := oas3WithComponentSection(t, "schemas", name, `{type: object}`)
+			assertErrorsMatch(t, validationErrors(t, spec), nil)
+		})
+	}
+}
+
+// TestComponentNameCharsetNotAppliedToOAS2 guards the constraint that made this
+// check version-specific.
+//
+// OAS 2.0 places no charset constraint on the keys of its root-level
+// parameters, definitions, and responses objects. Names containing "/" or "~"
+// are legitimate there and are referenced with RFC 6901 escaping, so applying
+// the OAS 3.x pattern to a 2.0 document would reject valid specs — the exact
+// false positive #379 fixed.
+func TestComponentNameCharsetNotAppliedToOAS2(t *testing.T) {
+	spec := `
+swagger: "2.0"
+info: {title: T, version: "1.0.0"}
+definitions:
+  pet/summary: {type: object, properties: {id: {type: string}}}
+parameters:
+  pet/id: {name: petId, in: path, required: true, type: string}
+responses:
+  not/found: {description: Not found}
+paths:
+  /pets/{petId}:
+    get:
+      summary: Get a pet
+      parameters:
+        - $ref: '#/parameters/pet~1id'
+      responses:
+        "200":
+          description: OK
+          schema: {$ref: '#/definitions/pet~1summary'}
+        "404": {$ref: '#/responses/not~1found'}
+`
+
+	assertErrorsMatch(t, validationErrors(t, spec), nil)
+}
+
+// TestComponentNameCharset_EscapedRefStillResolves records the interaction
+// between this check and #379.
+//
+// Before #379 this document failed with a misleading "does not resolve to a
+// valid component" error, because reference lookups did not escape. After it,
+// the reference resolved and the document validated clean — accepting a name the
+// specification forbids. Both halves are now right: exactly one error, and it
+// names the real defect.
+func TestComponentNameCharset_EscapedRefStillResolves(t *testing.T) {
+	spec := `
+openapi: 3.0.3
+info: {title: T, version: "1.0.0"}
+components:
+  schemas:
+    pet/summary: {type: object, properties: {id: {type: string}}}
+paths:
+  /pets:
+    get:
+      summary: List
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/pet~1summary'}
+`
+
+	assertErrorsMatch(t, validationErrors(t, spec), []string{
+		`components.schemas.pet/summary: Component name "pet/summary" must match`,
+	})
+}
+
+// TestComponentNameCharsetSkipsBlankNames keeps this check from double-reporting
+// a defect validateSchemaName already owns. An empty or whitespace-only name is
+// a missing name rather than a malformed one, and is reported as such.
+func TestComponentNameCharsetSkipsBlankNames(t *testing.T) {
+	spec := `
+openapi: 3.0.3
+info: {title: T, version: "1.0.0"}
+components:
+  schemas:
+    "": {type: object}
+paths: {}
+`
+
+	errs := validationErrors(t, spec)
+	assert.Len(t, errs, 1, "the blank name should be reported once, not also as a charset violation; got: %v", errs)
+	assert.Contains(t, strings.Join(errs, "\n"), "schema name cannot be empty")
+}

--- a/validator/oas3.go
+++ b/validator/oas3.go
@@ -263,6 +263,10 @@ func (v *Validator) validateOAS3Components(doc *parser.OAS3Document, result *Val
 		return
 	}
 
+	// Checked across every section first, so a nil value cannot cause its name
+	// to go unchecked by the loops below, several of which skip nil entries.
+	v.validateOAS3ComponentNames(doc.Components, result, baseURL)
+
 	// Validate schemas
 	for name, schema := range doc.Components.Schemas {
 		v.validateSchemaName(name, "components.schemas", result)

--- a/validator/ref_escaping_test.go
+++ b/validator/ref_escaping_test.go
@@ -11,7 +11,11 @@ import (
 //
 // OAS 2.0 places no charset constraint on the keys of the root-level
 // parameters, definitions, and responses objects, so these documents are all
-// legitimate.
+// legitimate and must validate completely clean.
+//
+// The OAS 3.x side is deliberately not here: those names are illegal per the
+// Components Object charset, so the equivalent document is expected to produce
+// exactly one error. See TestComponentNameCharset_EscapedRefStillResolves.
 func TestEscapedRefsResolve(t *testing.T) {
 	tests := []struct {
 		name string
@@ -86,31 +90,6 @@ paths:
       summary: List
       responses:
         "404": {$ref: '#/responses/not~1found'}
-`,
-		},
-		{
-			// OAS 3.x constrains component keys to a charset that excludes both
-			// characters, so this document is not strictly legal — but the
-			// validator does not enforce that charset, and until it does such a
-			// name must hit the same escaping path rather than a misleading
-			// "does not resolve" error.
-			name: "escaped slash in OAS 3.x schema name",
-			spec: `
-openapi: 3.0.3
-info: {title: T, version: "1.0.0"}
-components:
-  schemas:
-    pet/summary: {type: object, properties: {id: {type: string}}}
-paths:
-  /pets:
-    get:
-      summary: List
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema: {$ref: '#/components/schemas/pet~1summary'}
 `,
 		},
 	}

--- a/validator/ref_tracker.go
+++ b/validator/ref_tracker.go
@@ -366,18 +366,57 @@ func (rt *refTracker) addRef(ref string, opRef operationRef) {
 	rt.componentToOps[normalized] = append(existing, opRef)
 }
 
-// normalizeRef converts a $ref like "#/components/schemas/User" to "components.schemas.User".
+// normalizeRef converts a $ref like "#/components/schemas/User" to
+// "components.schemas.User", the form issue paths use.
+//
+// Each pointer token is unescaped per RFC 6901 so the result matches the issue
+// path the validator reports, which carries the component's real name. A
+// definition named "pet/summary" is referenced as "#/definitions/pet~1summary"
+// but reported at "definitions.pet/summary"; without unescaping, the two never
+// match and getComponentOperationContext calls a referenced component unused.
+//
+// Unescaping must happen per token, after splitting on "/" and before joining
+// on ".". Unescaping the whole string first would turn "~1" into a "/" that the
+// join then rewrites to ".", corrupting the name.
 func normalizeRef(ref string) string {
 	if !strings.HasPrefix(ref, "#/") {
 		return "" // External ref, not tracked
 	}
-	// Remove leading #/ and replace / with .
-	return strings.ReplaceAll(strings.TrimPrefix(ref, "#/"), "/", ".")
+	tokens := strings.Split(strings.TrimPrefix(ref, "#/"), "/")
+	for i, token := range tokens {
+		tokens[i] = pathutil.UnescapeRefToken(token)
+	}
+	return strings.Join(tokens, ".")
 }
 
-// getOperationsForComponent returns all operations that reference a component.
-func (rt *refTracker) getOperationsForComponent(componentPath string) []operationRef {
-	return rt.componentToOps[componentPath]
+// getOperationsForComponent returns the operations that reference the component
+// an issue path falls under, or nil when nothing references it.
+//
+// The path is matched against the components already known to reference
+// something rather than split positionally, because a component name may itself
+// contain dots — "microsoft.graph.user" is legal and accounts for every name in
+// some real specs — so the boundary between the name and the nesting after it
+// cannot be recovered from the path alone.
+//
+// Trying successively shorter prefixes yields the longest match first in one map
+// lookup per dot. Longest-first matters beyond dotted names: it keeps a
+// component named "User" from claiming an issue path under "UserProfile".
+//
+// No match means no operation references this component, which is exactly what
+// componentToOps records, so returning nil here is the right answer rather than
+// a failure to resolve.
+func (rt *refTracker) getOperationsForComponent(issuePath string) []operationRef {
+	for path := issuePath; path != ""; {
+		if ops, ok := rt.componentToOps[path]; ok {
+			return ops
+		}
+		i := strings.LastIndex(path, ".")
+		if i < 0 {
+			break
+		}
+		path = path[:i]
+	}
+	return nil
 }
 
 // getOperationContext builds an OperationContext for a given issue path.
@@ -446,10 +485,11 @@ func (rt *refTracker) getPathOrWebhookOperationContext(issuePath, prefix string,
 
 // getComponentOperationContext builds context for a reusable component.
 func (rt *refTracker) getComponentOperationContext(issuePath string) *issues.OperationContext {
-	// Normalize path to component root (e.g., "components.schemas.User.properties.id" -> "components.schemas.User")
-	componentPath := getComponentRoot(issuePath)
-
-	ops := rt.getOperationsForComponent(componentPath)
+	// The issue path may point inside a component — "components.schemas.User"
+	// for the component itself, "components.schemas.User.properties.id" for a
+	// problem nested within it — so the lookup resolves it to whichever
+	// component owns it.
+	ops := rt.getOperationsForComponent(issuePath)
 	if len(ops) == 0 {
 		// Unused component
 		return &issues.OperationContext{
@@ -491,26 +531,6 @@ func isReusableComponentPath(path string) bool {
 		}
 	}
 	return false
-}
-
-// getComponentRoot extracts the component root from a nested path.
-// e.g., "components.schemas.User.properties.id" -> "components.schemas.User"
-func getComponentRoot(path string) string {
-	// Handle OAS3 components
-	if strings.HasPrefix(path, "components.") {
-		parts := strings.Split(path, ".")
-		if len(parts) >= 3 {
-			return strings.Join(parts[:3], ".")
-		}
-	}
-	// Handle OAS2 definitions/parameters/responses
-	if strings.HasPrefix(path, "definitions.") || strings.HasPrefix(path, "parameters.") || strings.HasPrefix(path, "responses.") {
-		parts := strings.Split(path, ".")
-		if len(parts) >= 2 {
-			return strings.Join(parts[:2], ".")
-		}
-	}
-	return path
 }
 
 // parseMethod converts a lowercase method string to uppercase, or returns "" if not a valid method.

--- a/validator/ref_tracker_escaping_test.go
+++ b/validator/ref_tracker_escaping_test.go
@@ -135,11 +135,19 @@ func TestNormalizeRefUnescapesPerToken(t *testing.T) {
 	assert.Equal(t, "definitions.pet/summary", normalizeRef("#/definitions/pet~1summary"))
 	assert.NotEqual(t, "definitions.pet.summary", normalizeRef("#/definitions/pet~1summary"),
 		"the recovered slash must not be rewritten as a path separator")
+
+	// "~01" is an escaped tilde followed by a literal "1", so it must decode to
+	// the literal text "~1" rather than to a slash. Unescaping "~0" before "~1"
+	// would produce a "~" that then combines with the "1" into a slash, which
+	// the join would in turn rewrite as ".".
+	assert.Equal(t, "definitions.pet~1summary", normalizeRef("#/definitions/pet~01summary"))
 }
 
-// TestNormalizeRefIgnoresExternalRefs keeps the early return intact: an external
-// ref names nothing in this document and is deliberately untracked.
-func TestNormalizeRefIgnoresExternalRefs(t *testing.T) {
+// TestNormalizeRefIgnoresUntrackableRefs keeps the early return intact: a ref
+// that names nothing inside this document's component tree is deliberately
+// untracked, whether it points at another file or at the document root.
+func TestNormalizeRefIgnoresUntrackableRefs(t *testing.T) {
 	assert.Empty(t, normalizeRef("other.yaml#/definitions/User"))
 	assert.Empty(t, normalizeRef("https://example.com/spec.yaml#/definitions/User"))
+	assert.Empty(t, normalizeRef("#"))
 }

--- a/validator/ref_tracker_escaping_test.go
+++ b/validator/ref_tracker_escaping_test.go
@@ -1,0 +1,145 @@
+package validator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRefLookupMatchesIssuePath pins the invariant the reference tracker depends
+// on: the key it stores, derived from a $ref, must be findable from the issue
+// path the validator reports for that same component.
+//
+// The two come from different inputs — a $ref carries RFC 6901 escaping and the
+// issue path carries the component's real name, which may itself contain dots —
+// so nothing but a test holds them together. When they disagreed,
+// getComponentOperationContext found no operations for a component that is in
+// fact referenced and annotated it "unused component".
+//
+// Covers issues #380 (escaping, mostly OAS 2.0 where such names are legitimate)
+// and #383 (dots, legal and common in OAS 3.x).
+func TestRefLookupMatchesIssuePath(t *testing.T) {
+	tests := []struct {
+		name string
+		// ref is what a document carries; issuePath is where the validator
+		// reports a problem with the component that ref names.
+		ref       string
+		issuePath string
+	}{
+		{
+			name:      "OAS 2.0 definition",
+			ref:       "#/definitions/User",
+			issuePath: "definitions.User",
+		},
+		{
+			name:      "OAS 2.0 definition with escaped slash",
+			ref:       "#/definitions/pet~1summary",
+			issuePath: "definitions.pet/summary",
+		},
+		{
+			name:      "OAS 2.0 definition with escaped tilde",
+			ref:       "#/definitions/pet~0summary",
+			issuePath: "definitions.pet~summary",
+		},
+		{
+			name:      "OAS 2.0 parameter with escaped slash",
+			ref:       "#/parameters/pet~1id",
+			issuePath: "parameters.pet/id",
+		},
+		{
+			name:      "OAS 2.0 response with escaped slash",
+			ref:       "#/responses/not~1found",
+			issuePath: "responses.not/found",
+		},
+		{
+			name:      "OAS 3.x schema",
+			ref:       "#/components/schemas/User",
+			issuePath: "components.schemas.User",
+		},
+		{
+			name:      "OAS 3.x schema with escaped slash",
+			ref:       "#/components/schemas/pet~1summary",
+			issuePath: "components.schemas.pet/summary",
+		},
+		{
+			name:      "OAS 3.x schema with dots in the name",
+			ref:       "#/components/schemas/microsoft.graph.user",
+			issuePath: "components.schemas.microsoft.graph.user",
+		},
+		{
+			// The two defects together: a name that both contains dots and needs
+			// escaping must survive the round trip through either mechanism.
+			name:      "OAS 3.x schema with dots and an escaped slash",
+			ref:       "#/components/schemas/microsoft.graph~1user",
+			issuePath: "components.schemas.microsoft.graph/user",
+		},
+		{
+			// The issue is nested inside the component rather than on the
+			// component itself, which is the case getComponentRoot existed for.
+			name:      "issue nested inside a dotted component",
+			ref:       "#/components/schemas/microsoft.graph.user",
+			issuePath: "components.schemas.microsoft.graph.user.properties.id",
+		},
+	}
+
+	op := operationRef{Method: "GET", Path: "/pets", OperationID: "listPets"}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rt := newRefTracker()
+			rt.addRef(tt.ref, op)
+
+			assert.Equal(t, []operationRef{op}, rt.getOperationsForComponent(tt.issuePath),
+				"a component referenced by %q must be found from issue path %q", tt.ref, tt.issuePath)
+		})
+	}
+}
+
+// TestRefLookupPrefersLongestMatch guards the one way prefix matching can go
+// wrong: a component whose name is a prefix of another's must not claim the
+// other's issue paths.
+func TestRefLookupPrefersLongestMatch(t *testing.T) {
+	user := operationRef{Method: "GET", Path: "/users", OperationID: "getUser"}
+	profile := operationRef{Method: "GET", Path: "/profiles", OperationID: "getProfile"}
+
+	rt := newRefTracker()
+	rt.addRef("#/components/schemas/User", user)
+	rt.addRef("#/components/schemas/User.Profile", profile)
+
+	assert.Equal(t, []operationRef{user}, rt.getOperationsForComponent("components.schemas.User"))
+	assert.Equal(t, []operationRef{user}, rt.getOperationsForComponent("components.schemas.User.properties.id"))
+	assert.Equal(t, []operationRef{profile}, rt.getOperationsForComponent("components.schemas.User.Profile"))
+	assert.Equal(t, []operationRef{profile}, rt.getOperationsForComponent("components.schemas.User.Profile.properties.id"))
+}
+
+// TestRefLookupUnreferencedComponent keeps "nothing matched" meaning what it
+// should. componentToOps holds exactly the components something references, so
+// finding no match is the correct answer for an orphan rather than a lookup
+// failure — the distinction the annotation depends on.
+func TestRefLookupUnreferencedComponent(t *testing.T) {
+	rt := newRefTracker()
+	rt.addRef("#/components/schemas/User", operationRef{Method: "GET", Path: "/users"})
+
+	assert.Empty(t, rt.getOperationsForComponent("components.schemas.Orphan"))
+	assert.Empty(t, rt.getOperationsForComponent("components.schemas.Orphan.properties.id"))
+	assert.Empty(t, rt.getOperationsForComponent(""))
+}
+
+// TestNormalizeRefUnescapesPerToken guards the ordering the fix depends on.
+//
+// Unescaping the whole ref before joining tokens with "." would turn the "/"
+// recovered from "~1" into a ".", silently renaming the component. Only a name
+// containing an escape sequence can catch this, which is why it is asserted
+// directly rather than left to the pairing test above.
+func TestNormalizeRefUnescapesPerToken(t *testing.T) {
+	assert.Equal(t, "definitions.pet/summary", normalizeRef("#/definitions/pet~1summary"))
+	assert.NotEqual(t, "definitions.pet.summary", normalizeRef("#/definitions/pet~1summary"),
+		"the recovered slash must not be rewritten as a path separator")
+}
+
+// TestNormalizeRefIgnoresExternalRefs keeps the early return intact: an external
+// ref names nothing in this document and is deliberately untracked.
+func TestNormalizeRefIgnoresExternalRefs(t *testing.T) {
+	assert.Empty(t, normalizeRef("other.yaml#/definitions/User"))
+	assert.Empty(t, normalizeRef("https://example.com/spec.yaml#/definitions/User"))
+}


### PR DESCRIPTION
Two defects in how component names are validated and correlated, found while closing the gap #379 left behind.

#380: Adds validateOAS3ComponentNames, covering every fixed field of the Components Object rather than schemas alone, which was the only section with any name validation at all. Names run in one pass ahead of the per-section value loops, several of which skip nil entries before doing any work and would otherwise let a nil-valued component's name go unchecked.

Reported as an error rather than a warning. The specification says MUST, the validator already reports comparable MUST-level violations as errors.

Blank names are skipped deliberately: an empty or whitespace-only name is a missing name rather than a malformed one, and validateSchemaName already reports it with a message that says so.

This closes a gap that #379 made worse. Before that change, an OAS 3.x component named "pet/summary" failed with a misleading "does not resolve" error; after it, the reference resolved and the document validated clean, silently accepting a name the specification forbids. TestComponentNameCharset_EscapedRefStillResolves now asserts exactly one error naming the real defect.

#383: getComponentRoot recovered the component owning an issue path by splitting on "." and taking a fixed number of segments, so a name containing a dot resolved to the wrong root and its operation context was lost. Such names are legal and common: microsoft.graph.user and its 7,865 siblings account for every component name in the msgraph corpus spec.

    ✗ components.parameters.microsoft.graph.userId (unused component): ...
    ✗ components.parameters.userId2  (operationId: listUsers): ...

Identical documents, differing only in the name. Both are referenced by listUsers; only the second said so.

No positional split can work, because the component name may itself contain the separator. getOperationsForComponent now walks successively shorter prefixes of the issue path, giving the longest match first in one map lookup per dot. Longest-first also keeps a component named "User" from claiming issue paths under "UserProfile". Finding no match is already the correct answer for an orphan, since componentToOps holds exactly the referenced components, so getComponentRoot is deleted rather than kept as a fallback.

normalizeRef now unescapes per token, after splitting on "/" and before joining on ".". Unescaping the whole ref first would rewrite a slash recovered from "~1" as a path separator, renaming the component. This was filed under #380 as cosmetic, but it's not. The tracker keys componentToOps from a $ref, which carries escaping, and looks it up from an issue path, which carries the real name, so the two never matched for such a component; and in OAS 2.0 those names are legitimate rather than merely tolerated.

Corpus impact: none. No component name violates the charset, and no spec both uses dotted names and reports findings on them, so the unused-component annotation counts are unchanged across all ten specs. Validating github-api.json takes 525ms before and 524ms after.

Test count 8760 -> 8822. Each new test was verified to fail without its fix: 21 subtests for the charset check, 6 for the escaping fix.

Fixes #380
Fixes #383