### PR TITLE
feat(fixer): repair path parameters missing required: true

### DIFF
--- a/cmd/oastools/commands/fix.go
+++ b/cmd/oastools/commands/fix.go
@@ -96,6 +96,9 @@ func SetupFixFlags() (*flag.FlagSet, *FixFlags) {
 		Writef(fs.Output(), "  - Missing path parameters: Adds Parameter objects for path template\n")
 		Writef(fs.Output(), "    variables that are not declared in the operation's parameters list.\n")
 		Writef(fs.Output(), "    Default type is 'string'. Use --infer for smart type inference.\n")
+		Writef(fs.Output(), "  - Path parameters missing required: Sets 'required: true' on existing\n")
+		Writef(fs.Output(), "    'in: path' parameters that omit it, the only value the spec allows.\n")
+		Writef(fs.Output(), "    A $ref is fixed in the definition it names, not at the use site.\n")
 		Writef(fs.Output(), "  - Invalid schema names (--fix-schema-names): Renames schemas with\n")
 		Writef(fs.Output(), "    invalid characters (brackets, etc.) using configurable strategies.\n")
 		Writef(fs.Output(), "  - Duplicate operationIds (--fix-duplicate-operationids): Renames\n")
@@ -191,11 +194,9 @@ func HandleFix(args []string) error {
 		TagSeparator:  flags.OperationIdTagSep,
 	}
 
-	// Build enabled fixes list based on flags
-	var enabledFixes []fixer.FixType
-
-	// Always enable missing path parameters (default behavior)
-	enabledFixes = append(enabledFixes, fixer.FixTypeMissingPathParameter)
+	// Build enabled fixes list based on flags, starting from the fixer's own
+	// defaults so a new mechanical fix reaches the CLI without a flag.
+	enabledFixes := fixer.DefaultEnabledFixes()
 
 	// Add explicit fixes based on flags
 	if flags.FixSchemaNames {

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -174,6 +174,7 @@ oastools fix [flags] <file|url|->
 The fix command automatically corrects common validation errors in OpenAPI specifications. Currently supported fixes:
 
 - **Missing path parameters**: Adds missing path parameters (e.g., `{userId}`) that are referenced in the path but not declared in the parameters list
+- **Path parameters missing `required`**: Sets `required: true` on existing `in: path` parameters that omit it — the only value any OAS version permits. Applies to reusable parameter definitions and to path item and operation parameters; parameters that are a `$ref` are fixed in the definition they name
 - **Invalid schema names** (`--fix-schema-names`): Renames schemas with invalid characters (brackets, special characters) using configurable naming strategies
 - **Stub missing references** (`--stub-missing-refs`): Creates stub definitions for unresolved local `$ref` pointers. Schemas get empty `{}` stubs, responses get stubs with configurable descriptions
 - **Prune unused schemas** (`--prune-schemas`): Removes schema definitions that are not referenced anywhere in the document

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -490,7 +490,7 @@ Walk tools in `detail=true` mode use a default limit of **25** (vs 100 for summa
 ### Cross-Tool Limitations
 
 - **Cross-version diff:** Comparing specs across OAS versions (e.g., 2.0 vs 3.0) with `diff` reports structural format changes as breaking. This is technically correct but reflects version differences, not API changes.
-- **Fixer coverage:** `fix` handles structural issues (duplicate operationIds, missing path parameters, unused schemas, missing `$ref` targets). Semantic validation errors (invalid compositions, type mismatches) are not auto-fixable.
+- **Fixer coverage:** `fix` handles structural issues (duplicate operationIds, missing path parameters, path parameters missing `required: true`, unused schemas, missing `$ref` targets). Semantic validation errors (invalid compositions, type mismatches) are not auto-fixable.
 - **Validator strictness:** Specs using `allOf`/`anyOf`/`oneOf` compositions may produce high error counts in strict mode if required properties are distributed across composed schemas.
 
 ---

--- a/docs/whitepaper.md
+++ b/docs/whitepaper.md
@@ -573,6 +573,8 @@ The fixer package automatically corrects common validation errors, reducing manu
 
 **Missing Path Parameters (FixTypeMissingPathParameter):** When a path template contains variables like `/users/{userId}` but the operation lacks a corresponding parameter declaration, the fixer adds one. Type inference can be enabled to assign appropriate types based on naming conventions.
 
+**Path Parameters Missing `required` (FixTypePathParameterNotRequired):** Every OAS version requires `required: true` on an `in: path` parameter and permits no other value, so the fixer sets it wherever it is absent — in the reusable parameter definitions (OAS 2.0's root-level `parameters`, OAS 3.x's `components.parameters`) as well as on path items and operations. Parameters that are a `$ref` are skipped so the definition they name is repaired once instead of at every use site. The defect test is shared with the validator, so what `validate` reports is exactly what `fix` repairs.
+
 **Invalid Schema Names (FixTypeRenamedGenericSchema):** Schemas with names containing URL-encoding-required characters (such as `Response[User]` from code generators) are renamed using configurable strategies. All `$ref` values throughout the document are updated accordingly.
 
 **Unused Schemas (FixTypePrunedUnusedSchema):** Schema definitions not referenced anywhere in the document are removed, cleaning up orphaned definitions.
@@ -583,7 +585,7 @@ The fixer package automatically corrects common validation errors, reducing manu
 
 ### 6.2 Default Behavior
 
-For performance, only `FixTypeMissingPathParameter` is enabled by default. Schema renaming and pruning involve expensive operations (walking all references, computing unused schemas) that can significantly slow processing of large specifications.
+Only the path parameter fixes — `FixTypeMissingPathParameter` and `FixTypePathParameterNotRequired`, both returned by `DefaultEnabledFixes()` — are enabled by default. Each repairs a defect the spec leaves no room to interpret, and both are cheap. Schema renaming and pruning involve expensive operations (walking all references, computing unused schemas) that can significantly slow processing of large specifications, so they remain opt-in.
 
 ### 6.3 Type Inference
 

--- a/fixer/deep_dive.md
+++ b/fixer/deep_dive.md
@@ -40,6 +40,7 @@ The fixer analyzes OAS documents and applies fixes for issues that would cause v
 | Fix Type | Default | Description |
 |----------|---------|-------------|
 | `FixTypeMissingPathParameter` | ✅ Enabled | Adds Parameter objects for undeclared path template variables |
+| `FixTypePathParameterNotRequired` | ✅ Enabled | Sets `required: true` on existing `in: path` parameters that omit it |
 | `FixTypeRenamedGenericSchema` | ❌ Disabled | Renames schemas containing URL-unsafe characters |
 | `FixTypePrunedUnusedSchema` | ❌ Disabled | Removes unreferenced schema definitions |
 | `FixTypePrunedEmptyPath` | ❌ Disabled | Removes paths with no HTTP operations |
@@ -65,6 +66,28 @@ This is deliberately more conservative than the validator, which reports a
 reference naming a non-parameter component as an error. The fixer cannot know
 what the author intended by such a reference, so it declines to guess rather
 than adding a parameter beside one it does not understand.
+
+**Where `FixTypePathParameterNotRequired` applies**
+
+Every OAS version requires `required` on an `in: path` parameter and permits no
+value other than `true`, so this repair involves no judgment and loses nothing.
+It runs at the three sites the validator reports the defect:
+
+| Site | Reported path |
+|---|---|
+| OAS 2.0 root-level `parameters` | `parameters.{name}` |
+| OAS 3.x `components.parameters` | `components.parameters.{name}` |
+| Path item and operation, both versions | `paths.{path}[.{method}].parameters[{i}]` |
+
+Parameters that are a `$ref` are skipped. The defect belongs to the definition
+being referenced, not to the reference — writing `required` beside a `$ref` would
+add a sibling the spec does not allow there. Fixing the definition clears the
+error for every use site at once.
+
+The defect test itself, `paramutil.NeedsRequiredTrue`, is shared with the
+validator, so what `validate` reports is exactly what `fix` repairs. A parity test
+validates a defective spec, fixes it, and re-validates to assert no
+`required: true` error survives.
 
 **Why are some fixes disabled by default?**
 

--- a/fixer/doc.go
+++ b/fixer/doc.go
@@ -34,6 +34,14 @@
 //     declare a "userId" path parameter, the fixer adds one with type "string" (or
 //     inferred type if enabled).
 //
+//   - Path parameters missing required (FixTypePathParameterNotRequired): Sets
+//     required: true on parameters with "in": "path" that omit it. Every OAS version
+//     requires the field and permits no value other than true, so the repair is
+//     mechanical. Applies to reusable parameter definitions (root-level "parameters"
+//     in OAS 2.0, "components.parameters" in 3.x) as well as those declared on path
+//     items and operations. Parameters that are a $ref are left alone: the defect
+//     belongs to the definition they name, which is fixed there instead.
+//
 //   - Invalid schema names (FixTypeRenamedGenericSchema): Renames schemas with names
 //     containing characters that require URL encoding in $ref values. This commonly
 //     occurs with code generators that produce generic type names like "Response[User]".
@@ -69,10 +77,12 @@
 //
 // # Default Behavior
 //
-// For performance, only FixTypeMissingPathParameter is enabled by default.
-// The schema renaming and pruning fixes involve expensive operations (walking
-// all references, computing unused schemas) that can significantly slow down
-// processing of large specifications.
+// Only the path parameter fixes — FixTypeMissingPathParameter and
+// FixTypePathParameterNotRequired, both returned by DefaultEnabledFixes — are
+// enabled by default. Each repairs a defect the spec leaves no room to interpret,
+// and both are cheap. The schema renaming and pruning fixes involve expensive
+// operations (walking all references, computing unused schemas) that can
+// significantly slow down processing of large specifications, so they are opt-in.
 //
 // To enable additional fixes:
 //

--- a/fixer/fixer.go
+++ b/fixer/fixer.go
@@ -13,6 +13,11 @@ type FixType string
 const (
 	// FixTypeMissingPathParameter indicates a missing path parameter was added
 	FixTypeMissingPathParameter FixType = "missing-path-parameter"
+	// FixTypePathParameterNotRequired indicates an existing path parameter that
+	// omitted required: true had it set. Distinct from
+	// FixTypeMissingPathParameter, which adds a parameter the path template
+	// declares but the operation never mentions.
+	FixTypePathParameterNotRequired FixType = "path-parameter-not-required"
 	// FixTypePrunedEmptyPath indicates an empty path item was removed
 	FixTypePrunedEmptyPath FixType = "pruned-empty-path"
 	// FixTypePrunedUnusedSchema indicates an orphaned schema was removed
@@ -127,7 +132,8 @@ type Fixer struct {
 	// and all others become string type.
 	InferTypes bool
 	// EnabledFixes specifies which fix types to apply.
-	// Defaults to only FixTypeMissingPathParameter for performance.
+	// Defaults to [DefaultEnabledFixes]: the path parameter fixes, which are
+	// mechanical, and cheap enough to leave on.
 	// Set to include other FixType values to enable additional fixes.
 	// Set to empty slice ([]FixType{}) or nil to enable all fix types
 	// (for backward compatibility with pre-v1.28.1 behavior).
@@ -155,11 +161,23 @@ type Fixer struct {
 	MutableInput bool
 }
 
+// DefaultEnabledFixes returns the fix types enabled when a caller names none.
+//
+// Both repair a path parameter defect that the spec leaves no room to interpret —
+// one adds a parameter the path template declares, the other sets required: true,
+// which is the only value the spec permits. The remaining fix types rename or
+// remove content and stay opt-in.
+//
+// A fresh slice per call: callers own the value and may append to it.
+func DefaultEnabledFixes() []FixType {
+	return []FixType{FixTypeMissingPathParameter, FixTypePathParameterNotRequired}
+}
+
 // New creates a new Fixer instance with default settings
 func New() *Fixer {
 	return &Fixer{
 		InferTypes:              false,
-		EnabledFixes:            []FixType{FixTypeMissingPathParameter}, // only missing params by default
+		EnabledFixes:            DefaultEnabledFixes(),
 		GenericNamingConfig:     DefaultGenericNamingConfig(),
 		OperationIdNamingConfig: DefaultOperationIdNamingConfig(),
 		DryRun:                  false,
@@ -236,7 +254,7 @@ func applyOptions(opts ...Option) (*fixConfig, error) {
 	cfg := &fixConfig{
 		// Set defaults
 		inferTypes:              false,
-		enabledFixes:            []FixType{FixTypeMissingPathParameter}, // only missing params by default
+		enabledFixes:            DefaultEnabledFixes(),
 		userAgent:               "",
 		genericNamingConfig:     DefaultGenericNamingConfig(),
 		operationIdNamingConfig: DefaultOperationIdNamingConfig(),

--- a/fixer/fixer_test.go
+++ b/fixer/fixer_test.go
@@ -13,7 +13,18 @@ func TestNew(t *testing.T) {
 	f := New()
 	require.NotNil(t, f)
 	assert.False(t, f.InferTypes)
-	assert.Equal(t, []FixType{FixTypeMissingPathParameter}, f.EnabledFixes)
+	assert.Equal(t, []FixType{FixTypeMissingPathParameter, FixTypePathParameterNotRequired}, f.EnabledFixes)
+}
+
+// TestDefaultEnabledFixes_FreshSlice guards the contract that callers own the
+// returned slice. Callers assign it to the public EnabledFixes field and may
+// rewrite it, so a shared backing array would let one Fixer corrupt the defaults
+// every later one starts from.
+func TestDefaultEnabledFixes_FreshSlice(t *testing.T) {
+	first := DefaultEnabledFixes()
+	first[0] = FixTypePrunedUnusedSchema
+
+	assert.Equal(t, []FixType{FixTypeMissingPathParameter, FixTypePathParameterNotRequired}, DefaultEnabledFixes())
 }
 
 // TestFixWithOptions_NoInput tests that FixWithOptions fails with no input

--- a/fixer/operationid_test.go
+++ b/fixer/operationid_test.go
@@ -881,7 +881,7 @@ paths:
 	parseResult, err := parser.ParseWithOptions(parser.WithBytes([]byte(yaml)))
 	require.NoError(t, err)
 
-	f := New() // Default fixer, only FixTypeMissingPathParameter is enabled
+	f := New() // Default fixer: only the path parameter fixes are enabled
 
 	result, err := f.FixParsed(*parseResult)
 	require.NoError(t, err)

--- a/fixer/pathparam_required.go
+++ b/fixer/pathparam_required.go
@@ -1,0 +1,139 @@
+// pathparam_required.go sets required: true on path parameters that omit it,
+// repairing what the validator reports as "Path parameters must have
+// required: true".
+
+package fixer
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/erraggy/oastools/internal/paramutil"
+	"github.com/erraggy/oastools/parser"
+)
+
+// fixPathParamsRequiredOAS2 sets required: true on OAS 2.0 path parameters that
+// omit it, covering both the root-level reusable parameters and those declared
+// on path items and operations.
+func (f *Fixer) fixPathParamsRequiredOAS2(doc *parser.OAS2Document, result *FixResult) {
+	f.fixPathParamsRequiredInDefinitions(doc.Parameters, "parameters", result)
+	f.fixPathParamsRequiredInPaths(doc.Paths, parser.OASVersion20, result)
+}
+
+// fixPathParamsRequiredOAS3 sets required: true on OAS 3.x path parameters that
+// omit it, covering both components.parameters and those declared on path items
+// and operations.
+func (f *Fixer) fixPathParamsRequiredOAS3(doc *parser.OAS3Document, result *FixResult) {
+	if doc.Components != nil {
+		f.fixPathParamsRequiredInDefinitions(doc.Components.Parameters, "components.parameters", result)
+	}
+	f.fixPathParamsRequiredInPaths(doc.Paths, doc.OASVersion, result)
+}
+
+// fixPathParamsRequiredInDefinitions repairs a document's reusable parameter
+// definitions. Fixing them here is what lets the use-site passes skip $refs:
+// a referenced parameter is repaired once, in the definition that owns it.
+//
+// Definitions are visited in name order so the recorded fixes are deterministic.
+func (f *Fixer) fixPathParamsRequiredInDefinitions(defs map[string]*parser.Parameter, prefix string, result *FixResult) {
+	if len(defs) == 0 {
+		return
+	}
+
+	names := make([]string, 0, len(defs))
+	for name := range defs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		param := defs[name]
+		if !paramutil.NeedsRequiredTrue(param) {
+			continue
+		}
+		f.setPathParamRequired(param, prefix+"."+name, result)
+	}
+}
+
+// fixPathParamsRequiredInPaths repairs the parameters declared on path items and
+// their operations, in path then method order for deterministic output.
+func (f *Fixer) fixPathParamsRequiredInPaths(paths parser.Paths, version parser.OASVersion, result *FixResult) {
+	if len(paths) == 0 {
+		return
+	}
+
+	pathPatterns := make([]string, 0, len(paths))
+	for pathPattern := range paths {
+		pathPatterns = append(pathPatterns, pathPattern)
+	}
+	sort.Strings(pathPatterns)
+
+	for _, pathPattern := range pathPatterns {
+		pathItem := paths[pathPattern]
+		if pathItem == nil {
+			continue
+		}
+		prefix := "paths." + pathPattern
+
+		// A path item's parameters apply to every operation it holds, so they are
+		// visited once here rather than inside the operation loop below — which
+		// would otherwise record the same fix once per operation.
+		f.setPathParamsRequired(pathItem.Parameters, prefix, result)
+
+		operations := parser.GetOperations(pathItem, version)
+		methods := make([]string, 0, len(operations))
+		for method := range operations {
+			methods = append(methods, method)
+		}
+		sort.Strings(methods)
+
+		for _, method := range methods {
+			op := operations[method]
+			if op == nil {
+				continue
+			}
+			f.setPathParamsRequired(op.Parameters, prefix+"."+method, result)
+		}
+	}
+}
+
+// setPathParamsRequired repairs one parameter list, reporting each fix by the
+// parameter's position so the path matches the one the validator reports.
+func (f *Fixer) setPathParamsRequired(params []*parser.Parameter, prefix string, result *FixResult) {
+	for i, param := range params {
+		if !paramutil.NeedsRequiredTrue(param) {
+			continue
+		}
+		f.setPathParamRequired(param, fmt.Sprintf("%s.parameters[%d]", prefix, i), result)
+	}
+}
+
+// setPathParamRequired sets required: true on one path parameter and records the
+// fix. The spec permits no other value, so there is nothing to infer, nothing to
+// configure, and no information to lose.
+func (f *Fixer) setPathParamRequired(param *parser.Parameter, path string, result *FixResult) {
+	if !f.DryRun {
+		param.Required = true
+	}
+
+	fix := Fix{
+		Type:        FixTypePathParameterNotRequired,
+		Path:        path,
+		Description: buildPathParamRequiredDescription(param.Name),
+		Before:      false,
+		After:       true,
+	}
+	f.populateFixLocation(&fix)
+	result.Fixes = append(result.Fixes, fix)
+}
+
+// buildPathParamRequiredDescription describes a required: true fix, naming the
+// parameter when it has a name. A path parameter without one is invalid for a
+// separate reason the validator reports on its own; the description just avoids
+// rendering an empty quoted name.
+func buildPathParamRequiredDescription(paramName string) string {
+	if paramName == "" {
+		return "Set required: true on path parameter"
+	}
+	return fmt.Sprintf("Set required: true on path parameter '%s'", paramName)
+}

--- a/fixer/pathparam_required_test.go
+++ b/fixer/pathparam_required_test.go
@@ -1,0 +1,491 @@
+package fixer
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/erraggy/oastools/parser"
+	"github.com/erraggy/oastools/validator"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// requiredFixPaths returns the reported paths of every
+// FixTypePathParameterNotRequired fix, in the order they were recorded, so tests
+// can assert both coverage and ordering while ignoring fixes of other types.
+func requiredFixPaths(result *FixResult) []string {
+	var paths []string
+	for _, fix := range result.Fixes {
+		if fix.Type == FixTypePathParameterNotRequired {
+			paths = append(paths, fix.Path)
+		}
+	}
+	return paths
+}
+
+// TestFixPathParamsRequired_OAS3_Components tests that a path parameter in
+// components.parameters gets required: true, reported at the definition's path.
+func TestFixPathParamsRequired_OAS3_Components(t *testing.T) {
+	spec := `
+openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /users/{userId}:
+    get:
+      operationId: getUser
+      parameters:
+        - $ref: '#/components/parameters/UserId'
+      responses:
+        '200':
+          description: Success
+components:
+  parameters:
+    UserId:
+      name: userId
+      in: path
+      schema:
+        type: string
+`
+	parseResult, err := parser.New().ParseBytes([]byte(spec))
+	require.NoError(t, err)
+
+	result, err := New().FixParsed(*parseResult)
+	require.NoError(t, err)
+
+	// The $ref use site is skipped, so the definition is fixed exactly once.
+	assert.Equal(t, []string{"components.parameters.UserId"},
+		requiredFixPaths(result))
+
+	fix := result.Fixes[0]
+	assert.Equal(t, FixTypePathParameterNotRequired, fix.Type)
+	assert.Contains(t, fix.Description, "userId")
+	assert.Equal(t, false, fix.Before)
+	assert.Equal(t, true, fix.After)
+
+	doc, ok := result.Document.(*parser.OAS3Document)
+	require.True(t, ok, "expected OAS3Document")
+	require.NotNil(t, doc.Components)
+	require.NotNil(t, doc.Components.Parameters["UserId"])
+	assert.True(t, doc.Components.Parameters["UserId"].Required)
+
+	// The reference itself is untouched: writing required onto a $ref object
+	// would add a sibling the spec does not permit there.
+	refParam := doc.Paths["/users/{userId}"].Get.Parameters[0]
+	assert.Equal(t, "#/components/parameters/UserId", refParam.Ref)
+	assert.False(t, refParam.Required)
+}
+
+// TestFixPathParamsRequired_OAS3_PathItemFixedOnce tests that a parameter declared
+// on the path item is fixed once, not once per operation in that item.
+func TestFixPathParamsRequired_OAS3_PathItemFixedOnce(t *testing.T) {
+	spec := `
+openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /users/{userId}:
+    parameters:
+      - name: userId
+        in: path
+        schema:
+          type: string
+    get:
+      operationId: getUser
+      responses:
+        '200':
+          description: Success
+    delete:
+      operationId: deleteUser
+      responses:
+        '204':
+          description: No content
+`
+	parseResult, err := parser.New().ParseBytes([]byte(spec))
+	require.NoError(t, err)
+
+	result, err := New().FixParsed(*parseResult)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"paths./users/{userId}.parameters[0]"},
+		requiredFixPaths(result))
+
+	doc, ok := result.Document.(*parser.OAS3Document)
+	require.True(t, ok, "expected OAS3Document")
+	assert.True(t, doc.Paths["/users/{userId}"].Parameters[0].Required)
+}
+
+// TestFixPathParamsRequired_OAS3_OperationParams tests operation-level parameters,
+// including that only the in: path ones are touched and indexes are reported as-is.
+func TestFixPathParamsRequired_OAS3_OperationParams(t *testing.T) {
+	spec := `
+openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /users/{userId}/pets/{petId}:
+    get:
+      operationId: getUserPet
+      parameters:
+        - name: verbose
+          in: query
+          schema:
+            type: boolean
+        - name: userId
+          in: path
+          schema:
+            type: string
+        - name: petId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: X-Trace
+          in: header
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success
+`
+	parseResult, err := parser.New().ParseBytes([]byte(spec))
+	require.NoError(t, err)
+
+	result, err := New().FixParsed(*parseResult)
+	require.NoError(t, err)
+
+	// Only index 1 is defective: 0 and 3 are not path params, 2 is already required.
+	assert.Equal(t, []string{"paths./users/{userId}/pets/{petId}.get.parameters[1]"},
+		requiredFixPaths(result))
+
+	doc, ok := result.Document.(*parser.OAS3Document)
+	require.True(t, ok, "expected OAS3Document")
+	params := doc.Paths["/users/{userId}/pets/{petId}"].Get.Parameters
+	assert.False(t, params[0].Required, "query parameter must not be forced required")
+	assert.True(t, params[1].Required)
+	assert.True(t, params[2].Required)
+	assert.False(t, params[3].Required, "header parameter must not be forced required")
+}
+
+// TestFixPathParamsRequired_OAS2 tests all three OAS 2.0 sites: the root-level
+// parameters definitions, path item parameters, and operation parameters.
+func TestFixPathParamsRequired_OAS2(t *testing.T) {
+	spec := `
+swagger: "2.0"
+info:
+  title: Test API
+  version: 1.0.0
+parameters:
+  UserId:
+    name: userId
+    in: path
+    type: string
+  Verbose:
+    name: verbose
+    in: query
+    type: boolean
+paths:
+  /users/{userId}:
+    parameters:
+      - name: userId
+        in: path
+        type: string
+    get:
+      operationId: getUser
+      responses:
+        '200':
+          description: Success
+  /pets/{petId}:
+    get:
+      operationId: getPet
+      parameters:
+        - name: petId
+          in: path
+          type: string
+      responses:
+        '200':
+          description: Success
+`
+	parseResult, err := parser.New().ParseBytes([]byte(spec))
+	require.NoError(t, err)
+
+	result, err := New().FixParsed(*parseResult)
+	require.NoError(t, err)
+
+	// Definitions first, then paths in sorted order — /pets before /users.
+	assert.Equal(t, []string{
+		"parameters.UserId",
+		"paths./pets/{petId}.get.parameters[0]",
+		"paths./users/{userId}.parameters[0]",
+	}, requiredFixPaths(result))
+
+	doc, ok := result.Document.(*parser.OAS2Document)
+	require.True(t, ok, "expected OAS2Document")
+	assert.True(t, doc.Parameters["UserId"].Required)
+	assert.False(t, doc.Parameters["Verbose"].Required, "query definition must not be forced required")
+	assert.True(t, doc.Paths["/users/{userId}"].Parameters[0].Required)
+	assert.True(t, doc.Paths["/pets/{petId}"].Get.Parameters[0].Required)
+}
+
+// TestFixPathParamsRequired_DryRun tests that dry-run reports the fix without
+// modifying the document.
+func TestFixPathParamsRequired_DryRun(t *testing.T) {
+	spec := `
+openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /users/{userId}:
+    get:
+      operationId: getUser
+      parameters:
+        - name: userId
+          in: path
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success
+`
+	parseResult, err := parser.New().ParseBytes([]byte(spec))
+	require.NoError(t, err)
+
+	f := New()
+	f.DryRun = true
+	result, err := f.FixParsed(*parseResult)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"paths./users/{userId}.get.parameters[0]"},
+		requiredFixPaths(result))
+
+	doc, ok := result.Document.(*parser.OAS3Document)
+	require.True(t, ok, "expected OAS3Document")
+	assert.False(t, doc.Paths["/users/{userId}"].Get.Parameters[0].Required,
+		"dry run must not modify the document")
+}
+
+// TestFixPathParamsRequired_Disabled tests that the fix is skipped when the caller
+// enables a different fix type.
+func TestFixPathParamsRequired_Disabled(t *testing.T) {
+	spec := `
+openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /users/{userId}:
+    get:
+      operationId: getUser
+      parameters:
+        - name: userId
+          in: path
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success
+`
+	parseResult, err := parser.New().ParseBytes([]byte(spec))
+	require.NoError(t, err)
+
+	result, err := FixWithOptions(
+		WithParsed(*parseResult),
+		WithEnabledFixes(FixTypeMissingPathParameter),
+	)
+	require.NoError(t, err)
+
+	assert.Empty(t, requiredFixPaths(result))
+}
+
+// TestFixPathParamsRequired_NoDefect tests that a already-valid document records
+// no fixes.
+func TestFixPathParamsRequired_NoDefect(t *testing.T) {
+	spec := `
+openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /users/{userId}:
+    get:
+      operationId: getUser
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success
+`
+	parseResult, err := parser.New().ParseBytes([]byte(spec))
+	require.NoError(t, err)
+
+	result, err := New().FixParsed(*parseResult)
+	require.NoError(t, err)
+
+	assert.False(t, result.HasFixes())
+}
+
+// TestFixPathParamsRequired_ResolvesValidatorErrors is the parity check the fix
+// exists for: every "Path parameters must have required: true" the validator
+// reports must be gone after fixing, at all three sites and in both versions.
+func TestFixPathParamsRequired_ResolvesValidatorErrors(t *testing.T) {
+	const requiredMsg = "Path parameters must have required: true"
+
+	tests := []struct {
+		name string
+		spec string
+	}{
+		{
+			name: "OAS 3.x",
+			spec: `
+openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /users/{userId}:
+    parameters:
+      - name: userId
+        in: path
+        schema:
+          type: string
+    get:
+      operationId: getUser
+      responses:
+        '200':
+          description: Success
+  /pets/{petId}:
+    get:
+      operationId: getPet
+      parameters:
+        - $ref: '#/components/parameters/PetId'
+      responses:
+        '200':
+          description: Success
+components:
+  parameters:
+    PetId:
+      name: petId
+      in: path
+      schema:
+        type: string
+`,
+		},
+		{
+			name: "OAS 2.0",
+			spec: `
+swagger: "2.0"
+info:
+  title: Test API
+  version: 1.0.0
+parameters:
+  PetId:
+    name: petId
+    in: path
+    type: string
+paths:
+  /users/{userId}:
+    parameters:
+      - name: userId
+        in: path
+        type: string
+    get:
+      operationId: getUser
+      responses:
+        '200':
+          description: Success
+  /pets/{petId}:
+    get:
+      operationId: getPet
+      parameters:
+        - $ref: '#/parameters/PetId'
+      responses:
+        '200':
+          description: Success
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parseResult, err := parser.New().ParseBytes([]byte(tt.spec))
+			require.NoError(t, err)
+
+			v := validator.New()
+			before, err := v.ValidateParsed(*parseResult)
+			require.NoError(t, err)
+			require.NotZero(t, countErrorsContaining(before, requiredMsg),
+				"spec must exhibit the defect before fixing")
+
+			result, err := New().FixParsed(*parseResult)
+			require.NoError(t, err)
+			require.NotEmpty(t, requiredFixPaths(result))
+
+			after, err := v.ValidateParsed(*result.ToParseResult())
+			require.NoError(t, err)
+			assert.Zero(t, countErrorsContaining(after, requiredMsg),
+				"fixer must resolve every required: true error the validator reports")
+		})
+	}
+}
+
+// countErrorsContaining counts validation errors whose message contains substr.
+func countErrorsContaining(result *validator.ValidationResult, substr string) int {
+	count := 0
+	for _, e := range result.Errors {
+		if strings.Contains(e.Message, substr) {
+			count++
+		}
+	}
+	return count
+}
+
+// TestFixPathParamsRequired_NilTolerance tests that nil path items and nil
+// parameter entries are skipped rather than panicking. Parsers can leave either
+// behind for a document with an empty YAML mapping in the list.
+func TestFixPathParamsRequired_NilTolerance(t *testing.T) {
+	doc := &parser.OAS3Document{
+		OpenAPI:    "3.0.0",
+		OASVersion: parser.OASVersion300,
+		Paths: parser.Paths{
+			"/nil": nil,
+			"/users/{userId}": {
+				Parameters: []*parser.Parameter{nil},
+				Get: &parser.Operation{
+					Parameters: []*parser.Parameter{
+						nil,
+						{Name: "userId", In: parser.ParamInPath},
+					},
+				},
+			},
+		},
+		Components: &parser.Components{
+			Parameters: map[string]*parser.Parameter{"Nil": nil},
+		},
+	}
+
+	f := New()
+	result := &FixResult{}
+	f.fixPathParamsRequiredOAS3(doc, result)
+
+	assert.Equal(t, []string{"paths./users/{userId}.get.parameters[1]"},
+		requiredFixPaths(result))
+	assert.True(t, doc.Paths["/users/{userId}"].Get.Parameters[1].Required)
+}
+
+// TestBuildPathParamRequiredDescription tests that an unnamed parameter — invalid
+// for a reason the validator reports separately — does not produce a description
+// with an empty quoted name.
+func TestBuildPathParamRequiredDescription(t *testing.T) {
+	assert.Equal(t, "Set required: true on path parameter 'userId'",
+		buildPathParamRequiredDescription("userId"))
+	assert.Equal(t, "Set required: true on path parameter",
+		buildPathParamRequiredDescription(""))
+}

--- a/fixer/pipeline.go
+++ b/fixer/pipeline.go
@@ -6,6 +6,7 @@ import "github.com/erraggy/oastools/parser"
 type fixPipeline struct {
 	stubMissingRefs          func(*Fixer, any, *FixResult)
 	fixMissingPathParams     func(*Fixer, any, *FixResult)
+	fixPathParamsRequired    func(*Fixer, any, *FixResult)
 	fixDuplicateOperationIds func(*Fixer, any, *FixResult)
 	fixInvalidSchemas        func(*Fixer, any, *FixResult)
 	fixCSVEnums              func(*Fixer, any, *FixResult)
@@ -27,27 +28,34 @@ func (f *Fixer) applyFixPipeline(doc any, result *FixResult, pipeline fixPipelin
 		pipeline.fixMissingPathParams(f, doc, result)
 	}
 
-	// 2. Duplicate operationIds
+	// 2. Path parameters missing required: true. Runs after the pass above,
+	// whose added parameters already carry required: true, so this pass sees
+	// only parameters the document itself declared.
+	if f.isFixEnabled(FixTypePathParameterNotRequired) {
+		pipeline.fixPathParamsRequired(f, doc, result)
+	}
+
+	// 3. Duplicate operationIds
 	if f.isFixEnabled(FixTypeDuplicateOperationId) {
 		pipeline.fixDuplicateOperationIds(f, doc, result)
 	}
 
-	// 3. Rename invalid schema names (must happen BEFORE pruning)
+	// 4. Rename invalid schema names (must happen BEFORE pruning)
 	if f.isFixEnabled(FixTypeRenamedGenericSchema) {
 		pipeline.fixInvalidSchemas(f, doc, result)
 	}
 
-	// 4. Expand CSV enums
+	// 5. Expand CSV enums
 	if f.isFixEnabled(FixTypeEnumCSVExpanded) {
 		pipeline.fixCSVEnums(f, doc, result)
 	}
 
-	// 5. Prune unused schemas
+	// 6. Prune unused schemas
 	if f.isFixEnabled(FixTypePrunedUnusedSchema) {
 		pipeline.pruneUnusedSchemas(f, doc, result)
 	}
 
-	// 6. Prune empty paths
+	// 7. Prune empty paths
 	if f.isFixEnabled(FixTypePrunedEmptyPath) {
 		f.pruneEmptyPaths(pipeline.getPaths(doc), result, pipeline.getVersion(doc))
 	}
@@ -72,6 +80,9 @@ var oas2Pipeline = fixPipeline{
 	},
 	fixMissingPathParams: func(f *Fixer, doc any, result *FixResult) {
 		f.fixMissingPathParametersOAS2(mustOAS2(doc), result)
+	},
+	fixPathParamsRequired: func(f *Fixer, doc any, result *FixResult) {
+		f.fixPathParamsRequiredOAS2(mustOAS2(doc), result)
 	},
 	fixDuplicateOperationIds: func(f *Fixer, doc any, result *FixResult) {
 		f.fixDuplicateOperationIdsOAS2(mustOAS2(doc), result)
@@ -108,6 +119,9 @@ var oas3Pipeline = fixPipeline{
 	},
 	fixMissingPathParams: func(f *Fixer, doc any, result *FixResult) {
 		f.fixMissingPathParametersOAS3(mustOAS3(doc), result)
+	},
+	fixPathParamsRequired: func(f *Fixer, doc any, result *FixResult) {
+		f.fixPathParamsRequiredOAS3(mustOAS3(doc), result)
 	},
 	fixDuplicateOperationIds: func(f *Fixer, doc any, result *FixResult) {
 		f.fixDuplicateOperationIdsOAS3(mustOAS3(doc), result)

--- a/fixer/stub_missing_refs_test.go
+++ b/fixer/stub_missing_refs_test.go
@@ -604,7 +604,7 @@ paths:
 	// Use default fixer (no explicit enabled fixes for stub)
 	result, err := FixWithOptions(
 		WithParsed(*parseResult),
-		// Default EnabledFixes is only FixTypeMissingPathParameter
+		// Default EnabledFixes covers only the path parameter fixes
 	)
 	require.NoError(t, err)
 

--- a/integration/harness/pipeline_transform.go
+++ b/integration/harness/pipeline_transform.go
@@ -90,6 +90,8 @@ func mapFixTypeName(name string) fixer.FixType {
 	switch strings.ToLower(name) {
 	case "missing-path-params", "missing-path-parameter":
 		return fixer.FixTypeMissingPathParameter
+	case "path-params-required", "path-parameter-not-required":
+		return fixer.FixTypePathParameterNotRequired
 	case "generic-schemas", "renamed-generic-schema":
 		return fixer.FixTypeRenamedGenericSchema
 	case "duplicate-operationids", "duplicate-operation-id":

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -77,7 +77,7 @@ func registerAllTools(server *mcp.Server) {
 
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "fix",
-		Description: "Automatically fix common issues in an OpenAPI Specification document. Fix types: generic schema names, duplicate operationIds, missing path parameters, unused schemas/empty paths (prune), missing $ref targets (stub). Use dry_run=true to preview fixes before applying. Use output to write to a file instead of returning inline.",
+		Description: "Automatically fix common issues in an OpenAPI Specification document. Fix types: generic schema names, duplicate operationIds, missing path parameters, path parameters missing required: true, unused schemas/empty paths (prune), missing $ref targets (stub). Use dry_run=true to preview fixes before applying. Use output to write to a file instead of returning inline.",
 	}, handleFix)
 
 	mcp.AddTool(server, &mcp.Tool{

--- a/internal/mcpserver/tools_fix.go
+++ b/internal/mcpserver/tools_fix.go
@@ -126,10 +126,9 @@ func buildFixerOptions(input fixInput) ([]fixer.Option, error) {
 		return nil, fmt.Errorf("exactly one of file, url, or content must be provided")
 	}
 
-	// Build the list of enabled fix types based on input flags.
-	var fixes []fixer.FixType
-	// Missing path parameters are always enabled (default fixer behavior).
-	fixes = append(fixes, fixer.FixTypeMissingPathParameter)
+	// Build the list of enabled fix types based on input flags, starting from the
+	// fixer's own defaults (the mechanical path parameter fixes, always enabled).
+	fixes := fixer.DefaultEnabledFixes()
 	if input.FixSchemaNames {
 		fixes = append(fixes, fixer.FixTypeRenamedGenericSchema)
 	}

--- a/internal/paramutil/pathparam.go
+++ b/internal/paramutil/pathparam.go
@@ -1,0 +1,21 @@
+// pathparam.go holds predicates over a single parameter that both the validator
+// and the fixer apply, so the defect one reports is exactly the defect the other
+// repairs and the two cannot drift apart.
+
+package paramutil
+
+import "github.com/erraggy/oastools/parser"
+
+// NeedsRequiredTrue reports whether param is an in: path parameter that omits
+// required: true. Both OAS 2.0 and 3.x demand the field be present and true for
+// path parameters and permit no other value, so a parameter this returns true
+// for is invalid in every version and repairable without judgment or loss.
+//
+// A parameter carrying a $ref is skipped. References are preserved verbatim so
+// documents round-trip losslessly, which leaves every sibling field — Required
+// included — empty on the reference itself; the defect, if there is one, belongs
+// to the definition it names. Callers check the reusable definitions in their own
+// right, so a use site skipped here is still covered exactly once.
+func NeedsRequiredTrue(param *parser.Parameter) bool {
+	return param != nil && !param.Required && param.Ref == "" && param.In == parser.ParamInPath
+}

--- a/internal/paramutil/pathparam_test.go
+++ b/internal/paramutil/pathparam_test.go
@@ -1,0 +1,74 @@
+package paramutil_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/erraggy/oastools/internal/paramutil"
+	"github.com/erraggy/oastools/parser"
+)
+
+func TestNeedsRequiredTrue(t *testing.T) {
+	tests := []struct {
+		name  string
+		param *parser.Parameter
+		want  bool
+	}{
+		{
+			name:  "path parameter without required",
+			param: &parser.Parameter{Name: "userId", In: parser.ParamInPath},
+			want:  true,
+		},
+		{
+			name:  "path parameter with required true",
+			param: &parser.Parameter{Name: "userId", In: parser.ParamInPath, Required: true},
+			want:  false,
+		},
+		{
+			name:  "query parameter without required",
+			param: &parser.Parameter{Name: "verbose", In: parser.ParamInQuery},
+			want:  false,
+		},
+		{
+			name:  "header parameter without required",
+			param: &parser.Parameter{Name: "X-Trace", In: parser.ParamInHeader},
+			want:  false,
+		},
+		{
+			name:  "cookie parameter without required",
+			param: &parser.Parameter{Name: "session", In: parser.ParamInCookie},
+			want:  false,
+		},
+		{
+			// A reference carries no fields of its own; the defect belongs to the
+			// definition it names, which callers check separately.
+			name:  "reference to a path parameter definition",
+			param: &parser.Parameter{Ref: "#/components/parameters/UserId"},
+			want:  false,
+		},
+		{
+			// A $ref with siblings is not valid OAS, but the ref still wins: the
+			// target's own required field is what the document ends up using.
+			name:  "reference with in path sibling",
+			param: &parser.Parameter{Ref: "#/components/parameters/UserId", In: parser.ParamInPath},
+			want:  false,
+		},
+		{
+			name:  "missing in field",
+			param: &parser.Parameter{Name: "userId"},
+			want:  false,
+		},
+		{
+			name:  "nil parameter",
+			param: nil,
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, paramutil.NeedsRequiredTrue(tt.param))
+		})
+	}
+}

--- a/validator/oas2.go
+++ b/validator/oas2.go
@@ -198,7 +198,7 @@ func (v *Validator) validateOAS2Parameters(doc *parser.OAS2Document, result *Val
 
 		// Path parameters must have required: true. Swagger 2.0 states the
 		// property is required and its value MUST be true for in: path.
-		if param.In == parser.ParamInPath && !param.Required {
+		if paramutil.NeedsRequiredTrue(param) {
 			v.addError(result, path,
 				"Path parameters must have required: true",
 				withSpecRef(fmt.Sprintf("%s#parameter-object", baseURL)),

--- a/validator/oas3.go
+++ b/validator/oas3.go
@@ -333,7 +333,7 @@ func (v *Validator) validateOAS3Components(doc *parser.OAS3Document, result *Val
 		}
 
 		// Path parameters must have required: true
-		if param.In == "path" && !param.Required {
+		if paramutil.NeedsRequiredTrue(param) {
 			v.addError(result, path, "Path parameters must have required: true",
 				withSpecRef(fmt.Sprintf("%s#parameter-object", baseURL)),
 				withField("required"),

--- a/validator/path_validation.go
+++ b/validator/path_validation.go
@@ -215,9 +215,13 @@ func (v *Validator) validateParameterDefinitionRefs(
 //
 // Callers must invoke this once per path item rather than inside their
 // operation loop, or a path-item parameter is reported once per operation.
+//
+// The defect test itself lives in [paramutil.NeedsRequiredTrue], shared with the
+// fixer so what is reported here is exactly what fixer.FixTypePathParameterNotRequired
+// repairs.
 func (v *Validator) validatePathParamsRequired(params []*parser.Parameter, prefix string, result *ValidationResult, baseURL string) {
 	for i, param := range params {
-		if param == nil || param.Ref != "" || param.In != parser.ParamInPath || param.Required {
+		if !paramutil.NeedsRequiredTrue(param) {
 			continue
 		}
 		v.addError(result, prefix+".parameters["+strconv.Itoa(i)+"]",


### PR DESCRIPTION
Fixes #381.

#378 added the OAS 2.0 `required: true` check for path parameters and made the defect visible in both validators. It did not make it fixable — there was no corresponding FixType, and `oastools fix` left every one of those errors behind.

## The fix

`FixTypePathParameterNotRequired` ("path-parameter-not-required") sets `required: true` on any `in: path` parameter that omits it. The spec permits no other value, so there is no judgment call, nothing to configure, and no information to lose.

It runs at the three sites the validator reports the defect, with paths that match the validator's exactly:

| Site | Reported path |
|---|---|
| OAS 2.0 root-level `parameters` | `parameters.{name}` | | OAS 3.x `components.parameters` | `components.parameters.{name}` | | Path item and operation, both versions | `paths.{path}[.{method}].parameters[{i}]` |

Both constraints carried over from #378 hold: parameters that are a `$ref` are skipped so the definition they name is repaired once instead of at every use site, and the path-item pass runs once per path item rather than inside the per-operation loop.

## Keeping the validator and fixer aligned

Rather than duplicate the traversal, the *defect test* moved to `paramutil.NeedsRequiredTrue` and both packages now call it. That collapsed four copies of the condition into one and fixed a latent inconsistency along the way: `validator/oas3.go` compared against a bare `"path"` literal while `oas2.go` used `parser.ParamInPath`.

`TestFixPathParamsRequired_ResolvesValidatorErrors` is the guard: it validates a defective spec, asserts the error is reported, fixes, re-validates, and asserts no `required: true` error survives — for both OAS versions, including through `$ref` use sites. If the two sides ever drift, this fails.

## Enabled by default

The issue's complaint was that `oastools fix` could not repair this, so leaving the fix opt-in would have needed a new flag to actually resolve it. It joins `FixTypeMissingPathParameter` in the always-on set via a new exported `fixer.DefaultEnabledFixes()`, which the CLI and MCP server now call instead of each hardcoding their own copy of the list.

Corpus impact is nil: DigitalOcean, Asana, Plaid, and GitHub each produce 0 fixes with unchanged validation error counts; none of them exhibit this defect.

## Notes

- Honors `DryRun` (records the fix, leaves the document alone), which `FixTypeMissingPathParameter` currently does not.
- `webhooks` path items are untouched, matching the validator, which does not check them for this rule either.
- Docs updated: package docs, fixer/deep_dive.md, CLI `--help` and cli-reference.md, MCP tool description and mcp-server.md, whitepaper.

Verified with `make check` (green: lint + 8861 tests) and gopls diagnostics (clean), plus an end-to-end CLI round trip in both versions: validate reports the errors, fix repairs them, validate then passes.