### PR TITLE
chore: prepare v1.54.0 release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "oastools",
       "description": "15 MCP tools and 5 guided skills for working with OpenAPI specs — validate, fix, convert, diff, join, overlay, generate, and walk operations/schemas/parameters/responses/security/paths",
-      "version": "1.53.2",
+      "version": "1.54.0",
       "author": {
         "name": "erraggy",
         "url": "https://github.com/erraggy"

--- a/benchmarks/benchmark-v1.54.0.txt
+++ b/benchmarks/benchmark-v1.54.0.txt
@@ -1,0 +1,364 @@
+goos: linux
+goarch: amd64
+pkg: github.com/erraggy/oastools/parser
+cpu: AMD EPYC 7763 64-Core Processor                
+BenchmarkParseResultEquals/Identical/SmallOAS3-4         	 2614310	      2287 ns/op	       0 B/op	       0 allocs/op
+BenchmarkParseResultEquals/Identical/MediumOAS3-4        	  142081	     43149 ns/op	    6696 B/op	       9 allocs/op
+BenchmarkParseResultEquals/Identical/LargeOAS3-4         	   10000	    501313 ns/op	   54152 B/op	      15 allocs/op
+BenchmarkParseResultEquals/Identical/SmallOAS2-4         	 3089152	      1944 ns/op	       0 B/op	       0 allocs/op
+BenchmarkParseResultEquals/Identical/MediumOAS2-4        	  160658	     37433 ns/op	    6696 B/op	       9 allocs/op
+BenchmarkEquals_EarlyExit/DifferentVersion-4             	1000000000	         5.677 ns/op	       0 B/op	       0 allocs/op
+BenchmarkEquals_EarlyExit/DifferentOASVersion-4          	1000000000	         5.000 ns/op	       0 B/op	       0 allocs/op
+BenchmarkEquals_EarlyExit/DifferentInfo-4                	353520411	        17.12 ns/op	       0 B/op	       0 allocs/op
+BenchmarkEquals_EarlyExit/DifferentLastPath-4            	  242672	     24876 ns/op	    6696 B/op	       9 allocs/op
+BenchmarkSchemaEquals/Simple-4                           	33004527	       182.7 ns/op	       0 B/op	       0 allocs/op
+BenchmarkSchemaEquals/WithProperties-4                   	 4604920	      1302 ns/op	       0 B/op	       0 allocs/op
+BenchmarkSchemaEquals/Complex-4                          	 2433102	      2494 ns/op	     456 B/op	       3 allocs/op
+BenchmarkSchemaEquals/Nested-4                           	 5228179	      1151 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDocumentEquals/OAS3/Small-4                     	 2644708	      2276 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDocumentEquals/OAS3/Medium-4                    	  141578	     42325 ns/op	    6696 B/op	       9 allocs/op
+BenchmarkDocumentEquals/OAS3/Large-4                     	   10000	    520556 ns/op	   54152 B/op	      15 allocs/op
+BenchmarkDocumentEquals/OAS2/Small-4                     	 3134233	      1919 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDocumentEquals/OAS2/Medium-4                    	  161812	     37628 ns/op	    6696 B/op	       9 allocs/op
+BenchmarkMarshalInfo/NoExtra-4                           	 5385302	      1124 ns/op	     192 B/op	       2 allocs/op
+BenchmarkMarshalInfo/Extra1-4                            	 2451591	      2429 ns/op	     896 B/op	      16 allocs/op
+BenchmarkMarshalInfo/Extra5-4                            	 1453742	      4115 ns/op	    1376 B/op	      24 allocs/op
+BenchmarkMarshalInfo/Extra10-4                           	  772646	      7654 ns/op	    2697 B/op	      37 allocs/op
+BenchmarkMarshalInfo/Extra20-4                           	  425056	     14228 ns/op	    5227 B/op	      59 allocs/op
+BenchmarkMarshalContact/NoExtra-4                        	 5342379	      1136 ns/op	     192 B/op	       2 allocs/op
+BenchmarkMarshalContact/WithExtra-4                      	 1410381	      4255 ns/op	    1376 B/op	      24 allocs/op
+BenchmarkMarshalServer/NoExtra-4                         	 6259992	       968.3 ns/op	     160 B/op	       2 allocs/op
+BenchmarkMarshalServer/WithExtra-4                       	 1000000	      5872 ns/op	    2297 B/op	      30 allocs/op
+BenchmarkMarshalOAS3Document/Small-4                     	  131726	     45813 ns/op	    7008 B/op	      66 allocs/op
+BenchmarkMarshalOAS3Document/Medium-4                    	   12165	    492784 ns/op	   63774 B/op	     471 allocs/op
+BenchmarkMarshalOAS3Document/Large-4                     	    1014	   5975849 ns/op	  802603 B/op	    5335 allocs/op
+BenchmarkMarshalOAS2Document/Small-4                     	  149632	     40107 ns/op	    6374 B/op	      58 allocs/op
+BenchmarkMarshalOAS2Document/Medium-4                    	   15042	    400340 ns/op	   52869 B/op	     396 allocs/op
+BenchmarkUnmarshalInfo/NoExtra-4                         	 2843851	      2109 ns/op	     512 B/op	      10 allocs/op
+BenchmarkUnmarshalInfo/WithExtra-4                       	  760449	      7774 ns/op	    1736 B/op	      46 allocs/op
+BenchmarkJSONFastPath/FastPath-4                         	    7018	    840053 ns/op	  362641 B/op	    4847 allocs/op
+BenchmarkJSONFastPath/YAMLPath_SourceMap-4               	    1064	   5740329 ns/op	 5760609 B/op	   23028 allocs/op
+BenchmarkJSONFastPath/YAMLPath_PreserveOrder-4           	    1123	   5334144 ns/op	 5512209 B/op	   22348 allocs/op
+BenchmarkMarshalOrderedJSON/SmallOAS3-4                  	  275781	     21923 ns/op	    3761 B/op	     156 allocs/op
+BenchmarkMarshalOrderedJSON/MediumOAS3-4                 	   26824	    222951 ns/op	   40444 B/op	    1524 allocs/op
+BenchmarkMarshalOrderedJSON/LargeOAS3-4                  	    2356	   2524854 ns/op	  483848 B/op	   17421 allocs/op
+BenchmarkMarshalOrderedYAML/SmallOAS3-4                  	   46287	    130960 ns/op	  186026 B/op	     413 allocs/op
+BenchmarkMarshalOrderedYAML/MediumOAS3-4                 	    3838	   1518577 ns/op	 1766363 B/op	    3514 allocs/op
+BenchmarkMarshalOrderedYAML/LargeOAS3-4                  	     408	  15125232 ns/op	21480945 B/op	   38863 allocs/op
+BenchmarkMarshalOrderedJSONIndent-4                      	   19362	    310184 ns/op	   60954 B/op	    1525 allocs/op
+BenchmarkMarshalOrderedJSON_vs_Standard/OrderPreserving-4         	   26749	    224871 ns/op	   40450 B/op	    1524 allocs/op
+BenchmarkMarshalOrderedJSON_vs_Standard/Standard-4                	   12038	    497774 ns/op	   63968 B/op	     471 allocs/op
+BenchmarkPreserveOrderOverhead/WithPreserveOrder-4                	    1424	   4085667 ns/op	 1782960 B/op	   24722 allocs/op
+BenchmarkPreserveOrderOverhead/WithoutPreserveOrder-4             	    1975	   3101340 ns/op	 1514978 B/op	   19684 allocs/op
+BenchmarkParse/SmallOAS3-4                                        	   15336	    388947 ns/op	  208388 B/op	    2418 allocs/op
+BenchmarkParse/MediumOAS3-4                                       	    1934	   3142775 ns/op	 1528618 B/op	   19683 allocs/op
+BenchmarkParse/LargeOAS3-4                                        	     154	  38678395 ns/op	17371374 B/op	  223155 allocs/op
+BenchmarkParse/SmallOAS2-4                                        	   16150	    372124 ns/op	  184474 B/op	    2393 allocs/op
+BenchmarkParse/MediumOAS2-4                                       	    2156	   2798222 ns/op	 1300116 B/op	   18131 allocs/op
+BenchmarkParseNoValidation/SmallOAS3-4                            	   15536	    384770 ns/op	  207552 B/op	    2395 allocs/op
+BenchmarkParseNoValidation/MediumOAS3-4                           	    1922	   3150855 ns/op	 1524087 B/op	   19590 allocs/op
+BenchmarkParseBytes/SmallOAS3-4                                   	   16017	    373013 ns/op	  206633 B/op	    2413 allocs/op
+BenchmarkParseBytes/MediumOAS3-4                                  	    1738	   3187601 ns/op	 1514754 B/op	   19679 allocs/op
+BenchmarkParseCore/SmallOAS3-4                                    	   15912	    381096 ns/op	  206640 B/op	    2413 allocs/op
+BenchmarkParseCore/MediumOAS3-4                                   	    1862	   3269973 ns/op	 1514887 B/op	   19679 allocs/op
+BenchmarkParseCore/LargeOAS3-4                                    	     152	  39011684 ns/op	17207124 B/op	  223149 allocs/op
+BenchmarkParseCore/SmallOAS2-4                                    	   16708	    359042 ns/op	  182847 B/op	    2388 allocs/op
+BenchmarkParseCore/MediumOAS2-4                                   	    2166	   2813026 ns/op	 1287482 B/op	   18127 allocs/op
+BenchmarkParseWithOptions/FilePath/SmallOAS3-4                    	   15072	    399083 ns/op	  208723 B/op	    2425 allocs/op
+BenchmarkParseWithOptions/Bytes/SmallOAS3-4                       	   15876	    378318 ns/op	  206955 B/op	    2419 allocs/op
+BenchmarkParseWithOptions/ResolveRefs/SmallOAS3-4                 	   36148	    166671 ns/op	   65474 B/op	     954 allocs/op
+BenchmarkParseReader/MediumOAS3-4                                 	    1767	   3409646 ns/op	 1577511 B/op	   19693 allocs/op
+BenchmarkParseResultCopy/SmallOAS3-4                              	  466918	     12887 ns/op	   18664 B/op	     113 allocs/op
+BenchmarkParseResolveRefs/MediumOAS3-4                            	    3435	   1763610 ns/op	  722728 B/op	    8578 allocs/op
+BenchmarkFormatBytes-4                                            	 7214799	       832.2 ns/op	      64 B/op	       8 allocs/op
+BenchmarkDeepCopy/SmallOAS3-4                                     	 1332943	      4489 ns/op	    7936 B/op	      44 allocs/op
+BenchmarkDeepCopy/MediumOAS3-4                                    	   90333	     65683 ns/op	  121600 B/op	     466 allocs/op
+BenchmarkDeepCopy/LargeOAS3-4                                     	    6033	    972700 ns/op	 1313666 B/op	    4877 allocs/op
+BenchmarkDeepCopy/SmallOAS2-4                                     	 1555254	      3847 ns/op	    6768 B/op	      38 allocs/op
+BenchmarkDeepCopy/MediumOAS2-4                                    	  108788	     55632 ns/op	  106256 B/op	     387 allocs/op
+BenchmarkSourceMapOverhead/Small/Default-4                        	   14727	    407439 ns/op	  208722 B/op	    2425 allocs/op
+BenchmarkSourceMapOverhead/Small/SourceMapDisabled-4              	   14463	    414028 ns/op	  208737 B/op	    2426 allocs/op
+BenchmarkSourceMapOverhead/Small/SourceMapEnabled-4               	   10000	    554006 ns/op	  275535 B/op	    3115 allocs/op
+BenchmarkSourceMapOverhead/Medium/Default-4                       	    1756	   3398904 ns/op	 1529087 B/op	   19692 allocs/op
+BenchmarkSourceMapOverhead/Medium/SourceMapDisabled-4             	    1764	   3352239 ns/op	 1529112 B/op	   19693 allocs/op
+BenchmarkSourceMapOverhead/Medium/SourceMapEnabled-4              	    1292	   4666627 ns/op	 2066479 B/op	   25478 allocs/op
+BenchmarkSourceMapOverhead/Large/Default-4                        	     146	  40854751 ns/op	17371667 B/op	  223162 allocs/op
+BenchmarkSourceMapOverhead/Large/SourceMapDisabled-4              	     146	  40893648 ns/op	17371664 B/op	  223162 allocs/op
+BenchmarkSourceMapOverhead/Large/SourceMapEnabled-4               	     100	  55598247 ns/op	22764847 B/op	  286863 allocs/op
+BenchmarkParseURL_CustomClient-4                                  	    5446	   1092895 ns/op	  418763 B/op	    5216 allocs/op
+BenchmarkParseURL_DefaultClient-4                                 	    5332	   1093050 ns/op	  418801 B/op	    5216 allocs/op
+BenchmarkMarshalBufferPool-4                                      	288326895	        20.89 ns/op	       0 B/op	       0 allocs/op
+BenchmarkMarshalBufferNoPool-4                                    	 4337413	      1378 ns/op	    4144 B/op	       2 allocs/op
+BenchmarkMarshalBufferPool_LargePayload-4                         	 3890580	      1544 ns/op	       0 B/op	       0 allocs/op
+BenchmarkParameterSlice_WithPool-4                                	24041370	       243.7 ns/op	     704 B/op	       2 allocs/op
+BenchmarkParameterSlice_WithoutPool-4                             	25820761	       223.2 ns/op	     704 B/op	       2 allocs/op
+BenchmarkServerSlice_WithPool-4                                   	70958869	        85.37 ns/op	      96 B/op	       2 allocs/op
+BenchmarkServerSlice_WithoutPool-4                                	90837150	        65.76 ns/op	      96 B/op	       2 allocs/op
+BenchmarkStringSlice_WithPool-4                                   	331451853	        18.10 ns/op	       0 B/op	       0 allocs/op
+BenchmarkStringSlice_WithoutPool-4                                	1000000000	         5.000 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDeepCopyWork_WithPool-4                                  	124695216	        48.18 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDeepCopyWork_WithoutPool-4                               	170247018	        35.30 ns/op	       0 B/op	       0 allocs/op
+BenchmarkMarshalToJSON-4                                          	 6051478	       993.1 ns/op	     368 B/op	      11 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/parser	579.393s
+goos: linux
+goarch: amd64
+pkg: github.com/erraggy/oastools/validator
+cpu: AMD EPYC 7763 64-Core Processor                
+BenchmarkValidate/SmallOAS3-4    	   15678	    381911 ns/op	  215297 B/op	    2471 allocs/op
+BenchmarkValidate/MediumOAS3-4   	    1986	   3019581 ns/op	 1573351 B/op	   20252 allocs/op
+BenchmarkValidate/LargeOAS3-4    	     154	  38590090 ns/op	17821225 B/op	  228820 allocs/op
+BenchmarkValidate/SmallOAS2-4    	   16333	    364687 ns/op	  190590 B/op	    2435 allocs/op
+BenchmarkValidate/MediumOAS2-4   	    2211	   2731624 ns/op	 1337150 B/op	   18614 allocs/op
+BenchmarkValidateNoWarnings/SmallOAS3-4         	   15691	    382447 ns/op	  215228 B/op	    2471 allocs/op
+BenchmarkValidateNoWarnings/MediumOAS3-4        	    2001	   2976135 ns/op	 1571880 B/op	   20251 allocs/op
+BenchmarkValidateNoWarnings/LargeOAS3-4         	     154	  38510425 ns/op	17819856 B/op	  228819 allocs/op
+BenchmarkValidateParsed/SmallOAS3-4             	  613904	      9712 ns/op	    5625 B/op	      50 allocs/op
+BenchmarkValidateParsed/MediumOAS3-4            	   63848	     93151 ns/op	   37850 B/op	     565 allocs/op
+BenchmarkValidateParsed/LargeOAS3-4             	    5467	   1087748 ns/op	  412156 B/op	    5651 allocs/op
+BenchmarkValidateStrictMode/SmallOAS3-4         	   15651	    383729 ns/op	  215482 B/op	    2471 allocs/op
+BenchmarkValidateStrictMode/MediumOAS3-4        	    2006	   3032430 ns/op	 1574086 B/op	   20252 allocs/op
+BenchmarkValidateStrictMode/LargeOAS3-4         	     154	  38588556 ns/op	17819074 B/op	  228819 allocs/op
+BenchmarkValidateWithOptions/FilePath/SmallOAS3-4         	   15481	    386881 ns/op	  215789 B/op	    2475 allocs/op
+BenchmarkValidateWithOptions/Parsed/SmallOAS3-4           	  589978	      9945 ns/op	    5887 B/op	      53 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/validator	95.662s
+goos: linux
+goarch: amd64
+pkg: github.com/erraggy/oastools/fixer
+cpu: AMD EPYC 9V74 80-Core Processor                
+BenchmarkFixDocuments/SmallOAS3-4         	   18148	    329220 ns/op	  211287 B/op	    2434 allocs/op
+BenchmarkFixDocuments/MediumOAS3-4        	    2262	   2655651 ns/op	 1549038 B/op	   19802 allocs/op
+BenchmarkFixDocuments/LargeOAS3-4         	     175	  34128722 ns/op	17486610 B/op	  223888 allocs/op
+BenchmarkFixDocuments/SmallOAS2-4         	   19182	    312710 ns/op	  186984 B/op	    2409 allocs/op
+BenchmarkFixDocuments/MediumOAS2-4        	    2454	   2447388 ns/op	 1319682 B/op	   18251 allocs/op
+BenchmarkFixWithInferTypes/SmallOAS3-4    	   18315	    327733 ns/op	  211220 B/op	    2434 allocs/op
+BenchmarkFixWithInferTypes/MediumOAS3-4   	    2277	   2664033 ns/op	 1548436 B/op	   19802 allocs/op
+BenchmarkFixWithInferTypes/LargeOAS3-4    	     171	  34695385 ns/op	17484711 B/op	  223887 allocs/op
+BenchmarkFixParsed/SmallOAS3-4            	  933064	      6526 ns/op	    9356 B/op	      57 allocs/op
+BenchmarkFixParsed/MediumOAS3-4           	   79820	     75381 ns/op	  135602 B/op	     581 allocs/op
+BenchmarkFixParsed/LargeOAS3-4            	    6442	    959722 ns/op	 1398988 B/op	    5601 allocs/op
+BenchmarkFixWithOptions/FilePath/SmallOAS3-4         	   18146	    331411 ns/op	  212261 B/op	    2440 allocs/op
+BenchmarkFixWithOptions/Parsed/SmallOAS3-4           	  827569	      6875 ns/op	    9995 B/op	      62 allocs/op
+BenchmarkFix-4                                       	  549194	     11032 ns/op	   15111 B/op	     110 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/fixer	84.110s
+goos: linux
+goarch: amd64
+pkg: github.com/erraggy/oastools/httpvalidator
+cpu: AMD EPYC 9V74 80-Core Processor                
+BenchmarkMatchPattern-4                 	71842194	        84.74 ns/op	       0 B/op	       0 allocs/op
+BenchmarkMatchPatternParallel-4         	148540750	        40.22 ns/op	       0 B/op	       0 allocs/op
+BenchmarkValidateRequest/SmallOAS3-4    	11079961	       538.9 ns/op	     528 B/op	       8 allocs/op
+BenchmarkValidateRequest/MediumOAS3-4   	 9336128	       649.6 ns/op	     528 B/op	       8 allocs/op
+BenchmarkValidateRequest/LargeOAS3-4    	 5188117	      1161 ns/op	     528 B/op	       8 allocs/op
+BenchmarkValidateRequestWithParams-4    	11140797	       533.7 ns/op	     528 B/op	       8 allocs/op
+BenchmarkValidateRequestWithBody-4      	 5262687	      1139 ns/op	    1520 B/op	      16 allocs/op
+BenchmarkValidateResponse-4             	25404440	       235.4 ns/op	     256 B/op	       2 allocs/op
+BenchmarkValidateStrictMode-4           	11106627	       531.0 ns/op	     528 B/op	       8 allocs/op
+BenchmarkValidateRequestWithOptions/FilePath/SmallOAS3-4         	   16920	    357096 ns/op	  217941 B/op	    2551 allocs/op
+BenchmarkValidateRequestWithOptions/Parsed/SmallOAS3-4           	  714298	      8362 ns/op	    9252 B/op	     127 allocs/op
+BenchmarkPathMatching/SmallOAS3-4                                	10682762	       559.3 ns/op	     528 B/op	       8 allocs/op
+BenchmarkPathMatching/MediumOAS3-4                               	 8372732	       717.5 ns/op	     528 B/op	       8 allocs/op
+BenchmarkPathMatching/LargeOAS3-4                                	 2522518	      2376 ns/op	     528 B/op	       8 allocs/op
+BenchmarkParameterDeserialization-4                              	11199963	       537.6 ns/op	     528 B/op	       8 allocs/op
+BenchmarkSchemaValidation-4                                      	 5134982	      1168 ns/op	    1520 B/op	      16 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/httpvalidator	100.147s
+goos: linux
+goarch: amd64
+pkg: github.com/erraggy/oastools/converter
+cpu: INTEL(R) XEON(R) PLATINUM 8573C
+BenchmarkConvertOAS2ToOAS3/Small-4   	   20038	    292616 ns/op	  196717 B/op	    2496 allocs/op
+BenchmarkConvertOAS2ToOAS3/Medium-4  	    2606	   2259098 ns/op	 1455641 B/op	   18910 allocs/op
+BenchmarkConvertOAS3ToOAS2/Small-4   	   19774	    306086 ns/op	  222034 B/op	    2573 allocs/op
+BenchmarkConvertOAS3ToOAS2/Medium-4  	    2031	   2751185 ns/op	 1723125 B/op	   21832 allocs/op
+BenchmarkConvertParsedOAS2ToOAS3/Small-4         	  716187	      7973 ns/op	   12123 B/op	     100 allocs/op
+BenchmarkConvertParsedOAS2ToOAS3/Medium-4        	   65350	     92144 ns/op	  155482 B/op	     776 allocs/op
+BenchmarkConvertParsedOAS3ToOAS2/Small-4         	  516756	     11942 ns/op	   11897 B/op	     151 allocs/op
+BenchmarkConvertParsedOAS3ToOAS2/Medium-4        	   33691	    178009 ns/op	  181639 B/op	    2142 allocs/op
+BenchmarkConvertNoInfo/Small-4                   	   20944	    289729 ns/op	  196721 B/op	    2496 allocs/op
+BenchmarkConvertNoInfo/Medium-4                  	    2673	   2316681 ns/op	 1455673 B/op	   18910 allocs/op
+BenchmarkConvertWithOptions/FilePath/Small-4     	   20442	    286860 ns/op	  196876 B/op	    2500 allocs/op
+BenchmarkConvertWithOptions/Parsed/Small-4       	  722888	      8398 ns/op	   12451 B/op	     104 allocs/op
+BenchmarkConvertOAS30ToOAS31/Small-4             	   20028	    299642 ns/op	  217418 B/op	    2493 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/converter	77.521s
+goos: linux
+goarch: amd64
+pkg: github.com/erraggy/oastools/joiner
+cpu: AMD EPYC 9V74 80-Core Processor                
+BenchmarkCompareSchemas/SimpleSchemas-4         	23089455	       262.8 ns/op	     128 B/op	       1 allocs/op
+BenchmarkCompareSchemas/ObjectWithProperties-4  	 4735215	      1269 ns/op	     128 B/op	       1 allocs/op
+BenchmarkCompareSchemas/NestedSchemas-4         	 2553410	      2340 ns/op	     128 B/op	       1 allocs/op
+BenchmarkCompareSchemas/AllOfComposition-4      	 2597782	      2306 ns/op	     137 B/op	       4 allocs/op
+BenchmarkCompareSchemas/DeeplyNested-4          	 2560969	      2344 ns/op	     384 B/op	       2 allocs/op
+BenchmarkCompareSchemas/ShallowMode-4           	23639970	       250.7 ns/op	     128 B/op	       1 allocs/op
+BenchmarkComparePath/StringConcat-4             	53158794	       112.6 ns/op	      72 B/op	       3 allocs/op
+BenchmarkComparePath/ComparePathSlice-4         	52583040	       113.9 ns/op	     160 B/op	       2 allocs/op
+BenchmarkComparePath/ComparePathSliceDeep-4     	45626376	       131.3 ns/op	     160 B/op	       2 allocs/op
+BenchmarkCompareSchemasDifferences/SingleDifference-4         	19026112	       312.7 ns/op	     224 B/op	       2 allocs/op
+BenchmarkCompareSchemasDifferences/MultipleDifferences-4      	13439022	       445.6 ns/op	     448 B/op	       5 allocs/op
+BenchmarkCompareSchemasDifferences/NestedDifference-4         	 4778695	      1258 ns/op	     272 B/op	       3 allocs/op
+BenchmarkJoin/TwoDocs-4                                       	   26887	    224086 ns/op	  142033 B/op	    1731 allocs/op
+BenchmarkJoin/ThreeDocs-4                                     	   18079	    331659 ns/op	  210758 B/op	    2554 allocs/op
+BenchmarkJoin/FiveDocs-4                                      	   10000	    560744 ns/op	  354714 B/op	    4349 allocs/op
+BenchmarkJoinParsed/TwoDocs-4                                 	 3140271	      1900 ns/op	    1992 B/op	      22 allocs/op
+BenchmarkJoinParsed/ThreeDocs-4                               	 2826592	      2120 ns/op	    2184 B/op	      23 allocs/op
+BenchmarkJoinParsed/FiveDocs-4                                	  822411	      7334 ns/op	    6025 B/op	     110 allocs/op
+BenchmarkJoinStrategy/AcceptLeft-4                            	   26853	    222901 ns/op	  142033 B/op	    1731 allocs/op
+BenchmarkJoinStrategy/AcceptRight-4                           	   26925	    222513 ns/op	  142033 B/op	    1731 allocs/op
+BenchmarkJoinOptions/MergeArrays-4                            	   26886	    223542 ns/op	  142032 B/op	    1731 allocs/op
+BenchmarkJoinOptions/DeduplicateTags-4                        	   26838	    223962 ns/op	  142033 B/op	    1731 allocs/op
+BenchmarkJoinWithOptions/FilePaths-4                          	   26660	    226569 ns/op	  142643 B/op	    1738 allocs/op
+BenchmarkJoinWithOptions/Parsed-4                             	 2587338	      2316 ns/op	    3304 B/op	      29 allocs/op
+BenchmarkJoinWriteResult-4                                    	   38012	    158570 ns/op	  104741 B/op	     572 allocs/op
+BenchmarkJoinHelpers/DefaultConfig-4                          	149205058	        40.17 ns/op	      48 B/op	       1 allocs/op
+BenchmarkJoinHelpers/IsValidStrategy-4                        	480397486	        12.53 ns/op	       0 B/op	       0 allocs/op
+BenchmarkJoinHelpers/ValidStrategies-4                        	145588226	        41.19 ns/op	     112 B/op	       1 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/joiner	167.681s
+goos: linux
+goarch: amd64
+pkg: github.com/erraggy/oastools/differ
+cpu: AMD EPYC 9V74 80-Core Processor                
+BenchmarkDiff/FilePath-4     	    6685	    905281 ns/op	  643338 B/op	    8285 allocs/op
+BenchmarkDiff/Parsed-4       	  255586	     23502 ns/op	   21723 B/op	     369 allocs/op
+BenchmarkDiffMode/Simple-4   	  256370	     23550 ns/op	   21723 B/op	     369 allocs/op
+BenchmarkDiffMode/Breaking-4 	  254712	     23747 ns/op	   21723 B/op	     369 allocs/op
+BenchmarkDiffIncludeInfo/WithInfo-4         	  253147	     24139 ns/op	   21723 B/op	     369 allocs/op
+BenchmarkDiffIncludeInfo/WithoutInfo-4      	  247392	     24211 ns/op	   23516 B/op	     370 allocs/op
+BenchmarkDiffIdentical-4                    	  311704	     19251 ns/op	   16706 B/op	     325 allocs/op
+BenchmarkDiffWithOptions/FilePath-4         	    6480	    874308 ns/op	  643642 B/op	    8293 allocs/op
+BenchmarkChangeString-4                     	 9482707	       630.8 ns/op	     400 B/op	      15 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/differ	53.931s
+goos: linux
+goarch: amd64
+pkg: github.com/erraggy/oastools/generator
+cpu: AMD EPYC 7763 64-Core Processor                
+BenchmarkGenerate/Types-4               	    1897	   3076951 ns/op	   97609 B/op	    1405 allocs/op
+BenchmarkGenerate/Client-4              	     758	   7959600 ns/op	  470957 B/op	    8748 allocs/op
+BenchmarkGenerate/Server-4              	     940	   6273637 ns/op	  205168 B/op	    2662 allocs/op
+BenchmarkGenerate/All-4                 	     559	  10574615 ns/op	  534542 B/op	    8571 allocs/op
+BenchmarkTemplateBuffer_WithPool-4      	145062402	        41.41 ns/op	       0 B/op	       0 allocs/op
+BenchmarkTemplateBuffer_WithoutPool-4   	  584257	     11560 ns/op	   32816 B/op	       2 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/generator	38.855s
+goos: linux
+goarch: amd64
+pkg: github.com/erraggy/oastools/builder
+cpu: AMD EPYC 9V74 80-Core Processor                
+BenchmarkBuilderNew-4                   	 8938114	       668.9 ns/op	    1152 B/op	      18 allocs/op
+BenchmarkBuilderSetInfo-4               	 8489572	       728.1 ns/op	    1264 B/op	      19 allocs/op
+BenchmarkSchemaFrom/Primitive-4         	 6892341	       866.5 ns/op	    2048 B/op	      19 allocs/op
+BenchmarkSchemaFrom/Struct-4            	  719908	      8477 ns/op	   17080 B/op	      72 allocs/op
+BenchmarkSchemaFrom/NestedStruct-4      	  459514	     12996 ns/op	   26472 B/op	     102 allocs/op
+BenchmarkSchemaFrom/Slice-4             	  655543	      8698 ns/op	   17976 B/op	      73 allocs/op
+BenchmarkSchemaFrom/Map-4               	  689730	      8741 ns/op	   17976 B/op	      73 allocs/op
+BenchmarkBuilderAddOperation/Simple-4   	  540696	     10891 ns/op	   20885 B/op	      97 allocs/op
+BenchmarkBuilderAddOperation/WithParams-4         	  398349	     15421 ns/op	   29407 B/op	     137 allocs/op
+BenchmarkBuilderAddOperation/WithRequestBody-4    	  308485	     19120 ns/op	   35440 B/op	     159 allocs/op
+BenchmarkBuilderBuild-4                           	  291787	     20825 ns/op	   37865 B/op	     208 allocs/op
+BenchmarkBuilderMarshal/YAML-4                    	   65192	     92100 ns/op	  112001 B/op	     672 allocs/op
+BenchmarkBuilderMarshal/JSON-4                    	  152169	     39223 ns/op	    8501 B/op	      38 allocs/op
+BenchmarkOASTag/Apply-4                           	10424332	       577.1 ns/op	    1248 B/op	       5 allocs/op
+BenchmarkOASTag/Parse-4                           	19452303	       306.9 ns/op	     336 B/op	       2 allocs/op
+BenchmarkBuilderFormParams/OAS2-4                 	  972361	      6088 ns/op	   12163 B/op	      81 allocs/op
+BenchmarkBuilderFormParams/OAS3-4                 	  803499	      7044 ns/op	   15324 B/op	      87 allocs/op
+BenchmarkSchemaNaming/default-4                   	 1000000	      5847 ns/op	   10698 B/op	      63 allocs/op
+BenchmarkSchemaNaming/pascal-4                    	  989072	      6025 ns/op	   10722 B/op	      66 allocs/op
+BenchmarkSchemaNaming/camel-4                     	  971337	      6078 ns/op	   10738 B/op	      67 allocs/op
+BenchmarkSchemaNaming/snake-4                     	 1000000	      5936 ns/op	   10730 B/op	      66 allocs/op
+BenchmarkSchemaNaming/kebab-4                     	  972006	      5967 ns/op	   10746 B/op	      67 allocs/op
+BenchmarkSchemaNaming/type_only-4                 	 1000000	      5620 ns/op	   10658 B/op	      62 allocs/op
+BenchmarkSchemaNaming/full_path-4                 	 1000000	      5738 ns/op	   10754 B/op	      63 allocs/op
+BenchmarkGenericNaming/underscore-4               	  737300	      8124 ns/op	   13131 B/op	      80 allocs/op
+BenchmarkGenericNaming/of-4                       	  738417	      8154 ns/op	   13131 B/op	      80 allocs/op
+BenchmarkGenericNaming/for-4                      	  732596	      8178 ns/op	   13155 B/op	      80 allocs/op
+BenchmarkGenericNaming/flat-4                     	  739749	      8141 ns/op	   13115 B/op	      79 allocs/op
+BenchmarkGenericNaming/angle_brackets-4           	  752152	      8233 ns/op	   13131 B/op	      80 allocs/op
+BenchmarkSchemaNameTemplate/simple-4              	  372994	     15814 ns/op	   19837 B/op	     134 allocs/op
+BenchmarkSchemaNameTemplate/pascal-4              	  274177	     21928 ns/op	   20790 B/op	     171 allocs/op
+BenchmarkSchemaNameTemplate/complex-4             	  245142	     24380 ns/op	   21422 B/op	     187 allocs/op
+BenchmarkSchemaNameTemplate/generic_aware-4       	  281732	     21462 ns/op	   20965 B/op	     170 allocs/op
+BenchmarkCaseConversions/toPascalCase-4           	35192487	       168.1 ns/op	      56 B/op	       3 allocs/op
+BenchmarkCaseConversions/toCamelCase-4            	18751254	       320.2 ns/op	      80 B/op	       4 allocs/op
+BenchmarkCaseConversions/toSnakeCase-4            	33906018	       177.4 ns/op	      56 B/op	       3 allocs/op
+BenchmarkCaseConversions/toKebabCase-4            	24823213	       242.6 ns/op	      80 B/op	       4 allocs/op
+BenchmarkCaseConversions_Separators/toPascalCase-4         	29227876	       204.6 ns/op	      56 B/op	       3 allocs/op
+BenchmarkCaseConversions_Separators/toCamelCase-4          	15506253	       386.1 ns/op	      88 B/op	       4 allocs/op
+BenchmarkCaseConversions_Separators/toSnakeCase-4          	29279766	       203.7 ns/op	      56 B/op	       3 allocs/op
+BenchmarkCaseConversions_Separators/toKebabCase-4          	21250938	       282.1 ns/op	      88 B/op	       4 allocs/op
+BenchmarkExtractGenericParams/simple-4                     	74591452	        78.74 ns/op	      24 B/op	       2 allocs/op
+BenchmarkExtractGenericParams/multi-4                      	37537062	       159.4 ns/op	      64 B/op	       4 allocs/op
+BenchmarkExtractGenericParams/nested-4                     	43572715	       135.9 ns/op	      40 B/op	       3 allocs/op
+BenchmarkExtractGenericParams/triple-4                     	31164291	       190.0 ns/op	     136 B/op	       6 allocs/op
+BenchmarkExtractGenericParams/deeply_nested-4              	26737015	       221.7 ns/op	      72 B/op	       4 allocs/op
+BenchmarkExtractGenericParams/none-4                       	412766682	        14.54 ns/op	       0 B/op	       0 allocs/op
+BenchmarkExtractBaseTypeName/generic-4                     	946908637	         6.234 ns/op	       0 B/op	       0 allocs/op
+BenchmarkExtractBaseTypeName/non_generic-4                 	851855874	         6.914 ns/op	       0 B/op	       0 allocs/op
+BenchmarkExtractBaseTypeName/nested-4                      	895375347	         6.698 ns/op	       0 B/op	       0 allocs/op
+BenchmarkSanitizeSchemaName/clean-4                        	99502052	        60.59 ns/op	       0 B/op	       0 allocs/op
+BenchmarkSanitizeSchemaName/brackets-4                     	44306892	       135.6 ns/op	      32 B/op	       2 allocs/op
+BenchmarkSanitizeSchemaName/complex-4                      	22763904	       258.8 ns/op	      96 B/op	       4 allocs/op
+BenchmarkSanitizeSchemaName/spaces-4                       	53918228	       110.2 ns/op	      16 B/op	       1 allocs/op
+BenchmarkSchemaNamer_Name/default_simple-4                 	29693504	       199.6 ns/op	      72 B/op	       2 allocs/op
+BenchmarkSchemaNamer_Name/default_generic-4                	 7176849	       834.8 ns/op	     272 B/op	      10 allocs/op
+BenchmarkSchemaNamer_Name/pascal_simple-4                  	17275562	       348.1 ns/op	      96 B/op	       5 allocs/op
+BenchmarkSchemaNamer_Name/pascal_generic-4                 	 5504599	      1092 ns/op	     336 B/op	      14 allocs/op
+BenchmarkSchemaNamer_Name/snake_nested-4                   	16530770	       366.4 ns/op	     104 B/op	       5 allocs/op
+BenchmarkSchemaNamer_BuildContext/simple-4                 	43670518	       136.6 ns/op	      48 B/op	       1 allocs/op
+BenchmarkSchemaNamer_BuildContext/generic-4                	 7728542	       779.4 ns/op	     240 B/op	       9 allocs/op
+BenchmarkSchemaNamer_BuildContext/nested_generic-4         	 7731166	       776.7 ns/op	     240 B/op	       9 allocs/op
+BenchmarkGenericNamingConfig/default-4                     	  708550	      8200 ns/op	   13179 B/op	      80 allocs/op
+BenchmarkGenericNamingConfig/of_strategy-4                 	  728371	      8216 ns/op	   13179 B/op	      80 allocs/op
+BenchmarkGenericNamingConfig/include_package-4             	  711117	      8391 ns/op	   13379 B/op	      81 allocs/op
+BenchmarkGenericNamingConfig/apply_casing-4                	  731716	      8229 ns/op	   13179 B/op	      80 allocs/op
+BenchmarkGenericNamingConfig/custom_separators-4           	  722980	      8226 ns/op	   13203 B/op	      80 allocs/op
+BenchmarkBuilderWithNamingOptions/default-4                	  366289	     15351 ns/op	   26327 B/op	     138 allocs/op
+BenchmarkBuilderWithNamingOptions/with_pascal_naming-4     	  373071	     16002 ns/op	   26463 B/op	     149 allocs/op
+BenchmarkBuilderWithNamingOptions/with_template-4          	  189760	     31236 ns/op	   34497 B/op	     242 allocs/op
+BenchmarkBuilderWithNamingOptions/with_custom_func-4       	  380161	     15868 ns/op	   26463 B/op	     149 allocs/op
+BenchmarkBuilderWithNamingOptions/combined_pascal_of-4     	  380030	     15913 ns/op	   26479 B/op	     150 allocs/op
+BenchmarkSchemaNameFunc/simple_func_non_generic-4          	38684882	       153.4 ns/op	      48 B/op	       1 allocs/op
+BenchmarkSchemaNameFunc/simple_func_generic-4              	 7581952	       788.2 ns/op	     240 B/op	       9 allocs/op
+BenchmarkSchemaNameFunc/complex_func_non_generic-4         	22684231	       262.0 ns/op	      80 B/op	       3 allocs/op
+BenchmarkSchemaNameFunc/complex_func_generic-4             	 7299888	       820.4 ns/op	     264 B/op	      10 allocs/op
+BenchmarkFormatGenericSuffix/underscore-4                  	79255590	        73.07 ns/op	      32 B/op	       2 allocs/op
+BenchmarkFormatGenericSuffix/of-4                          	80620618	        74.01 ns/op	      32 B/op	       2 allocs/op
+BenchmarkFormatGenericSuffix/for-4                         	77386435	        76.08 ns/op	      32 B/op	       2 allocs/op
+BenchmarkFormatGenericSuffix/flat-4                        	153930104	        38.96 ns/op	      16 B/op	       1 allocs/op
+BenchmarkFormatGenericSuffix/angle-4                       	80647316	        74.29 ns/op	      32 B/op	       2 allocs/op
+BenchmarkSanitizeGenericParams/exclude_package-4           	27421456	       217.0 ns/op	      48 B/op	       1 allocs/op
+BenchmarkSanitizeGenericParams/include_package-4           	16088376	       373.6 ns/op	      96 B/op	       4 allocs/op
+BenchmarkSanitizeGenericParams/apply_casing-4              	16434969	       364.5 ns/op	      72 B/op	       4 allocs/op
+BenchmarkTemplateParsing/simple-4                          	 1000000	      5549 ns/op	    5849 B/op	      44 allocs/op
+BenchmarkTemplateParsing/pascal-4                          	  726236	      8260 ns/op	    6433 B/op	      63 allocs/op
+BenchmarkTemplateParsing/complex-4                         	  593617	     10097 ns/op	    6993 B/op	      78 allocs/op
+BenchmarkTemplateParsing/full-4                            	  635443	      9446 ns/op	    7057 B/op	      76 allocs/op
+BenchmarkSanitizePath/short-4                              	473203430	        12.69 ns/op	       0 B/op	       0 allocs/op
+BenchmarkSanitizePath/medium-4                             	92637787	        62.79 ns/op	      24 B/op	       1 allocs/op
+BenchmarkSanitizePath/long-4                               	56360497	       105.1 ns/op	      64 B/op	       1 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/builder	541.738s
+goos: linux
+goarch: amd64
+pkg: github.com/erraggy/oastools/walker
+cpu: AMD EPYC 7763 64-Core Processor                
+BenchmarkWalk_WithPooling-4          	 2985177	      2036 ns/op	     856 B/op	      16 allocs/op
+BenchmarkWalk_WithMapRefTracking-4   	 4141119	      1442 ns/op	     784 B/op	      11 allocs/op
+BenchmarkWalk_WithParentTracking/without_parent_tracking-4         	 1872793	      3200 ns/op	    1272 B/op	      21 allocs/op
+BenchmarkWalk_WithParentTracking/with_parent_tracking-4            	 1621778	      3706 ns/op	    1904 B/op	      33 allocs/op
+BenchmarkWalk_WithPostHandler-4                                    	   69894	     85762 ns/op	   32278 B/op	     708 allocs/op
+BenchmarkWalk_WithRefTracking-4                                    	 2624582	      2294 ns/op	     928 B/op	      14 allocs/op
+BenchmarkWalk_WithoutRefTracking-4                                 	 2465848	      2435 ns/op	     880 B/op	      13 allocs/op
+BenchmarkWalkSmallDocument-4                                       	 3988860	      1502 ns/op	     720 B/op	      12 allocs/op
+BenchmarkWalkMediumDocument-4                                      	   76441	     77921 ns/op	   20339 B/op	     457 allocs/op
+BenchmarkWalkNoHandlers-4                                          	 6710008	       896.3 ns/op	     616 B/op	       8 allocs/op
+BenchmarkWalkAllHandlers-4                                         	 2440321	      2455 ns/op	    1016 B/op	      27 allocs/op
+BenchmarkWalkSchemaOnly-4                                          	 3283814	      1814 ns/op	     864 B/op	      12 allocs/op
+BenchmarkWalkWithStop-4                                            	  768786	      7837 ns/op	    2232 B/op	       6 allocs/op
+BenchmarkWalkOAS2-4                                                	 3956943	      1518 ns/op	     744 B/op	      13 allocs/op
+PASS
+ok  	github.com/erraggy/oastools/walker	84.036s

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "oastools",
   "description": "OpenAPI Specification tools — validate, fix, convert, diff, walk, and generate from OAS 2.0-3.2 documents",
-  "version": "1.53.2",
+  "version": "1.54.0",
   "author": {
     "name": "erraggy",
     "url": "https://github.com/erraggy"


### PR DESCRIPTION
## Summary

- Pre-release preparation for v1.54.0
- Plugin/marketplace version → 1.54.0
- CI benchmark results recorded

## Benchmarks

Allocation increases vs v1.53.2, knowingly accepted — this release is scoped to bug fixes, with allocation reduction planned as follow-up work:

| Source | Delta |
|--------|-------|
| Parser (inherited by all parse-path benchmarks) | +12–16% |
| Validator, on already-parsed input | +20–22% |
| `BenchmarkJoinWriteResult` | +37.5% |
| `BenchmarkBuilderMarshal/YAML` | +34.9% |
| 195 of 304 benchmarks | unchanged |

No improvements and no regressions outside the above. Traced to the `$ref` tracking, component-name validation, and conditional marshaler paths added by #377, #382, and #384.

Note: `ns/op` is not comparable between the two benchmark files — v1.53.2 ran on Intel Xeon 8370C, v1.54.0 on AMD EPYC 7763. `allocs/op` is hardware-independent and GOMAXPROCS matched (`-4`), so the comparison above uses allocations.

## Checklist

- [x] `make check` — 8,845 tests pass
- [x] `govulncheck` clean
- [x] Benchmarks recorded
- [x] Documentation reviewed
