### PR TITLE
fix(fixer): detect OAS 3.x schema names by charset, not by a denylist

### DIFF
--- a/fixer/component_name_charset_test.go
+++ b/fixer/component_name_charset_test.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/erraggy/oastools/internal/naming"
 	"github.com/erraggy/oastools/internal/pathutil"
 	"github.com/erraggy/oastools/parser"
 	"github.com/erraggy/oastools/validator"
@@ -12,10 +13,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// componentNamePattern is the OAS 3.x Components Object key rule, restated here
-// so these tests assert against the spec rather than against the fixer's own
-// idea of it. Kept in sync with validator.componentNamePattern.
-var componentNamePattern = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
+// componentNamePattern compiles the shared rule, so these tests assert against
+// the same definition the validator enforces rather than a copy of it.
+var componentNamePattern = regexp.MustCompile(naming.ComponentNamePattern)
 
 // oas3SpecNamed renders a one-schema OAS 3.0.3 document whose single $ref reaches
 // that schema.
@@ -310,18 +310,5 @@ func TestFoldToASCII(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, foldToASCII(tt.input))
 		})
-	}
-}
-
-// TestIsComponentNameChar covers the charset predicate against the pattern it
-// restates, including the ASCII-only boundary that unicode.IsLetter gets wrong.
-func TestIsComponentNameChar(t *testing.T) {
-	for _, r := range []rune{'a', 'z', 'A', 'Z', '0', '9', '.', '-', '_'} {
-		assert.True(t, isComponentNameChar(r), "%q should be allowed", r)
-		assert.Regexp(t, componentNamePattern, string(r), "%q should match the pattern", r)
-	}
-	for _, r := range []rune{'/', '~', '@', '!', ' ', '[', ']', 'é', '宠', '中', 'Ω'} {
-		assert.False(t, isComponentNameChar(r), "%q should be rejected", r)
-		assert.NotRegexp(t, componentNamePattern, string(r), "%q should not match the pattern", r)
 	}
 }

--- a/fixer/component_name_charset_test.go
+++ b/fixer/component_name_charset_test.go
@@ -1,0 +1,327 @@
+package fixer
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/erraggy/oastools/internal/pathutil"
+	"github.com/erraggy/oastools/parser"
+	"github.com/erraggy/oastools/validator"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// componentNamePattern is the OAS 3.x Components Object key rule, restated here
+// so these tests assert against the spec rather than against the fixer's own
+// idea of it. Kept in sync with validator.componentNamePattern.
+var componentNamePattern = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
+
+// oas3SpecNamed renders a one-schema OAS 3.0.3 document whose single $ref reaches
+// that schema.
+//
+// A builder rather than a spec per case: here the schema *name* is the variable
+// under test and everything around it is noise, unlike the encoding tests in
+// generic_names_slash_test.go where the literal bytes of each $ref were the
+// thing being pinned. The ref is built with EscapeRefToken so a name containing
+// "/" or "~" still produces a document that resolves before the fix.
+func oas3SpecNamed(name string) string {
+	return fmt.Sprintf(`
+openapi: 3.0.3
+info: {title: T, version: "1.0"}
+components:
+  schemas:
+    %q: {type: object, properties: {id: {type: string}}}
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: {$ref: %q}
+`, name, pathutil.RefPrefixSchemas+pathutil.EscapeRefToken(name))
+}
+
+// oas2SpecNamed is the OAS 2.0 counterpart of [oas3SpecNamed].
+func oas2SpecNamed(name string) string {
+	return fmt.Sprintf(`
+swagger: "2.0"
+info: {title: T, version: "1.0"}
+definitions:
+  %q: {type: object, properties: {id: {type: string}}}
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        "200":
+          description: OK
+          schema: {$ref: %q}
+`, name, pathutil.RefPrefixDefinitions+pathutil.EscapeRefToken(name))
+}
+
+// illegalOAS3Names are names that violate the OAS 3.x component-name charset
+// without containing any character from invalidSchemaNameChars, so a denylist
+// cannot see them. Issue #405 reported the first of these; the rest are the same
+// gap reached by other characters.
+var illegalOAS3Names = []struct {
+	name string
+	want string
+}{
+	{"pkg/Pet", "pkg.Pet"},
+	{"example.com/pkg/Pet", "example.com.pkg.Pet"},
+	{"pet~summary", "pet_summary"},
+	{"Pet@v1", "Pet_v1"},
+	{"Pet#1", "Pet_1"},
+	{"Pet&Co", "Pet_Co"},
+	{"Pet%20", "Pet_20"},
+	{"Pet:1", "Pet_1"},
+	{"Pet(1)", "Pet_1"},
+	{"Pet!", "Pet"},
+	{"Pet$", "Pet"},
+	{"Pet*", "Pet"},
+	{"Pet+", "Pet"},
+	{"Pet=", "Pet"},
+	{"Pet?", "Pet"},
+	{"Pet;", "Pet"},
+	{"Pet'", "Pet"},
+	// Non-ASCII letters: legal to unicode.IsLetter, illegal to the spec.
+	{"Pét", "Pet"},
+	{"café.Order", "cafe.Order"},
+	{"Ünïcödé", "Unicode"},
+	// No ASCII base form exists, so the sanitizer replaces it and the empty
+	// result falls back rather than emitting an unnamed key.
+	{"宠物", "UnnamedSchema"},
+}
+
+// TestFixSchemaNamesDetectsIllegalOAS3ComponentNames is the regression for
+// issue #405.
+//
+// Detection used a denylist of characters while OAS 3.x enforces an allowlist,
+// so any name illegal for a reason not on the list was never considered for
+// renaming. --fix-schema-names reported no fix and left a document the validator
+// rejects.
+func TestFixSchemaNamesDetectsIllegalOAS3ComponentNames(t *testing.T) {
+	for _, tt := range illegalOAS3Names {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := oas3SpecNamed(tt.name)
+
+			// The input is invalid, or this case proves nothing.
+			parseResult, err := parser.ParseWithOptions(parser.WithBytes([]byte(spec)))
+			require.NoError(t, err)
+			before, err := validator.New().ValidateParsed(*parseResult)
+			require.NoError(t, err)
+			require.False(t, before.Valid, "the unfixed document should fail validation")
+
+			result := fixSchemaNamesParsed(t, parseResult, GenericNamingUnderscore)
+			require.True(t, result.HasFixes(), "the illegal name should be renamed")
+
+			names := schemaNames(t, result.Document)
+			assert.Contains(t, names, tt.want)
+			assert.NotContains(t, names, tt.name, "the illegal key must be gone")
+			assert.Equal(t, pathutil.RefPrefixSchemas+tt.want,
+				responseSchemaRef(t, result.Document),
+				"the $ref must follow the rename")
+
+			after, err := validator.New().ValidateParsed(*result.ToParseResult())
+			require.NoError(t, err)
+			assert.True(t, after.Valid, "errors: %v", after.Errors)
+		})
+	}
+}
+
+// TestFixSchemaNamesLeavesValidOAS2NamesAlone pins the version-aware half of the
+// decision.
+//
+// OAS 2.0 places no charset constraint on definitions keys, so every name here
+// is legitimate and resolves correctly once escaped per RFC 6901. Renaming them
+// would rewrite a valid document, so detection must stay on the denylist for
+// 2.0 even though the identical name is renamed under 3.x.
+func TestFixSchemaNamesLeavesValidOAS2NamesAlone(t *testing.T) {
+	for _, tt := range illegalOAS3Names {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := oas2SpecNamed(tt.name)
+
+			// The premise: this document is already valid as OAS 2.0.
+			parseResult, err := parser.ParseWithOptions(parser.WithBytes([]byte(spec)))
+			require.NoError(t, err)
+			before, err := validator.New().ValidateParsed(*parseResult)
+			require.NoError(t, err)
+			require.True(t, before.Valid, "spec should be valid OAS 2.0; errors: %v", before.Errors)
+
+			result := fixSchemaNamesParsed(t, parseResult, GenericNamingUnderscore)
+
+			assert.False(t, result.HasFixes(), "a valid OAS 2.0 name must not be renamed")
+			assert.Contains(t, schemaNames(t, result.Document), tt.name,
+				"the original key must survive untouched")
+		})
+	}
+}
+
+// TestFixSchemaNamesOAS2StillRenamesBracketNames is the control for the test
+// above: leaving valid names alone must not stop OAS 2.0 renaming the names it
+// always did.
+func TestFixSchemaNamesOAS2StillRenamesBracketNames(t *testing.T) {
+	spec := oas2SpecNamed("Response[User]")
+
+	result := fixSchemaNames(t, spec, GenericNamingOf)
+
+	require.True(t, result.HasFixes(), "a bracketed name is still renamed under OAS 2.0")
+	assert.Contains(t, schemaNames(t, result.Document), "ResponseOfUser")
+	assert.Equal(t, pathutil.RefPrefixDefinitions+"ResponseOfUser",
+		responseSchemaRef(t, result.Document))
+}
+
+// TestFixSchemaNamesOAS2KeepsNonASCII is the second control: the replacement
+// side is version-aware too. Folding "Pét" to "Pet" is required under OAS 3.x
+// and unwanted under 2.0, where the accent is perfectly legal.
+func TestFixSchemaNamesOAS2KeepsNonASCII(t *testing.T) {
+	spec := oas2SpecNamed("Pét[User]")
+
+	result := fixSchemaNames(t, spec, GenericNamingOf)
+
+	require.True(t, result.HasFixes(), "the bracket still triggers a rename")
+	assert.Contains(t, schemaNames(t, result.Document), "PétOfUser",
+		"OAS 2.0 has no reason to strip the accent")
+}
+
+// TestTransformSchemaNameIsAlwaysLegalForOAS3 asserts the honest-fix invariant
+// across the whole detection surface: if the fixer decides an OAS 3.x name needs
+// renaming, the name it produces must satisfy the charset it renamed for.
+//
+// Without it, widening detection just converts silent no-ops into fixes that are
+// reported as applied and leave the document equally invalid — which is how the
+// accented-name case behaved before this change.
+func TestTransformSchemaNameIsAlwaysLegalForOAS3(t *testing.T) {
+	bases := []string{"", "R", "Resp", "pkg/v1.R", "Pét", "宠物", "a_", "example.com/x", "Ünï"}
+	frags := []string{"", "[U]", "<U>", "[a,b]", "[pkg/x.Y]", "[Pét]", "[宠物]", " ", ",", "@", "%", "~", "!", "(", "\"", "宠"}
+	strategies := []GenericNamingStrategy{
+		GenericNamingUnderscore, GenericNamingOf, GenericNamingFor,
+		GenericNamingFlattened, GenericNamingDot,
+	}
+
+	checked := 0
+	for _, b := range bases {
+		for _, f := range frags {
+			for _, suffix := range []string{"", "X"} {
+				name := b + f + suffix
+				if !hasInvalidSchemaNameChars(name, charsetComponentName) {
+					continue
+				}
+				for _, s := range strategies {
+					cfg := GenericNamingConfig{Strategy: s, Separator: "_", ParamSeparator: "_"}
+					got := transformSchemaName(name, cfg, charsetComponentName)
+					checked++
+					assert.Regexp(t, componentNamePattern, got,
+						"transform of %q under %s produced an illegal component name", name, s)
+					assert.False(t, hasInvalidSchemaNameChars(got, charsetComponentName),
+						"transform of %q under %s produced a name that would be renamed again", name, s)
+				}
+			}
+		}
+	}
+	require.Positive(t, checked, "the table should exercise some invalid names")
+}
+
+// TestHasInvalidSchemaNameCharsByCharset covers detection directly, including
+// the names whose treatment differs by version.
+func TestHasInvalidSchemaNameCharsByCharset(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantOK3 bool // detected under OAS 3.x
+		wantOK2 bool // detected under OAS 2.0
+	}{
+		{"plain name", "Pet", false, false},
+		{"dots and dashes are legal in both", "pkg.v1-Pet", false, false},
+		{"underscores are legal in both", "__Pet__", false, false},
+		{"brackets are caught by both", "Response[User]", true, true},
+		{"space is caught by both", "Res ponse", true, true},
+		{"slash is 3.x only", "pkg/Pet", true, false},
+		{"tilde is 3.x only", "pet~summary", true, false},
+		{"at sign is 3.x only", "Pet@v1", true, false},
+		{"accented letter is 3.x only", "Pét", true, false},
+		{"CJK is 3.x only", "宠物", true, false},
+		{"empty is caught by both", "", true, true},
+		{"whitespace only is caught by both", "   ", true, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantOK3, hasInvalidSchemaNameChars(tt.input, charsetComponentName), "OAS 3.x")
+			assert.Equal(t, tt.wantOK2, hasInvalidSchemaNameChars(tt.input, charsetUnrestricted), "OAS 2.0")
+		})
+	}
+}
+
+// TestCharsetForVersion pins which rule each OAS version gets. Every 3.x
+// release is listed rather than a sample, so adding a version without deciding
+// its charset shows up here.
+func TestCharsetForVersion(t *testing.T) {
+	tests := []struct {
+		version parser.OASVersion
+		want    nameCharset
+	}{
+		{parser.OASVersion20, charsetUnrestricted},
+		{parser.OASVersion300, charsetComponentName},
+		{parser.OASVersion301, charsetComponentName},
+		{parser.OASVersion302, charsetComponentName},
+		{parser.OASVersion303, charsetComponentName},
+		{parser.OASVersion304, charsetComponentName},
+		{parser.OASVersion310, charsetComponentName},
+		{parser.OASVersion311, charsetComponentName},
+		{parser.OASVersion312, charsetComponentName},
+		{parser.OASVersion320, charsetComponentName},
+		// An unclassified document gets the stricter rule, matching how
+		// schemaPathPrefix treats anything that is not OAS 2.0.
+		{parser.Unknown, charsetComponentName},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.version.String(), func(t *testing.T) {
+			assert.Equal(t, tt.want, charsetForVersion(tt.version))
+		})
+	}
+}
+
+// TestFoldToASCII covers the diacritic stripping that keeps an accented name
+// readable instead of reducing it to underscores.
+func TestFoldToASCII(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"ascii is returned unchanged", "Pet", "Pet"},
+		{"empty is unchanged", "", ""},
+		{"acute accent", "Pét", "Pet"},
+		{"several accents", "Ünïcödé", "Unicode"},
+		{"accent inside a qualified name", "café.Order", "cafe.Order"},
+		{"cedilla", "façade", "facade"},
+		{"already-decomposed input", "Pét", "Pet"},
+		{"no ascii base form is left alone", "宠物", "宠物"},
+		{"mixed scripts keep what cannot fold", "Pét宠", "Pet宠"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, foldToASCII(tt.input))
+		})
+	}
+}
+
+// TestIsComponentNameChar covers the charset predicate against the pattern it
+// restates, including the ASCII-only boundary that unicode.IsLetter gets wrong.
+func TestIsComponentNameChar(t *testing.T) {
+	for _, r := range []rune{'a', 'z', 'A', 'Z', '0', '9', '.', '-', '_'} {
+		assert.True(t, isComponentNameChar(r), "%q should be allowed", r)
+		assert.Regexp(t, componentNamePattern, string(r), "%q should match the pattern", r)
+	}
+	for _, r := range []rune{'/', '~', '@', '!', ' ', '[', ']', 'é', '宠', '中', 'Ω'} {
+		assert.False(t, isComponentNameChar(r), "%q should be rejected", r)
+		assert.NotRegexp(t, componentNamePattern, string(r), "%q should not match the pattern", r)
+	}
+}

--- a/fixer/generic_names.go
+++ b/fixer/generic_names.go
@@ -12,6 +12,7 @@ import (
 	"unicode"
 	"unicode/utf8"
 
+	"github.com/erraggy/oastools/internal/naming"
 	"github.com/erraggy/oastools/internal/pathutil"
 	"github.com/erraggy/oastools/parser"
 	"golang.org/x/text/cases"
@@ -148,7 +149,8 @@ const (
 	charsetUnrestricted nameCharset = iota
 
 	// charsetComponentName applies to OAS 3.x, whose Components Object requires
-	// every key to match ^[a-zA-Z0-9._-]+$. That rule is an allowlist, so a
+	// every key to match [naming.ComponentNamePattern]. That rule is an
+	// allowlist, so a
 	// denylist can never keep up with it: "pkg/Pet", "Pet@v1" and "Pét" are all
 	// illegal without containing a single character worth enumerating.
 	charsetComponentName
@@ -171,7 +173,7 @@ func charsetForVersion(version parser.OASVersion) nameCharset {
 // break tooling. Under OAS 3.x the spec itself settles it.
 func (c nameCharset) allowsInName(r rune) bool {
 	if c == charsetComponentName {
-		return isComponentNameChar(r)
+		return naming.IsComponentNameChar(r)
 	}
 	return !slices.Contains(invalidSchemaNameChars, r)
 }
@@ -183,23 +185,9 @@ func (c nameCharset) allowsInName(r rune) bool {
 // escaped, even where the spec would permit it.
 func (c nameCharset) allowsInReplacement(r rune) bool {
 	if c == charsetComponentName {
-		return isComponentNameChar(r)
+		return naming.IsComponentNameChar(r)
 	}
 	return unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' || r == '-' || r == '.'
-}
-
-// isComponentNameChar reports whether r is permitted by the OAS 3.x Components
-// Object key pattern, ^[a-zA-Z0-9._-]+$.
-//
-// Spelled out rather than deferring to unicode.IsLetter: the pattern is ASCII
-// only, so "é" and "宠" are letters that it nonetheless rejects.
-func isComponentNameChar(r rune) bool {
-	switch {
-	case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
-		return true
-	default:
-		return r == '.' || r == '-' || r == '_'
-	}
 }
 
 // hasInvalidSchemaNameChars returns true if name contains characters that
@@ -471,7 +459,8 @@ func toNameFragment(name string, charset nameCharset) string {
 //
 // Code-first generators emit these for package-qualified generic parameters, and
 // a "/" cannot stay in the new name: OAS 3.x rejects a component name outright
-// unless it matches ^[a-zA-Z0-9._-]+$, and while OAS 2.0 permits one in a
+// unless it satisfies [naming.ComponentNamePattern], and while OAS 2.0 permits
+// one in a
 // definitions key, every $ref reaching it then needs escaping — exactly the
 // encoding trouble this fix removes.
 //

--- a/fixer/generic_names.go
+++ b/fixer/generic_names.go
@@ -10,11 +10,15 @@ import (
 	"slices"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/erraggy/oastools/internal/pathutil"
 	"github.com/erraggy/oastools/parser"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
+	"golang.org/x/text/runes"
+	"golang.org/x/text/transform"
+	"golang.org/x/text/unicode/norm"
 )
 
 // GenericNamingStrategy defines how generic type parameters are formatted
@@ -114,6 +118,11 @@ func DefaultGenericNamingConfig() GenericNamingConfig {
 // invalidSchemaNameChars contains characters that require URL encoding in $ref values.
 // These characters cause issues when used in schema names because JSON Pointer
 // references to them require percent-encoding.
+//
+// This is the whole detection rule only under [charsetUnrestricted], where the
+// spec imposes none of its own. OAS 3.x has an allowlist that already covers
+// every character here, so [charsetComponentName] never consults this list —
+// see [nameCharset.allowsInName].
 var invalidSchemaNameChars = []rune{
 	'[', ']', // square brackets (generics)
 	'<', '>', // angle brackets (generics in some languages)
@@ -126,16 +135,83 @@ var invalidSchemaNameChars = []rune{
 	'`',  // backtick
 }
 
-// hasInvalidSchemaNameChars returns true if name contains characters that are
-// problematic in schema names (require URL encoding in $ref values).
-func hasInvalidSchemaNameChars(name string) bool {
+// nameCharset is the set of characters a schema name may use. The OAS versions
+// disagree, so both halves of a rename — deciding a name needs one, and building
+// the replacement — are driven by this rather than by one hardcoded rule.
+type nameCharset uint8
+
+const (
+	// charsetUnrestricted applies to OAS 2.0, which places no charset constraint
+	// on the keys of the definitions object. A name there is renamed only for
+	// the characters in [invalidSchemaNameChars], which is the fixer's own
+	// judgement about what trips up tooling rather than anything the spec says.
+	charsetUnrestricted nameCharset = iota
+
+	// charsetComponentName applies to OAS 3.x, whose Components Object requires
+	// every key to match ^[a-zA-Z0-9._-]+$. That rule is an allowlist, so a
+	// denylist can never keep up with it: "pkg/Pet", "Pet@v1" and "Pét" are all
+	// illegal without containing a single character worth enumerating.
+	charsetComponentName
+)
+
+// charsetForVersion returns the charset a document's schema names must satisfy.
+func charsetForVersion(version parser.OASVersion) nameCharset {
+	if version == parser.OASVersion20 {
+		return charsetUnrestricted
+	}
+	return charsetComponentName
+}
+
+// allowsInName reports whether r may appear in a name the fixer leaves alone.
+//
+// This is the detection rule, and it is deliberately not the same question as
+// [nameCharset.allowsInReplacement]. Under OAS 2.0 a "/" is legal in a
+// definitions key and resolves correctly once escaped, so renaming it would
+// rewrite a valid document; the fixer only steps in for the characters it knows
+// break tooling. Under OAS 3.x the spec itself settles it.
+func (c nameCharset) allowsInName(r rune) bool {
+	if c == charsetComponentName {
+		return isComponentNameChar(r)
+	}
+	return !slices.Contains(invalidSchemaNameChars, r)
+}
+
+// allowsInReplacement reports whether r may appear in a name the fixer builds.
+//
+// Stricter than [nameCharset.allowsInName] under OAS 2.0: a generated name
+// should not reintroduce a character that forces every $ref reaching it to be
+// escaped, even where the spec would permit it.
+func (c nameCharset) allowsInReplacement(r rune) bool {
+	if c == charsetComponentName {
+		return isComponentNameChar(r)
+	}
+	return unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' || r == '-' || r == '.'
+}
+
+// isComponentNameChar reports whether r is permitted by the OAS 3.x Components
+// Object key pattern, ^[a-zA-Z0-9._-]+$.
+//
+// Spelled out rather than deferring to unicode.IsLetter: the pattern is ASCII
+// only, so "é" and "宠" are letters that it nonetheless rejects.
+func isComponentNameChar(r rune) bool {
+	switch {
+	case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+		return true
+	default:
+		return r == '.' || r == '-' || r == '_'
+	}
+}
+
+// hasInvalidSchemaNameChars returns true if name contains characters that
+// require the schema to be renamed under the given charset.
+func hasInvalidSchemaNameChars(name string, charset nameCharset) bool {
 	// Empty or whitespace-only names are invalid
 	if strings.TrimSpace(name) == "" {
 		return true
 	}
 
 	for _, c := range name {
-		if slices.Contains(invalidSchemaNameChars, c) {
+		if !charset.allowsInName(c) {
 			return true
 		}
 	}
@@ -247,7 +323,7 @@ func splitTypeParams(s string) []string {
 //	"Response[User]" -> "ResponseOfUser"
 //	"Map[string,int]" -> "MapOfStringOfInt"
 //	"Response[List[User]]" -> "ResponseOfListOfUser"
-func transformSchemaName(name string, config GenericNamingConfig) string {
+func transformSchemaName(name string, config GenericNamingConfig, charset nameCharset) string {
 	// Handle empty or whitespace-only names
 	if strings.TrimSpace(name) == "" {
 		return "UnnamedSchema"
@@ -255,13 +331,17 @@ func transformSchemaName(name string, config GenericNamingConfig) string {
 
 	base, params, _ := parseGenericName(name)
 
-	// If no type parameters, just sanitize and return
+	// If no type parameters, the whole name is one fragment. It gets the same
+	// treatment a base or a type parameter would, so a path-qualified name
+	// reduces the same way whether or not it happens to be generic:
+	// "example.com/pkg/Pet" and "Resp[example.com/pkg/Pet]" both keep their
+	// qualification as dots rather than losing it to underscores.
 	if len(params) == 0 {
-		sanitized := sanitizeSchemaName(name)
-		if sanitized == "" {
+		fragment := toNameFragment(name, charset)
+		if fragment == "" {
 			return "UnnamedSchema"
 		}
-		return sanitized
+		return fragment
 	}
 
 	// The base is spliced into the result below, so it carries whatever the
@@ -269,12 +349,12 @@ func transformSchemaName(name string, config GenericNamingConfig) string {
 	// "pkg/v1.Response[Pet]" both reach here. Only the parameters were being
 	// cleaned, so the base needs the same treatment or the new name is no more
 	// legal than the old one.
-	base = toNameFragment(base)
+	base = toNameFragment(base, charset)
 
 	// Recursively transform nested generic types in parameters
 	transformedParams := make([]string, len(params))
 	for i, param := range params {
-		transformedParams[i] = transformTypeParam(param, config)
+		transformedParams[i] = transformTypeParam(param, config, charset)
 	}
 
 	// Apply strategy
@@ -312,7 +392,7 @@ func transformSchemaName(name string, config GenericNamingConfig) string {
 //	"common.Pet" → "common.Pet" (package preserved)
 //	"*User" → "User" (pointer stripped, then PascalCased if configured)
 //	"List[User]" → recursively transformed
-func transformTypeParam(param string, config GenericNamingConfig) string {
+func transformTypeParam(param string, config GenericNamingConfig, charset nameCharset) string {
 	// Strip leading pointer asterisks (Go pointer syntax leaking from code generators)
 	param = strings.TrimLeft(param, "*")
 
@@ -320,11 +400,11 @@ func transformTypeParam(param string, config GenericNamingConfig) string {
 	// qualification to avoid corrupting the reference, cleaning only the
 	// characters that cannot survive into a schema name
 	if isPackageQualifiedName(param) {
-		return toNameFragment(param)
+		return toNameFragment(param, charset)
 	}
 
 	// For generic types or simple names, apply normal transformation
-	transformed := transformSchemaName(param, config)
+	transformed := transformSchemaName(param, config, charset)
 
 	// Apply PascalCase if not preserving casing (for non-package names)
 	if !config.PreserveCasing {
@@ -332,6 +412,41 @@ func transformTypeParam(param string, config GenericNamingConfig) string {
 	}
 
 	return transformed
+}
+
+// foldToASCII rewrites accented letters as their base letter, so "Pét" becomes
+// "Pet" rather than "P_t".
+//
+// It decomposes each rune into a base plus its combining marks, drops the marks,
+// and recomposes. That covers the Latin-alphabet names code generators actually
+// produce; a script with no ASCII base form, such as "宠物", is returned
+// unchanged and the caller's sanitizer replaces it. Transliterating those would
+// need a per-script romanization table, which is a different job.
+//
+// The transformer is built per call rather than shared, because it carries state
+// and the fixer may run concurrently. The ASCII fast path keeps that off the
+// common route: almost every name is already ASCII.
+func foldToASCII(name string) string {
+	if isASCII(name) {
+		return name
+	}
+
+	folded, _, err := transform.String(
+		transform.Chain(norm.NFD, runes.Remove(runes.In(unicode.Mn)), norm.NFC), name)
+	if err != nil {
+		return name
+	}
+	return folded
+}
+
+// isASCII reports whether name is entirely ASCII.
+func isASCII(name string) bool {
+	for i := range len(name) {
+		if name[i] >= utf8.RuneSelf {
+			return false
+		}
+	}
+	return true
 }
 
 // toNameFragment reduces one fragment of a generated schema name — a base name
@@ -346,8 +461,8 @@ func transformTypeParam(param string, config GenericNamingConfig) string {
 // do not become the "_" it would otherwise produce: a dot is what the fragment
 // already uses to qualify its package, and it keeps every segment, so two types
 // differing only by package still reduce to distinct names.
-func toNameFragment(name string) string {
-	return sanitizeSchemaName(flattenPathQualifier(name))
+func toNameFragment(name string, charset nameCharset) string {
+	return sanitizeSchemaName(flattenPathQualifier(name), charset)
 }
 
 // flattenPathQualifier rewrites the "/" separators of a path-qualified type
@@ -372,12 +487,18 @@ func flattenPathQualifier(name string) string {
 // sanitizeSchemaName removes or replaces invalid characters with underscores.
 // This is a fallback for names that aren't cleanly generic-style but still
 // contain problematic characters.
-func sanitizeSchemaName(name string) string {
+func sanitizeSchemaName(name string, charset nameCharset) string {
+	// Fold before the loop so an accented letter reaches it as its base letter
+	// rather than as a rune the ASCII charset has no choice but to replace.
+	if charset == charsetComponentName {
+		name = foldToASCII(name)
+	}
+
 	var result strings.Builder
 	result.Grow(len(name))
 
 	for _, r := range name {
-		if isValidSchemaNameChar(r) {
+		if charset.allowsInReplacement(r) {
 			result.WriteRune(r)
 		} else {
 			result.WriteRune('_')
@@ -394,12 +515,6 @@ func sanitizeSchemaName(name string) string {
 	s = strings.Trim(s, "_")
 
 	return s
-}
-
-// isValidSchemaNameChar returns true if the character is valid in schema names.
-// Valid characters are: alphanumeric, underscore, hyphen, and dot.
-func isValidSchemaNameChar(r rune) bool {
-	return unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' || r == '-' || r == '.'
 }
 
 // toPascalCase converts a string to PascalCase.

--- a/fixer/generic_names_slash_test.go
+++ b/fixer/generic_names_slash_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/erraggy/oastools/internal/naming"
 	"github.com/erraggy/oastools/internal/pathutil"
 	"github.com/erraggy/oastools/parser"
 	"github.com/erraggy/oastools/validator"
@@ -636,7 +637,7 @@ func TestTransformSchemaNameCleansBase(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := transformSchemaName(tt.input, GenericNamingConfig{Strategy: GenericNamingOf}, charsetComponentName)
 			assert.Equal(t, tt.want, got)
-			assert.Regexp(t, `^[a-zA-Z0-9._-]+$`, got,
+			assert.Regexp(t, naming.ComponentNamePattern, got,
 				"a generated name must satisfy the OAS 3.x component-name charset")
 		})
 	}

--- a/fixer/generic_names_slash_test.go
+++ b/fixer/generic_names_slash_test.go
@@ -341,6 +341,15 @@ func fixSchemaNames(t *testing.T, spec string, strategy GenericNamingStrategy) *
 	parseResult, err := parser.ParseWithOptions(parser.WithBytes([]byte(spec)))
 	require.NoError(t, err)
 
+	return fixSchemaNamesParsed(t, parseResult, strategy)
+}
+
+// fixSchemaNamesParsed is [fixSchemaNames] for a document a test has already
+// parsed, typically to assert its validity before the fix. parseResult is left
+// untouched: FixParsed copies unless MutableInput is set.
+func fixSchemaNamesParsed(t *testing.T, parseResult *parser.ParseResult, strategy GenericNamingStrategy) *FixResult {
+	t.Helper()
+
 	f := New()
 	f.EnabledFixes = []FixType{FixTypeRenamedGenericSchema}
 	f.GenericNamingConfig.Strategy = strategy
@@ -415,7 +424,7 @@ func TestFixSchemaNamesRoundTripsToValid(t *testing.T) {
 							require.False(t, before.Valid,
 								"the unfixed document should fail validation, or this case proves nothing")
 
-							result := fixSchemaNames(t, spec, strategy)
+							result := fixSchemaNamesParsed(t, parseResult, strategy)
 							require.True(t, result.HasFixes(), "the invalid schema name should be renamed")
 
 							after, err := validator.New().ValidateParsed(*result.ToParseResult())
@@ -625,7 +634,7 @@ func TestTransformSchemaNameCleansBase(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := transformSchemaName(tt.input, GenericNamingConfig{Strategy: GenericNamingOf})
+			got := transformSchemaName(tt.input, GenericNamingConfig{Strategy: GenericNamingOf}, charsetComponentName)
 			assert.Equal(t, tt.want, got)
 			assert.Regexp(t, `^[a-zA-Z0-9._-]+$`, got,
 				"a generated name must satisfy the OAS 3.x component-name charset")

--- a/fixer/version_helpers.go
+++ b/fixer/version_helpers.go
@@ -188,9 +188,11 @@ func (f *Fixer) renameInvalidSchemas(
 	// "RespOfa.b.Pet" — and the loser takes the numeric suffix
 	// resolveNameCollision appends. Ranging over the map instead would hand that
 	// suffix to a different schema on each run.
+	charset := charsetForVersion(accessor.GetVersion())
+
 	candidates := make([]string, 0, len(schemas))
 	for name := range schemas {
-		if hasInvalidSchemaNameChars(name) {
+		if hasInvalidSchemaNameChars(name, charset) {
 			candidates = append(candidates, name)
 		}
 	}
@@ -205,7 +207,7 @@ func (f *Fixer) renameInvalidSchemas(
 	claimed := make(map[string]bool, len(candidates))
 	for _, name := range candidates {
 		newName := resolveNameCollision(
-			transformSchemaName(name, f.GenericNamingConfig), schemas, renames, claimed)
+			transformSchemaName(name, f.GenericNamingConfig, charset), schemas, renames, claimed)
 		renames[name] = newName
 		claimed[newName] = true
 	}

--- a/internal/naming/component_names.go
+++ b/internal/naming/component_names.go
@@ -1,0 +1,57 @@
+package naming
+
+// ComponentNamePattern is the charset OAS 3.x requires of every fixed field of
+// the Components Object: "All the fixed fields declared above are objects that
+// MUST use keys that match the regular expression: ^[a-zA-Z0-9\.\-_]+$".
+//
+// See: https://spec.openapis.org/oas/v3.0.0.html#components-object
+//
+// The spec writes "." and "-" escaped inside the character class, where neither
+// needs escaping; this is the same expression written plainly. It is a string
+// rather than a compiled [regexp.Regexp] because nothing needs to run it —
+// [IsValidComponentName] decides membership directly, and this exists so an
+// error message can quote the rule it enforces.
+//
+// OAS 2.0 has no counterpart, deliberately. It places no charset constraint on
+// the keys of the root-level parameters, definitions, and responses objects, so
+// a name containing "/" or "~" is legitimate there and is escaped per RFC 6901
+// when referenced. Applying this pattern to an OAS 2.0 document would reject
+// valid specs.
+const ComponentNamePattern = `^[a-zA-Z0-9._-]+$`
+
+// IsComponentNameChar reports whether r may appear in an OAS 3.x component name.
+//
+// Spelled out rather than deferring to unicode.IsLetter or unicode.IsDigit:
+// [ComponentNamePattern] is ASCII only, so "é" and "宠" are letters it
+// nonetheless rejects, and "٣" is a digit it rejects.
+func IsComponentNameChar(r rune) bool {
+	switch {
+	case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+		return true
+	default:
+		return r == '.' || r == '-' || r == '_'
+	}
+}
+
+// IsValidComponentName reports whether name satisfies [ComponentNamePattern].
+//
+// This is the single implementation of that rule. Validation asks whether a
+// document's names are legal and the fixer asks which characters it may keep
+// when building a replacement, so both consume this rather than restating the
+// charset; a hand-maintained copy on either side would be free to drift from
+// the spec and from the other.
+//
+// The empty string is not valid: the pattern's "+" requires at least one
+// character. Callers that want to report an empty name differently should test
+// for it before calling.
+func IsValidComponentName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for _, r := range name {
+		if !IsComponentNameChar(r) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/naming/component_names_test.go
+++ b/internal/naming/component_names_test.go
@@ -1,0 +1,118 @@
+package naming
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIsValidComponentNameMatchesPattern is the drift guard.
+//
+// [ComponentNamePattern] and [IsValidComponentName] are two statements of one
+// rule — the string exists to be quoted in error messages, the function to be
+// run — so a change to either that the other does not follow is a silent bug.
+// Running the compiled pattern against the predicate over every rune the rule
+// could plausibly meet, plus the strings whose regexp behavior is easy to get
+// wrong, keeps them honest.
+func TestIsValidComponentNameMatchesPattern(t *testing.T) {
+	pattern := regexp.MustCompile(ComponentNamePattern)
+
+	t.Run("every single rune agrees", func(t *testing.T) {
+		// Through the Latin, Greek, Cyrillic, Hebrew and Arabic blocks, which is
+		// where a letter that unicode.IsLetter accepts and the ASCII-only rule
+		// rejects actually turns up, plus a CJK sample.
+		for r := rune(0); r <= 0x0700; r++ {
+			s := string(r)
+			require.Equal(t, pattern.MatchString(s), IsValidComponentName(s),
+				"disagreement on rune %U (%q)", r, s)
+		}
+		for _, r := range []rune{'宠', '物', '中', '日', 'é', '́', 'Ａ'} {
+			s := string(r)
+			require.Equal(t, pattern.MatchString(s), IsValidComponentName(s),
+				"disagreement on rune %U (%q)", r, s)
+		}
+	})
+
+	t.Run("whole strings agree", func(t *testing.T) {
+		names := []string{
+			"", "Pet", "pet", "PET", "Pet1", "1Pet", "0", "_", "-", ".",
+			"pkg.v1-Pet_2", "...", "___", "---",
+			"pkg/Pet", "pet~summary", "Pet@v1", "Pet Name", "Response[User]",
+			"Pét", "café.Order", "宠物", "Ünïcödé",
+			// A trailing newline is the classic way a "$"-anchored pattern and a
+			// hand-rolled loop part company.
+			"Pet\n", "\nPet", "Pet\n\n", "\n",
+			"Pet\t", "Pet\r", "Pet\x00",
+		}
+		for _, name := range names {
+			assert.Equal(t, pattern.MatchString(name), IsValidComponentName(name),
+				"disagreement on %q", name)
+		}
+	})
+
+	t.Run("predicate agrees with the pattern per character", func(t *testing.T) {
+		for r := rune(0); r <= 0x0700; r++ {
+			assert.Equal(t, pattern.MatchString(string(r)), IsComponentNameChar(r),
+				"disagreement on rune %U", r)
+		}
+	})
+}
+
+// TestIsComponentNameChar covers the charset boundaries directly, so a failure
+// names the character rather than pointing at a sweep.
+func TestIsComponentNameChar(t *testing.T) {
+	allowed := []rune{'a', 'm', 'z', 'A', 'M', 'Z', '0', '5', '9', '.', '-', '_'}
+	for _, r := range allowed {
+		assert.True(t, IsComponentNameChar(r), "%q should be allowed", r)
+	}
+
+	rejected := []rune{
+		'/', '~', '@', '!', '#', '$', '%', '&', '*', '+', '=', '?', ':', ';',
+		'\'', '"', '(', ')', '[', ']', '{', '}', '<', '>', ',', '|', '\\', '^',
+		'`', ' ', '\t', '\n',
+		// Letters and digits that are not ASCII.
+		'é', '宠', '中', 'Ω', 'Я', '٣',
+	}
+	for _, r := range rejected {
+		assert.False(t, IsComponentNameChar(r), "%q should be rejected", r)
+	}
+}
+
+// TestIsValidComponentName covers the string-level rule, including the empty
+// name that the pattern's "+" quantifier excludes.
+func TestIsValidComponentName(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"simple name", "Pet", true},
+		{"all the allowed punctuation", "pkg.v1-Pet_2", true},
+		{"digits only", "12345", true},
+		{"punctuation only", "._-", true},
+		{"empty is rejected by the + quantifier", "", false},
+		{"whitespace", "   ", false},
+		{"slash", "pkg/Pet", false},
+		{"tilde", "pet~summary", false},
+		{"accented letter", "Pét", false},
+		{"CJK", "宠物", false},
+		{"one bad character in a long name", "PetPetPetPet@", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsValidComponentName(tt.input))
+		})
+	}
+}
+
+func ExampleIsValidComponentName() {
+	fmt.Println(IsValidComponentName("pkg.v1-Pet"))
+	fmt.Println(IsValidComponentName("pkg/Pet"))
+	// Output:
+	// true
+	// false
+}

--- a/internal/naming/doc.go
+++ b/internal/naming/doc.go
@@ -1,4 +1,5 @@
-// Package naming provides shared case conversion utilities for oastools packages.
+// Package naming provides shared naming utilities for oastools packages: case
+// conversion, and the charset rule OAS 3.x imposes on component names.
 //
 // This internal package contains common string transformation functions used
 // by multiple oastools packages including builder and joiner. Functions include
@@ -7,6 +8,15 @@
 // These functions are used for:
 //   - Builder package: Schema and operation naming from titles
 //   - Joiner package: Template functions for operation-aware schema renaming
+//   - Fixer package: Operation ID naming
+//
+// # Component Names
+//
+// [ComponentNamePattern] and [IsValidComponentName] state, once, the charset
+// OAS 3.x requires of every key of the Components Object. The validator asks
+// whether a document's names are legal and the fixer asks which characters it
+// may keep when building a replacement; both consume the same definition so
+// neither can drift from the spec or from the other.
 //
 // As an internal package, these functions are not part of the public API
 // and may change without notice.

--- a/internal/pathutil/doc.go
+++ b/internal/pathutil/doc.go
@@ -1,6 +1,3 @@
-// Copyright 2024 Erraggy
-// SPDX-License-Identifier: MIT
-
 // Package pathutil provides reference building, escaping, and path
 // sanitization utilities for OpenAPI document traversal.
 //

--- a/internal/pathutil/refs.go
+++ b/internal/pathutil/refs.go
@@ -1,6 +1,3 @@
-// Copyright 2024 Erraggy
-// SPDX-License-Identifier: MIT
-
 package pathutil
 
 import (

--- a/internal/pathutil/refs_test.go
+++ b/internal/pathutil/refs_test.go
@@ -1,6 +1,3 @@
-// Copyright 2024 Erraggy
-// SPDX-License-Identifier: MIT
-
 package pathutil
 
 import (

--- a/validator/component_names.go
+++ b/validator/component_names.go
@@ -2,28 +2,12 @@ package validator
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
 
 	"github.com/erraggy/oastools/internal/maputil"
+	"github.com/erraggy/oastools/internal/naming"
 	"github.com/erraggy/oastools/parser"
 )
-
-// componentNamePattern is the key charset OAS 3.x requires of every fixed field
-// of the Components Object: "All the fixed fields declared above are objects
-// that MUST use keys that match the regular expression: ^[a-zA-Z0-9\.\-_]+$".
-//
-// See: https://spec.openapis.org/oas/v3.0.0.html#components-object
-//
-// The spec writes "." and "-" escaped inside the character class, where neither
-// needs escaping; this is the same expression written plainly.
-//
-// OAS 2.0 has no counterpart, deliberately. It places no charset constraint on
-// the keys of the root-level parameters, definitions, and responses objects, so
-// a name containing "/" or "~" is legitimate there and is escaped per RFC 6901
-// when referenced: see [pathutil.EscapeRefToken]. Applying this pattern to an
-// OAS 2.0 document would reject valid specs.
-var componentNamePattern = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
 
 // validateOAS3ComponentNames reports component names that violate the charset
 // OAS 3.x requires.
@@ -54,7 +38,7 @@ func (v *Validator) validateOAS3ComponentNames(components *parser.Components, re
 const componentSchemasName = "schemas"
 
 // checkComponentNames reports every key of one Components section that falls
-// outside [componentNamePattern].
+// outside [naming.ComponentNamePattern].
 //
 // A free function rather than a method because Go does not permit type
 // parameters on methods, and the sections hold eleven different value types.
@@ -111,7 +95,7 @@ func checkComponentNames[V any](
 
 		case componentNameCharset:
 			v.addError(result, prefix+"."+name,
-				fmt.Sprintf("Component name %q must match %s", name, componentNamePattern),
+				fmt.Sprintf("Component name %q must match %s", name, naming.ComponentNamePattern),
 				specRef, withField("name"), withValue(name),
 			)
 		}
@@ -139,7 +123,7 @@ func classifyComponentName(name string, blankNamesReportedElsewhere bool) compon
 		return componentNameEmpty
 	case strings.TrimSpace(name) == "":
 		return componentNameWhitespace
-	case !componentNamePattern.MatchString(name):
+	case !naming.IsValidComponentName(name):
 		return componentNameCharset
 	default:
 		return componentNameOK


### PR DESCRIPTION
Fixes #405 🎯

`--fix-schema-names` decided a name needed renaming by scanning it for characters on a fixed list. OAS 3.x states the rule the other way round — a Components Object key must match `^[a-zA-Z0-9._-]+$`. **A denylist can never keep up with an allowlist**, so any name illegal for a reason not on the list was never even considered: no fix reported, exit 0, and a document the validator rejects.

## The gap is much wider than the reported `/`

The issue reported `pkg/Pet`. Probing the actual boundary found **20+ characters** that slip detection while failing the charset:

```
pkg/Pet   pet~summary   Pet@v1   Pet#1   Pet$   Pet%20   Pet&Co   Pet*   Pet+
Pet=      Pet?          Pet:1    Pet;    Pet'   Pet(1)   Pet!     Pét    宠物
```

So the fix is not "add `/` to the list" — it is to drive detection from the version's own rule. Same altitude lesson as #404, one level up: special-casing a single character on a shared path is the wrong depth.

## A second bug this forced into the open 🐛

The replacement side had the identical mismatch, and it was **already wrong on `main`**. `sanitizeSchemaName` tested characters with `unicode.IsLetter`, which accepts the non-ASCII letters the ASCII-only spec pattern rejects:

```console
$ oastools fix --fix-schema-names -q accent.json | oastools validate -no-warnings -strict -
  ✗ components.schemas.Pét_User_: Component name "Pét_User_" must match ^[a-zA-Z0-9._-]+$
```

`Pét[User]` is detected today via its brackets, "fixed", and reported as applied — while staying illegal. Fixing detection without this would have converted silent no-ops into more dishonest fixes, so both ship together.

## Design decisions 🧭

Two calls the issue explicitly left open, both settled deliberately:

**OAS 2.0 keeps the denylist.** It places no charset constraint on `definitions` keys — I verified `pkg/Pet`, `Pét` and `宠物` all validate clean as OAS 2.0 — so those names are legitimate and resolve correctly once escaped per RFC 6901. Renaming them would rewrite a valid document. The repo already has tested commitment to this (`TestPruneKeepsEscapedNameSchema`, #379). Opting 2.0 in later is easy; opting it out would be breaking.

**Accents fold to their base letter.** `Pét` → `Pet`, `café.Order` → `cafe.Order`, `Ünïcödé` → `Unicode` — readable names for the common European-API case, rather than `P_t`. Scripts with no ASCII base form fall back (`宠物` → `UnnamedSchema`). Uses `golang.org/x/text/unicode/norm`, already a direct dependency of this very file, behind an ASCII fast path so the common route is untouched.

The version split lives in two deliberately-different predicates:

| | `allowsInName` (detection) | `allowsInReplacement` (output) |
|---|---|---|
| OAS 2.0 | denylist only — `/` is legal here | stricter — never *generate* a `/` |
| OAS 3.x | `^[a-zA-Z0-9._-]+$` | same |

They differ under 2.0 on purpose: a `/` already in a document is fine, but a name the fixer *builds* should not force every `$ref` reaching it to be escaped.

## Also fixed: an inconsistency between the two paths

The non-generic branch of `transformSchemaName` bypassed `flattenPathQualifier`, so `pkg/Pet` reduced to `pkg_Pet` while `Resp[pkg/Pet]` reduced to `RespOfpkg.Pet`. Both now route through `toNameFragment`, so a path-qualified name keeps its qualification as dots whether or not it happens to be generic.

## Testing 🧪

- **22-name table** × fix-then-validate, covering the reported case and every category of the wider gap.
- **The same table asserted the other way for OAS 2.0** — every name must be left untouched. This pins the design decision itself, so a future change cannot silently reverse it.
- **Property test** `TestTransformSchemaNameIsAlwaysLegalForOAS3`: across a generated matrix of bases × fragments × all five naming strategies, any name the fixer decides to rename must produce one matching the charset *and* not need renaming again.
- **Every part proven load-bearing** — reverting it makes a named test fail:

| Reverted | Test that fails |
|---|---|
| Charset-based detection | `TestFixSchemaNamesDetectsIllegalOAS3ComponentNames` |
| ASCII-legal replacement | `TestTransformSchemaNameIsAlwaysLegalForOAS3` |
| Diacritic folding | `TestFixSchemaNamesDetectsIllegalOAS3ComponentNames` |
| OAS 2.0 exemption | `TestFixSchemaNamesLeavesValidOAS2NamesAlone` |

Controls included: OAS 2.0 still renames bracketed names, and OAS 2.0 keeps `PétOfUser` un-folded.

`make check` exits 0 (**9206 tests**, up from 9123) · gopls clean · govulncheck clean · **corpus suite passes** (Stripe, Microsoft Graph unaffected) · new code at 83–100% coverage.

## Performance 📊

Benchmarked against `main` on the same machine with `benchstat`, 8 samples: **no regressions**, every allocation row unchanged. Detection actually does less work under OAS 3.x — a few character comparisons instead of a linear scan of the denylist — and `foldToASCII` sits behind an ASCII fast path on a path only reached when a name is actually being renamed.

## Follow-up: one rule, one definition 🔗

Review flagged that the OAS 3.x component-name charset was duplicated. It was — across **four** spellings, not three: a compiled regexp in the validator, the hand-rolled predicate this PR added to the fixer, and two more regexps in fixer tests (one of them carrying a comment that it must be "kept in sync" with the validator's, which is the drift risk written down rather than removed).

`internal/naming` now holds the single definition. It exports the pattern as a string for error messages and a predicate for per-character callers, because the two consumers ask different questions — the validator whether a whole name is legal, the fixer which characters it may keep while building a replacement. `internal/naming` was the right home over exporting from `validator`: `fixer` already imports it, and a fixer depending on a validator reads backwards.

A test runs the compiled pattern against the predicate over every rune through U+0700 plus CJK samples, and over strings whose regexp behaviour is easy to get wrong (a trailing `\n`, since Go's `$` anchors to end-of-text). Verified load-bearing: adding `/` to the predicate fails it with `disagreement on rune U+002F`.

Side effect: the validator now decides membership with the predicate rather than a regexp. Its reported message is byte-identical, and the component-name check drops **83µs → 10µs** on a 500-schema section (±3%/±8%, n=15, zero allocations either way). That function's own comment says the common case is meant to stay cheap; the regexp engine was the reason it wasn't.

## Also in this branch: per-file license headers removed 🧹

Noticed while adding a new file: three files in `internal/pathutil` carried a copyright and SPDX header that the other 600 in the repo do not. Licensing is declared once in the root `LICENSE`, so the headers were inconsistency rather than coverage. Removed in a separate commit — unrelated to #405, small and low risk.

## On the comment density 📝

As in #406, several of these carry fuller doc comments than their size suggests. The reason a name is renamed under one OAS version and left alone under another is not visible from the code, and neither is why detection and replacement ask deliberately different questions. Each carries the case it exists for, so a future reader simplifying in good faith meets the reason before the regression. Most often that "future reader" is me, and so I've really pinned things down in code comments to protect myself from... myself 😜
