### PR TITLE
fix(parser): promote Schema.Items and siblings on the YAML decode path

### DIFF
--- a/converter/ref_rewrite_nested_test.go
+++ b/converter/ref_rewrite_nested_test.go
@@ -1,0 +1,59 @@
+package converter
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/erraggy/oastools/parser"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Converting between dialects has to rewrite every $ref, and rewriteSchemaRefs
+// reaches into items and additionalProperties by type-asserting the any-typed
+// field to *parser.Schema. A YAML document whose nested schemas were left as
+// map[string]any therefore converted into a document with dangling refs — the
+// output still pointed at #/components/schemas after a downconvert to 2.0.
+// See erraggy/oastools#396.
+
+const nestedRefSpecYAML = `openapi: "3.0.3"
+info:
+  title: Test
+  version: "1.0.0"
+paths: {}
+components:
+  schemas:
+    Pet:
+      type: object
+    PetList:
+      type: array
+      items:
+        $ref: '#/components/schemas/Pet'
+    PetMap:
+      type: object
+      additionalProperties:
+        $ref: '#/components/schemas/Pet'
+`
+
+func TestConvertRewritesRefsNestedInYAMLSchemas(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "spec.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(nestedRefSpecYAML), 0o644))
+
+	result, err := New().Convert(path, "2.0")
+	require.NoError(t, err)
+	require.True(t, result.Success)
+
+	doc, ok := result.Document.(*parser.OAS2Document)
+	require.True(t, ok)
+
+	items, ok := doc.Definitions["PetList"].Items.(*parser.Schema)
+	require.True(t, ok, "expected items to be *parser.Schema, got %T", doc.Definitions["PetList"].Items)
+	assert.Equal(t, "#/definitions/Pet", items.Ref,
+		"a ref inside items must be rewritten for the target dialect")
+
+	addProps, ok := doc.Definitions["PetMap"].AdditionalProperties.(*parser.Schema)
+	require.True(t, ok, "expected additionalProperties to be *parser.Schema, got %T", doc.Definitions["PetMap"].AdditionalProperties)
+	assert.Equal(t, "#/definitions/Pet", addProps.Ref,
+		"a ref inside additionalProperties must be rewritten for the target dialect")
+}

--- a/parser/schema_2020_12_test.go
+++ b/parser/schema_2020_12_test.go
@@ -132,7 +132,7 @@ components:
 
 			if tt.expected == "schema" {
 				nested, ok := schema.UnevaluatedProperties.(*Schema)
-				assert.True(t, ok, "expected unevaluatedProperties to be a *Schema, got %T", schema.UnevaluatedProperties)
+				require.True(t, ok, "expected unevaluatedProperties to be a *Schema, got %T", schema.UnevaluatedProperties)
 				assert.Equal(t, "string", nested.Type)
 			} else {
 				assert.Equal(t, tt.expected, schema.UnevaluatedProperties)
@@ -208,7 +208,7 @@ components:
 
 			if tt.expected == "schema" {
 				nested, ok := schema.UnevaluatedItems.(*Schema)
-				assert.True(t, ok, "expected unevaluatedItems to be a *Schema, got %T", schema.UnevaluatedItems)
+				require.True(t, ok, "expected unevaluatedItems to be a *Schema, got %T", schema.UnevaluatedItems)
 				assert.Equal(t, "integer", nested.Type)
 			} else {
 				assert.Equal(t, tt.expected, schema.UnevaluatedItems)

--- a/parser/schema_2020_12_test.go
+++ b/parser/schema_2020_12_test.go
@@ -131,10 +131,9 @@ components:
 			require.NotNil(t, schema)
 
 			if tt.expected == "schema" {
-				// Should be a map representing a schema
-				schemaMap, ok := schema.UnevaluatedProperties.(map[string]any)
-				assert.True(t, ok, "expected unevaluatedProperties to be a schema map")
-				assert.Equal(t, "string", schemaMap["type"])
+				nested, ok := schema.UnevaluatedProperties.(*Schema)
+				assert.True(t, ok, "expected unevaluatedProperties to be a *Schema, got %T", schema.UnevaluatedProperties)
+				assert.Equal(t, "string", nested.Type)
 			} else {
 				assert.Equal(t, tt.expected, schema.UnevaluatedProperties)
 			}
@@ -208,9 +207,9 @@ components:
 			require.NotNil(t, schema)
 
 			if tt.expected == "schema" {
-				schemaMap, ok := schema.UnevaluatedItems.(map[string]any)
-				assert.True(t, ok, "expected unevaluatedItems to be a schema map")
-				assert.Equal(t, "integer", schemaMap["type"])
+				nested, ok := schema.UnevaluatedItems.(*Schema)
+				assert.True(t, ok, "expected unevaluatedItems to be a *Schema, got %T", schema.UnevaluatedItems)
+				assert.Equal(t, "integer", nested.Type)
 			} else {
 				assert.Equal(t, tt.expected, schema.UnevaluatedItems)
 			}

--- a/parser/schema_yaml.go
+++ b/parser/schema_yaml.go
@@ -6,6 +6,133 @@ import (
 	"go.yaml.in/yaml/v4"
 )
 
+// UnmarshalYAML implements custom YAML unmarshaling for Schema.
+//
+// The alias type sheds this method so default struct decoding (including the
+// inline Extra map) applies, then the any-typed schema-or-bool fields are
+// promoted to *Schema. Without the promotion the decoder leaves a nested
+// mapping as map[string]any, and every consumer that type-asserts to *Schema
+// silently skips the subtree: validation, $ref rewriting, and fixes inside
+// `items:` would all no-op.
+//
+// Schema.UnmarshalJSON does the same job for JSON, and decodeFromMap for the
+// ResolveRefs path. All three must agree on the decoded types.
+func (s *Schema) UnmarshalYAML(node *yaml.Node) error {
+	type Alias Schema
+	var alias Alias
+	if err := node.Decode(&alias); err != nil {
+		return err
+	}
+	*s = Schema(alias)
+
+	// Promotion reads the mapping's keys, so the wrappers have to come off
+	// first. A nil result only means there is nothing to look inside.
+	node = unwrapSchemaNode(node)
+
+	var err error
+	if s.Items, err = promoteYAMLSchemaOrBool(s.Items, node, "items"); err != nil {
+		return err
+	}
+	if s.AdditionalProperties, err = promoteYAMLSchemaOrBool(s.AdditionalProperties, node, "additionalProperties"); err != nil {
+		return err
+	}
+	if s.AdditionalItems, err = promoteYAMLSchemaOrBool(s.AdditionalItems, node, "additionalItems"); err != nil {
+		return err
+	}
+	if s.UnevaluatedItems, err = promoteYAMLSchemaOrBool(s.UnevaluatedItems, node, "unevaluatedItems"); err != nil {
+		return err
+	}
+	if s.UnevaluatedProperties, err = promoteYAMLSchemaOrBool(s.UnevaluatedProperties, node, "unevaluatedProperties"); err != nil {
+		return err
+	}
+	return nil
+}
+
+// promoteYAMLSchemaOrBool converts the generic value the YAML decoder leaves in
+// an any-typed schema-or-bool field into a *Schema, or a []*Schema for the OAS
+// 2.0 tuple form. Bools and absent values pass through untouched.
+//
+// parent is the mapping the field was decoded from and key its spec name, so the
+// field's own node can be decoded rather than the generic map. That routes the
+// nested schema back through this method, giving it the same decoding — and the
+// same errors — as a top-level one, and keeps the inline Extra map that the
+// map-based decoder narrows to x-* keys.
+func promoteYAMLSchemaOrBool(v any, parent *yaml.Node, key string) (any, error) {
+	switch v.(type) {
+	case map[string]any, []any:
+		// Generic representation left behind by the decoder — needs promoting.
+	default:
+		// bool, nil, or already a *Schema: nothing to do. Checked before
+		// scanning parent so the common absent-field case stays free.
+		return v, nil
+	}
+
+	node := unwrapSchemaNode(childValueNode(parent, key))
+
+	switch {
+	case node == nil:
+		// The value arrived through a merge key (`<<`): the decoder resolved the
+		// merge, but the merged pairs live in the anchored node, so there is
+		// nothing under parent to decode. Promoting the map the decoder produced
+		// costs only the non-x- unknown keys of Extra.
+		return decodeSchemaOrBool(v), nil
+
+	case node.Kind == yaml.MappingNode:
+		schema := new(Schema)
+		if err := node.Decode(schema); err != nil {
+			return nil, err
+		}
+		return schema, nil
+
+	case node.Kind == yaml.SequenceNode:
+		// OAS 2.0 tuple validation: items may be a sequence of schemas.
+		var schemas []*Schema
+		if err := node.Decode(&schemas); err != nil {
+			return nil, err
+		}
+		return schemas, nil
+
+	default:
+		return v, nil
+	}
+}
+
+// childValueNode returns the value node stored under key in a mapping node, or
+// nil when the mapping has no such key.
+func childValueNode(node *yaml.Node, key string) *yaml.Node {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value == key {
+			return node.Content[i+1]
+		}
+	}
+	return nil
+}
+
+// unwrapSchemaNode strips the wrappers that stand between a node and the
+// mapping it represents: a DocumentNode when the Schema is the root of the
+// decoded document — yaml.Unmarshal hands an Unmarshaler the document node
+// rather than its content — and an AliasNode when the schema was written as
+// `*anchor`. Returns nil when no node is left to unwrap.
+func unwrapSchemaNode(node *yaml.Node) *yaml.Node {
+	for node != nil {
+		switch node.Kind {
+		case yaml.DocumentNode:
+			if len(node.Content) != 1 {
+				return node
+			}
+			node = node.Content[0]
+		case yaml.AliasNode:
+			node = node.Alias
+		default:
+			return node
+		}
+	}
+	return nil
+}
+
 // UnmarshalYAML implements custom YAML unmarshaling for Discriminator.
 //
 // Both dialects are accepted: the OAS 2.0 string-only form (`discriminator:

--- a/parser/schema_yaml_test.go
+++ b/parser/schema_yaml_test.go
@@ -202,6 +202,8 @@ func TestSchemaUnmarshalYAMLPromotesThroughMergeKey(t *testing.T) {
 base: &base
   items:
     type: object
+    x-inner: inner
+    unknown-inner: 2
 schema:
   <<: *base
   type: array
@@ -214,6 +216,15 @@ schema:
 	items, ok := doc.Schema.Items.(*Schema)
 	require.True(t, ok, "expected *Schema, got %T", doc.Schema.Items)
 	assert.Equal(t, "object", items.Type)
+
+	// Known limitation of the fallback, pinned rather than fixed. The map-based
+	// decoder collects only x-* keys, so an unrecognized key inside a merged
+	// subtree is dropped where the node-based path would have kept it. Matching
+	// the node path would mean carrying a YAML-only quirk further: the JSON
+	// path's ExtractExtensions is x-* only too, so what the fallback produces
+	// here is what an equivalent JSON document produces everywhere.
+	assert.Equal(t, "inner", items.Extra["x-inner"])
+	assert.NotContains(t, items.Extra, "unknown-inner")
 }
 
 func TestSchemaUnmarshalYAMLKeepsExtensions(t *testing.T) {

--- a/parser/schema_yaml_test.go
+++ b/parser/schema_yaml_test.go
@@ -1,0 +1,282 @@
+package parser
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v4"
+)
+
+// Items, AdditionalProperties, AdditionalItems, UnevaluatedItems and
+// UnevaluatedProperties are typed any because JSON Schema lets each hold either
+// a schema or a bool. Every decode path therefore has to promote the mapping
+// form to *Schema itself, or consumers that type-assert to *Schema skip the
+// subtree without reporting anything. The parser has three independent decode
+// paths — encoding/json, YAML, and the generated decodeFromMap used when
+// ResolveRefs is enabled — and they must agree on the decoded types.
+
+// schemaOrBoolFields lists the any-typed schema-or-bool fields alongside a
+// minimal document in each of the two forms, so a test can cover all five
+// uniformly.
+var schemaOrBoolFields = []struct {
+	name       string
+	get        func(*Schema) any
+	schemaForm string
+	boolForm   string
+}{
+	{
+		name: "items",
+		get:  func(s *Schema) any { return s.Items },
+		schemaForm: `
+items:
+  type: object
+`,
+		boolForm: `
+items: false
+`,
+	},
+	{
+		name: "additionalProperties",
+		get:  func(s *Schema) any { return s.AdditionalProperties },
+		schemaForm: `
+additionalProperties:
+  type: object
+`,
+		boolForm: `
+additionalProperties: false
+`,
+	},
+	{
+		name: "additionalItems",
+		get:  func(s *Schema) any { return s.AdditionalItems },
+		schemaForm: `
+additionalItems:
+  type: object
+`,
+		boolForm: `
+additionalItems: false
+`,
+	},
+	{
+		name: "unevaluatedItems",
+		get:  func(s *Schema) any { return s.UnevaluatedItems },
+		schemaForm: `
+unevaluatedItems:
+  type: object
+`,
+		boolForm: `
+unevaluatedItems: false
+`,
+	},
+	{
+		name: "unevaluatedProperties",
+		get:  func(s *Schema) any { return s.UnevaluatedProperties },
+		schemaForm: `
+unevaluatedProperties:
+  type: object
+`,
+		boolForm: `
+unevaluatedProperties: false
+`,
+	},
+}
+
+func TestSchemaUnmarshalYAMLPromotesSchemaOrBoolFields(t *testing.T) {
+	for _, field := range schemaOrBoolFields {
+		t.Run(field.name, func(t *testing.T) {
+			var s Schema
+			require.NoError(t, yaml.Unmarshal([]byte(field.schemaForm), &s))
+
+			nested, ok := field.get(&s).(*Schema)
+			require.True(t, ok, "expected *Schema, got %T", field.get(&s))
+			assert.Equal(t, "object", nested.Type)
+		})
+	}
+}
+
+func TestSchemaUnmarshalYAMLKeepsBoolForm(t *testing.T) {
+	for _, field := range schemaOrBoolFields {
+		t.Run(field.name, func(t *testing.T) {
+			var s Schema
+			require.NoError(t, yaml.Unmarshal([]byte(field.boolForm), &s))
+
+			assert.Equal(t, false, field.get(&s), "bool form must survive promotion untouched")
+		})
+	}
+}
+
+func TestSchemaDecodePathsAgreeOnSchemaOrBoolTypes(t *testing.T) {
+	const yamlSrc = `
+type: array
+items:
+  type: object
+  additionalProperties:
+    type: string
+additionalProperties:
+  type: string
+additionalItems:
+  type: integer
+unevaluatedItems:
+  type: number
+unevaluatedProperties:
+  type: boolean
+`
+	const jsonSrc = `{
+  "type": "array",
+  "items": {"type": "object", "additionalProperties": {"type": "string"}},
+  "additionalProperties": {"type": "string"},
+  "additionalItems": {"type": "integer"},
+  "unevaluatedItems": {"type": "number"},
+  "unevaluatedProperties": {"type": "boolean"}
+}`
+
+	var fromYAML, fromJSON, fromMap Schema
+	require.NoError(t, yaml.Unmarshal([]byte(yamlSrc), &fromYAML))
+	require.NoError(t, json.Unmarshal([]byte(jsonSrc), &fromJSON))
+
+	var raw map[string]any
+	require.NoError(t, yaml.Unmarshal([]byte(yamlSrc), &raw))
+	fromMap.decodeFromMap(raw)
+
+	for _, field := range schemaOrBoolFields {
+		t.Run(field.name, func(t *testing.T) {
+			assert.IsType(t, field.get(&fromJSON), field.get(&fromYAML),
+				"YAML and JSON paths must decode %s to the same type", field.name)
+			assert.IsType(t, field.get(&fromMap), field.get(&fromYAML),
+				"YAML and decodeFromMap paths must decode %s to the same type", field.name)
+		})
+	}
+
+	// Nesting has to promote too: a consumer walking into items and then into
+	// that schema's additionalProperties must find a *Schema at both hops.
+	items, ok := fromYAML.Items.(*Schema)
+	require.True(t, ok, "expected items to be *Schema, got %T", fromYAML.Items)
+	nested, ok := items.AdditionalProperties.(*Schema)
+	require.True(t, ok, "expected items.additionalProperties to be *Schema, got %T", items.AdditionalProperties)
+	assert.Equal(t, "string", nested.Type)
+}
+
+func TestSchemaUnmarshalYAMLItemsTupleForm(t *testing.T) {
+	// OAS 2.0 tuple validation: items may be a sequence of schemas.
+	const src = `
+type: array
+items:
+  - type: string
+  - type: integer
+`
+	var s Schema
+	require.NoError(t, yaml.Unmarshal([]byte(src), &s))
+
+	schemas, ok := s.Items.([]*Schema)
+	require.True(t, ok, "expected []*Schema, got %T", s.Items)
+	require.Len(t, schemas, 2)
+	assert.Equal(t, "string", schemas[0].Type)
+	assert.Equal(t, "integer", schemas[1].Type)
+}
+
+func TestSchemaUnmarshalYAMLPromotesThroughAnchor(t *testing.T) {
+	const src = `
+shared: &shared
+  type: object
+schema:
+  type: array
+  items: *shared
+`
+	var doc struct {
+		Schema Schema `yaml:"schema"`
+	}
+	require.NoError(t, yaml.Unmarshal([]byte(src), &doc))
+
+	items, ok := doc.Schema.Items.(*Schema)
+	require.True(t, ok, "expected *Schema, got %T", doc.Schema.Items)
+	assert.Equal(t, "object", items.Type)
+}
+
+func TestSchemaUnmarshalYAMLPromotesThroughMergeKey(t *testing.T) {
+	// A merged key is resolved by the decoder but never appears under the
+	// merging node, so promotion falls back to the decoded map. The field must
+	// still end up a *Schema.
+	const src = `
+base: &base
+  items:
+    type: object
+schema:
+  <<: *base
+  type: array
+`
+	var doc struct {
+		Schema Schema `yaml:"schema"`
+	}
+	require.NoError(t, yaml.Unmarshal([]byte(src), &doc))
+
+	items, ok := doc.Schema.Items.(*Schema)
+	require.True(t, ok, "expected *Schema, got %T", doc.Schema.Items)
+	assert.Equal(t, "object", items.Type)
+}
+
+func TestSchemaUnmarshalYAMLKeepsExtensions(t *testing.T) {
+	const src = `
+type: array
+x-outer: outer
+unknown-outer: 1
+items:
+  type: object
+  x-inner: inner
+  unknown-inner: 2
+`
+	var s Schema
+	require.NoError(t, yaml.Unmarshal([]byte(src), &s))
+
+	assert.Equal(t, "outer", s.Extra["x-outer"], "the inline Extra map must survive the alias decode")
+
+	items, ok := s.Items.(*Schema)
+	require.True(t, ok, "expected *Schema, got %T", s.Items)
+	assert.Equal(t, "inner", items.Extra["x-inner"], "a promoted schema must capture its own extensions")
+
+	// The inline Extra map keeps every unrecognized key, not just x-*. Promoting
+	// through the field's node preserves that; promoting the decoded map would
+	// narrow it to x-* and lose these on a round trip.
+	assert.Equal(t, 1, s.Extra["unknown-outer"])
+	assert.Equal(t, 2, items.Extra["unknown-inner"], "a promoted schema must decode like a top-level one")
+}
+
+func TestSchemaUnmarshalYAMLReportsNestedDecodeErrors(t *testing.T) {
+	// Promoting through the field's own node means a nested schema gets the
+	// same decoding — and the same errors — as a top-level one. A sequence is
+	// neither discriminator form, so Discriminator.UnmarshalYAML rejects it.
+	const src = `
+type: array
+items:
+  discriminator:
+    - petType
+`
+	var s Schema
+	err := yaml.Unmarshal([]byte(src), &s)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "discriminator")
+}
+
+func TestSchemaUnmarshalYAMLRoundTrip(t *testing.T) {
+	const src = `
+type: array
+items:
+  type: object
+  additionalProperties: false
+`
+	var s Schema
+	require.NoError(t, yaml.Unmarshal([]byte(src), &s))
+
+	out, err := yaml.Marshal(&s)
+	require.NoError(t, err)
+
+	var reparsed Schema
+	require.NoError(t, yaml.Unmarshal(out, &reparsed))
+
+	items, ok := reparsed.Items.(*Schema)
+	require.True(t, ok, "expected *Schema, got %T", reparsed.Items)
+	assert.Equal(t, "object", items.Type)
+	assert.Equal(t, false, items.AdditionalProperties)
+}

--- a/validator/schema_nested_yaml_test.go
+++ b/validator/schema_nested_yaml_test.go
@@ -1,0 +1,151 @@
+package validator
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/erraggy/oastools/parser"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// validateNestedSchemas reaches into items, additionalProperties and friends by
+// type-asserting the any-typed field to *parser.Schema. Those fields only hold
+// a *parser.Schema once the decode path promotes them, so a YAML document whose
+// nested schemas were left as map[string]any validated clean no matter what was
+// inside them. See erraggy/oastools#396.
+
+// validateSpecFile writes spec to a file with the given extension and validates
+// it. The extension matters: the parser picks its decode path from it, so the
+// same document takes the YAML struct-decode path as .yaml and the JSON
+// fast-path as .json.
+func validateSpecFile(t *testing.T, ext, spec string) *ValidationResult {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "spec"+ext)
+	require.NoError(t, os.WriteFile(path, []byte(spec), 0o644))
+
+	result, err := New().Validate(path)
+	require.NoError(t, err)
+	return result
+}
+
+// enumTypeErrorPaths returns the paths of the enum-type errors in result. Paths
+// rather than messages, because the messages name the Go type of the offending
+// value and YAML decodes an integer to int where JSON decodes it to float64 —
+// a difference unrelated to which schemas were visited.
+func enumTypeErrorPaths(t *testing.T, result *ValidationResult) []string {
+	t.Helper()
+
+	var paths []string
+	for _, e := range result.Errors {
+		if strings.Contains(e.Message, "Enum value must be a string") {
+			paths = append(paths, e.Path)
+		}
+	}
+	return paths
+}
+
+// wantEnumErrorPaths is one path per schema in the fixtures below: the direct
+// case that always worked, plus the three that are only reachable once the
+// schema-or-bool fields hold a *parser.Schema.
+var wantEnumErrorPaths = []string{
+	"components.schemas.Direct.enum[1]",
+	"components.schemas.UnderItems.items.enum[1]",
+	"components.schemas.UnderAdditionalProperties.additionalProperties.enum[1]",
+	"components.schemas.UnderNestedItems.items.items.enum[1]",
+}
+
+// A string enum holding an integer, buried one level deeper each time. The
+// error is reported for the top-level form on every decode path, so reaching it
+// under items is purely a question of whether the subtree was visited.
+const nestedEnumSpecYAML = `openapi: "3.0.3"
+info:
+  title: Test
+  version: "1.0.0"
+paths: {}
+components:
+  schemas:
+    Direct:
+      type: string
+      enum: [ok, 42]
+    UnderItems:
+      type: array
+      items:
+        type: string
+        enum: [ok, 42]
+    UnderAdditionalProperties:
+      type: object
+      additionalProperties:
+        type: string
+        enum: [ok, 42]
+    UnderNestedItems:
+      type: array
+      items:
+        type: array
+        items:
+          type: string
+          enum: [ok, 42]
+`
+
+const nestedEnumSpecJSON = `{
+  "openapi": "3.0.3",
+  "info": {"title": "Test", "version": "1.0.0"},
+  "paths": {},
+  "components": {
+    "schemas": {
+      "Direct": {"type": "string", "enum": ["ok", 42]},
+      "UnderItems": {
+        "type": "array",
+        "items": {"type": "string", "enum": ["ok", 42]}
+      },
+      "UnderAdditionalProperties": {
+        "type": "object",
+        "additionalProperties": {"type": "string", "enum": ["ok", 42]}
+      },
+      "UnderNestedItems": {
+        "type": "array",
+        "items": {
+          "type": "array",
+          "items": {"type": "string", "enum": ["ok", 42]}
+        }
+      }
+    }
+  }
+}`
+
+func TestValidateReportsEnumErrorsNestedInYAMLSpec(t *testing.T) {
+	result := validateSpecFile(t, ".yaml", nestedEnumSpecYAML)
+
+	assert.ElementsMatch(t, wantEnumErrorPaths, enumTypeErrorPaths(t, result))
+	assert.False(t, result.Valid)
+}
+
+func TestValidateReportsSameNestedErrorsForYAMLAndJSON(t *testing.T) {
+	// Identical documents must validate identically; before the YAML decode
+	// path promoted its schema-or-bool fields, only the JSON form reported the
+	// three nested errors.
+	fromYAML := enumTypeErrorPaths(t, validateSpecFile(t, ".yaml", nestedEnumSpecYAML))
+	fromJSON := enumTypeErrorPaths(t, validateSpecFile(t, ".json", nestedEnumSpecJSON))
+
+	assert.ElementsMatch(t, fromJSON, fromYAML)
+}
+
+func TestValidateReportsNestedErrorsForYAMLPathsUnderResolveRefs(t *testing.T) {
+	// The ResolveRefs path decodes through decodeFromMap rather than the YAML
+	// struct decoder, so it is a third implementation that has to agree.
+	path := filepath.Join(t.TempDir(), "spec.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(nestedEnumSpecYAML), 0o644))
+
+	p := parser.New()
+	p.ResolveRefs = true
+	parseResult, err := p.Parse(path)
+	require.NoError(t, err)
+
+	result, err := New().ValidateParsed(*parseResult)
+	require.NoError(t, err)
+
+	assert.ElementsMatch(t, wantEnumErrorPaths, enumTypeErrorPaths(t, result))
+}


### PR DESCRIPTION
## Summary

- 🐛 `Schema.Items` and its four siblings were left as `map[string]any` by the YAML struct decode, so every consumer that type-asserts to `*parser.Schema` silently skipped the subtree
- 🔍 Two user-visible symptoms confirmed and pinned by tests: **validation ran no checks at all inside `items:`**, and **`convert -target 2.0` emitted a broken document** with a dangling `#/components/schemas/...` ref
- ✅ One fix in the parser repairs all 43 assertion sites across validator, converter, fixer, joiner, generator and httpvalidator

## Context

`parser.Schema` has five `any`-typed fields that per JSON Schema hold either a `*Schema` or a bool: `Items`, `AdditionalProperties`, `AdditionalItems`, `UnevaluatedItems`, `UnevaluatedProperties`. There are three decode paths, and only one failed to promote them:

| Path | When | Promoted? |
|---|---|---|
| `parseJSONFastPath` → `UnmarshalJSON` | JSON, no source map | ✅ |
| `decodeDocumentFromMap` → `decodeSchemaOrBool` | `ResolveRefs=true` | ✅ |
| `parseVersionSpecific` → yaml struct decode | everything else | ❌ |

Worth noting beyond the issue's framing: that third path also catches **JSON** input whenever `BuildSourceMap` or `PreserveOrder` is on (`parser.go:443` gates the fast path), so this was never strictly YAML-only.

## Changes

**`parser/schema_yaml.go`** — `Schema.UnmarshalYAML` decodes through an alias type (which sheds the method so default struct decoding, including the inline `Extra` map, still applies), then promotes the five fields the way `UnmarshalJSON` always has.

Two properties of `go.yaml.in/yaml/v4` shaped the implementation, both established by experiment rather than assumption:

1. **Merge keys are invisible in `node.Content`.** `<<: *base` is resolved by the decoder, but the merged pairs live in the anchored node — a pure node-walk misses them. Hence the map-based fallback.
2. **Pure map-based promotion loses data.** The inline `Extra` map keeps *all* unknown keys; `extractExtensionsFromMap` keeps only `x-*`. Promoting from the map would silently drop non-`x-` unknown keys under `items:` on round-trip. Hence node-decode is preferred.

`unwrapSchemaNode` handles the two wrappers that hide the mapping: `yaml.Unmarshal` hands an `Unmarshaler` the **DocumentNode** rather than its content, so a root-level `Schema` sees a different node kind than a nested one, and `items: *anchor` arrives as an `AliasNode`.

**`parser/schema_2020_12_test.go`** — two tests asserted `map[string]any` for `unevaluatedItems`/`unevaluatedProperties`. They encoded the bug; now they assert `*Schema`.

## Testing

- `parser/schema_yaml_test.go` — all five fields; three-way type parity across JSON / YAML / `decodeFromMap` for the same document; bool form, OAS 2.0 tuple form, anchors, merge keys, extension preservation, nested decode-error propagation, round trip
- `validator/schema_nested_yaml_test.go` — a bad enum under `items:` in YAML is now reported. Asserts on error **paths**, not messages, since YAML decodes `42` to `int` and JSON to `float64` (a pre-existing difference, unrelated to this fix)
- `converter/ref_rewrite_nested_test.go` — refs inside `items:` and `additionalProperties:` are rewritten on downconvert

**Every new test was verified to fail without the parser change**, except the two that must not: the bool form was never broken, and the `ResolveRefs` path was already correct.

**Corpus error counts are unchanged** (DigitalOcean 128, Asana 9, Plaid 93, GitHub 115, MSGraph 0), so no `ExpectedErrors` needed revisiting — real-world specs' `items:` subtrees are clean.

- [x] All tests pass (`make check` — exit 0, 0 lint issues, 8933 tests)
- [x] Coverage reviewed
- [x] Security scan clean (`govulncheck` — no vulnerabilities found)

## ⚠️ Performance

Promoting costs roughly **+4.8% allocs/op** and **+8.0% B/op** on the YAML parse path (benchstat, 6 runs). `unsafe.Sizeof(Schema{})` is **824 bytes**, so every nested subtree that used to be a small map now materializes that struct. This is intrinsic to the fix and is what the JSON path has always paid.

I prototyped a variant that withholds the five keys from the alias decode to avoid building the throwaway map — it reclaimed only 0.7pp of allocs and 0.4pp of B/op, so I reverted it in favor of the simpler code. Happy to bring it back if the trade looks different to you.

## Related Issues

Fixes #396