### PR TITLE
fix(fixer): rewrite $refs and emit legal names for generic schemas with "/"

### DIFF
--- a/fixer/generic_names.go
+++ b/fixer/generic_names.go
@@ -200,10 +200,11 @@ func splitTypeParams(s string) []string {
 		return nil
 	}
 
-	var params []string
-	var current strings.Builder
-	depth := 0
-
+	var (
+		params  []string
+		current strings.Builder
+		depth   = 0
+	)
 	for _, r := range s {
 		switch r {
 		case '[', '<':
@@ -263,6 +264,13 @@ func transformSchemaName(name string, config GenericNamingConfig) string {
 		return sanitized
 	}
 
+	// The base is spliced into the result below, so it carries whatever the
+	// original name had in front of the bracket — "Res ponse[User]" and
+	// "pkg/v1.Response[Pet]" both reach here. Only the parameters were being
+	// cleaned, so the base needs the same treatment or the new name is no more
+	// legal than the old one.
+	base = toNameFragment(base)
+
 	// Recursively transform nested generic types in parameters
 	transformedParams := make([]string, len(params))
 	for i, param := range params {
@@ -308,10 +316,11 @@ func transformTypeParam(param string, config GenericNamingConfig) string {
 	// Strip leading pointer asterisks (Go pointer syntax leaking from code generators)
 	param = strings.TrimLeft(param, "*")
 
-	// If it's a package-qualified name (like common.Pet), preserve it as-is
-	// to avoid corrupting the reference
+	// If it's a package-qualified name (like common.Pet), preserve the
+	// qualification to avoid corrupting the reference, cleaning only the
+	// characters that cannot survive into a schema name
 	if isPackageQualifiedName(param) {
-		return param
+		return toNameFragment(param)
 	}
 
 	// For generic types or simple names, apply normal transformation
@@ -323,6 +332,41 @@ func transformTypeParam(param string, config GenericNamingConfig) string {
 	}
 
 	return transformed
+}
+
+// toNameFragment reduces one fragment of a generated schema name — a base name
+// or a package-qualified type parameter — to the characters a schema name may
+// contain.
+//
+// Every fragment spliced into a transformed name needs this. Cleaning only the
+// parameters leaves the base free to carry a bracket-adjacent space, comma, or
+// brace straight through, producing a name as illegal as the one it replaced.
+//
+// Path separators are folded to "." before the general sanitizer runs, so they
+// do not become the "_" it would otherwise produce: a dot is what the fragment
+// already uses to qualify its package, and it keeps every segment, so two types
+// differing only by package still reduce to distinct names.
+func toNameFragment(name string) string {
+	return sanitizeSchemaName(flattenPathQualifier(name))
+}
+
+// flattenPathQualifier rewrites the "/" separators of a path-qualified type
+// name as dots: "example.com/petstore/pkg/store.Pet" becomes
+// "example.com.petstore.pkg.store.Pet".
+//
+// Code-first generators emit these for package-qualified generic parameters, and
+// a "/" cannot stay in the new name: OAS 3.x rejects a component name outright
+// unless it matches ^[a-zA-Z0-9._-]+$, and while OAS 2.0 permits one in a
+// definitions key, every $ref reaching it then needs escaping — exactly the
+// encoding trouble this fix removes.
+//
+// Empty segments are dropped, so a doubled, leading, or trailing slash cannot
+// leave a stray dot behind.
+func flattenPathQualifier(name string) string {
+	if !strings.Contains(name, "/") {
+		return name
+	}
+	return strings.Join(strings.FieldsFunc(name, func(r rune) bool { return r == '/' }), ".")
 }
 
 // sanitizeSchemaName removes or replaces invalid characters with underscores.
@@ -396,8 +440,57 @@ func toPascalCase(s string) string {
 	return result.String()
 }
 
+// splitSchemaRef splits a schema $ref into its prefix and its name token, for
+// either OAS version. ok is false for a ref that names something other than a
+// local schema, an external one included.
+func splitSchemaRef(ref string) (prefix, name string, ok bool) {
+	if n, found := strings.CutPrefix(ref, pathutil.RefPrefixSchemas); found {
+		return pathutil.RefPrefixSchemas, n, true
+	}
+	if n, found := strings.CutPrefix(ref, pathutil.RefPrefixDefinitions); found {
+		return pathutil.RefPrefixDefinitions, n, true
+	}
+	return "", "", false
+}
+
+// canonicalSchemaRefKey reduces a schema $ref to the decoded key
+// [buildRefRenameMap] registers alongside the undecoded one: the prefix
+// verbatim, followed by the name with both escaping conventions reversed.
+//
+// This is the fallback half of the lookup, not the whole of it. Decoding is
+// lossy — see [pathutil.DecodeRefToken] — so a ref is matched against its exact
+// spelling first and only reduced here when that misses. Reducing
+// unconditionally would stop a component genuinely named "Foo%20Bar[Pet]" from
+// matching a $ref that spells it the same way.
+//
+// A ref that names something other than a schema is returned unchanged, and so
+// matches no key.
+func canonicalSchemaRefKey(ref string) string {
+	// Without an escape sequence the ref is already its own decoded form. This
+	// runs for every $ref in the document, so the fast path is worth it.
+	if !strings.ContainsAny(ref, "%~") {
+		return ref
+	}
+	prefix, name, ok := splitSchemaRef(ref)
+	if !ok {
+		return ref
+	}
+	return prefix + pathutil.DecodeRefToken(name)
+}
+
+// lookupRenamedRef resolves ref against the rename map, trying its exact
+// spelling before the decoded fallback.
+func lookupRenamedRef(ref string, renames map[string]string) (string, bool) {
+	if newRef, ok := renames[ref]; ok {
+		return newRef, true
+	}
+	newRef, ok := renames[canonicalSchemaRefKey(ref)]
+	return newRef, ok
+}
+
 // rewriteSchemaRefs recursively rewrites $ref values in a schema using the rename map.
-// The renames map contains old $ref -> new $ref mappings.
+// Look refs up with [lookupRenamedRef] rather than indexing the map directly,
+// or a ref that spells the name in any encoding will miss.
 //
 // Example:
 //
@@ -440,7 +533,7 @@ func rewriteSchemaRefsRecursive(schema *parser.Schema, renames map[string]string
 
 	// Rewrite direct $ref
 	if schema.Ref != "" {
-		if newRef, ok := renames[schema.Ref]; ok {
+		if newRef, ok := lookupRenamedRef(schema.Ref, renames); ok {
 			schema.Ref = newRef
 		}
 	}
@@ -524,16 +617,19 @@ func rewriteSchemaRefsRecursive(schema *parser.Schema, renames map[string]string
 	if schema.Discriminator != nil && schema.Discriminator.Mapping != nil {
 		for key, ref := range schema.Discriminator.Mapping {
 			// Check if it's a full ref path
-			if newRef, ok := renames[ref]; ok {
+			if newRef, ok := lookupRenamedRef(ref, renames); ok {
 				schema.Discriminator.Mapping[key] = newRef
 			} else {
 				// Also check for bare names (discriminator mapping can use just the schema name)
 				// e.g., "Dog" instead of "#/components/schemas/Dog"
+				//
+				// Keys carry the name undecoded, so it compares directly against a
+				// bare mapping value. Values carry it escaped for a pointer, so the
+				// escaping is reversed before it is written back as a bare name.
 				for oldRef, newRef := range renames {
 					oldName := extractSchemaNameFromRefPath(oldRef)
-					newName := extractSchemaNameFromRefPath(newRef)
 					if ref == oldName {
-						schema.Discriminator.Mapping[key] = newName
+						schema.Discriminator.Mapping[key] = pathutil.UnescapeRefToken(extractSchemaNameFromRefPath(newRef))
 						break
 					}
 				}
@@ -545,13 +641,6 @@ func rewriteSchemaRefsRecursive(schema *parser.Schema, renames map[string]string
 // extractSchemaNameFromRefPath extracts the schema name from a $ref path.
 // Returns empty string if not a schema reference.
 func extractSchemaNameFromRefPath(ref string) string {
-	// OAS 3.x style
-	if name, found := strings.CutPrefix(ref, pathutil.RefPrefixSchemas); found {
-		return name
-	}
-	// OAS 2.0 style
-	if name, found := strings.CutPrefix(ref, pathutil.RefPrefixDefinitions); found {
-		return name
-	}
-	return ""
+	_, name, _ := splitSchemaRef(ref)
+	return name
 }

--- a/fixer/generic_names.go
+++ b/fixer/generic_names.go
@@ -616,26 +616,41 @@ func rewriteSchemaRefsRecursive(schema *parser.Schema, renames map[string]string
 	// Discriminator mapping values
 	if schema.Discriminator != nil && schema.Discriminator.Mapping != nil {
 		for key, ref := range schema.Discriminator.Mapping {
-			// Check if it's a full ref path
-			if newRef, ok := lookupRenamedRef(ref, renames); ok {
-				schema.Discriminator.Mapping[key] = newRef
-			} else {
-				// Also check for bare names (discriminator mapping can use just the schema name)
-				// e.g., "Dog" instead of "#/components/schemas/Dog"
-				//
-				// Keys carry the name undecoded, so it compares directly against a
-				// bare mapping value. Values carry it escaped for a pointer, so the
-				// escaping is reversed before it is written back as a bare name.
-				for oldRef, newRef := range renames {
-					oldName := extractSchemaNameFromRefPath(oldRef)
-					if ref == oldName {
-						schema.Discriminator.Mapping[key] = pathutil.UnescapeRefToken(extractSchemaNameFromRefPath(newRef))
-						break
-					}
-				}
+			if newValue, ok := lookupRenamedMappingValue(ref, renames); ok {
+				schema.Discriminator.Mapping[key] = newValue
 			}
 		}
 	}
+}
+
+// lookupRenamedMappingValue resolves one discriminator mapping value against the
+// rename map, in the spelling the document used it: a full $ref stays a $ref, a
+// bare schema name stays a bare name.
+//
+// A mapping may name its target either way — "#/components/schemas/Dog" or just
+// "Dog" — so a bare name is completed into a ref before lookup rather than
+// compared against the map's keys directly. That routes it through the same
+// exact-then-decoded match every other ref gets, so a bare name carrying an
+// encoding resolves too, and an exact spelling still wins over a decoded one.
+// Comparing against extracted key names instead would have to iterate the map,
+// and no iteration order can honor that precedence.
+//
+// Both prefixes are tried because a rename map is built for one OAS version, so
+// the other simply matches nothing.
+func lookupRenamedMappingValue(ref string, renames map[string]string) (string, bool) {
+	if newRef, ok := lookupRenamedRef(ref, renames); ok {
+		return newRef, true
+	}
+
+	for _, prefix := range [2]string{pathutil.RefPrefixSchemas, pathutil.RefPrefixDefinitions} {
+		if newRef, ok := lookupRenamedRef(prefix+ref, renames); ok {
+			// Values are escaped for a pointer, so the escaping is reversed
+			// before the name goes back as a bare value.
+			return pathutil.UnescapeRefToken(extractSchemaNameFromRefPath(newRef)), true
+		}
+	}
+
+	return "", false
 }
 
 // extractSchemaNameFromRefPath extracts the schema name from a $ref path.

--- a/fixer/generic_names_slash_test.go
+++ b/fixer/generic_names_slash_test.go
@@ -1,7 +1,7 @@
 package fixer
 
 import (
-	"maps"
+	"fmt"
 	"slices"
 	"strings"
 	"testing"
@@ -649,10 +649,12 @@ components:
         mapping:
           encoded: '#/components/schemas/Dog%5Bexample.com/pkg.Breed%5D'
           bare: 'Cat[example.com/pkg.Breed]'
+          bareEncoded: 'Fish%5Bexample.com%2Fpkg.Breed%5D'
       properties:
         kind: {type: string}
     "Dog[example.com/pkg.Breed]": {type: object}
     "Cat[example.com/pkg.Breed]": {type: object}
+    "Fish[example.com/pkg.Breed]": {type: object}
 paths:
   /pets:
     get:
@@ -672,6 +674,8 @@ paths:
 		"a percent-encoded full ref must be rewritten")
 	assert.Equal(t, "CatOfexample.com.pkg.Breed", mapping["bare"],
 		"a bare name must be rewritten and stay bare")
+	assert.Equal(t, "FishOfexample.com.pkg.Breed", mapping["bareEncoded"],
+		"a bare name carrying an encoding must be rewritten too")
 }
 
 // TestFixSchemaNamesKeepsLiteralPercentName covers a name that genuinely
@@ -772,17 +776,33 @@ paths:
       responses:
         "200": {description: OK}
 `
+	// Compare the old->new pairs, not the set of new names. All three reduce to
+	// the same base, so the resulting names are always {X, X2, X3} whichever
+	// schema gets which — only the pairing reveals an ordering flip.
 	var first []string
 	for range 12 {
 		result := fixSchemaNames(t, spec, GenericNamingOf)
-		got := slices.Sorted(maps.Keys(schemaNames(t, result.Document)))
+
+		got := make([]string, 0, len(result.Fixes))
+		for _, fix := range result.Fixes {
+			got = append(got, fmt.Sprintf("%v->%v", fix.Before, fix.After))
+		}
+		slices.Sort(got)
+
 		if first == nil {
 			first = got
 			continue
 		}
 		require.Equal(t, first, got, "collision suffixes must not depend on map iteration order")
 	}
-	assert.Len(t, first, 3, "all three schemas must survive")
+
+	// The unsuffixed name goes to the first candidate in byte order ("." is 0x2E,
+	// "/" is 0x2F), and the suffixes follow from there.
+	assert.Equal(t, []string{
+		"Resp[a.b.Pet]->RespOfa.b.Pet",
+		"Resp[a//b.Pet]->RespOfa.b.Pet2",
+		"Resp[a/b.Pet]->RespOfa.b.Pet3",
+	}, first, "all three schemas must survive, each with a stable name")
 }
 
 // TestPruneKeepsMixedEncodingRefSchema covers the pruning half of the same
@@ -901,4 +921,41 @@ paths:
 	after, err := validator.New().ValidateParsed(*result.ToParseResult())
 	require.NoError(t, err)
 	assert.True(t, after.Valid, "errors: %v", after.Errors)
+}
+
+// TestBuildRefRenameMapDecodedKeyIsDeterministic covers two names that share a
+// decoded form without either being it: "A%2FB[Pet]" and "A~1B[Pet]" both reduce
+// to "A/B[Pet]", and only one can claim that key.
+//
+// Ranging over the rename map to register decoded keys handed it to a different
+// name on each run, so a $ref spelled "#/components/schemas/A/B[Pet]" resolved
+// to a different schema run to run.
+func TestBuildRefRenameMapDecodedKeyIsDeterministic(t *testing.T) {
+	spec := `
+openapi: 3.0.3
+info: {title: T, version: "1.0"}
+components:
+  schemas:
+    "A%2FB[Pet]": {type: object}
+    "A~1B[Pet]": {type: object}
+    Pet: {type: object}
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/A/B[Pet]'}
+`
+	seen := make(map[string]bool)
+	for range 40 {
+		result := fixSchemaNames(t, spec, GenericNamingOf)
+		seen[responseSchemaRef(t, result.Document)] = true
+	}
+
+	assert.Equal(t, map[string]bool{pathutil.RefPrefixSchemas + "A_2FBOfPet": true}, seen,
+		"an ambiguous ref must resolve to the same schema on every run")
 }

--- a/fixer/generic_names_slash_test.go
+++ b/fixer/generic_names_slash_test.go
@@ -1,0 +1,904 @@
+package fixer
+
+import (
+	"maps"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/erraggy/oastools/internal/pathutil"
+	"github.com/erraggy/oastools/parser"
+	"github.com/erraggy/oastools/validator"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// slashCase is one spelling of a reference to a generic schema whose type
+// parameter contains "/". Every case names the same schema; only the encoding
+// of the $ref that reaches it differs.
+type slashCase struct {
+	name     string
+	oas2Spec string
+	oas3Spec string
+	// schemaName is the definitions/components key the refs point at before the
+	// fix. It must be gone from the fixed document: a rename that left it in
+	// place would satisfy every other assertion here.
+	schemaName string
+	// control marks a case that worked before issue #404 was fixed. They are
+	// carried so a change to the matching rule cannot quietly break the
+	// spellings that already resolved.
+	control bool
+}
+
+// slashCases enumerates the encodings from issue #404, plus the two controls the
+// issue identifies. Specs are written out per case rather than templated: the
+// bug was a byte-level mismatch between a $ref and a schema key, so the exact
+// literal spelling of each is the thing under test.
+var slashCases = []slashCase{
+	{
+		name:       "no slash, percent-encoded brackets",
+		schemaName: "PagedResponse[store.Pet]",
+		control:    true,
+		oas2Spec: `
+swagger: "2.0"
+info: {title: T, version: "1.0"}
+definitions:
+  PagedResponse[store.Pet]:
+    type: object
+    properties:
+      items: {type: array, items: {$ref: '#/definitions/store.Pet'}}
+  store.Pet: {type: object, properties: {name: {type: string}}}
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        "200":
+          description: OK
+          schema: {$ref: '#/definitions/PagedResponse%5Bstore.Pet%5D'}
+`,
+		oas3Spec: `
+openapi: 3.0.3
+info: {title: T, version: "1.0"}
+components:
+  schemas:
+    PagedResponse[store.Pet]:
+      type: object
+      properties:
+        items: {type: array, items: {$ref: '#/components/schemas/store.Pet'}}
+    store.Pet: {type: object, properties: {name: {type: string}}}
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/PagedResponse%5Bstore.Pet%5D'}
+`,
+	},
+	{
+		name:       "nested generic, no slash",
+		schemaName: "PagedResponse[store.Record[store.Pet]]",
+		control:    true,
+		oas2Spec: `
+swagger: "2.0"
+info: {title: T, version: "1.0"}
+definitions:
+  PagedResponse[store.Record[store.Pet]]:
+    type: object
+    properties:
+      items: {type: array, items: {$ref: '#/definitions/store.Pet'}}
+  store.Pet: {type: object, properties: {name: {type: string}}}
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        "200":
+          description: OK
+          schema: {$ref: '#/definitions/PagedResponse%5Bstore.Record%5Bstore.Pet%5D%5D'}
+`,
+		oas3Spec: `
+openapi: 3.0.3
+info: {title: T, version: "1.0"}
+components:
+  schemas:
+    PagedResponse[store.Record[store.Pet]]:
+      type: object
+      properties:
+        items: {type: array, items: {$ref: '#/components/schemas/store.Pet'}}
+    store.Pet: {type: object, properties: {name: {type: string}}}
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/PagedResponse%5Bstore.Record%5Bstore.Pet%5D%5D'}
+`,
+	},
+	{
+		name:       "percent-encoded brackets, raw slashes",
+		schemaName: "PagedResponse[example.com/petstore/pkg/store.Pet]",
+		oas2Spec: `
+swagger: "2.0"
+info: {title: T, version: "1.0"}
+definitions:
+  PagedResponse[example.com/petstore/pkg/store.Pet]:
+    type: object
+    properties:
+      items: {type: array, items: {$ref: '#/definitions/store.Pet'}}
+  store.Pet: {type: object, properties: {name: {type: string}}}
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        "200":
+          description: OK
+          schema: {$ref: '#/definitions/PagedResponse%5Bexample.com/petstore/pkg/store.Pet%5D'}
+`,
+		oas3Spec: `
+openapi: 3.0.3
+info: {title: T, version: "1.0"}
+components:
+  schemas:
+    PagedResponse[example.com/petstore/pkg/store.Pet]:
+      type: object
+      properties:
+        items: {type: array, items: {$ref: '#/components/schemas/store.Pet'}}
+    store.Pet: {type: object, properties: {name: {type: string}}}
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/PagedResponse%5Bexample.com/petstore/pkg/store.Pet%5D'}
+`,
+	},
+	{
+		name:       "raw brackets, raw slashes",
+		schemaName: "PagedResponse[example.com/petstore/pkg/store.Pet]",
+		oas2Spec: `
+swagger: "2.0"
+info: {title: T, version: "1.0"}
+definitions:
+  PagedResponse[example.com/petstore/pkg/store.Pet]:
+    type: object
+    properties:
+      items: {type: array, items: {$ref: '#/definitions/store.Pet'}}
+  store.Pet: {type: object, properties: {name: {type: string}}}
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        "200":
+          description: OK
+          schema: {$ref: '#/definitions/PagedResponse[example.com/petstore/pkg/store.Pet]'}
+`,
+		oas3Spec: `
+openapi: 3.0.3
+info: {title: T, version: "1.0"}
+components:
+  schemas:
+    PagedResponse[example.com/petstore/pkg/store.Pet]:
+      type: object
+      properties:
+        items: {type: array, items: {$ref: '#/components/schemas/store.Pet'}}
+    store.Pet: {type: object, properties: {name: {type: string}}}
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/PagedResponse[example.com/petstore/pkg/store.Pet]'}
+`,
+	},
+	{
+		name:       "percent-encoded brackets, JSON Pointer slashes",
+		schemaName: "PagedResponse[example.com/petstore/pkg/store.Pet]",
+		oas2Spec: `
+swagger: "2.0"
+info: {title: T, version: "1.0"}
+definitions:
+  PagedResponse[example.com/petstore/pkg/store.Pet]:
+    type: object
+    properties:
+      items: {type: array, items: {$ref: '#/definitions/store.Pet'}}
+  store.Pet: {type: object, properties: {name: {type: string}}}
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        "200":
+          description: OK
+          schema: {$ref: '#/definitions/PagedResponse%5Bexample.com~1petstore~1pkg~1store.Pet%5D'}
+`,
+		oas3Spec: `
+openapi: 3.0.3
+info: {title: T, version: "1.0"}
+components:
+  schemas:
+    PagedResponse[example.com/petstore/pkg/store.Pet]:
+      type: object
+      properties:
+        items: {type: array, items: {$ref: '#/components/schemas/store.Pet'}}
+    store.Pet: {type: object, properties: {name: {type: string}}}
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/PagedResponse%5Bexample.com~1petstore~1pkg~1store.Pet%5D'}
+`,
+	},
+	{
+		name:       "fully percent-encoded",
+		schemaName: "PagedResponse[example.com/petstore/pkg/store.Pet]",
+		oas2Spec: `
+swagger: "2.0"
+info: {title: T, version: "1.0"}
+definitions:
+  PagedResponse[example.com/petstore/pkg/store.Pet]:
+    type: object
+    properties:
+      items: {type: array, items: {$ref: '#/definitions/store.Pet'}}
+  store.Pet: {type: object, properties: {name: {type: string}}}
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        "200":
+          description: OK
+          schema: {$ref: '#/definitions/PagedResponse%5Bexample.com%2Fpetstore%2Fpkg%2Fstore.Pet%5D'}
+`,
+		oas3Spec: `
+openapi: 3.0.3
+info: {title: T, version: "1.0"}
+components:
+  schemas:
+    PagedResponse[example.com/petstore/pkg/store.Pet]:
+      type: object
+      properties:
+        items: {type: array, items: {$ref: '#/components/schemas/store.Pet'}}
+    store.Pet: {type: object, properties: {name: {type: string}}}
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/PagedResponse%5Bexample.com%2Fpetstore%2Fpkg%2Fstore.Pet%5D'}
+`,
+	},
+}
+
+// versionedSpec pairs an OAS version label with the spec written for it.
+type versionedSpec struct {
+	name string
+	spec string
+}
+
+// versions returns the case's two specs in a fixed order. A map would let Go's
+// randomized iteration reorder the subtests on every run.
+func (c slashCase) versions() []versionedSpec {
+	return []versionedSpec{{"oas2", c.oas2Spec}, {"oas3", c.oas3Spec}}
+}
+
+// slashCaseNamed looks a case up by name so a test that needs one specific
+// encoding does not break when the table is reordered or extended.
+func slashCaseNamed(t *testing.T, name string) slashCase {
+	t.Helper()
+
+	for _, tc := range slashCases {
+		if tc.name == name {
+			return tc
+		}
+	}
+	t.Fatalf("no slashCase named %q", name)
+	return slashCase{}
+}
+
+// allNamingStrategies is every strategy --generic-naming accepts. Issue #404
+// reproduced under all of them, so the regression is pinned across all of them.
+var allNamingStrategies = []GenericNamingStrategy{
+	GenericNamingUnderscore,
+	GenericNamingOf,
+	GenericNamingFor,
+	GenericNamingFlattened,
+	GenericNamingDot,
+}
+
+// fixSchemaNames renames invalid schema names in spec and returns the fix
+// result, whose Document field carries the fixed document.
+func fixSchemaNames(t *testing.T, spec string, strategy GenericNamingStrategy) *FixResult {
+	t.Helper()
+
+	parseResult, err := parser.ParseWithOptions(parser.WithBytes([]byte(spec)))
+	require.NoError(t, err)
+
+	f := New()
+	f.EnabledFixes = []FixType{FixTypeRenamedGenericSchema}
+	f.GenericNamingConfig.Strategy = strategy
+	result, err := f.FixParsed(*parseResult)
+	require.NoError(t, err)
+
+	return result
+}
+
+// responseSchemaRef returns the $ref of the 200 response schema for GET /pets,
+// for either OAS version.
+func responseSchemaRef(t *testing.T, doc any) string {
+	t.Helper()
+
+	switch d := doc.(type) {
+	case *parser.OAS2Document:
+		resp := d.Paths["/pets"].Get.Responses.Codes["200"]
+		require.NotNil(t, resp.Schema)
+		return resp.Schema.Ref
+	case *parser.OAS3Document:
+		resp := d.Paths["/pets"].Get.Responses.Codes["200"]
+		mt, ok := resp.Content["application/json"]
+		require.True(t, ok, "expected an application/json response body")
+		require.NotNil(t, mt.Schema)
+		return mt.Schema.Ref
+	default:
+		t.Fatalf("unexpected document type %T", doc)
+		return ""
+	}
+}
+
+// schemaNames returns the definitions/components.schemas keys of either version.
+func schemaNames(t *testing.T, doc any) map[string]*parser.Schema {
+	t.Helper()
+
+	switch d := doc.(type) {
+	case *parser.OAS2Document:
+		return d.Definitions
+	case *parser.OAS3Document:
+		require.NotNil(t, d.Components)
+		return d.Components.Schemas
+	default:
+		t.Fatalf("unexpected document type %T", doc)
+		return nil
+	}
+}
+
+// TestFixSchemaNamesRoundTripsToValid is the regression for issue #404.
+//
+// The fixer reported a rename as applied while leaving every $ref to the
+// renamed schema untouched, so its output failed validation with exactly the
+// unresolved-$ref error the input had. Under OAS 3.x it also emitted a name
+// containing "/", which the component-name charset rejects outright.
+//
+// The invariant asserted is the one the issue asks for: a document the fixer
+// reports as fixed must validate. Checking validity rather than a literal name
+// keeps the assertion meaningful across all five naming strategies, whose
+// outputs differ.
+func TestFixSchemaNamesRoundTripsToValid(t *testing.T) {
+	for _, tc := range slashCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, v := range tc.versions() {
+				version, spec := v.name, v.spec
+				t.Run(version, func(t *testing.T) {
+					for _, strategy := range allNamingStrategies {
+						t.Run(strategy.String(), func(t *testing.T) {
+							// The input is invalid: the encoded $ref resolves to nothing.
+							parseResult, err := parser.ParseWithOptions(parser.WithBytes([]byte(spec)))
+							require.NoError(t, err)
+							before, err := validator.New().ValidateParsed(*parseResult)
+							require.NoError(t, err)
+							require.False(t, before.Valid,
+								"the unfixed document should fail validation, or this case proves nothing")
+
+							result := fixSchemaNames(t, spec, strategy)
+							require.True(t, result.HasFixes(), "the invalid schema name should be renamed")
+
+							after, err := validator.New().ValidateParsed(*result.ToParseResult())
+							require.NoError(t, err)
+							assert.True(t, after.Valid,
+								"a document reported as fixed must validate; errors: %v", after.Errors)
+
+							// Validity alone would also hold if the fixer had reverted the
+							// rename, so pin the actual outcome: the ref reaches a schema
+							// that exists, under a name that no longer needs encoding.
+							ref := responseSchemaRef(t, result.Document)
+							names := schemaNames(t, result.Document)
+							renamed := strings.TrimPrefix(strings.TrimPrefix(ref,
+								pathutil.RefPrefixSchemas), pathutil.RefPrefixDefinitions)
+							assert.Contains(t, names, renamed,
+								"the rewritten ref must name an existing schema")
+							assert.NotContains(t, names, tc.schemaName,
+								"the old key must be gone, not merely joined by a new one")
+							assert.NotContains(t, ref, "%",
+								"the rewritten ref should need no percent-encoding")
+							assert.NotContains(t, renamed, "~",
+								"the rewritten ref should need no JSON Pointer escaping")
+						})
+					}
+				})
+			}
+		})
+	}
+}
+
+// TestFixSchemaNamesSlashProducesLegalComponentName covers Bug B of issue #404
+// on its own terms.
+//
+// The OAS 3.x component-name charset is what rejected the old output, but a "/"
+// is equally unwanted in an OAS 2.0 definitions key: it is legal there, yet
+// forces every $ref reaching it to be escaped, which is the encoding trouble
+// --fix-schema-names exists to remove. Both versions are therefore asserted.
+func TestFixSchemaNamesSlashProducesLegalComponentName(t *testing.T) {
+	for _, tc := range slashCases {
+		if tc.control {
+			continue
+		}
+		t.Run(tc.name, func(t *testing.T) {
+			for _, v := range tc.versions() {
+				version, spec := v.name, v.spec
+				t.Run(version, func(t *testing.T) {
+					for _, strategy := range allNamingStrategies {
+						t.Run(strategy.String(), func(t *testing.T) {
+							result := fixSchemaNames(t, spec, strategy)
+
+							for name := range schemaNames(t, result.Document) {
+								assert.NotContains(t, name, "/",
+									"a renamed schema must not carry a path separator")
+							}
+							for _, fix := range result.Fixes {
+								after, ok := fix.After.(string)
+								require.True(t, ok, "a rename fix should record the new name")
+								assert.NotContains(t, after, "/",
+									"the reported new name must not carry a path separator")
+							}
+						})
+					}
+				})
+			}
+		})
+	}
+}
+
+// TestFixSchemaNamesSlashExactName pins the names from the issue's own
+// reproduction, so the flattening is not merely legal but the intended shape.
+func TestFixSchemaNamesSlashExactName(t *testing.T) {
+	tests := []struct {
+		strategy GenericNamingStrategy
+		want     string
+	}{
+		{GenericNamingOf, "PagedResponseOfexample.com.petstore.pkg.store.Pet"},
+		{GenericNamingFor, "PagedResponseForexample.com.petstore.pkg.store.Pet"},
+		{GenericNamingFlattened, "PagedResponseexample.com.petstore.pkg.store.Pet"},
+		{GenericNamingDot, "PagedResponse.example.com.petstore.pkg.store.Pet"},
+		{GenericNamingUnderscore, "PagedResponse_example.com.petstore.pkg.store.Pet_"},
+	}
+
+	spec := slashCaseNamed(t, "percent-encoded brackets, raw slashes").oas3Spec
+
+	for _, tt := range tests {
+		t.Run(tt.strategy.String(), func(t *testing.T) {
+			result := fixSchemaNames(t, spec, tt.strategy)
+
+			assert.Contains(t, schemaNames(t, result.Document), tt.want)
+			assert.Equal(t, pathutil.RefPrefixSchemas+tt.want,
+				responseSchemaRef(t, result.Document))
+		})
+	}
+}
+
+// TestCanonicalSchemaRefKey covers the matching rule that replaced the fixed
+// candidate-encoding list, including the mixed spelling no candidate covered.
+func TestCanonicalSchemaRefKey(t *testing.T) {
+	tests := []struct {
+		name string
+		ref  string
+		want string
+	}{
+		{
+			name: "plain name is unchanged",
+			ref:  "#/components/schemas/Pet",
+			want: "#/components/schemas/Pet",
+		},
+		{
+			name: "percent-encoded brackets",
+			ref:  "#/components/schemas/Response%5BUser%5D",
+			want: "#/components/schemas/Response[User]",
+		},
+		{
+			name: "JSON Pointer slash",
+			ref:  "#/definitions/pet~1summary",
+			want: "#/definitions/pet/summary",
+		},
+		{
+			name: "JSON Pointer tilde",
+			ref:  "#/definitions/pet~0summary",
+			want: "#/definitions/pet~summary",
+		},
+		{
+			name: "mixed: percent-encoded brackets with raw slashes",
+			ref:  "#/definitions/Paged%5Bexample.com/pkg.Pet%5D",
+			want: "#/definitions/Paged[example.com/pkg.Pet]",
+		},
+		{
+			name: "mixed: percent-encoded brackets with pointer slashes",
+			ref:  "#/definitions/Paged%5Bexample.com~1pkg.Pet%5D",
+			want: "#/definitions/Paged[example.com/pkg.Pet]",
+		},
+		{
+			name: "fully percent-encoded",
+			ref:  "#/definitions/Paged%5Bexample.com%2Fpkg.Pet%5D",
+			want: "#/definitions/Paged[example.com/pkg.Pet]",
+		},
+		{
+			name: "invalid percent sequence is left alone rather than failing",
+			ref:  "#/definitions/Discount%OFF",
+			want: "#/definitions/Discount%OFF",
+		},
+		{
+			name: "a non-schema ref is not a key and passes through",
+			ref:  "#/components/parameters/Limit%5Bx%5D",
+			want: "#/components/parameters/Limit%5Bx%5D",
+		},
+		{
+			name: "an external ref passes through",
+			ref:  "other.yaml#/components/schemas/Pet",
+			want: "other.yaml#/components/schemas/Pet",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, canonicalSchemaRefKey(tt.ref))
+		})
+	}
+}
+
+// TestFlattenPathQualifier covers the "/" replacement behind Bug B, including
+// the degenerate separators that must not leave a stray dot behind.
+func TestFlattenPathQualifier(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"no slash is unchanged", "store.Pet", "store.Pet"},
+		{"empty is unchanged", "", ""},
+		{"package path", "example.com/petstore/pkg/store.Pet", "example.com.petstore.pkg.store.Pet"},
+		{"single slash", "pkg/Pet", "pkg.Pet"},
+		{"doubled slash drops the empty segment", "pkg//Pet", "pkg.Pet"},
+		{"leading slash does not produce a leading dot", "/pkg.Pet", "pkg.Pet"},
+		{"trailing slash does not produce a trailing dot", "pkg.Pet/", "pkg.Pet"},
+		{"only slashes", "//", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, flattenPathQualifier(tt.input))
+		})
+	}
+}
+
+// TestTransformSchemaNameCleansBase covers the base half of the name, which
+// carries whatever preceded the bracket.
+//
+// Only the type parameters were being cleaned, so any invalid character in the
+// base survived into the new name and the fixer reported a fix that left the
+// document as illegal as it found it.
+func TestTransformSchemaNameCleansBase(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"path-qualified base", "pkg/v1.Response[Pet]", "pkg.v1.ResponseOfPet"},
+		{"space in base", "Res ponse[User]", "Res_ponseOfUser"},
+		{"comma in base", "Res,ponse[User]", "Res_ponseOfUser"},
+		{"braces in base", "Res{p}onse[User]", "Res_p_onseOfUser"},
+		{"pipe in base", "a|b[User]", "a_bOfUser"},
+		{"clean base is untouched", "Response[User]", "ResponseOfUser"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := transformSchemaName(tt.input, GenericNamingConfig{Strategy: GenericNamingOf})
+			assert.Equal(t, tt.want, got)
+			assert.Regexp(t, `^[a-zA-Z0-9._-]+$`, got,
+				"a generated name must satisfy the OAS 3.x component-name charset")
+		})
+	}
+}
+
+// TestFixSchemaNamesRewritesDiscriminatorMapping covers the discriminator
+// branch of the ref rewriting, for both the full-ref and bare-name spellings a
+// mapping may use.
+func TestFixSchemaNamesRewritesDiscriminatorMapping(t *testing.T) {
+	spec := `
+openapi: 3.0.3
+info: {title: T, version: "1.0"}
+components:
+  schemas:
+    Pet:
+      type: object
+      discriminator:
+        propertyName: kind
+        mapping:
+          encoded: '#/components/schemas/Dog%5Bexample.com/pkg.Breed%5D'
+          bare: 'Cat[example.com/pkg.Breed]'
+      properties:
+        kind: {type: string}
+    "Dog[example.com/pkg.Breed]": {type: object}
+    "Cat[example.com/pkg.Breed]": {type: object}
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Pet'}
+`
+	result := fixSchemaNames(t, spec, GenericNamingOf)
+	doc := result.Document.(*parser.OAS3Document)
+
+	mapping := doc.Components.Schemas["Pet"].Discriminator.Mapping
+	assert.Equal(t, pathutil.RefPrefixSchemas+"DogOfexample.com.pkg.Breed", mapping["encoded"],
+		"a percent-encoded full ref must be rewritten")
+	assert.Equal(t, "CatOfexample.com.pkg.Breed", mapping["bare"],
+		"a bare name must be rewritten and stay bare")
+}
+
+// TestFixSchemaNamesKeepsLiteralPercentName covers a name that genuinely
+// contains a percent sequence, pinning that the rename map's keys and the
+// lookup agree about decoding.
+//
+// Decoding is lossy — "Foo%20Bar[Pet]" decodes to "Foo Bar[Pet]" — so it is
+// only safe when both sides do it. Keying on the undecoded name while looking
+// up a decoded one (or the reverse) makes this ref match nothing, which is the
+// unrewritten-$ref half of issue #404 reintroduced for these documents.
+//
+// Which schema an ambiguous spelling resolves to is pinned separately, by
+// TestFixSchemaNamesDisambiguatesEncodedTwin.
+func TestFixSchemaNamesKeepsLiteralPercentName(t *testing.T) {
+	spec := `
+openapi: 3.0.3
+info: {title: T, version: "1.0"}
+components:
+  schemas:
+    "Foo%20Bar[Pet]": {type: object}
+    Pet: {type: object}
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Foo%20Bar[Pet]'}
+`
+	result := fixSchemaNames(t, spec, GenericNamingOf)
+
+	assert.Equal(t, pathutil.RefPrefixSchemas+"Foo_20BarOfPet",
+		responseSchemaRef(t, result.Document),
+		"the ref must be rewritten, not left dangling")
+
+	after, err := validator.New().ValidateParsed(*result.ToParseResult())
+	require.NoError(t, err)
+	assert.True(t, after.Valid, "errors: %v", after.Errors)
+}
+
+// TestFixSchemaNamesDistinctNamesStayDistinct covers collision handling for
+// names that only differ in a character the transform removes.
+//
+// "a/b.Pet" and "a.b.Pet" both reduce to "a.b.Pet", so without a claimed-name
+// check the second rename is handed a name the first already took and one
+// schema is silently overwritten — while both renames are still reported as
+// applied.
+func TestFixSchemaNamesDistinctNamesStayDistinct(t *testing.T) {
+	spec := `
+openapi: 3.0.3
+info: {title: T, version: "1.0"}
+components:
+  schemas:
+    "Resp[a/b.Pet]": {type: object, properties: {x: {type: string}}}
+    "Resp[a.b.Pet]": {type: object, properties: {y: {type: integer}}}
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Resp%5Ba/b.Pet%5D'}
+`
+	result := fixSchemaNames(t, spec, GenericNamingOf)
+	names := schemaNames(t, result.Document)
+
+	assert.Len(t, names, 2, "neither schema may be overwritten by the other")
+	assert.Len(t, result.Fixes, 2, "both renames should be reported")
+
+	after, err := validator.New().ValidateParsed(*result.ToParseResult())
+	require.NoError(t, err)
+	assert.True(t, after.Valid, "errors: %v", after.Errors)
+}
+
+// TestFixSchemaNamesCollisionIsDeterministic pins which schema keeps the
+// unsuffixed name when two reduce to the same one. Building the rename map by
+// ranging over the schemas map would hand the suffix to a different schema on
+// each run.
+func TestFixSchemaNamesCollisionIsDeterministic(t *testing.T) {
+	spec := `
+openapi: 3.0.3
+info: {title: T, version: "1.0"}
+components:
+  schemas:
+    "Resp[a/b.Pet]": {type: object}
+    "Resp[a.b.Pet]": {type: object}
+    "Resp[a//b.Pet]": {type: object}
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        "200": {description: OK}
+`
+	var first []string
+	for range 12 {
+		result := fixSchemaNames(t, spec, GenericNamingOf)
+		got := slices.Sorted(maps.Keys(schemaNames(t, result.Document)))
+		if first == nil {
+			first = got
+			continue
+		}
+		require.Equal(t, first, got, "collision suffixes must not depend on map iteration order")
+	}
+	assert.Len(t, first, 3, "all three schemas must survive")
+}
+
+// TestPruneKeepsMixedEncodingRefSchema covers the pruning half of the same
+// encoding problem: a referenced schema whose $ref mixes the two conventions
+// was recovered under a name no key matched, so pruning deleted it.
+func TestPruneKeepsMixedEncodingRefSchema(t *testing.T) {
+	spec := `
+swagger: "2.0"
+info: {title: T, version: "1.0"}
+definitions:
+  "Paged[example.com/pkg.Pet]": {type: object}
+paths:
+  /p:
+    get:
+      operationId: g
+      responses:
+        "200":
+          description: OK
+          schema: {$ref: '#/definitions/Paged%5Bexample.com/pkg.Pet%5D'}
+`
+	parseResult, err := parser.ParseWithOptions(parser.WithBytes([]byte(spec)))
+	require.NoError(t, err)
+
+	f := New()
+	f.EnabledFixes = []FixType{FixTypePrunedUnusedSchema}
+	result, err := f.FixParsed(*parseResult)
+	require.NoError(t, err)
+
+	doc := result.Document.(*parser.OAS2Document)
+	assert.Contains(t, doc.Definitions, "Paged[example.com/pkg.Pet]",
+		"a referenced schema must survive pruning whatever encoding its ref uses")
+	assert.Zero(t, result.FixCount, "nothing should have been pruned")
+}
+
+// TestPruneStillRemovesUnreferencedMixedEncodingSchema is the control: matching
+// more spellings must not make every schema look referenced.
+func TestPruneStillRemovesUnreferencedMixedEncodingSchema(t *testing.T) {
+	spec := `
+swagger: "2.0"
+info: {title: T, version: "1.0"}
+definitions:
+  "Paged[example.com/pkg.Pet]": {type: object}
+  "Paged[example.com/pkg.Orphan]": {type: object}
+paths:
+  /p:
+    get:
+      operationId: g
+      responses:
+        "200":
+          description: OK
+          schema: {$ref: '#/definitions/Paged%5Bexample.com/pkg.Pet%5D'}
+`
+	parseResult, err := parser.ParseWithOptions(parser.WithBytes([]byte(spec)))
+	require.NoError(t, err)
+
+	f := New()
+	f.EnabledFixes = []FixType{FixTypePrunedUnusedSchema}
+	result, err := f.FixParsed(*parseResult)
+	require.NoError(t, err)
+
+	doc := result.Document.(*parser.OAS2Document)
+	assert.Contains(t, doc.Definitions, "Paged[example.com/pkg.Pet]")
+	assert.NotContains(t, doc.Definitions, "Paged[example.com/pkg.Orphan]",
+		"the unreferenced schema should still be pruned")
+}
+
+// TestFixSchemaNamesDisambiguatesEncodedTwin covers two schemas whose names
+// differ only by percent-encoding, which is what the exact-spelling key in
+// buildRefRenameMap exists for.
+//
+// "Foo%20Bar[Pet]" and "Foo Bar[Pet]" share a decoded form, so registering only
+// the decoded key would collapse them and send one schema's refs to the other's
+// new name. Registering the exact spelling first keeps each ref pointing at the
+// schema it actually named.
+func TestFixSchemaNamesDisambiguatesEncodedTwin(t *testing.T) {
+	spec := `
+openapi: 3.0.3
+info: {title: T, version: "1.0"}
+components:
+  schemas:
+    "Foo%20Bar[Pet]": {type: object}
+    "Foo Bar[Pet]": {type: object}
+    Pet: {type: object}
+paths:
+  /encoded:
+    get:
+      operationId: getEncoded
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Foo%20Bar[Pet]'}
+  /literal:
+    get:
+      operationId: getLiteral
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Foo Bar[Pet]'}
+`
+	result := fixSchemaNames(t, spec, GenericNamingOf)
+	doc := result.Document.(*parser.OAS3Document)
+
+	refFor := func(path string) string {
+		return doc.Paths[path].Get.Responses.Codes["200"].Content["application/json"].Schema.Ref
+	}
+
+	assert.Equal(t, pathutil.RefPrefixSchemas+"Foo_20BarOfPet", refFor("/encoded"),
+		"the percent-spelled ref must follow the schema it named")
+	assert.Equal(t, pathutil.RefPrefixSchemas+"Foo_BarOfPet", refFor("/literal"),
+		"the literal-space ref must follow the schema it named")
+
+	after, err := validator.New().ValidateParsed(*result.ToParseResult())
+	require.NoError(t, err)
+	assert.True(t, after.Valid, "errors: %v", after.Errors)
+}

--- a/fixer/prune.go
+++ b/fixer/prune.go
@@ -7,6 +7,7 @@ package fixer
 import (
 	"fmt"
 	"net/url"
+	"slices"
 	"strings"
 
 	"github.com/erraggy/oastools/internal/pathutil"
@@ -41,15 +42,16 @@ func buildReferencedSchemaSet(collector *RefCollector, schemas map[string]*parse
 
 	prefix := accessor.SchemaRefPrefix()
 
-	// 1. Get directly referenced schemas from collector
+	// 1. Get directly referenced schemas from collector. names is reused across
+	// refs so the candidate spellings cost no allocation after the first ref.
+	var names []string
 	for ref := range collector.RefsByType[RefTypeSchema] {
-		name := extractSchemaName(ref, prefix)
-		if name == "" {
-			continue
-		}
-		if _, exists := schemas[name]; exists && !referenced[name] {
-			referenced[name] = true
-			queue = append(queue, name)
+		names = appendSchemaNames(names[:0], ref, prefix)
+		for _, name := range names {
+			if _, exists := schemas[name]; exists && !referenced[name] {
+				referenced[name] = true
+				queue = append(queue, name)
+			}
 		}
 	}
 
@@ -76,29 +78,57 @@ func buildReferencedSchemaSet(collector *RefCollector, schemas map[string]*parse
 	return referenced
 }
 
-// extractSchemaName extracts the schema name from a reference path.
-// Handles both URL-encoded and non-encoded refs.
+// appendSchemaNames appends to dst every schema name a reference path could
+// denote, most-faithful spelling first. It appends nothing for a ref that does
+// not name a local schema.
 //
-// The JSON Pointer escaping is reversed so the name matches the key it was
-// built from. Without it, a schema named "pet/summary" is referenced as
-// "#/definitions/pet~1summary", the recovered name never matches the schemas
-// map, and pruning deletes a schema that is in fact referenced.
-func extractSchemaName(ref, prefix string) string {
-	// Try direct prefix match first
-	if name, found := strings.CutPrefix(ref, prefix); found {
-		return pathutil.UnescapeRefToken(name)
-	}
-
-	// Try URL-decoded version. This is a different escaping from the JSON
-	// Pointer form above, handled because some tools emit percent-encoded refs.
-	decoded, err := url.PathUnescape(ref)
-	if err == nil {
-		if name, found := strings.CutPrefix(decoded, prefix); found {
-			return pathutil.UnescapeRefToken(name)
+// More than one candidate is needed because generators disagree about how to
+// escape a name, and a wrong guess makes pruning delete a schema that is in
+// fact referenced. Escaping is reversed so the name matches the key it was
+// built from: without it, a schema named "pet/summary" is referenced as
+// "#/definitions/pet~1summary" and the recovered name never matches the schemas
+// map. But one reversal is not enough either — generators mix the conventions,
+// so "#/definitions/Paged%5Bpkg/store.Pet%5D" percent-encodes the brackets and
+// leaves the slashes raw, and RFC 6901 unescaping alone recovers a name no key
+// matches.
+//
+// Returning candidates rather than picking one keeps both readings alive: a
+// schema genuinely named "Foo%20Bar" is matched by the undecoded spelling, and
+// a mixed-encoding ref by the decoded one. Every caller looks each name up in
+// the schemas map before acting, so a candidate that names nothing costs a
+// lookup and no more.
+//
+// Appending to dst rather than returning a fresh slice keeps the common case
+// allocation-free: this runs for every $ref in the document, and almost all of
+// them are unencoded and yield a single name.
+func appendSchemaNames(dst []string, ref, prefix string) []string {
+	name, found := strings.CutPrefix(ref, prefix)
+	if !found {
+		// The prefix itself may be percent-encoded.
+		decoded, err := url.PathUnescape(ref)
+		if err != nil {
+			return dst
+		}
+		if name, found = strings.CutPrefix(decoded, prefix); !found {
+			return dst
 		}
 	}
 
-	return ""
+	start := len(dst)
+	dst = append(dst, name)
+
+	// Without an escape sequence every spelling of the name is the same string.
+	if !strings.ContainsAny(name, "%~") {
+		return dst
+	}
+
+	// this utilizes array notation `[2]string` to allowcate our known set of two on the stack
+	for _, candidate := range [2]string{pathutil.UnescapeRefToken(name), pathutil.DecodeRefToken(name)} {
+		if !slices.Contains(dst[start:], candidate) {
+			dst = append(dst, candidate)
+		}
+	}
+	return dst
 }
 
 // collectSchemaRefs extracts all schema reference names from a schema.
@@ -128,9 +158,7 @@ func collectSchemaRefsRecursive(refs *[]string, schema *parser.Schema, prefix st
 	visited[schema] = true
 
 	// Direct schema ref
-	if name := extractSchemaName(schema.Ref, prefix); name != "" {
-		*refs = append(*refs, name)
-	}
+	*refs = appendSchemaNames(*refs, schema.Ref, prefix)
 
 	// Properties
 	for _, propSchema := range schema.Properties {
@@ -189,9 +217,7 @@ func collectSchemaRefsRecursive(refs *[]string, schema *parser.Schema, prefix st
 	// Discriminator mapping values are references
 	if schema.Discriminator != nil {
 		for _, mappingRef := range schema.Discriminator.Mapping {
-			if name := extractSchemaName(mappingRef, prefix); name != "" {
-				*refs = append(*refs, name)
-			}
+			*refs = appendSchemaNames(*refs, mappingRef, prefix)
 		}
 	}
 }
@@ -264,16 +290,25 @@ func (f *Fixer) pruneEmptyPaths(paths parser.Paths, result *FixResult, version p
 // resolveNameCollision ensures a new name doesn't conflict with existing schemas.
 // If newName exists in schemas (and is not being renamed away), appends a numeric suffix.
 // Returns the resolved unique name.
-func resolveNameCollision(newName string, schemas map[string]*parser.Schema, pendingRenames map[string]string) string {
+//
+// claimed carries the names earlier renames already took; the caller adds each
+// resolved name to it. See [isNameAvailable] for why that set is separate from
+// pendingRenames.
+func resolveNameCollision(
+	newName string,
+	schemas map[string]*parser.Schema,
+	pendingRenames map[string]string,
+	claimed map[string]bool,
+) string {
 	// Check if the name is available
-	if isNameAvailable(newName, schemas, pendingRenames) {
+	if isNameAvailable(newName, schemas, pendingRenames, claimed) {
 		return newName
 	}
 
 	// Find a unique name by appending a numeric suffix
 	for i := 2; ; i++ {
 		candidate := fmt.Sprintf("%s%d", newName, i)
-		if isNameAvailable(candidate, schemas, pendingRenames) {
+		if isNameAvailable(candidate, schemas, pendingRenames, claimed) {
 			return candidate
 		}
 	}
@@ -281,9 +316,30 @@ func resolveNameCollision(newName string, schemas map[string]*parser.Schema, pen
 
 // isNameAvailable checks if a name is available for use.
 // A name is available if:
-// 1. It doesn't exist in schemas, OR
-// 2. It exists but is being renamed away (in pendingRenames as a key)
-func isNameAvailable(name string, schemas map[string]*parser.Schema, pendingRenames map[string]string) bool {
+//  1. No earlier rename has already claimed it, AND
+//  2. It doesn't exist in schemas, OR it exists but is being renamed away
+//     (in pendingRenames as a key)
+//
+// The claimed check is what stops two schemas from being renamed to the same
+// thing. Distinct names can transform to one result — "Resp[a/b.Pet]" and
+// "Resp[a.b.Pet]" both reduce to "RespOfa.b.Pet" — and the second rename would
+// otherwise be handed a name the first already took, so applying them in turn
+// overwrites one schema with the other and silently drops it.
+//
+// claimed is a set rather than a scan of pendingRenames' values because this
+// runs once per candidate name: deriving it here would make assigning n names
+// quadratic, which is measurable on the code-first specs that produce hundreds
+// of generic schemas at once.
+func isNameAvailable(
+	name string,
+	schemas map[string]*parser.Schema,
+	pendingRenames map[string]string,
+	claimed map[string]bool,
+) bool {
+	if claimed[name] {
+		return false
+	}
+
 	// If the name doesn't exist in schemas, it's available
 	if _, exists := schemas[name]; !exists {
 		return true
@@ -327,9 +383,7 @@ func isComponentsEmpty(comp *parser.Components) bool {
 func collectRefsFromMap(refs *[]string, m map[string]any, prefix string) {
 	// Check for direct $ref
 	if refStr, ok := m["$ref"].(string); ok {
-		if name := extractSchemaName(refStr, prefix); name != "" {
-			*refs = append(*refs, name)
-		}
+		*refs = appendSchemaNames(*refs, refStr, prefix)
 	}
 
 	// Check nested properties

--- a/fixer/prune.go
+++ b/fixer/prune.go
@@ -122,7 +122,6 @@ func appendSchemaNames(dst []string, ref, prefix string) []string {
 		return dst
 	}
 
-	// this utilizes array notation `[2]string` to allowcate our known set of two on the stack
 	for _, candidate := range [2]string{pathutil.UnescapeRefToken(name), pathutil.DecodeRefToken(name)} {
 		if !slices.Contains(dst[start:], candidate) {
 			dst = append(dst, candidate)

--- a/fixer/version_helpers.go
+++ b/fixer/version_helpers.go
@@ -29,9 +29,14 @@ func schemaPathPrefix(version parser.OASVersion) string {
 // match a name that carries none of them. Registering only one of the two loses
 // whichever case it does not cover.
 //
-// Exact keys are registered first and never overwritten, so where a decoded key
-// would collide with another rename's exact spelling, the exact match wins and
-// the result does not depend on map iteration order.
+// Exact keys are registered first and never overwritten, so a decoded key that
+// would collide with another rename's exact spelling loses to it.
+//
+// The decoded pass runs in sorted order because two names can share a decoded
+// form without either being it — "A%2FB[Pet]" and "A~1B[Pet]" both reduce to
+// "A/B[Pet]" — and only one of them can claim that key. Ranging over the map
+// would hand it to a different rename on each run, so a $ref spelled that way
+// would resolve to a different schema run to run.
 //
 // Values are ready to write into a $ref, so the new name is escaped per RFC
 // 6901: a name containing "/" or "~" must build the pointer that reaches the
@@ -40,14 +45,17 @@ func buildRefRenameMap(renames map[string]string, accessor parser.DocumentAccess
 	prefix := accessor.SchemaRefPrefix()
 	refRenames := make(map[string]string, len(renames)*2)
 
+	oldNames := make([]string, 0, len(renames))
 	for oldName, newName := range renames {
 		refRenames[prefix+oldName] = prefix + pathutil.EscapeRefToken(newName)
+		oldNames = append(oldNames, oldName)
 	}
+	sort.Strings(oldNames)
 
-	for oldName, newName := range renames {
+	for _, oldName := range oldNames {
 		decoded := prefix + pathutil.DecodeRefToken(oldName)
 		if _, taken := refRenames[decoded]; !taken {
-			refRenames[decoded] = prefix + pathutil.EscapeRefToken(newName)
+			refRenames[decoded] = prefix + pathutil.EscapeRefToken(renames[oldName])
 		}
 	}
 

--- a/fixer/version_helpers.go
+++ b/fixer/version_helpers.go
@@ -4,7 +4,6 @@ package fixer
 
 import (
 	"fmt"
-	"net/url"
 	"sort"
 
 	"github.com/erraggy/oastools/internal/paramutil"
@@ -21,25 +20,34 @@ func schemaPathPrefix(version parser.OASVersion) string {
 }
 
 // buildRefRenameMap creates a map of old refs to new refs for schema renames.
-// It handles both URL-encoded and non-encoded refs.
+//
+// Each rename registers two keys, matching the two-step lookup in
+// [lookupRenamedRef]: the name exactly as the document spells it, and the name
+// with both escaping conventions reversed. The exact key is what lets a
+// component genuinely named "Foo%20Bar[Pet]" match a $ref spelling it the same
+// way; the decoded key is what lets any of the encodings a generator might emit
+// match a name that carries none of them. Registering only one of the two loses
+// whichever case it does not cover.
+//
+// Exact keys are registered first and never overwritten, so where a decoded key
+// would collide with another rename's exact spelling, the exact match wins and
+// the result does not depend on map iteration order.
+//
+// Values are ready to write into a $ref, so the new name is escaped per RFC
+// 6901: a name containing "/" or "~" must build the pointer that reaches the
+// renamed component.
 func buildRefRenameMap(renames map[string]string, accessor parser.DocumentAccessor) map[string]string {
 	prefix := accessor.SchemaRefPrefix()
 	refRenames := make(map[string]string, len(renames)*2)
 
 	for oldName, newName := range renames {
-		// Names are escaped per RFC 6901 so a name containing "/" or "~" builds
-		// the pointer a document actually carries, and so the renamed component
-		// stays reachable afterwards.
-		oldRef := prefix + pathutil.EscapeRefToken(oldName)
-		newRef := prefix + pathutil.EscapeRefToken(newName)
-		refRenames[oldRef] = newRef
+		refRenames[prefix+oldName] = prefix + pathutil.EscapeRefToken(newName)
+	}
 
-		// Add URL-encoded version for refs that might be encoded. This is a
-		// different escaping from the JSON Pointer form above, kept because
-		// some tools emit percent-encoded refs.
-		encodedOldRef := prefix + url.PathEscape(oldName)
-		if encodedOldRef != oldRef {
-			refRenames[encodedOldRef] = newRef
+	for oldName, newName := range renames {
+		decoded := prefix + pathutil.DecodeRefToken(oldName)
+		if _, taken := refRenames[decoded]; !taken {
+			refRenames[decoded] = prefix + pathutil.EscapeRefToken(newName)
 		}
 	}
 
@@ -167,26 +175,39 @@ func (f *Fixer) renameInvalidSchemas(
 		return nil
 	}
 
-	// Build rename map: old name -> new name
-	renames := make(map[string]string)
+	// Sort the candidates before assigning new names. Two names can transform to
+	// the same result — "Resp[a/b.Pet]" and "Resp[a.b.Pet]" both reduce to
+	// "RespOfa.b.Pet" — and the loser takes the numeric suffix
+	// resolveNameCollision appends. Ranging over the map instead would hand that
+	// suffix to a different schema on each run.
+	candidates := make([]string, 0, len(schemas))
 	for name := range schemas {
 		if hasInvalidSchemaNameChars(name) {
-			newName := transformSchemaName(name, f.GenericNamingConfig)
-			newName = resolveNameCollision(newName, schemas, renames)
-			renames[name] = newName
+			candidates = append(candidates, name)
 		}
+	}
+	sort.Strings(candidates)
+
+	// Build rename map: old name -> new name.
+	//
+	// No candidate can transform to itself — it was selected for containing a
+	// character transformSchemaName always removes — so every candidate yields a
+	// real rename and none needs a no-op guard here.
+	renames := make(map[string]string, len(candidates))
+	claimed := make(map[string]bool, len(candidates))
+	for _, name := range candidates {
+		newName := resolveNameCollision(
+			transformSchemaName(name, f.GenericNamingConfig), schemas, renames, claimed)
+		renames[name] = newName
+		claimed[newName] = true
 	}
 
 	if len(renames) == 0 {
 		return nil
 	}
 
-	// Sort old names for deterministic processing order
-	oldNames := make([]string, 0, len(renames))
-	for oldName := range renames {
-		oldNames = append(oldNames, oldName)
-	}
-	sort.Strings(oldNames)
+	// Already sorted, so the fixes are recorded in a deterministic order.
+	oldNames := candidates
 
 	// Apply renames to schemas map and record fixes
 	pathPrefix := schemaPathPrefix(accessor.GetVersion())

--- a/internal/pathutil/refs.go
+++ b/internal/pathutil/refs.go
@@ -3,7 +3,10 @@
 
 package pathutil
 
-import "strings"
+import (
+	"net/url"
+	"strings"
+)
 
 // EscapeRefToken escapes a component name for use as a single JSON Pointer
 // token, per RFC 6901: "~" becomes "~0" and "/" becomes "~1".
@@ -42,6 +45,31 @@ func UnescapeRefToken(token string) string {
 	}
 	token = strings.ReplaceAll(token, "~1", "/")
 	return strings.ReplaceAll(token, "~0", "~")
+}
+
+// DecodeRefToken reverses both escaping conventions a reference token may
+// carry, recovering the component name it denotes.
+//
+// Documents are inconsistent here. RFC 6901 asks for "~1" and "~0", but code
+// generators commonly percent-encode instead — and often encode only what their
+// URL escaper considers unsafe, so "[" becomes "%5B" while "/" is left raw. A
+// token like "Paged%5Bexample.com/pkg.Pet%5D" is therefore in neither
+// convention, and no single unescaper recovers it.
+//
+// Percent-decoding runs first so a percent-encoded tilde ("%7E1") is still
+// recognized as a JSON Pointer escape afterwards. An invalid percent sequence
+// leaves the token untouched rather than failing: a token that cannot be
+// decoded is already the only form it has.
+//
+// Decoding is lossy, so prefer the undecoded token when it already matches:
+// a component genuinely named "Foo%20Bar" decodes to "Foo Bar" and would
+// otherwise stop matching itself. Callers should try the exact spelling first
+// and fall back to this.
+func DecodeRefToken(token string) string {
+	if decoded, err := url.PathUnescape(token); err == nil {
+		token = decoded
+	}
+	return UnescapeRefToken(token)
 }
 
 // OAS 2.0 reference prefixes

--- a/internal/pathutil/refs_test.go
+++ b/internal/pathutil/refs_test.go
@@ -120,3 +120,34 @@ func TestRefBuildersEscape(t *testing.T) {
 	assert.Equal(t, "#/components/schemas/Pet", SchemaRef("Pet"))
 	assert.Equal(t, "#/definitions/Pet", DefinitionRef("Pet"))
 }
+
+// TestDecodeRefToken covers both escaping conventions and the mixed spellings
+// that satisfy neither, which is what the function exists for.
+func TestDecodeRefToken(t *testing.T) {
+	tests := []struct {
+		name  string
+		token string
+		want  string
+	}{
+		{"plain name is unchanged", "Pet", "Pet"},
+		{"empty is unchanged", "", ""},
+		{"percent-encoded brackets", "Response%5BUser%5D", "Response[User]"},
+		{"JSON Pointer slash", "pet~1summary", "pet/summary"},
+		{"JSON Pointer tilde", "pet~0summary", "pet~summary"},
+		{"percent-encoded slash", "pkg%2FPet", "pkg/Pet"},
+		{"mixed: encoded brackets, raw slashes", "Paged%5Bexample.com/pkg.Pet%5D", "Paged[example.com/pkg.Pet]"},
+		{"mixed: encoded brackets, pointer slashes", "Paged%5Bexample.com~1pkg.Pet%5D", "Paged[example.com/pkg.Pet]"},
+		{"fully percent-encoded", "Paged%5Bexample.com%2Fpkg.Pet%5D", "Paged[example.com/pkg.Pet]"},
+		{"percent-encoded tilde becomes a pointer escape", "pet%7E1summary", "pet/summary"},
+		{"invalid percent sequence is left alone", "Discount%OFF", "Discount%OFF"},
+		{"lone percent is left alone", "100%", "100%"},
+		{"plus is not a space", "a+b", "a+b"},
+		{"escaped tilde-one survives", "x~01y", "x~1y"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, DecodeRefToken(tt.token))
+		})
+	}
+}


### PR DESCRIPTION
Fixes #404 🎯

`--fix-schema-names` reported a rename as applied while leaving every `$ref` to the renamed schema **untouched**, and under OAS 3.x emitted a name still containing `/`, which the component-name charset rejects. Exit code 0, "1 fix(es) applied", and a document exactly as invalid as it started — the worst outcome, since `fix` looks successful in CI while the spec stays broken.

## Bug A — `$ref` values left unrewritten

`buildRefRenameMap` pre-generated **two candidate keys** per rename (`EscapeRefToken` and `url.PathEscape`) and hoped a document's `$ref` matched one. Real generators emit a *mixed* spelling — brackets percent-encoded, slashes raw — that sits between the two and matches neither:

| | spelling |
|---|---|
| `EscapeRefToken` candidate | `#/definitions/PagedResponse[example.com~1pkg~1store.Pet]` |
| `url.PathEscape` candidate | `#/definitions/PagedResponse%5Bexample.com%2Fpkg%2Fstore.Pet%5D` |
| **what the document carries** | `#/definitions/PagedResponse%5Bexample.com/pkg/store.Pet%5D` |

Enumerating fixed encodings can't win — the mixed forms outnumber the ones worth listing. Refs are now matched against their **exact spelling first, a fully decoded form second**. The two-step order matters: decoding is lossy (`Foo%20Bar` decodes to `Foo Bar`), so trying the exact spelling first keeps a name that genuinely contains a percent sequence resolvable.

Notably, this ordering was already the working pattern in `extractSchemaName` — the rename map was the one place that enumerated instead. The fix makes the two agree rather than inventing a third approach.

## Bug B — illegal generated name

`isPackageQualifiedName` returns true for `example.com/petstore/pkg/store.Pet` (it has a dot, no brackets), so `transformTypeParam` returned it **verbatim**, bypassing every sanitizer. The base name was never sanitized at all, so `Res ponse[User]` → `Res ponseOfUser` and `a|b[User]` → `a|bOfUser` were equally broken.

Every fragment now runs through one `toNameFragment` helper — path separators folded to `.` (keeping package qualification), then the general sanitizer. Result: `PagedResponse[example.com/petstore/pkg/store.Pet]` → `PagedResponseOfexample.com.petstore.pkg.store.Pet` ✅

## Two adjacent defects fixed while verifying 🔍

1. **Silent schema loss.** Folding `/` to `.` means `Resp[a/b.Pet]` and `Resp[a.b.Pet]` both reduce to `RespOfa.b.Pet`. `isNameAvailable` only checked whether a candidate existed in `schemas`, never whether an earlier rename had already *claimed* it — so two fixes were reported and one schema's body silently vanished.
2. **`--prune-unused` deleting a referenced schema.** The same mixed-encoding `$ref` recovered a name no key matched, so the schema looked orphaned and was pruned. Verified independently of the fixer path.

## Performance ⚡

Both correctness fixes landed on hot paths, so each got measured rather than assumed:

**Collision resolution** — the claimed-name check was a linear scan over pending renames inside a per-candidate loop, making name assignment O(n²). Swapped for a set:

| n | before | after |
|---|---|---|
| 500 | 1.35 ms | 402 µs |
| 1000 | 4.79 ms | 978 µs |
| 2000 | 16.3 ms | 1.86 ms |

Doubling 1000→2000 now costs 1.9× instead of 3.4×. This matters for exactly the specs the feature targets — code-first generators emitting hundreds of generic schemas at once.

**Ref walking** — returning a candidate slice per `$ref` tripled allocations on a path that visits every ref in the document (one extra allocation per ref: the returned slice). An append-style API plus a fast path for unencoded names restores baseline:

| | ns/op | B/op | allocs/op |
|---|---|---|---|
| main | 424 µs | 420,535 | 2,000 |
| naive fix | 412 µs | 484,535 | **6,000** |
| this PR | ~380 µs | 420,003 | 2,000 |

## On the comment density 📝

Several functions here carry noticeably verbose doc comments, and that is deliberate. This change deals with two kinds of complexity that are invisible at the call site:

- **Correctness that looks arbitrary.** Why refs are matched exact-first-then-decoded, why decoding is deliberately lossy, why `/` becomes `.` rather than `_`, why a fragment is sanitized in two stages — every one of these looks like it could be simplified until you know the case it exists for. The comments name that case, so a future reader simplifying in good faith hits the reason before the regression.
- **Performance that looks like noise.** The `claimed` set, the `strings.ContainsAny` fast paths, and the append-style API with its reused scratch buffer all read as micro-optimization without the measurement behind them. Each carries a note on what it costs to remove, so the shape survives future cleanup.

The intent is that neither the complexity nor the performance work reads as accidental to whoever touches this next.

## Testing 🧪

- **Full encoding matrix** from the issue: 6 spellings × 2 OAS versions × 5 `--generic-naming` strategies = **60 combinations**, all fix-then-validate clean. Cases 1–2 are the issue's controls (they passed before) and are kept so a change to the matching rule can't quietly break the spellings that already worked.
- **Property test** the issue asked for: a document the fixer reports as fixed must validate.
- **Every correctness fix proven load-bearing** — reverting it makes a specific named test fail:

| Fix | Test that fails without it |
|---|---|
| Exact-spelling key | `TestFixSchemaNamesDisambiguatesEncodedTwin` |
| General fragment sanitization | `TestTransformSchemaNameCleansBase` |
| Claimed-name collision check | `TestFixSchemaNamesDistinctNamesStayDistinct` |
| Prune multi-candidate | `TestPruneKeepsMixedEncodingRefSchema` |

Also pinned: discriminator mappings (full-ref and bare-name), deterministic collision suffixes across 12 runs, and `pathutil.DecodeRefToken` in isolation.

`make check` exits 0 (9122 tests, up from 9093) · gopls reports no diagnostics · govulncheck clean · new code at 87–100% coverage.

## Correction to an earlier claim in this description ✏️

An earlier revision of this description credited part of the allocation win to using `[2]string` rather than `[]string` for the candidate pair. **That was wrong.** `go build -gcflags=-m` reports `[]string{...} does not escape` at that site, so the slice form was already stack-allocated and the array form saves nothing. The entire 6,000 → 2,000 alloc improvement came from removing the *returned* result slice — 4,000 extra allocations over 4,000 refs, exactly one each. The array literal is retained only because it states that the candidate set is exactly two; the comment claiming otherwise has been removed.

## Full performance assessment 📊

Measured branch vs `main` on the same machine (Apple M4) with `benchstat`, 8–16 samples per benchmark.

**Most of this PR is free by construction.** `fixInvalidSchemaNamesOAS2/3` return early on `len(refRenames) == 0`, so `canonicalSchemaRefKey`, `lookupRenamedRef`, `lookupRenamedMappingValue` and every ref rewrite cost exactly zero on documents with no invalid schema names. The only always-on changed path is `appendSchemaNames` during pruning.

| Path | ns/op | allocs/op |
|---|---|---|
| Prune, clean names *(always-on)* | -2.9% | ~ |
| Fix, no renames *(gating proof)* | ~ | ~ |
| Fix, 300 schemas all renamed | ~ | +0.01% |
| Rename + prune together | ~ | +0.00% |
| `collectSchemaRefs` | ~ | ~ |
| **Discriminator mappings** | **-39.9%** | +4.95% |
| `FixDocuments` Small/Medium/Large × OAS 2+3 | ~ | ~ |
| `FixParsed` LargeOAS3 | -3.6% | ~ |
| `FixWithOptions` both variants | ~ | ~ |

Two results worth stating plainly rather than burying:

- **The discriminator change trades allocations for time.** Replacing the O(n) rename-map scan with two map lookups is a 40% time win but costs +5% allocations, from the `prefix+ref` concatenation for bare names. It does not appear on real documents — every `FixDocuments` and `FixParsed` allocation row is unchanged — only on a synthetic spec with 300 mappings.
- **Two apparent signals were measurement noise.** `PruneCleanNames` read as -14% at 8 samples (`main` varied ±30%); at 12 samples it is -2.9%. `FixWithOptions/FilePath` read as a +7.94% *regression* at p=0.010; at 16 samples it is unchanged at p=0.402, while its `Parsed` sibling doing the same work showed no regression at all. File-path benchmarks include disk I/O and are noisy. Allocation counts were stable at ±0% throughout, which is consistent with this repo's guidance that allocs/op is the trustworthy signal.

Costs not visible above: `buildRefRenameMap` now sorts and registers up to two keys per rename, so the map can be roughly 2× larger — proportional to the number of renames, not document size, and it measured +0.16% B/op with 300 renames. `renameInvalidSchemas` adds one `claimed` map of the same size.

## Scope note

The prune fix touches `fixer/prune.go`, beyond `--fix-schema-names`. Same encoding root cause, and silent data loss is worse than a dangling ref, so it is fixed here rather than deferred.

#405 (a schema name containing `/` with *no* generic brackets is never detected, so it can't be fixed at all) is filed separately and deliberately untouched — that's a detection-side change requiring a version-aware decision, since OAS 2.0 permits `/` in a definitions key.
