### PR TITLE
docs(examples): demonstrate all 8 fix types in fixer-showcase

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -47,7 +47,7 @@ Common OpenAPI transformation patterns covering 6 packages.
 | Example | Package | Description |
 |---------|---------|-------------|
 | [pipeline-compositions/](workflows/pipeline-compositions/) | multiple | Chain convert→fix→join→generate pipelines |
-| [fixer-showcase/](workflows/fixer-showcase/) | fixer | Common fix types with before/after |
+| [fixer-showcase/](workflows/fixer-showcase/) | fixer | All 8 fix types with before/after |
 | [validate-and-fix/](workflows/validate-and-fix/) | fixer | Parse, validate, auto-fix common errors |
 | [version-conversion/](workflows/version-conversion/) | converter | Convert OAS 2.0 (Swagger) → OAS 3.0.3 |
 | [version-migration/](workflows/version-migration/) | converter | OAS 3.1/3.2 upgrades, lossy downgrades |

--- a/examples/workflows/README.md
+++ b/examples/workflows/README.md
@@ -49,7 +49,9 @@ The [fixer-showcase](fixer-showcase/) workflow demonstrates the most common fix 
 3. Empty path item removal
 4. Generic schema name sanitization
 5. Missing path parameter injection
-6. Unused schema pruning
+6. `required: true` repair on declared path parameters
+7. Unused schema pruning
+8. Stub creation for unresolved `$ref`s
 
 **Use cases:** Understanding all fixer capabilities, comparing fix types, learning the API
 

--- a/examples/workflows/README.md
+++ b/examples/workflows/README.md
@@ -7,7 +7,7 @@ This directory contains examples demonstrating common OpenAPI workflows using th
 | Workflow | Package | Description | Time |
 |----------|---------|-------------|------|
 | [pipeline-compositions](pipeline-compositions/) | multiple | Chain multiple oastools operations together | 5 min |
-| [fixer-showcase](fixer-showcase/) | fixer | Demonstrate common fix types | 5 min |
+| [fixer-showcase](fixer-showcase/) | fixer | Demonstrate all available fix types | 5 min |
 | [validate-and-fix](validate-and-fix/) | fixer | Parse, validate, auto-fix common errors | 3 min |
 | [version-conversion](version-conversion/) | converter | Convert OAS 2.0 (Swagger) → OAS 3.0.3 | 3 min |
 | [version-migration](version-migration/) | converter | OAS 3.1/3.2 upgrades and lossy downgrades | 4 min |
@@ -42,7 +42,7 @@ The [pipeline-compositions](pipeline-compositions/) workflow demonstrates multi-
 
 ### Fixer Showcase
 
-The [fixer-showcase](fixer-showcase/) workflow demonstrates the most common fix types:
+The [fixer-showcase](fixer-showcase/) workflow demonstrates all available fix types:
 
 1. CSV enum expansion (go-restful-openapi pattern)
 2. Duplicate operationId renaming

--- a/examples/workflows/fixer-showcase/README.md
+++ b/examples/workflows/fixer-showcase/README.md
@@ -1,10 +1,10 @@
 # Fixer Showcase
 
-Demonstrates the most common fix types in the oastools fixer package with before/after comparison.
+Demonstrates all available fix types in the oastools fixer package with before/after comparison.
 
 ## What You'll Learn
 
-- Common fix types and what each one does
+- All available fix types and what each one does
 - When to use each fix type
 - Using dry-run mode to preview changes
 - Applying multiple fixes at once
@@ -30,13 +30,15 @@ go run main.go
 | `FixTypePrunedEmptyPath` | Empty path items | `/empty: {}` -> removed |
 | `FixTypeRenamedGenericSchema` | Generic schema names | `Response[Pet]` -> `Response_Pet_` |
 | `FixTypeMissingPathParameter` | Missing path params | `/{petId}` without param -> param added |
+| `FixTypePathParameterNotRequired` | Declared path params missing `required` | `in: path` without `required` -> `required: true` |
 | `FixTypePrunedUnusedSchema` | Unreferenced schemas | Orphan schemas -> removed |
+| `FixTypeStubMissingRef` | `$ref` to an undefined target | `$ref: '#/components/schemas/Order'` -> stub created |
 
 ## Expected Output
 
 ```
-Fixer Showcase: Common Fix Types
-================================
+Fixer Showcase: All Available Fix Types
+=======================================
 
 This spec intentionally contains common issues:
   - CSV enum values (should be array)
@@ -44,24 +46,25 @@ This spec intentionally contains common issues:
   - Empty path items
   - Generic schema names like Response[Pet]
   - Missing path parameter definitions
+  - Declared path parameters missing required: true
   - Unused/unreferenced schemas
+  - $refs pointing at schemas that do not exist
 
-[0/7] Initial Validation
+[0/9] Initial Validation
 ------------------------
-  [X] Found 5 validation errors:
+  [X] Found 8 validation errors:
     - oas 3.0.3: duplicate operationId 'getPets' at 'paths./pet...
+    - oas 3.0.3: invalid parameter 'paths./orders/{orderId}.get...
     - Component name "Response[Pet]" must match ^[a-zA-Z0-9._-]+$
-    - Path template references parameter '{petId}' but it is no...
-    - Path template references parameter '{petId}' but it is no...
-    - Duplicate operationId 'getPets' (first seen at paths./pet...
+    ... and 5 more
 
-[1/7] Fix: CSV Enums
+[1/9] Fix: CSV Enums
 ------------------------
   -> CSV enum values -> proper arrays
   [OK] Applied 1 fix(es):
     - expanded CSV enum string to 5 individual values
 
-[2/7] Fix: Duplicate OperationIds
+[2/9] Fix: Duplicate OperationIds
 ------------------------
   -> Duplicate IDs -> unique suffixed IDs
   [OK] Applied 1 fix(es):
@@ -69,60 +72,87 @@ This spec intentionally contains common issues:
 
 ...
 
-[7/7] Apply ALL Fixes
+[6/9] Fix: Path Parameters Missing required
+------------------------
+  -> Declared {orderId} param -> required: true
+  [OK] Applied 1 fix(es):
+    - Set required: true on path parameter 'orderId'
+
+...
+
+[8/9] Fix: Stub Missing Refs
+------------------------
+  -> $ref to undefined Order -> stub created
+  [OK] Applied 1 fix(es):
+    - Created stub schema for missing reference #/components/schemas/Order
+
+[9/9] Apply ALL Fixes
 ------------------------
   Dry-run preview:
-    Would apply 8 fixes
-    - pruned-unused-schema: 2
-    - pruned-empty-path: 1
-    - missing-path-parameter: 2
+    Would apply 9 fixes
     - duplicate-operation-id: 1
-    - renamed-generic-schema: 1
     - enum-csv-expanded: 1
+    - missing-path-parameter: 2
+    - path-parameter-not-required: 1
+    - pruned-empty-path: 1
+    - pruned-unused-schema: 2
+    - renamed-generic-schema: 1
+    (stub-missing-ref is absent above: stubbing is skipped in
+     dry-run mode, so the applied count below is higher)
 
   Applying all fixes:
-  [OK] Applied 8 total fixes
+  [OK] Applied 10 total fixes
 
   Validation after fixes:
   [OK] Spec is now VALID!
-  -> Final schema count: 2
-  -> Schemas: Pet, Response_Pet_
+  -> Final schema count: 3
+  -> Schemas: Order, Pet, Response_Pet_
 
 =======================================
-Fix Types Demonstrated Above:
-  fixer.FixTypeEnumCSVExpanded       - Convert CSV enums to arrays
-  fixer.FixTypeDuplicateOperationId  - Make operation IDs unique
-  fixer.FixTypePrunedEmptyPath       - Remove empty path items
-  fixer.FixTypeRenamedGenericSchema  - Sanitize generic names
-  fixer.FixTypeMissingPathParameter  - Add missing path params
-  fixer.FixTypePrunedUnusedSchema    - Remove unreferenced schemas
+Available Fix Types:
+  fixer.FixTypeEnumCSVExpanded            - Convert CSV enums to arrays
+  fixer.FixTypeDuplicateOperationId       - Make operation IDs unique
+  fixer.FixTypePrunedEmptyPath            - Remove empty path items
+  fixer.FixTypeRenamedGenericSchema       - Sanitize generic names
+  fixer.FixTypeMissingPathParameter       - Add missing path params
+  fixer.FixTypePathParameterNotRequired   - Set required: true on path params
+  fixer.FixTypePrunedUnusedSchema         - Remove unreferenced schemas
+  fixer.FixTypeStubMissingRef             - Stub out unresolved $refs
 ```
+
+> The `[0/9]` error list is elided above because the validator does not fix the
+> order of its findings; the `[9/9]` fix-type summary is sorted and stable.
 
 ## Files
 
 | File | Purpose |
 |------|---------|
-| main.go | Demonstrates each fix type individually and combined |
-| specs/problematic-api.yaml | OpenAPI spec with the issues shown above |
+| main.go | Demonstrates all fix types individually and combined |
+| specs/problematic-api.yaml | OpenAPI spec with all fixable issues |
 
 ## Key Concepts
 
 ### FixType Constants
 
-Each fix demonstrated here has a corresponding constant:
+Each fix has a corresponding constant:
 
 ```go
-fixer.FixTypeEnumCSVExpanded       // "enum-csv-expanded"
-fixer.FixTypeDuplicateOperationId  // "duplicate-operation-id"
-fixer.FixTypePrunedEmptyPath       // "pruned-empty-path"
-fixer.FixTypeRenamedGenericSchema  // "renamed-generic-schema"
-fixer.FixTypeMissingPathParameter  // "missing-path-parameter"
-fixer.FixTypePrunedUnusedSchema    // "pruned-unused-schema"
+fixer.FixTypeEnumCSVExpanded            // "enum-csv-expanded"
+fixer.FixTypeDuplicateOperationId       // "duplicate-operation-id"
+fixer.FixTypePrunedEmptyPath            // "pruned-empty-path"
+fixer.FixTypeRenamedGenericSchema       // "renamed-generic-schema"
+fixer.FixTypeMissingPathParameter       // "missing-path-parameter"
+fixer.FixTypePathParameterNotRequired   // "path-parameter-not-required"
+fixer.FixTypePrunedUnusedSchema         // "pruned-unused-schema"
+fixer.FixTypeStubMissingRef             // "stub-missing-ref"
 ```
 
 ### Enabling Specific Fixes
 
-By default, only the path parameter fixes are enabled — `FixTypeMissingPathParameter` and `FixTypePathParameterNotRequired`, both returned by `fixer.DefaultEnabledFixes()`. To enable others:
+By default, only the two path parameter fixes are enabled (`DefaultEnabledFixes()`:
+`FixTypeMissingPathParameter` and `FixTypePathParameterNotRequired`) — both are
+mechanical repairs the spec leaves no room to interpret. Every other fix type
+renames or removes content, so it stays opt-in:
 
 ```go
 f := fixer.New()
@@ -157,6 +187,10 @@ preview, err := fixer.FixWithOptions(
 )
 fmt.Printf("Would apply %d fixes\n", preview.FixCount)
 ```
+
+`FixTypeStubMissingRef` is the one exception: stubbing runs first in the pipeline
+because later passes traverse `$ref`s, and it is skipped under dry-run. A preview
+therefore undercounts by the number of stubs a real run would create.
 
 ### Chaining with ToParseResult()
 

--- a/examples/workflows/fixer-showcase/main.go
+++ b/examples/workflows/fixer-showcase/main.go
@@ -1,4 +1,4 @@
-// Fixer Showcase example demonstrating the most common fix types.
+// Fixer Showcase example demonstrating all available fix types.
 //
 // This example shows how to:
 //   - Identify common OpenAPI spec issues
@@ -20,11 +20,25 @@ import (
 	"github.com/erraggy/oastools/validator"
 )
 
+// allFixTypes lists every fixer.FixType. Declared once so the individual demos
+// below and the combined run below them cannot drift out of sync -- the drift
+// that let two fix types go undemonstrated for several releases.
+var allFixTypes = []fixer.FixType{
+	fixer.FixTypeEnumCSVExpanded,
+	fixer.FixTypeDuplicateOperationId,
+	fixer.FixTypePrunedEmptyPath,
+	fixer.FixTypeRenamedGenericSchema,
+	fixer.FixTypeMissingPathParameter,
+	fixer.FixTypePathParameterNotRequired,
+	fixer.FixTypePrunedUnusedSchema,
+	fixer.FixTypeStubMissingRef,
+}
+
 func main() {
 	specPath := findSpecPath("specs/problematic-api.yaml")
 
-	fmt.Println("Fixer Showcase: Common Fix Types")
-	fmt.Println("================================")
+	fmt.Println("Fixer Showcase: All Available Fix Types")
+	fmt.Println("=======================================")
 	fmt.Println()
 	fmt.Println("This spec intentionally contains common issues:")
 	fmt.Println("  - CSV enum values (should be array)")
@@ -32,60 +46,74 @@ func main() {
 	fmt.Println("  - Empty path items")
 	fmt.Println("  - Generic schema names like Response[Pet]")
 	fmt.Println("  - Missing path parameter definitions")
+	fmt.Println("  - Declared path parameters missing required: true")
 	fmt.Println("  - Unused/unreferenced schemas")
+	fmt.Println("  - $refs pointing at schemas that do not exist")
 	fmt.Println()
 
 	// First, show the validation errors
-	fmt.Println("[0/7] Initial Validation")
+	fmt.Println("[0/9] Initial Validation")
 	fmt.Println("------------------------")
 	showValidationStatus(specPath)
 
 	// Demo each fix type
 	fmt.Println()
-	fmt.Println("[1/7] Fix: CSV Enums")
+	fmt.Println("[1/9] Fix: CSV Enums")
 	fmt.Println("------------------------")
 	demonstrateFix(specPath, fixer.FixTypeEnumCSVExpanded, "CSV enum values -> proper arrays")
 
 	fmt.Println()
-	fmt.Println("[2/7] Fix: Duplicate OperationIds")
+	fmt.Println("[2/9] Fix: Duplicate OperationIds")
 	fmt.Println("------------------------")
 	demonstrateFix(specPath, fixer.FixTypeDuplicateOperationId, "Duplicate IDs -> unique suffixed IDs")
 
 	fmt.Println()
-	fmt.Println("[3/7] Fix: Empty Paths")
+	fmt.Println("[3/9] Fix: Empty Paths")
 	fmt.Println("------------------------")
 	demonstrateFix(specPath, fixer.FixTypePrunedEmptyPath, "Empty path items -> removed")
 
 	fmt.Println()
-	fmt.Println("[4/7] Fix: Generic Schema Names")
+	fmt.Println("[4/9] Fix: Generic Schema Names")
 	fmt.Println("------------------------")
 	demonstrateFix(specPath, fixer.FixTypeRenamedGenericSchema, "Response[Pet] -> Response_Pet_")
 
 	fmt.Println()
-	fmt.Println("[5/7] Fix: Missing Path Parameters")
+	fmt.Println("[5/9] Fix: Missing Path Parameters")
 	fmt.Println("------------------------")
 	demonstrateFix(specPath, fixer.FixTypeMissingPathParameter, "Missing {petId} param -> added")
 
 	fmt.Println()
-	fmt.Println("[6/7] Fix: Unused Schemas")
+	fmt.Println("[6/9] Fix: Path Parameters Missing required")
+	fmt.Println("------------------------")
+	demonstrateFix(specPath, fixer.FixTypePathParameterNotRequired, "Declared {orderId} param -> required: true")
+
+	fmt.Println()
+	fmt.Println("[7/9] Fix: Unused Schemas")
 	fmt.Println("------------------------")
 	demonstrateFix(specPath, fixer.FixTypePrunedUnusedSchema, "Unreferenced schemas -> removed")
 
+	fmt.Println()
+	fmt.Println("[8/9] Fix: Stub Missing Refs")
+	fmt.Println("------------------------")
+	demonstrateFix(specPath, fixer.FixTypeStubMissingRef, "$ref to undefined Order -> stub created")
+
 	// Demo all fixes combined
 	fmt.Println()
-	fmt.Println("[7/7] Apply ALL Fixes")
+	fmt.Println("[9/9] Apply ALL Fixes")
 	fmt.Println("------------------------")
 	demonstrateAllFixes(specPath)
 
 	fmt.Println()
 	fmt.Println("=======================================")
-	fmt.Println("Fix Types Demonstrated Above:")
-	fmt.Println("  fixer.FixTypeEnumCSVExpanded       - Convert CSV enums to arrays")
-	fmt.Println("  fixer.FixTypeDuplicateOperationId  - Make operation IDs unique")
-	fmt.Println("  fixer.FixTypePrunedEmptyPath       - Remove empty path items")
-	fmt.Println("  fixer.FixTypeRenamedGenericSchema  - Sanitize generic names")
-	fmt.Println("  fixer.FixTypeMissingPathParameter  - Add missing path params")
-	fmt.Println("  fixer.FixTypePrunedUnusedSchema    - Remove unreferenced schemas")
+	fmt.Println("Available Fix Types:")
+	fmt.Println("  fixer.FixTypeEnumCSVExpanded            - Convert CSV enums to arrays")
+	fmt.Println("  fixer.FixTypeDuplicateOperationId       - Make operation IDs unique")
+	fmt.Println("  fixer.FixTypePrunedEmptyPath            - Remove empty path items")
+	fmt.Println("  fixer.FixTypeRenamedGenericSchema       - Sanitize generic names")
+	fmt.Println("  fixer.FixTypeMissingPathParameter       - Add missing path params")
+	fmt.Println("  fixer.FixTypePathParameterNotRequired   - Set required: true on path params")
+	fmt.Println("  fixer.FixTypePrunedUnusedSchema         - Remove unreferenced schemas")
+	fmt.Println("  fixer.FixTypeStubMissingRef             - Stub out unresolved $refs")
 }
 
 func showValidationStatus(specPath string) {
@@ -166,14 +194,7 @@ func demonstrateAllFixes(specPath string) {
 	fmt.Println("  Dry-run preview:")
 	preview, err := fixer.FixWithOptions(
 		fixer.WithParsed(*parsed),
-		fixer.WithEnabledFixes(
-			fixer.FixTypeEnumCSVExpanded,
-			fixer.FixTypeDuplicateOperationId,
-			fixer.FixTypePrunedEmptyPath,
-			fixer.FixTypeRenamedGenericSchema,
-			fixer.FixTypeMissingPathParameter,
-			fixer.FixTypePrunedUnusedSchema,
-		),
+		fixer.WithEnabledFixes(allFixTypes...),
 		fixer.WithDryRun(true),
 	)
 	if err != nil {
@@ -182,27 +203,29 @@ func demonstrateAllFixes(specPath string) {
 	}
 	fmt.Printf("    Would apply %d fixes\n", preview.FixCount)
 
-	// Group fixes by type for summary
+	// Group fixes by type for summary. Map iteration order is random, so sort
+	// the types before printing -- otherwise this block reorders itself run to
+	// run, which is exactly the noise a showcase should not produce.
 	fixCounts := make(map[fixer.FixType]int)
 	for _, fix := range preview.Fixes {
 		fixCounts[fix.Type]++
 	}
-	for fixType, count := range fixCounts {
-		fmt.Printf("    - %s: %d\n", fixType, count)
+	types := make([]fixer.FixType, 0, len(fixCounts))
+	for fixType := range fixCounts {
+		types = append(types, fixType)
 	}
+	slices.Sort(types)
+	for _, fixType := range types {
+		fmt.Printf("    - %s: %d\n", fixType, fixCounts[fixType])
+	}
+	fmt.Println("    (stub-missing-ref is absent above: stubbing is skipped in")
+	fmt.Println("     dry-run mode, so the applied count below is higher)")
 
 	// Now apply all fixes
 	fmt.Println()
 	fmt.Println("  Applying all fixes:")
 	f := fixer.New()
-	f.EnabledFixes = []fixer.FixType{
-		fixer.FixTypeEnumCSVExpanded,
-		fixer.FixTypeDuplicateOperationId,
-		fixer.FixTypePrunedEmptyPath,
-		fixer.FixTypeRenamedGenericSchema,
-		fixer.FixTypeMissingPathParameter,
-		fixer.FixTypePrunedUnusedSchema,
-	}
+	f.EnabledFixes = slices.Clone(allFixTypes)
 	fixed, err := f.FixParsed(*parsed)
 	if err != nil {
 		log.Printf("  Fix error: %v", err)

--- a/examples/workflows/fixer-showcase/specs/problematic-api.yaml
+++ b/examples/workflows/fixer-showcase/specs/problematic-api.yaml
@@ -55,6 +55,25 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Pet'
+  /orders/{orderId}:
+    get:
+      operationId: getOrder
+      tags: [orders]
+      parameters:
+        # Path parameter not required fix: unlike the paths above, {orderId} IS
+        # declared -- it just omits the required: true that path params demand
+        - name: orderId
+          in: path
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                # Stub missing ref fix: Order is referenced but never defined
+                $ref: '#/components/schemas/Order'
   # Empty path fix: path item with no operations
   /empty: {}
 components:


### PR DESCRIPTION
The fixer-showcase example claimed to demonstrate every fix type but covered 6 of 8. It had been stale since v1.46.0 for `FixTypeStubMissingRef`, and v1.56.0 added `FixTypePathParameterNotRequired` without extending it.

Release prep for v1.56.0 softened the wording to "common fix types" rather than extend the example on a release branch. This closes it properly, so the exhaustive claim is true again and the wording is restored.

## What changed

- **`main.go`** demonstrates all eight fix types, growing from 7 steps to 9. Two new steps: `[6/9] Fix: Path Parameters Missing required` and `[8/9] Fix: Stub Missing Refs`.
- **`specs/problematic-api.yaml`** gained the two triggering defects: a path parameter that is *declared but omits* `required: true` (distinct from the missing-parameter case, which the fixer already adds with `required: true` set), and a `$ref` pointing at a schema that does not exist.
- **READMEs** updated: the fix-type table, the constants list, the expected-output block, and the exhaustiveness wording in `examples/README.md` and `examples/workflows/README.md`.

## Two things worth a reviewer's attention

**The dry-run summary is now sorted.** It aggregates into a `map[FixType]int`, and Go randomizes map iteration order, so the printed order previously varied run to run (verified: three different orderings in four runs). Sorting makes the example's output stable and matches how the fixer package already sorts elsewhere for determinism.

**Dry-run under-reports, and the example says so.** The preview shows 9 fixes while applying yields 10, because `fixer/pipeline.go:22` skips the stub pass entirely when `DryRun` is set. The example documents this in its output rather than papering over it. That behavior is pre-existing and is being addressed separately — `DryRun` should report what stubbing would do without writing it.

## Scope

Examples and documentation only. No production code: `git diff --name-only main...HEAD` touches nothing under `fixer/` or `validator/`. Related follow-up work on `DryRun` semantics and on webhook path parameters is deliberately **not** included here and will land separately.

## Verification

- `make check` green: 0 golangci-lint issues, 0 markdownlint issues, 8863 tests — identical to `main`, as expected for a docs-only change.
- `go run main.go` executes clean and produces all eight fix types; the README expected-output block agrees on every count (8 validation errors, 9 previewed, 10 applied, spec valid afterward). That block remains an abbreviated transcript with elisions, matching the file's existing convention.