### PR TITLE
fix(parser): accept OAS 2.0 string discriminator, reject cross-dialect forms

### DIFF
--- a/converter/ref_rewrite.go
+++ b/converter/ref_rewrite.go
@@ -71,98 +71,105 @@ func rewriteRefOAS3ToOAS2(ref string) string {
 // The function receives the original $ref value and returns the rewritten value.
 type refRewriter func(ref string) string
 
-// walkSchemaRefs recursively walks a schema and rewrites all $ref values using the provided rewriter function.
-// This is a generic traversal function that handles all nested schema locations.
-func walkSchemaRefs(schema *parser.Schema, rewrite refRewriter) {
+// walkSchemas recursively walks a schema and every schema nested within it,
+// calling visit once per schema. This is the generic traversal that handles all
+// nested schema locations; callers supply the per-schema work.
+func walkSchemas(schema *parser.Schema, visit func(*parser.Schema)) {
 	if schema == nil {
 		return
 	}
 
-	// Rewrite the $ref in this schema
-	if schema.Ref != "" {
-		schema.Ref = rewrite(schema.Ref)
-	}
+	visit(schema)
 
-	// Recursively rewrite nested schemas in properties
+	// Recursively visit nested schemas in properties
 	for _, propSchema := range schema.Properties {
-		walkSchemaRefs(propSchema, rewrite)
+		walkSchemas(propSchema, visit)
 	}
 
 	for _, propSchema := range schema.PatternProperties {
-		walkSchemaRefs(propSchema, rewrite)
+		walkSchemas(propSchema, visit)
 	}
 
 	// Handle polymorphic fields with type assertion.
 	// These can be bool (OAS 3.1+) or *Schema - only *Schema needs traversal.
 	if addProps, ok := schema.AdditionalProperties.(*parser.Schema); ok {
-		walkSchemaRefs(addProps, rewrite)
+		walkSchemas(addProps, visit)
 	}
 
 	if items, ok := schema.Items.(*parser.Schema); ok {
-		walkSchemaRefs(items, rewrite)
+		walkSchemas(items, visit)
 	}
 
 	// Composition keywords
 	for _, subSchema := range schema.AllOf {
-		walkSchemaRefs(subSchema, rewrite)
+		walkSchemas(subSchema, visit)
 	}
 
 	for _, subSchema := range schema.AnyOf {
-		walkSchemaRefs(subSchema, rewrite)
+		walkSchemas(subSchema, visit)
 	}
 
 	for _, subSchema := range schema.OneOf {
-		walkSchemaRefs(subSchema, rewrite)
+		walkSchemas(subSchema, visit)
 	}
 
-	walkSchemaRefs(schema.Not, rewrite)
+	walkSchemas(schema.Not, visit)
 
 	// Array-related keywords
 	if addItems, ok := schema.AdditionalItems.(*parser.Schema); ok {
-		walkSchemaRefs(addItems, rewrite)
+		walkSchemas(addItems, visit)
 	}
 
 	for _, prefixItem := range schema.PrefixItems {
-		walkSchemaRefs(prefixItem, rewrite)
+		walkSchemas(prefixItem, visit)
 	}
 
-	walkSchemaRefs(schema.Contains, rewrite)
+	walkSchemas(schema.Contains, visit)
 
 	// Object validation keywords
-	walkSchemaRefs(schema.PropertyNames, rewrite)
+	walkSchemas(schema.PropertyNames, visit)
 
 	for _, depSchema := range schema.DependentSchemas {
-		walkSchemaRefs(depSchema, rewrite)
+		walkSchemas(depSchema, visit)
 	}
 
 	// JSON Schema 2020-12 unevaluated keywords (can be bool or *Schema)
 	if unevalProps, ok := schema.UnevaluatedProperties.(*parser.Schema); ok {
-		walkSchemaRefs(unevalProps, rewrite)
+		walkSchemas(unevalProps, visit)
 	}
 
 	if unevalItems, ok := schema.UnevaluatedItems.(*parser.Schema); ok {
-		walkSchemaRefs(unevalItems, rewrite)
+		walkSchemas(unevalItems, visit)
 	}
 
 	// JSON Schema 2020-12 content keywords
-	walkSchemaRefs(schema.ContentSchema, rewrite)
+	walkSchemas(schema.ContentSchema, visit)
 
 	// Conditional keywords
-	walkSchemaRefs(schema.If, rewrite)
-	walkSchemaRefs(schema.Then, rewrite)
-	walkSchemaRefs(schema.Else, rewrite)
+	walkSchemas(schema.If, visit)
+	walkSchemas(schema.Then, visit)
+	walkSchemas(schema.Else, visit)
 
 	// Schema definitions
 	for _, defSchema := range schema.Defs {
-		walkSchemaRefs(defSchema, rewrite)
+		walkSchemas(defSchema, visit)
 	}
+}
 
-	// Discriminator mapping contains schema refs
-	if schema.Discriminator != nil {
-		for key, ref := range schema.Discriminator.Mapping {
-			schema.Discriminator.Mapping[key] = rewrite(ref)
+// walkSchemaRefs recursively walks a schema and rewrites all $ref values using the provided rewriter function.
+func walkSchemaRefs(schema *parser.Schema, rewrite refRewriter) {
+	walkSchemas(schema, func(s *parser.Schema) {
+		if s.Ref != "" {
+			s.Ref = rewrite(s.Ref)
 		}
-	}
+
+		// Discriminator mapping values are schema refs too
+		if s.Discriminator != nil {
+			for key, ref := range s.Discriminator.Mapping {
+				s.Discriminator.Mapping[key] = rewrite(ref)
+			}
+		}
+	})
 }
 
 // rewriteSchemaRefsOAS2ToOAS3 recursively rewrites all $ref values in a schema from OAS 2.0 to OAS 3.x format.

--- a/converter/schema_convert.go
+++ b/converter/schema_convert.go
@@ -20,12 +20,46 @@ func (c *Converter) convertOAS2SchemaToOAS3(schema *parser.Schema, targetVersion
 	// Rewrite all $ref paths from OAS 2.0 to OAS 3.x format
 	rewriteSchemaRefsOAS2ToOAS3(converted)
 
+	// Promote the OAS 2.0 bare-string discriminator to the OAS 3.x object form
+	discriminatorToObjectForm(converted)
+
 	// For OAS 3.1+, convert boolean exclusiveMaximum/exclusiveMinimum to numeric form
 	if c.isOAS31OrLater(targetVersion) {
 		fixSchemaExclusiveMinMaxForOAS31(c, converted, result, path, make(map[*parser.Schema]bool))
 	}
 
 	return converted
+}
+
+// discriminatorToObjectForm clears StringForm on every discriminator in the
+// schema tree so they serialize as OAS 3.x objects. The property name carries
+// over unchanged; only the spelling differs between dialects.
+func discriminatorToObjectForm(schema *parser.Schema) {
+	walkSchemas(schema, func(s *parser.Schema) {
+		if s.Discriminator != nil {
+			s.Discriminator.StringForm = false
+		}
+	})
+}
+
+// discriminatorToStringForm sets StringForm on every discriminator in the
+// schema tree so they serialize as OAS 2.0 bare strings. OAS 2.0 has no
+// equivalent of the 3.x mapping, so any mapping is dropped and reported.
+func discriminatorToStringForm(c *Converter, schema *parser.Schema, result *ConversionResult, path string) {
+	walkSchemas(schema, func(s *parser.Schema) {
+		d := s.Discriminator
+		if d == nil {
+			return
+		}
+		if len(d.Mapping) > 0 {
+			c.addIssueWithContext(result, path,
+				"Schema discriminator uses 'mapping' which has no OAS 2.0 equivalent; mapping dropped",
+				"OAS 2.0 resolves the discriminator by schema name only; rename the target definitions to match the discriminator values")
+			d.Mapping = nil
+		}
+		d.Extra = nil
+		d.StringForm = true
+	})
 }
 
 // fixSchemaExclusiveMinMaxForOAS31 recursively converts boolean exclusiveMaximum/exclusiveMinimum
@@ -132,6 +166,9 @@ func (c *Converter) convertOAS3SchemaToOAS2(schema *parser.Schema, result *Conve
 
 	// Rewrite all $ref paths from OAS 3.x to OAS 2.0 format on the deep copy
 	rewriteSchemaRefsOAS3ToOAS2(converted)
+
+	// Demote the OAS 3.x discriminator object to the OAS 2.0 bare-string form
+	discriminatorToStringForm(c, converted, result, path)
 
 	return converted
 }

--- a/converter/schema_convert.go
+++ b/converter/schema_convert.go
@@ -4,6 +4,9 @@ package converter
 
 import (
 	"fmt"
+	"maps"
+	"slices"
+	"strings"
 
 	"github.com/erraggy/oastools/parser"
 )
@@ -43,8 +46,9 @@ func discriminatorToObjectForm(schema *parser.Schema) {
 }
 
 // discriminatorToStringForm sets StringForm on every discriminator in the
-// schema tree so they serialize as OAS 2.0 bare strings. OAS 2.0 has no
-// equivalent of the 3.x mapping, so any mapping is dropped and reported.
+// schema tree so they serialize as OAS 2.0 bare strings. OAS 2.0 spells the
+// discriminator as a bare string with no object to hang anything off, so both
+// the 3.x mapping and any specification extensions are dropped and reported.
 func discriminatorToStringForm(c *Converter, schema *parser.Schema, result *ConversionResult, path string) {
 	walkSchemas(schema, func(s *parser.Schema) {
 		d := s.Discriminator
@@ -57,7 +61,13 @@ func discriminatorToStringForm(c *Converter, schema *parser.Schema, result *Conv
 				"OAS 2.0 resolves the discriminator by schema name only; rename the target definitions to match the discriminator values")
 			d.Mapping = nil
 		}
-		d.Extra = nil
+		if len(d.Extra) > 0 {
+			c.addIssueWithContext(result, path,
+				fmt.Sprintf("Schema discriminator carries extensions (%s) which have no OAS 2.0 equivalent; extensions dropped",
+					strings.Join(slices.Sorted(maps.Keys(d.Extra)), ", ")),
+				"OAS 2.0 spells the discriminator as a bare string, so it has no object to hold extensions; move them onto the enclosing Schema Object, which does accept them")
+			d.Extra = nil
+		}
 		d.StringForm = true
 	})
 }

--- a/converter/schema_discriminator_test.go
+++ b/converter/schema_discriminator_test.go
@@ -1,0 +1,110 @@
+package converter
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/erraggy/oastools/parser"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A discriminator means the same thing in both dialects but is spelled
+// differently: a bare string in OAS 2.0, an object in OAS 3.0+. Conversion has
+// to re-spell it, or it produces a document that is invalid at the target
+// version. See erraggy/oastools#394.
+
+func TestConvertOAS2StringDiscriminatorToOAS3Object(t *testing.T) {
+	result, err := New().Convert("../testdata/discriminator-2.0.yaml", "3.0.3")
+	require.NoError(t, err)
+	require.True(t, result.Success)
+
+	doc, ok := result.Document.(*parser.OAS3Document)
+	require.True(t, ok)
+
+	pet := doc.Components.Schemas["Pet"]
+	require.NotNil(t, pet)
+	require.NotNil(t, pet.Discriminator)
+	assert.Equal(t, "petType", pet.Discriminator.PropertyName)
+	assert.False(t, pet.Discriminator.StringForm,
+		"a 2.0 string discriminator must become the 3.x object form")
+}
+
+func TestConvertOAS3DiscriminatorObjectToOAS2String(t *testing.T) {
+	result, err := New().Convert("../testdata/join-discriminator-base-3.0.yaml", "2.0")
+	require.NoError(t, err)
+	require.True(t, result.Success)
+
+	doc, ok := result.Document.(*parser.OAS2Document)
+	require.True(t, ok)
+
+	pet := doc.Definitions["Pet"]
+	require.NotNil(t, pet)
+	require.NotNil(t, pet.Discriminator)
+	assert.Equal(t, "petType", pet.Discriminator.PropertyName)
+	assert.True(t, pet.Discriminator.StringForm,
+		"a 3.x discriminator object must become the 2.0 string form")
+	assert.Nil(t, pet.Discriminator.Mapping, "OAS 2.0 has no discriminator mapping")
+}
+
+func TestConvertOAS3ToOAS2ReportsDroppedDiscriminatorMapping(t *testing.T) {
+	// The base fixture's Pet carries a mapping, which has no OAS 2.0
+	// equivalent; silently dropping it would hide real information loss.
+	result, err := New().Convert("../testdata/join-discriminator-base-3.0.yaml", "2.0")
+	require.NoError(t, err)
+
+	var found bool
+	for _, issue := range result.Issues {
+		if strings.Contains(issue.Message, "discriminator uses 'mapping'") {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected an issue reporting the dropped discriminator mapping")
+}
+
+func TestConvertOAS2DiscriminatorRoundTrip(t *testing.T) {
+	// 2.0 -> 3.0 -> 2.0 must land back on the string form rather than
+	// accumulating the dialect it passed through.
+	toOAS3, err := New().Convert("../testdata/discriminator-2.0.yaml", "3.0.3")
+	require.NoError(t, err)
+
+	backToOAS2, err := New().ConvertParsed(parser.ParseResult{
+		Document:   toOAS3.Document,
+		Version:    "3.0.3",
+		OASVersion: parser.OASVersion303,
+		Data:       make(map[string]any),
+		SourcePath: "converted.yaml",
+	}, "2.0")
+	require.NoError(t, err)
+
+	doc, ok := backToOAS2.Document.(*parser.OAS2Document)
+	require.True(t, ok)
+
+	pet := doc.Definitions["Pet"]
+	require.NotNil(t, pet)
+	require.NotNil(t, pet.Discriminator)
+	assert.Equal(t, "petType", pet.Discriminator.PropertyName)
+	assert.True(t, pet.Discriminator.StringForm)
+}
+
+func TestDiscriminatorFormNormalizationReachesNestedSchemas(t *testing.T) {
+	// Normalization rides the shared schema walk, so it must reach a
+	// discriminator nested below the schema root.
+	nested := &parser.Schema{
+		Type: "object",
+		Properties: map[string]*parser.Schema{
+			"pet": {
+				AllOf: []*parser.Schema{
+					{Discriminator: &parser.Discriminator{PropertyName: "petType", StringForm: true}},
+				},
+			},
+		},
+	}
+
+	discriminatorToObjectForm(nested)
+	assert.False(t, nested.Properties["pet"].AllOf[0].Discriminator.StringForm)
+
+	discriminatorToStringForm(New(), nested, &ConversionResult{}, "test")
+	assert.True(t, nested.Properties["pet"].AllOf[0].Discriminator.StringForm)
+}

--- a/converter/schema_discriminator_test.go
+++ b/converter/schema_discriminator_test.go
@@ -63,6 +63,42 @@ func TestConvertOAS3ToOAS2ReportsDroppedDiscriminatorMapping(t *testing.T) {
 	assert.True(t, found, "expected an issue reporting the dropped discriminator mapping")
 }
 
+func TestConvertOAS3ToOAS2ReportsDroppedDiscriminatorExtensions(t *testing.T) {
+	// OAS 2.0 spells the discriminator as a bare string, so there is no object
+	// left to carry x- extensions. Dropping them is unavoidable; dropping them
+	// silently is not.
+	schema := &parser.Schema{
+		Discriminator: &parser.Discriminator{
+			PropertyName: "petType",
+			Extra:        map[string]any{"x-vendor": true, "x-internal": "yes"},
+		},
+	}
+	result := &ConversionResult{}
+
+	discriminatorToStringForm(New(), schema, result, "definitions.Pet")
+
+	require.Len(t, result.Issues, 1)
+	// Keys are sorted so the message is stable across map iteration order.
+	assert.Contains(t, result.Issues[0].Message, "x-internal, x-vendor")
+	assert.Contains(t, result.Issues[0].Message, "extensions dropped")
+	assert.Nil(t, schema.Discriminator.Extra)
+	assert.True(t, schema.Discriminator.StringForm)
+}
+
+func TestConvertOAS3ToOAS2SilentWhenDiscriminatorHasNothingToDrop(t *testing.T) {
+	// A discriminator with neither mapping nor extensions converts losslessly
+	// and must not manufacture a warning.
+	schema := &parser.Schema{
+		Discriminator: &parser.Discriminator{PropertyName: "petType"},
+	}
+	result := &ConversionResult{}
+
+	discriminatorToStringForm(New(), schema, result, "definitions.Pet")
+
+	assert.Empty(t, result.Issues)
+	assert.True(t, schema.Discriminator.StringForm)
+}
+
 func TestConvertOAS2DiscriminatorRoundTrip(t *testing.T) {
 	// 2.0 -> 3.0 -> 2.0 must land back on the string form rather than
 	// accumulating the dialect it passed through.

--- a/internal/codegen/decode/main.go
+++ b/internal/codegen/decode/main.go
@@ -56,6 +56,14 @@ var polymorphicFields = map[string]bool{
 	"Schema.UnevaluatedProperties": true,
 }
 
+// stringOrObjectFields maps "StructName.FieldName" to true for pointer-to-OAS-struct
+// fields that a document may also spell as a bare string. Schema.Discriminator is
+// an object in OAS 3.0+ but a plain string in OAS 2.0, so the default oas_ptr
+// strategy (which only matches map[string]any) would silently drop the 2.0 form.
+var stringOrObjectFields = map[string]bool{
+	"Schema.Discriminator": true,
+}
+
 // oasStructTypes is populated during discovery with the names of all struct
 // types in the parser package that have an Extra map[string]any field.
 var oasStructTypes = map[string]bool{}
@@ -85,14 +93,15 @@ func main() {
 	// Use an overlay to replace the generated file with a minimal stub.
 	// This prevents stale method signatures from causing type errors
 	// during package loading, while keeping decode_helpers.go compilable
-	// by providing the three methods it references.
+	// by providing every method it references.
 	stub := []byte(`package parser
 
-func (x *OAS2Document) decodeFromMap(m map[string]any) {}
-func (x *OAS3Document) decodeFromMap(m map[string]any) {}
-func (x *Schema) decodeFromMap(m map[string]any)       {}
-func (x *PathItem) decodeFromMap(m map[string]any)     {}
-func (x *Response) decodeFromMap(m map[string]any)     {}
+func (x *OAS2Document) decodeFromMap(m map[string]any)  {}
+func (x *OAS3Document) decodeFromMap(m map[string]any)  {}
+func (x *Schema) decodeFromMap(m map[string]any)        {}
+func (x *PathItem) decodeFromMap(m map[string]any)      {}
+func (x *Response) decodeFromMap(m map[string]any)      {}
+func (x *Discriminator) decodeFromMap(m map[string]any) {}
 `)
 
 	// Load the parser package using go/types
@@ -279,6 +288,17 @@ func classifyField(structName, fieldName string, t types.Type) (strategy, elemTy
 	// 1. Check polymorphic override (Schema.Items, etc.)
 	if polymorphicFields[structName+"."+fieldName] {
 		return "polymorphic_schema", ""
+	}
+
+	// 1b. Check string-or-object override (Schema.Discriminator). The named
+	// decode helper handles both spellings; ElemType selects which one.
+	if stringOrObjectFields[structName+"."+fieldName] {
+		if ptr, ok := types.Unalias(t).(*types.Pointer); ok {
+			if named, ok := ptr.Elem().(*types.Named); ok {
+				return "string_or_object", named.Obj().Name()
+			}
+		}
+		fatal("stringOrObjectFields entry %s.%s is not a pointer to a named type", structName, fieldName)
 	}
 
 	// 2. Check for Extra field — handled separately
@@ -486,6 +506,8 @@ func (x *{{.Name}}) decodeFromMap(m map[string]any) {
 		x.{{.FieldName}} = new({{.ElemType}})
 		x.{{.FieldName}}.decodeFromMap(sub)
 	}
+{{- else if eq .Strategy "string_or_object"}}
+	x.{{.FieldName}} = decode{{.ElemType}}(m["{{.JSONKey}}"])
 {{- else if eq .Strategy "oas_map"}}
 	if sub, ok := m["{{.JSONKey}}"].(map[string]any); ok {
 		x.{{.FieldName}} = make(map[string]*{{.ElemType}}, len(sub))

--- a/parser/decode_helpers.go
+++ b/parser/decode_helpers.go
@@ -220,6 +220,23 @@ func decodeSchemaOrBool(v any) any {
 	}
 }
 
+// decodeDiscriminator decodes a value that can be either the OAS 2.0
+// bare-string form (`discriminator: petType`) or the OAS 3.0+ object form.
+// Anything else yields nil, matching how the generated decoder skips values of
+// an unexpected shape.
+func decodeDiscriminator(v any) *Discriminator {
+	switch val := v.(type) {
+	case string:
+		return &Discriminator{PropertyName: val, StringForm: true}
+	case map[string]any:
+		d := new(Discriminator)
+		d.decodeFromMap(val)
+		return d
+	default:
+		return nil
+	}
+}
+
 // decodePaths decodes a map[string]any into a Paths value.
 func decodePaths(m map[string]any) Paths {
 	if m == nil {

--- a/parser/schema.go
+++ b/parser/schema.go
@@ -67,7 +67,7 @@ type Schema struct {
 
 	// OAS specific extensions
 	Nullable      bool           `yaml:"nullable,omitempty" json:"nullable,omitempty"`           // OAS 3.0 only (replaced by type: [T, "null"] in 3.1+)
-	Discriminator *Discriminator `yaml:"discriminator,omitempty" json:"discriminator,omitempty"` // OAS 3.0+
+	Discriminator *Discriminator `yaml:"discriminator,omitempty" json:"discriminator,omitempty"` // OAS 2.0+ (bare string in 2.0, object in 3.0+)
 	ReadOnly      bool           `yaml:"readOnly,omitempty" json:"readOnly,omitempty"`           // OAS 2.0+
 	WriteOnly     bool           `yaml:"writeOnly,omitempty" json:"writeOnly,omitempty"`         // OAS 3.0+
 	XML           *XML           `yaml:"xml,omitempty" json:"xml,omitempty"`                     // OAS 2.0+
@@ -100,11 +100,27 @@ type Schema struct {
 	Extra map[string]any `yaml:",inline" json:"-"`
 }
 
-// Discriminator represents a discriminator for polymorphism (OAS 3.0+)
+// Discriminator represents a discriminator for polymorphism.
+//
+// The two OAS dialects spell this differently. In OAS 2.0 the Schema Object's
+// discriminator is a bare string naming the property; in OAS 3.0+ it is an
+// object with propertyName and an optional mapping. A single Go type serves
+// both: the string form decodes into PropertyName with StringForm set, so the
+// dialect a document was written in survives a parse/serialize round trip.
 type Discriminator struct {
 	PropertyName string            `yaml:"propertyName" json:"propertyName"`
-	Mapping      map[string]string `yaml:"mapping,omitempty" json:"mapping,omitempty"`
+	Mapping      map[string]string `yaml:"mapping,omitempty" json:"mapping,omitempty"` // OAS 3.0+ only
 	Extra        map[string]any    `yaml:",inline" json:"-"`
+
+	// StringForm reports that this discriminator came from — and should be
+	// written back as — the OAS 2.0 bare-string form (`discriminator: petType`)
+	// rather than the OAS 3.0+ object form. It is not itself a specification
+	// field, so it is excluded from both JSON and YAML.
+	//
+	// Mapping and Extra have no representation in the string form and are
+	// dropped when serializing with StringForm set. Converting between
+	// dialects must set or clear this flag; see the converter package.
+	StringForm bool `yaml:"-" json:"-"`
 }
 
 // XML represents metadata for XML encoding (OAS 2.0+)

--- a/parser/schema_discriminator_test.go
+++ b/parser/schema_discriminator_test.go
@@ -1,0 +1,251 @@
+package parser
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v4"
+)
+
+// The Schema Object's discriminator is a bare string in OAS 2.0 and an object
+// in OAS 3.0+. One Go type serves both, so every decode path has to recognize
+// both spellings and every encode path has to reproduce the one it was given.
+// The parser has three independent decode paths: encoding/json, YAML, and the
+// generated decodeFromMap used when ResolveRefs is enabled.
+
+func TestDiscriminatorUnmarshalJSONStringForm(t *testing.T) {
+	var d Discriminator
+	require.NoError(t, json.Unmarshal([]byte(`"petType"`), &d))
+
+	assert.Equal(t, "petType", d.PropertyName)
+	assert.True(t, d.StringForm, "string form must be recorded so it round-trips")
+	assert.Nil(t, d.Mapping)
+}
+
+func TestDiscriminatorUnmarshalJSONObjectForm(t *testing.T) {
+	var d Discriminator
+	require.NoError(t, json.Unmarshal(
+		[]byte(`{"propertyName":"petType","mapping":{"dog":"#/components/schemas/Dog"},"x-vendor":true}`), &d))
+
+	assert.Equal(t, "petType", d.PropertyName)
+	assert.False(t, d.StringForm)
+	assert.Equal(t, map[string]string{"dog": "#/components/schemas/Dog"}, d.Mapping)
+	assert.Equal(t, true, d.Extra["x-vendor"])
+}
+
+func TestDiscriminatorUnmarshalJSONInvalidForm(t *testing.T) {
+	var d Discriminator
+	assert.Error(t, json.Unmarshal([]byte(`["petType"]`), &d))
+}
+
+func TestDiscriminatorMarshalJSONRoundTrip(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"OAS 2.0 string form", `"petType"`},
+		{"OAS 3.x object form", `{"propertyName":"petType"}`},
+		{"OAS 3.x with mapping", `{"propertyName":"petType","mapping":{"dog":"Dog"}}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var d Discriminator
+			require.NoError(t, json.Unmarshal([]byte(tt.input), &d))
+
+			out, err := json.Marshal(&d)
+			require.NoError(t, err)
+			assert.JSONEq(t, tt.input, string(out))
+		})
+	}
+}
+
+func TestDiscriminatorUnmarshalYAMLStringForm(t *testing.T) {
+	var s Schema
+	require.NoError(t, yaml.Unmarshal([]byte("type: object\ndiscriminator: petType\n"), &s))
+
+	require.NotNil(t, s.Discriminator)
+	assert.Equal(t, "petType", s.Discriminator.PropertyName)
+	assert.True(t, s.Discriminator.StringForm)
+}
+
+func TestDiscriminatorUnmarshalYAMLObjectForm(t *testing.T) {
+	var s Schema
+	require.NoError(t, yaml.Unmarshal(
+		[]byte("type: object\ndiscriminator:\n  propertyName: petType\n  mapping:\n    dog: Dog\n"), &s))
+
+	require.NotNil(t, s.Discriminator)
+	assert.Equal(t, "petType", s.Discriminator.PropertyName)
+	assert.False(t, s.Discriminator.StringForm)
+	assert.Equal(t, map[string]string{"dog": "Dog"}, s.Discriminator.Mapping)
+}
+
+func TestDiscriminatorUnmarshalYAMLAnchor(t *testing.T) {
+	// An anchored scalar must still be classified as the string form rather
+	// than falling through to the mapping branch.
+	src := "x-name: &petType petType\ntype: object\ndiscriminator: *petType\n"
+
+	var s Schema
+	require.NoError(t, yaml.Unmarshal([]byte(src), &s))
+
+	require.NotNil(t, s.Discriminator)
+	assert.Equal(t, "petType", s.Discriminator.PropertyName)
+	assert.True(t, s.Discriminator.StringForm)
+}
+
+func TestDiscriminatorUnmarshalYAMLInvalidForm(t *testing.T) {
+	var s Schema
+	err := yaml.Unmarshal([]byte("type: object\ndiscriminator:\n  - petType\n"), &s)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(),
+		"'discriminator' must be a string (OAS 2.0) or a mapping (OAS 3.0+), but got: SequenceNode")
+	// yaml supplies its own "line N:" prefix; ours must not duplicate it.
+	assert.NotContains(t, err.Error(), "line 3: line 3:")
+}
+
+func TestDiscriminatorMarshalYAMLRoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{"OAS 2.0 string form", "discriminator: petType\n", "discriminator: petType\n"},
+		{"OAS 3.x object form", "discriminator:\n  propertyName: petType\n", "propertyName: petType"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var s Schema
+			require.NoError(t, yaml.Unmarshal([]byte(tt.src), &s))
+
+			out, err := yaml.Marshal(&s)
+			require.NoError(t, err)
+			assert.Contains(t, string(out), tt.want)
+		})
+	}
+}
+
+func TestDiscriminatorDecodeFromMap(t *testing.T) {
+	// decodeFromMap is the path taken when ResolveRefs is enabled. Before the
+	// string form was handled here it was silently dropped rather than erroring.
+	tests := []struct {
+		name           string
+		value          any
+		wantProperty   string
+		wantStringForm bool
+		wantNil        bool
+	}{
+		{name: "OAS 2.0 string form", value: "petType", wantProperty: "petType", wantStringForm: true},
+		{name: "OAS 3.x object form", value: map[string]any{"propertyName": "petType"}, wantProperty: "petType"},
+		{name: "unsupported form", value: []any{"petType"}, wantNil: true},
+		{name: "absent", value: nil, wantNil: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := map[string]any{"type": "object"}
+			if tt.value != nil {
+				m["discriminator"] = tt.value
+			}
+
+			var s Schema
+			s.decodeFromMap(m)
+
+			if tt.wantNil {
+				assert.Nil(t, s.Discriminator)
+				return
+			}
+			require.NotNil(t, s.Discriminator)
+			assert.Equal(t, tt.wantProperty, s.Discriminator.PropertyName)
+			assert.Equal(t, tt.wantStringForm, s.Discriminator.StringForm)
+		})
+	}
+}
+
+func TestParseOAS2StringDiscriminator(t *testing.T) {
+	// Regression for erraggy/oastools#394: a spec-conformant OAS 2.0 document
+	// with a string discriminator was rejected outright at parse time.
+	for _, path := range []string{
+		"../testdata/discriminator-2.0.yaml",
+		"../testdata/discriminator-2.0.json",
+	} {
+		t.Run(path, func(t *testing.T) {
+			result, err := New().Parse(path)
+			require.NoError(t, err)
+			require.Empty(t, result.Errors)
+
+			doc, ok := result.Document.(*OAS2Document)
+			require.True(t, ok)
+
+			pet := doc.Definitions["Pet"]
+			require.NotNil(t, pet)
+			require.NotNil(t, pet.Discriminator)
+			assert.Equal(t, "petType", pet.Discriminator.PropertyName)
+			assert.True(t, pet.Discriminator.StringForm)
+		})
+	}
+}
+
+func TestParseOAS2StringDiscriminatorWithResolvedRefs(t *testing.T) {
+	// ResolveRefs swaps in decodeFromMap, a decode path the plain Parse tests
+	// never reach.
+	p := New()
+	p.ResolveRefs = true
+
+	result, err := p.Parse("../testdata/discriminator-2.0.yaml")
+	require.NoError(t, err)
+
+	doc, ok := result.Document.(*OAS2Document)
+	require.True(t, ok)
+
+	pet := doc.Definitions["Pet"]
+	require.NotNil(t, pet)
+	require.NotNil(t, pet.Discriminator, "discriminator must survive $ref resolution")
+	assert.Equal(t, "petType", pet.Discriminator.PropertyName)
+	assert.True(t, pet.Discriminator.StringForm)
+}
+
+func TestOAS2StringDiscriminatorSurvivesSerialization(t *testing.T) {
+	// The CLI writes fixed/joined documents by marshaling the typed document,
+	// so a 2.0 document must not come back out in the OAS 3.x object form.
+	for _, path := range []string{
+		"../testdata/discriminator-2.0.yaml",
+		"../testdata/discriminator-2.0.json",
+	} {
+		t.Run(path, func(t *testing.T) {
+			result, err := New().Parse(path)
+			require.NoError(t, err)
+
+			jsonOut, err := json.Marshal(result.Document)
+			require.NoError(t, err)
+			assert.Contains(t, string(jsonOut), `"discriminator":"petType"`)
+			assert.NotContains(t, string(jsonOut), `"propertyName"`)
+
+			yamlOut, err := yaml.Marshal(result.Document)
+			require.NoError(t, err)
+			assert.Contains(t, string(yamlOut), "discriminator: petType")
+			assert.NotContains(t, string(yamlOut), "propertyName")
+		})
+	}
+}
+
+func TestDiscriminatorDeepCopyPreservesStringForm(t *testing.T) {
+	d := &Discriminator{PropertyName: "petType", StringForm: true}
+
+	got := d.DeepCopy()
+	require.NotNil(t, got)
+	assert.True(t, got.StringForm)
+	assert.Equal(t, "petType", got.PropertyName)
+}
+
+func TestDiscriminatorEqualsIgnoresStringForm(t *testing.T) {
+	// StringForm records the dialect's spelling, not the meaning: both forms
+	// select the same property, so a cross-version diff must not report one.
+	a := &Discriminator{PropertyName: "petType", StringForm: true}
+	b := &Discriminator{PropertyName: "petType"}
+
+	assert.True(t, equalDiscriminator(a, b))
+}

--- a/parser/schema_discriminator_test.go
+++ b/parser/schema_discriminator_test.go
@@ -106,6 +106,23 @@ func TestDiscriminatorUnmarshalYAMLInvalidForm(t *testing.T) {
 	assert.NotContains(t, err.Error(), "line 3: line 3:")
 }
 
+func TestYAMLKindName(t *testing.T) {
+	// yaml.Kind has no String method, so error messages depend on this mapping
+	// staying in step with the constants.
+	tests := map[yaml.Kind]string{
+		yaml.DocumentNode: "DocumentNode",
+		yaml.SequenceNode: "SequenceNode",
+		yaml.MappingNode:  "MappingNode",
+		yaml.ScalarNode:   "ScalarNode",
+		yaml.AliasNode:    "AliasNode",
+		yaml.Kind(0):      "unknown yaml.Kind(0)",
+	}
+
+	for kind, want := range tests {
+		assert.Equal(t, want, yamlKindName(kind))
+	}
+}
+
 func TestDiscriminatorMarshalYAMLRoundTrip(t *testing.T) {
 	tests := []struct {
 		name string

--- a/parser/schema_equals.go
+++ b/parser/schema_equals.go
@@ -307,6 +307,11 @@ func equalSchemaMapWithVisited(a, b map[string]*Schema, visited map[schemaPair]b
 }
 
 // equalDiscriminator compares two *Discriminator for equality.
+//
+// StringForm is deliberately excluded: it records which dialect spelled the
+// discriminator, not what it means. An OAS 2.0 `discriminator: petType` and an
+// OAS 3.x `{propertyName: petType}` select the same property, so treating them
+// as different would make every cross-version diff report a phantom change.
 func equalDiscriminator(a, b *Discriminator) bool {
 	if a == nil && b == nil {
 		return true

--- a/parser/schema_json.go
+++ b/parser/schema_json.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 
@@ -156,7 +157,16 @@ func promoteSchemaOrBool(v any) (any, error) {
 // This is required to flatten Extra fields (specification extensions like x-*)
 // into the top-level JSON object, as Go's encoding/json doesn't support
 // inline maps like yaml:",inline".
+//
+// When StringForm is set the OAS 2.0 bare-string form is emitted instead, so a
+// 2.0 document is not silently rewritten into the OAS 3.x object form.
 func (d *Discriminator) MarshalJSON() ([]byte, error) {
+	// OAS 2.0: a bare string naming the property. Mapping and Extra have no
+	// representation in this form and are dropped.
+	if d.StringForm {
+		return json.Marshal(d.PropertyName)
+	}
+
 	// Fast path: no Extra fields, use standard marshaling
 	if len(d.Extra) == 0 {
 		type Alias Discriminator
@@ -175,7 +185,26 @@ func (d *Discriminator) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements custom JSON unmarshaling for Discriminator.
 // This captures unknown fields (specification extensions like x-*) in the Extra map.
+//
+// Both dialects are accepted: the OAS 2.0 bare-string form decodes into
+// PropertyName with StringForm set, and the OAS 3.0+ object form decodes
+// normally. Rejecting the form that is wrong for the document's version is the
+// validator's job, since the parser cannot see the version from here.
 func (d *Discriminator) UnmarshalJSON(data []byte) error {
+	// OAS 2.0: "discriminator": "petType"
+	// Sniffing the first byte avoids the cost of a failed string decode on the
+	// far more common OAS 3.x object form.
+	if trimmed := bytes.TrimLeft(data, " \t\n\r"); len(trimmed) > 0 && trimmed[0] == '"' {
+		var name string
+		if err := json.Unmarshal(data, &name); err != nil {
+			return err
+		}
+		d.PropertyName = name
+		d.StringForm = true
+		return nil
+	}
+
+	// OAS 3.0+: "discriminator": {"propertyName": "petType", ...}
 	type Alias Discriminator
 	if err := json.Unmarshal(data, (*Alias)(d)); err != nil {
 		return err

--- a/parser/schema_yaml.go
+++ b/parser/schema_yaml.go
@@ -1,0 +1,85 @@
+package parser
+
+import (
+	"fmt"
+
+	"go.yaml.in/yaml/v4"
+)
+
+// UnmarshalYAML implements custom YAML unmarshaling for Discriminator.
+//
+// Both dialects are accepted: the OAS 2.0 string-only form (`discriminator:
+// petType`) decodes into PropertyName with StringForm set to true, and the
+// OAS 3.0+ mapping form decodes normally. Rejecting the form that is wrong
+// for the document's version is the validator's job, since the parser cannot
+// see the version from here.
+func (d *Discriminator) UnmarshalYAML(node *yaml.Node) error {
+	// Follow anchors so `discriminator: *petTypeAnchor` is classified by the
+	// kind of the node it points at rather than always failing the scalar test.
+	for node.Kind == yaml.AliasNode && node.Alias != nil {
+		node = node.Alias
+	}
+
+	switch node.Kind {
+	case yaml.ScalarNode:
+		// OAS 2.0: a scalar naming the property.
+		var name string
+		if err := node.Decode(&name); err != nil {
+			return err
+		}
+		d.PropertyName = name
+		d.StringForm = true
+		return nil
+
+	case yaml.MappingNode:
+		// OAS 3.0+: the alias type sheds this method so default struct
+		// decoding (including the inline Extra map) applies.
+		type Alias Discriminator
+		var alias Alias
+		if err := node.Decode(&alias); err != nil {
+			return err
+		}
+		*d = Discriminator(alias)
+		return nil
+
+	default:
+		// Naming the offending kind is better than yaml's default message,
+		// which would report the unexported Alias type rather than Discriminator.
+		// yaml prefixes its own "line N:", so this message must not add one.
+		return fmt.Errorf("'discriminator' must be a string (OAS 2.0) "+
+			"or a mapping (OAS 3.0+), but got: %s", yamlKindName(node.Kind))
+	}
+}
+
+// yamlKindName renders a yaml.Kind as its constant name for error messages.
+// yaml.Kind is a bare integer constant with no String method, so formatting it
+// directly yields an unhelpful number.
+func yamlKindName(k yaml.Kind) string {
+	switch k {
+	case yaml.DocumentNode:
+		return "DocumentNode"
+	case yaml.SequenceNode:
+		return "SequenceNode"
+	case yaml.MappingNode:
+		return "MappingNode"
+	case yaml.ScalarNode:
+		return "ScalarNode"
+	case yaml.AliasNode:
+		return "AliasNode"
+	default:
+		return fmt.Sprintf("unknown yaml.Kind(%d)", k)
+	}
+}
+
+// MarshalYAML implements custom YAML marshaling for Discriminator.
+//
+// When StringForm is set the OAS 2.0 bare-string form is emitted, so a 2.0
+// document is not silently rewritten into the OAS 3.x object form. Mapping and
+// Extra have no representation in that form and are dropped.
+func (d *Discriminator) MarshalYAML() (any, error) {
+	if d.StringForm {
+		return d.PropertyName, nil
+	}
+	type Alias Discriminator
+	return (*Alias)(d), nil
+}

--- a/parser/zz_generated_decode.go
+++ b/parser/zz_generated_decode.go
@@ -862,10 +862,7 @@ func (x *Schema) decodeFromMap(m map[string]any) {
 		x.Not.decodeFromMap(sub)
 	}
 	x.Nullable, _ = m["nullable"].(bool)
-	if sub, ok := m["discriminator"].(map[string]any); ok {
-		x.Discriminator = new(Discriminator)
-		x.Discriminator.decodeFromMap(sub)
-	}
+	x.Discriminator = decodeDiscriminator(m["discriminator"])
 	x.ReadOnly, _ = m["readOnly"].(bool)
 	x.WriteOnly, _ = m["writeOnly"].(bool)
 	if sub, ok := m["xml"].(map[string]any); ok {

--- a/testdata/discriminator-2.0.json
+++ b/testdata/discriminator-2.0.json
@@ -1,0 +1,68 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Discriminator (OAS 2.0 string form)",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/pets": {
+      "get": {
+        "summary": "Get a pet",
+        "responses": {
+          "200": {
+            "description": "a pet",
+            "schema": { "$ref": "#/definitions/Pet" }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Pet": {
+      "type": "object",
+      "discriminator": "petType",
+      "properties": {
+        "name": { "type": "string" },
+        "petType": { "type": "string" }
+      },
+      "required": ["name", "petType"]
+    },
+    "Cat": {
+      "description": "A representation of a cat",
+      "allOf": [
+        { "$ref": "#/definitions/Pet" },
+        {
+          "type": "object",
+          "properties": {
+            "huntingSkill": {
+              "type": "string",
+              "description": "The measured skill for hunting",
+              "default": "lazy",
+              "enum": ["clueless", "lazy", "adventurous", "aggressive"]
+            }
+          },
+          "required": ["huntingSkill"]
+        }
+      ]
+    },
+    "Dog": {
+      "description": "A representation of a dog",
+      "allOf": [
+        { "$ref": "#/definitions/Pet" },
+        {
+          "type": "object",
+          "properties": {
+            "packSize": {
+              "type": "integer",
+              "format": "int32",
+              "description": "the size of the pack the dog is from",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          "required": ["packSize"]
+        }
+      ]
+    }
+  }
+}

--- a/testdata/discriminator-2.0.yaml
+++ b/testdata/discriminator-2.0.yaml
@@ -1,0 +1,60 @@
+# OAS 2.0 polymorphism: the Schema Object's discriminator is a bare string
+# naming the property, not the object form introduced in OAS 3.0.
+# Adapted from the "Models with Polymorphism Support" example in the OAS 2.0
+# specification.
+swagger: "2.0"
+info:
+  title: Discriminator (OAS 2.0 string form)
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      summary: Get a pet
+      responses:
+        "200":
+          description: a pet
+          schema:
+            $ref: '#/definitions/Pet'
+definitions:
+  Pet:
+    type: object
+    discriminator: petType
+    properties:
+      name:
+        type: string
+      petType:
+        type: string
+    required:
+      - name
+      - petType
+  Cat:
+    description: A representation of a cat
+    allOf:
+      - $ref: '#/definitions/Pet'
+      - type: object
+        properties:
+          huntingSkill:
+            type: string
+            description: The measured skill for hunting
+            default: lazy
+            enum:
+              - clueless
+              - lazy
+              - adventurous
+              - aggressive
+        required:
+          - huntingSkill
+  Dog:
+    description: A representation of a dog
+    allOf:
+      - $ref: '#/definitions/Pet'
+      - type: object
+        properties:
+          packSize:
+            type: integer
+            format: int32
+            description: the size of the pack the dog is from
+            default: 0
+            minimum: 0
+        required:
+          - packSize

--- a/testdata/discriminator-object-form-2.0.yaml
+++ b/testdata/discriminator-object-form-2.0.yaml
@@ -1,0 +1,30 @@
+# Intentionally invalid: the OAS 3.0 discriminator object form used inside a
+# Swagger 2.0 document. The parser accepts both spellings (it decodes a Schema
+# Object before it knows the document version); the validator is what must
+# reject this one.
+swagger: "2.0"
+info:
+  title: Discriminator (OAS 3.0 object form in a 2.0 document)
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      summary: Get a pet
+      responses:
+        "200":
+          description: a pet
+          schema:
+            $ref: '#/definitions/Pet'
+definitions:
+  Pet:
+    type: object
+    discriminator:
+      propertyName: petType
+    properties:
+      name:
+        type: string
+      petType:
+        type: string
+    required:
+      - name
+      - petType

--- a/validator/schema.go
+++ b/validator/schema.go
@@ -60,6 +60,9 @@ func (v *Validator) validateSchemaWithVisited(schema *parser.Schema, path string
 	// Validate type-specific constraints
 	v.validateSchemaTypeConstraints(schema, path, result)
 
+	// Validate the discriminator meets the varying requirements of each OAS version
+	v.validateDiscriminatorForm(schema, path, result)
+
 	// Validate required fields
 	v.validateRequiredFields(schema, path, result)
 
@@ -192,6 +195,45 @@ func (v *Validator) validateSchemaTypeConstraints(schema *parser.Schema, path st
 // where "null" is not a valid schema type.
 func isOAS30x(version parser.OASVersion) bool {
 	return version >= parser.OASVersion300 && version <= parser.OASVersion304
+}
+
+// validateDiscriminatorForm checks that a schema's discriminator uses the
+// form its OAS version requires: a bare string in OAS 2.0, an object with
+// propertyName in OAS 3.0+.
+//
+// The parser accepts both forms regardless of version, because a Schema Object
+// is decoded before the document version is known to it. That makes this check
+// the only thing standing between a document and a silently accepted
+// cross-dialect discriminator.
+func (v *Validator) validateDiscriminatorForm(schema *parser.Schema, path string, result *ValidationResult) {
+	if schema.Discriminator == nil {
+		return
+	}
+
+	// An unrecognized version says nothing about which form is correct, so
+	// there is nothing to enforce. ValidateParsed always sets this; a
+	// hand-assembled ParseResult may not.
+	if !v.oasVersion.IsValid() {
+		return
+	}
+
+	switch {
+	case v.oasVersion == parser.OASVersion20 && !schema.Discriminator.StringForm:
+		v.addError(result, path,
+			"discriminator must be a string naming the property in OpenAPI 2.0; the object form with 'propertyName' was introduced in OpenAPI 3.0",
+			withSpecRef("https://spec.openapis.org/oas/v2.0.html#schema-object"),
+			withField("discriminator"),
+			withValue(schema.Discriminator.PropertyName),
+		)
+
+	case v.oasVersion != parser.OASVersion20 && schema.Discriminator.StringForm:
+		v.addError(result, path,
+			"discriminator must be an object with 'propertyName' in OpenAPI 3.0+; the bare string form is OpenAPI 2.0 only",
+			withSpecRef("https://spec.openapis.org/oas/v3.0.0.html#discriminator-object"),
+			withField("discriminator"),
+			withValue(schema.Discriminator.PropertyName),
+		)
+	}
 }
 
 // validateRequiredFields validates that required fields exist in properties

--- a/validator/schema_discriminator_test.go
+++ b/validator/schema_discriminator_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/erraggy/oastools/parser"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -92,6 +93,23 @@ components:
 	require.Len(t, msgs, 1)
 	assert.Contains(t, msgs[0], "must be an object with 'propertyName' in OpenAPI 3.0+")
 	assert.False(t, result.Valid)
+}
+
+func TestValidateDiscriminatorFormSkippedForUnknownVersion(t *testing.T) {
+	// ValidateParsed always sets oasVersion, but a hand-assembled ParseResult
+	// may not. An unrecognized version says nothing about which form is
+	// correct, so neither form may be flagged.
+	for _, stringForm := range []bool{true, false} {
+		schema := &parser.Schema{
+			Discriminator: &parser.Discriminator{PropertyName: "petType", StringForm: stringForm},
+		}
+		result := &ValidationResult{}
+
+		// Zero Validator: oasVersion is the invalid zero value.
+		New().validateDiscriminatorForm(schema, "components.schemas.Pet", result)
+
+		assert.Empty(t, result.Errors, "StringForm=%v must not be flagged without a known version", stringForm)
+	}
 }
 
 func TestValidateDiscriminatorFormCheckedOnNestedSchemas(t *testing.T) {

--- a/validator/schema_discriminator_test.go
+++ b/validator/schema_discriminator_test.go
@@ -1,0 +1,127 @@
+package validator
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The parser accepts both discriminator spellings regardless of version — it
+// decodes a Schema Object before it knows the document version — so the
+// validator is the only thing enforcing that OAS 2.0 documents use the bare
+// string and OAS 3.0+ documents use the object. See erraggy/oastools#394.
+
+// discriminatorErrors returns the validation errors mentioning discriminator.
+func discriminatorErrors(t *testing.T, result *ValidationResult) []string {
+	t.Helper()
+
+	var msgs []string
+	for _, e := range result.Errors {
+		if strings.Contains(e.Message, "discriminator") {
+			msgs = append(msgs, e.Message)
+		}
+	}
+	return msgs
+}
+
+// validateInlineSpec validates a spec written inline in the test, since the
+// discriminator-form cases are too small to justify their own fixture files.
+func validateInlineSpec(t *testing.T, spec string) *ValidationResult {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "spec.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(spec), 0o644))
+
+	result, err := New().Validate(path)
+	require.NoError(t, err)
+	return result
+}
+
+func TestValidateDiscriminatorStringFormValidInOAS2(t *testing.T) {
+	v := New()
+	result, err := v.Validate("../testdata/discriminator-2.0.yaml")
+	require.NoError(t, err)
+
+	assert.Empty(t, discriminatorErrors(t, result))
+	assert.True(t, result.Valid)
+}
+
+func TestValidateDiscriminatorObjectFormRejectedInOAS2(t *testing.T) {
+	v := New()
+	result, err := v.Validate("../testdata/discriminator-object-form-2.0.yaml")
+	require.NoError(t, err)
+
+	msgs := discriminatorErrors(t, result)
+	require.Len(t, msgs, 1)
+	assert.Contains(t, msgs[0], "must be a string naming the property in OpenAPI 2.0")
+	assert.False(t, result.Valid)
+}
+
+func TestValidateDiscriminatorObjectFormValidInOAS3(t *testing.T) {
+	v := New()
+	result, err := v.Validate("../testdata/join-discriminator-base-3.0.yaml")
+	require.NoError(t, err)
+
+	assert.Empty(t, discriminatorErrors(t, result))
+}
+
+func TestValidateDiscriminatorStringFormRejectedInOAS3(t *testing.T) {
+	spec := `openapi: 3.0.3
+info:
+  title: String discriminator in a 3.0 document
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Pet:
+      type: object
+      discriminator: petType
+      required:
+        - petType
+      properties:
+        petType:
+          type: string
+`
+	result := validateInlineSpec(t, spec)
+
+	msgs := discriminatorErrors(t, result)
+	require.Len(t, msgs, 1)
+	assert.Contains(t, msgs[0], "must be an object with 'propertyName' in OpenAPI 3.0+")
+	assert.False(t, result.Valid)
+}
+
+func TestValidateDiscriminatorFormCheckedOnNestedSchemas(t *testing.T) {
+	// The check hangs off the recursive schema walk, so it has to fire on
+	// schemas nested well below a definition's root.
+	//
+	// This nests through allOf rather than items because the YAML decode path
+	// leaves items as a raw map, so the validator never descends into it —
+	// see erraggy/oastools#396.
+	spec := `openapi: 3.0.3
+info:
+  title: Nested string discriminator
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Wrapper:
+      type: object
+      properties:
+        pet:
+          allOf:
+            - type: object
+              discriminator: petType
+              properties:
+                petType:
+                  type: string
+`
+	result := validateInlineSpec(t, spec)
+
+	msgs := discriminatorErrors(t, result)
+	require.Len(t, msgs, 1)
+	assert.Contains(t, msgs[0], "must be an object with 'propertyName' in OpenAPI 3.0+")
+}


### PR DESCRIPTION
## Summary

- OAS 2.0 spells a Schema Object's `discriminator` as a bare string; OAS 3.0+ spells it as an object. `parser.Schema` modeled only the 3.x shape, so the two versions were handled exactly backwards for 2.0 input — conformant documents were rejected outright, and the illegal object form was silently accepted.
- The fix spans four packages, because parsing the string form is only useful if serialization, validation, and conversion all agree on which dialect a document is written in.
- Adds `Discriminator.StringForm`, the first regression fixtures for a 2.0 `discriminator` in either form, and dialect enforcement in the validator.

## Changes

### Parser

All three decode paths mishandled the string form, not only the one in the report:

| Path | Before |
|---|---|
| `encoding/json` | errored, naming the internal `parser.Alias` type |
| YAML struct decode | errored differently — `cannot construct !!str` |
| generated `decodeFromMap` (`ResolveRefs`) | **silently dropped the field** — `m["discriminator"].(map[string]any)` merely failed its assertion |

- `Discriminator` gains `StringForm bool` (`json:"-" yaml:"-"`) recording which dialect spelled it.
- New `parser/schema_yaml.go` adds `UnmarshalYAML`/`MarshalYAML`, which the type previously lacked entirely. It follows anchors so `discriminator: *anchor` is classified by the node it points at, and reports an unexpected node kind by its constant name rather than yaml's default message about the unexported alias type.
- `decodeDiscriminator` handles both spellings on the `decodeFromMap` path.

### Validator

Parsing is now deliberately permissive, so `validateDiscriminatorForm` is the only thing enforcing the dialect. It rejects the object form in 2.0 documents — the silent false-accept half of the issue — and the bare string in 3.x, reusing the existing `v.oasVersion` context already used for the OAS 3.0 `type: "null"` check. Unrecognized versions are skipped, since they say nothing about which form is correct.

### Converter

`convert -target 3.0` was emitting the string form *into a 3.0 document*, faithfully preserving a spelling illegal at the target. Both directions now re-spell the discriminator, and a dropped 3.x `mapping` is reported rather than silently lost. `walkSchemas` is extracted from `walkSchemaRefs` so this reuses the existing traversal instead of adding a third copy of it.

### Codegen

`parser/zz_generated_decode.go` is regenerated, not hand-edited. The generator gains a `stringOrObjectFields` escape hatch mirroring the existing `polymorphicFields` one, plus a `Discriminator` entry in the type-check overlay stub. `go run ./internal/codegen/decode -check` passes.

## Context

**Why a struct field rather than just a permissive unmarshaler.** The issue proposed accepting both forms on decode and left the marshaling decision open. That decision turns out to be load-bearing: the CLI writes `fix`/`join` output by marshaling the **typed** document (`cmd/oastools/commands/common.go:182`), not from the preserved source node. A permissive unmarshaler alone would have parsed `discriminator: petType` and written back `{"propertyName": "petType"}` — trading a false rejection for silent corruption of a valid 2.0 spec. `StringForm` is additive and exported, so `DeepCopy` (which does `*out = *in`) needed no regeneration.

**Why `StringForm` is excluded from equality.** `equalDiscriminator` deliberately ignores it. The flag records which dialect spelled the discriminator, not what it means — both forms select the same property, so comparing it would make every cross-version diff report a phantom change. `internal/schemautil/hash.go` already hashes only `PropertyName` and `Mapping`, so the two stay consistent.

**Scope note.** The issue suggested a separate `OAS2Schema` type as the alternative. That models the dialects more honestly but is a large, API-breaking change; this keeps the exported shape of `Discriminator` intact and needs no migration for library consumers.

## Testing

- Fixtures use the canonical "Models with Polymorphism Support" example from the OAS 2.0 specification, in both JSON and YAML, plus a companion asserting the object form is rejected in a 2.0 document — the `testdata/` gap the issue identified.
- Coverage spans all three decode paths, both round trips, YAML anchors and invalid node kinds, deep copy, equality, and both conversion directions.
- Corpus error counts are unchanged (DigitalOcean 128, Asana 9, Plaid 93, GitHub 115), confirming the new validator error does not fire on real-world specs.
- Every new function reports 100% statement coverage; `validateDiscriminatorForm` 100%, `walkSchemas` 100%, `decodeDiscriminator` 100%, `yamlKindName` 100%.

- [x] All tests pass (`make check`) — 8901 tests
- [x] Coverage reviewed (`go tool cover`) — parser 80.6%, validator 91.3%, converter 88.2%
- [x] Security scan clean (`govulncheck ./...` — no vulnerabilities found)
- [x] Local code review passed

## Reviewer notes

Two things found while working on this were filed separately rather than folded in:

- **#396** — on the YAML path `Schema.Items` decodes as `map[string]any` instead of `*Schema` (the JSON path promotes it via `promoteSchemaOrBool`). The validator therefore descends into nothing under `items:` for YAML specs. Pre-existing, much broader, and likely to move corpus expectations. The one test that works around it carries a comment pointing at the issue.
- **#397** — `Discriminator.defaultMapping` and 15 other OAS 3.2.0 fields are unmodeled, and unmodeled fields are silently dropped from JSON documents on round trip. Relevant here because `XML.nodeType` in that issue is the same shape of problem this PR solves — a field that supersedes an existing representation rather than sitting beside it. `StringForm` is a reasonable precedent for carrying "which spelling did this document use" without breaking the public type.

## Related Issues

Fixes #394
Related to #396
Related to #397
