### PR TITLE
fix: support the full OAS 3.2.0 field set, and the ref/validation gaps it exposed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,5 +82,8 @@ docs/examples/
 # Playwright MCP (browser automation screenshots/data)
 .playwright-mcp/
 
+# Local MCP server configuration (per-developer tooling, not project config)
+.air/
+
 # Git worktrees for isolated development
 .worktrees/

--- a/cmd/oastools/commands/walk_operations.go
+++ b/cmd/oastools/commands/walk_operations.go
@@ -112,7 +112,7 @@ func filterOperations(
 		extFilter = &ef
 	}
 
-	var matched []*walker.OperationInfo
+	matched := make([]*walker.OperationInfo, 0, len(ops))
 	for _, op := range ops {
 		if !matchOperationMethod(op.Method, method) {
 			continue

--- a/cmd/oastools/commands/walk_operations.go
+++ b/cmd/oastools/commands/walk_operations.go
@@ -112,6 +112,11 @@ func filterOperations(
 		extFilter = &ef
 	}
 
+	// Nothing to filter: skip the walk and the allocation.
+	if len(ops) == 0 {
+		return nil, nil
+	}
+
 	matched := make([]*walker.OperationInfo, 0, len(ops))
 	for _, op := range ops {
 		if !matchOperationMethod(op.Method, method) {

--- a/cmd/oastools/commands/walk_parameters.go
+++ b/cmd/oastools/commands/walk_parameters.go
@@ -89,6 +89,12 @@ func handleWalkParameters(args []string) error {
 		hasExtFilter = true
 	}
 
+	// Nothing to filter: skip the walk and the allocation.
+	if len(collector.All) == 0 {
+		renderNoResults("parameters", flags.Quiet)
+		return nil
+	}
+
 	filtered := make([]*walker.ParameterInfo, 0, len(collector.All))
 	for _, info := range collector.All {
 		if flags.In != "" && !strings.EqualFold(info.In, flags.In) {

--- a/cmd/oastools/commands/walk_parameters.go
+++ b/cmd/oastools/commands/walk_parameters.go
@@ -89,7 +89,7 @@ func handleWalkParameters(args []string) error {
 		hasExtFilter = true
 	}
 
-	var filtered []*walker.ParameterInfo
+	filtered := make([]*walker.ParameterInfo, 0, len(collector.All))
 	for _, info := range collector.All {
 		if flags.In != "" && !strings.EqualFold(info.In, flags.In) {
 			continue
@@ -131,7 +131,7 @@ func handleWalkParameters(args []string) error {
 
 	// Summary table
 	headers := []string{headerName, "IN", "REQUIRED", headerPath, headerMethod, headerExtensions}
-	var rows [][]string
+	rows := make([][]string, 0, len(filtered))
 	for _, info := range filtered {
 		rows = append(rows, []string{
 			info.Name,

--- a/cmd/oastools/commands/walk_paths.go
+++ b/cmd/oastools/commands/walk_paths.go
@@ -122,7 +122,7 @@ func filterPaths(paths []pathInfo, pathPattern, extension string) ([]pathInfo, e
 		extFilter = &ef
 	}
 
-	var matched []pathInfo
+	matched := make([]pathInfo, 0, len(paths))
 	for _, p := range paths {
 		if !matchPath(p.pathTemplate, pathPattern) {
 			continue

--- a/cmd/oastools/commands/walk_paths.go
+++ b/cmd/oastools/commands/walk_paths.go
@@ -122,6 +122,11 @@ func filterPaths(paths []pathInfo, pathPattern, extension string) ([]pathInfo, e
 		extFilter = &ef
 	}
 
+	// Nothing to filter: skip the walk and the allocation.
+	if len(paths) == 0 {
+		return nil, nil
+	}
+
 	matched := make([]pathInfo, 0, len(paths))
 	for _, p := range paths {
 		if !matchPath(p.pathTemplate, pathPattern) {

--- a/cmd/oastools/commands/walk_schemas.go
+++ b/cmd/oastools/commands/walk_schemas.go
@@ -101,7 +101,7 @@ func handleWalkSchemas(args []string) error {
 		extFilter = &ef
 	}
 
-	var filtered []*walker.SchemaInfo
+	filtered := make([]*walker.SchemaInfo, 0, len(schemas))
 	for _, info := range schemas {
 		if flags.Name != "" && !strings.EqualFold(info.Name, flags.Name) {
 			continue

--- a/cmd/oastools/commands/walk_schemas.go
+++ b/cmd/oastools/commands/walk_schemas.go
@@ -101,6 +101,12 @@ func handleWalkSchemas(args []string) error {
 		extFilter = &ef
 	}
 
+	// Nothing to filter: skip the walk and the allocation.
+	if len(schemas) == 0 {
+		renderNoResults("schemas", flags.Quiet)
+		return nil
+	}
+
 	filtered := make([]*walker.SchemaInfo, 0, len(schemas))
 	for _, info := range schemas {
 		if flags.Name != "" && !strings.EqualFold(info.Name, flags.Name) {

--- a/cmd/oastools/commands/walk_security.go
+++ b/cmd/oastools/commands/walk_security.go
@@ -107,6 +107,11 @@ func filterSecuritySchemes(
 		extFilter = &ef
 	}
 
+	// Nothing to filter: skip the walk and the allocation.
+	if len(schemes) == 0 {
+		return nil, nil
+	}
+
 	matched := make([]*walker.SecuritySchemeInfo, 0, len(schemes))
 	for _, info := range schemes {
 		if info == nil || info.SecurityScheme == nil {

--- a/cmd/oastools/commands/walk_security.go
+++ b/cmd/oastools/commands/walk_security.go
@@ -107,7 +107,7 @@ func filterSecuritySchemes(
 		extFilter = &ef
 	}
 
-	var matched []*walker.SecuritySchemeInfo
+	matched := make([]*walker.SecuritySchemeInfo, 0, len(schemes))
 	for _, info := range schemes {
 		if info == nil || info.SecurityScheme == nil {
 			continue

--- a/converter/converter.go
+++ b/converter/converter.go
@@ -32,6 +32,24 @@ const (
 	securityTypeOAuth2 = "oauth2"
 )
 
+// OAuth flow names. The two versions agree on implicit and password and rename
+// the other two, which is the mapping convertSecuritySchemes implements.
+// https://spec.openapis.org/oas/v3.2.0.html#oauth-flows-object
+const (
+	// Spelled the same in both versions.
+	oauthFlowImplicit = "implicit"
+	oauthFlowPassword = "password"
+
+	// OAS 2.0 spellings of the remaining two.
+	oas2FlowApplication = "application"
+	oas2FlowAccessCode  = "accessCode"
+
+	// OAS 3.x spellings of the same two, plus the flow 3.2 added.
+	oas3FlowClientCredentials   = "clientCredentials"
+	oas3FlowAuthorizationCode   = "authorizationCode"
+	oas3FlowDeviceAuthorization = "deviceAuthorization"
+)
+
 // ConversionIssue represents a single conversion issue or limitation
 type ConversionIssue = issues.Issue
 

--- a/converter/converter.go
+++ b/converter/converter.go
@@ -510,6 +510,13 @@ func (c *Converter) convertOAS3ToOAS3(parseResult parser.ParseResult, targetVers
 		c.checkNullableDeprecation(converted, result)
 	}
 
+	// Report the 3.2 fixed fields when the target predates them. Gated on the
+	// target rather than on the source being 3.2, because a document may carry a
+	// 3.2 field whatever version string it declares.
+	if targetVersion < parser.OASVersion320 {
+		c.detectOAS32Features(converted, result)
+	}
+
 	return nil
 }
 

--- a/converter/oas2_to_oas3.go
+++ b/converter/oas2_to_oas3.go
@@ -435,22 +435,22 @@ func (c *Converter) convertSecurityDefinitions(src *parser.OAS2Document, dst *pa
 			scheme.Flows = &parser.OAuthFlows{}
 
 			switch secDef.Flow {
-			case "implicit":
+			case oauthFlowImplicit:
 				scheme.Flows.Implicit = &parser.OAuthFlow{
 					AuthorizationURL: secDef.AuthorizationURL,
 					Scopes:           secDef.Scopes,
 				}
-			case "password":
+			case oauthFlowPassword:
 				scheme.Flows.Password = &parser.OAuthFlow{
 					TokenURL: secDef.TokenURL,
 					Scopes:   secDef.Scopes,
 				}
-			case "application":
+			case oas2FlowApplication:
 				scheme.Flows.ClientCredentials = &parser.OAuthFlow{
 					TokenURL: secDef.TokenURL,
 					Scopes:   secDef.Scopes,
 				}
-			case "accessCode":
+			case oas2FlowAccessCode:
 				scheme.Flows.AuthorizationCode = &parser.OAuthFlow{
 					AuthorizationURL: secDef.AuthorizationURL,
 					TokenURL:         secDef.TokenURL,

--- a/converter/oas32_features.go
+++ b/converter/oas32_features.go
@@ -1,0 +1,374 @@
+// oas32_features.go reports the OAS 3.2.0 fixed fields a document uses when the
+// conversion target predates 3.2.
+
+package converter
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/erraggy/oastools/parser"
+)
+
+// detectOAS32Features reports every OAS 3.2 fixed field the document uses, for a
+// conversion whose target version predates 3.2.
+//
+// Reporting rather than stripping is this package's established convention for a
+// field the target does not define. detectOAS3SchemaFeatures leaves `nullable`,
+// `if`, `prefixItems` and the rest in place and records an issue; convertOAS3ToOAS3
+// removes nothing at all, so even a 3.1 to 3.0 conversion keeps $defs. A field is
+// cleared only where the target's serialization structurally cannot hold it: see
+// discriminatorToStringForm, where the OAS 2.0 bare-string discriminator has
+// nowhere to put `mapping` or `defaultMapping`.
+//
+// Before this ran, `query` and `additionalOperations` were the only 3.2 features
+// reported on downconversion, and only on the OAS 2.0 path. The fixed fields 3.2
+// added were emitted into a 3.0 or 3.1 document with no warning at all, which is
+// the half of issue #397 that survives once the fields are modeled: they now round
+// trip, so they reach a target that has no meaning for them.
+//
+// Severity is Warning rather than Critical throughout. These are additive
+// annotations (a name for a server, a summary for a tag) so a consumer of the
+// converted document is no worse off than before the field existed. That is
+// unlike `query` or `additionalOperations`, which describe an operation the target
+// version cannot express at all and are reported as Critical where they are found.
+func (c *Converter) detectOAS32Features(doc *parser.OAS3Document, result *ConversionResult) {
+	target := result.TargetVersion
+
+	// define our oas32Reporter to use here and pass into downnstream functions expecting it
+	report := func(path, field string) {
+		c.addIssueWithContext(result, path,
+			fmt.Sprintf("'%s' is OAS 3.2+ only and has no equivalent in OAS %s", field, target),
+			fmt.Sprintf("The field is preserved in the output, which is no longer a valid OAS %s document; remove it or keep the target at 3.2", target))
+	}
+
+	if doc.Self != "" {
+		report("$self", "$self")
+	}
+
+	for i, server := range doc.Servers {
+		if server != nil && server.Name != "" {
+			report("servers["+strconv.Itoa(i)+"]", "name")
+		}
+	}
+
+	for i, tag := range doc.Tags {
+		if tag == nil {
+			continue
+		}
+		tagPath := "tags[" + strconv.Itoa(i) + "]"
+		for field, present := range map[string]bool{
+			"summary": tag.Summary != "",
+			"parent":  tag.Parent != "",
+			"kind":    tag.Kind != "",
+		} {
+			if present {
+				report(tagPath, field)
+			}
+		}
+	}
+
+	for name, item := range doc.Paths {
+		c.detectOAS32PathItemFeatures(item, "paths."+name, doc.OASVersion, report)
+	}
+	for name, item := range doc.Webhooks {
+		c.detectOAS32PathItemFeatures(item, "webhooks."+name, doc.OASVersion, report)
+	}
+
+	if doc.Components == nil {
+		return
+	}
+	comp := doc.Components
+
+	if len(comp.MediaTypes) > 0 {
+		report("components.mediaTypes", "mediaTypes")
+	}
+	for name, item := range comp.PathItems {
+		c.detectOAS32PathItemFeatures(item, "components.pathItems."+name, doc.OASVersion, report)
+	}
+	for name, schema := range comp.Schemas {
+		c.detectOAS32SchemaFeatures(schema, "components.schemas."+name, report, make(map[*parser.Schema]bool))
+	}
+	for name, ex := range comp.Examples {
+		detectOAS32ExampleFeatures(ex, "components.examples."+name, report)
+	}
+	for name, param := range comp.Parameters {
+		c.detectOAS32ParameterFeatures(param, "components.parameters."+name, report)
+	}
+	for name, header := range comp.Headers {
+		c.detectOAS32HeaderFeatures(header, "components.headers."+name, report)
+	}
+	for name, rb := range comp.RequestBodies {
+		if rb != nil {
+			c.detectOAS32ContentFeatures(rb.Content, "components.requestBodies."+name, report)
+		}
+	}
+	for name, resp := range comp.Responses {
+		c.detectOAS32ResponseFeatures(resp, "components.responses."+name, report)
+	}
+	for name, scheme := range comp.SecuritySchemes {
+		detectOAS32SecuritySchemeFeatures(scheme, "components.securitySchemes."+name, report)
+	}
+}
+
+// oas32Reporter records one 3.2-only field at one location.
+type oas32Reporter func(path, field string)
+
+func (c *Converter) detectOAS32PathItemFeatures(
+	item *parser.PathItem,
+	prefix string,
+	version parser.OASVersion,
+	report oas32Reporter,
+) {
+	if item == nil {
+		return
+	}
+
+	for i, param := range item.Parameters {
+		c.detectOAS32ParameterFeatures(param, prefix+".parameters["+strconv.Itoa(i)+"]", report)
+	}
+
+	// GetOperations only surfaces query and additionalOperations at 3.2+, which is
+	// exactly the case this function runs in, so the 3.2 methods are covered by the
+	// loop rather than needing their own checks. They are reported as Critical
+	// where the OAS 2.0 path finds them, since an operation the target cannot
+	// express is a different kind of loss from an unusable annotation.
+	for method, op := range parser.GetOperations(item, version) {
+		if op == nil {
+			continue
+		}
+		opPath := prefix + "." + method
+
+		for i, param := range op.Parameters {
+			c.detectOAS32ParameterFeatures(param, opPath+".parameters["+strconv.Itoa(i)+"]", report)
+		}
+		if op.RequestBody != nil {
+			c.detectOAS32ContentFeatures(op.RequestBody.Content, opPath+".requestBody", report)
+		}
+		if op.Responses != nil {
+			for code, resp := range op.Responses.Codes {
+				c.detectOAS32ResponseFeatures(resp, opPath+".responses."+code, report)
+			}
+		}
+	}
+}
+
+func (c *Converter) detectOAS32ParameterFeatures(param *parser.Parameter, prefix string, report oas32Reporter) {
+	if param == nil || param.Ref != "" {
+		return
+	}
+	if param.In == parser.ParamInQueryString {
+		report(prefix, `in: "querystring"`)
+	}
+	for name, ex := range param.Examples {
+		detectOAS32ExampleFeatures(ex, prefix+".examples."+name, report)
+	}
+	c.detectOAS32ContentFeatures(param.Content, prefix, report)
+}
+
+func (c *Converter) detectOAS32HeaderFeatures(header *parser.Header, prefix string, report oas32Reporter) {
+	if header == nil || header.Ref != "" {
+		return
+	}
+	for name, ex := range header.Examples {
+		detectOAS32ExampleFeatures(ex, prefix+".examples."+name, report)
+	}
+	c.detectOAS32ContentFeatures(header.Content, prefix, report)
+}
+
+func (c *Converter) detectOAS32ResponseFeatures(resp *parser.Response, prefix string, report oas32Reporter) {
+	if resp == nil || resp.Ref != "" {
+		return
+	}
+	if resp.Summary != "" {
+		report(prefix, "summary")
+	}
+	c.detectOAS32ContentFeatures(resp.Content, prefix, report)
+	for name, header := range resp.Headers {
+		c.detectOAS32HeaderFeatures(header, prefix+".headers."+name, report)
+	}
+}
+
+func (c *Converter) detectOAS32ContentFeatures(content map[string]*parser.MediaType, prefix string, report oas32Reporter) {
+	for mediaType, mt := range content {
+		c.detectOAS32MediaTypeFeatures(mt, prefix+".content."+mediaType, report)
+	}
+}
+
+func (c *Converter) detectOAS32MediaTypeFeatures(mt *parser.MediaType, prefix string, report oas32Reporter) {
+	if mt == nil {
+		return
+	}
+	if mt.ItemSchema != nil {
+		report(prefix, "itemSchema")
+	}
+	if mt.ItemEncoding != nil {
+		report(prefix, "itemEncoding")
+	}
+	if len(mt.PrefixEncoding) > 0 {
+		report(prefix, "prefixEncoding")
+	}
+	for name, ex := range mt.Examples {
+		detectOAS32ExampleFeatures(ex, prefix+".examples."+name, report)
+	}
+	if mt.ItemSchema != nil {
+		c.detectOAS32SchemaFeatures(mt.ItemSchema, prefix+".itemSchema", report, make(map[*parser.Schema]bool))
+	}
+	for name, enc := range mt.Encoding {
+		detectOAS32EncodingFeatures(enc, prefix+".encoding."+name, report, 0)
+	}
+	detectOAS32EncodingFeatures(mt.ItemEncoding, prefix+".itemEncoding", report, 0)
+	for i, enc := range mt.PrefixEncoding {
+		detectOAS32EncodingFeatures(enc, prefix+".prefixEncoding["+strconv.Itoa(i)+"]", report, 0)
+	}
+}
+
+// maxEncodingNestingDepth bounds the recursive Encoding walk. The parser decodes
+// each level into a fresh value, so a document cannot build a cyclic Encoding
+// graph, but the bound keeps a hand-assembled one from recursing without end.
+const maxEncodingNestingDepth = 100
+
+func detectOAS32EncodingFeatures(enc *parser.Encoding, prefix string, report oas32Reporter, depth int) {
+	if enc == nil || depth > maxEncodingNestingDepth {
+		return
+	}
+	if len(enc.Encoding) > 0 {
+		report(prefix, "encoding")
+	}
+	if enc.ItemEncoding != nil {
+		report(prefix, "itemEncoding")
+	}
+	if len(enc.PrefixEncoding) > 0 {
+		report(prefix, "prefixEncoding")
+	}
+
+	for name, nested := range enc.Encoding {
+		detectOAS32EncodingFeatures(nested, prefix+".encoding."+name, report, depth+1)
+	}
+	detectOAS32EncodingFeatures(enc.ItemEncoding, prefix+".itemEncoding", report, depth+1)
+	for i, nested := range enc.PrefixEncoding {
+		detectOAS32EncodingFeatures(nested, prefix+".prefixEncoding["+strconv.Itoa(i)+"]", report, depth+1)
+	}
+}
+
+func detectOAS32ExampleFeatures(ex *parser.Example, prefix string, report oas32Reporter) {
+	if ex == nil || ex.Ref != "" {
+		return
+	}
+	if ex.DataValue != nil {
+		report(prefix, "dataValue")
+	}
+	if ex.SerializedValue != "" {
+		report(prefix, "serializedValue")
+	}
+}
+
+func detectOAS32SecuritySchemeFeatures(scheme *parser.SecurityScheme, prefix string, report oas32Reporter) {
+	if scheme == nil || scheme.Ref != "" {
+		return
+	}
+	if scheme.Deprecated {
+		report(prefix, "deprecated")
+	}
+	if scheme.OAuth2MetadataURL != "" {
+		report(prefix, "oauth2MetadataUrl")
+	}
+	if scheme.Flows == nil {
+		return
+	}
+	if scheme.Flows.DeviceAuthorization != nil {
+		report(prefix+".flows", "deviceAuthorization")
+	}
+	for name, flow := range map[string]*parser.OAuthFlow{
+		"implicit":            scheme.Flows.Implicit,
+		"password":            scheme.Flows.Password,
+		"clientCredentials":   scheme.Flows.ClientCredentials,
+		"authorizationCode":   scheme.Flows.AuthorizationCode,
+		"deviceAuthorization": scheme.Flows.DeviceAuthorization,
+	} {
+		if flow != nil && flow.DeviceAuthorizationURL != "" {
+			report(prefix+".flows."+name, "deviceAuthorizationUrl")
+		}
+	}
+}
+
+// detectOAS32SchemaFeatures reports the 3.2 fields carried by a Schema Object and
+// its nested schemas.
+//
+// A schema with a $ref is skipped for the same reason walkSchemaFeatures skips
+// one: the definition it names is walked at the top level, so checking here would
+// double-report.
+func (c *Converter) detectOAS32SchemaFeatures(
+	schema *parser.Schema,
+	prefix string,
+	report oas32Reporter,
+	visited map[*parser.Schema]bool,
+) {
+	if schema == nil || visited[schema] || schema.Ref != "" {
+		return
+	}
+	visited[schema] = true
+
+	if schema.Discriminator != nil && schema.Discriminator.DefaultMapping != "" {
+		report(prefix+".discriminator", "defaultMapping")
+	}
+	if schema.XML != nil && schema.XML.NodeType != "" {
+		report(prefix+".xml", "nodeType")
+	}
+
+	for name, prop := range schema.Properties {
+		c.detectOAS32SchemaFeatures(prop, prefix+".properties."+name, report, visited)
+	}
+	for pattern, prop := range schema.PatternProperties {
+		c.detectOAS32SchemaFeatures(prop, prefix+".patternProperties."+pattern, report, visited)
+	}
+	for name, def := range schema.Defs {
+		c.detectOAS32SchemaFeatures(def, prefix+".$defs."+name, report, visited)
+	}
+	for name, dep := range schema.DependentSchemas {
+		c.detectOAS32SchemaFeatures(dep, prefix+".dependentSchemas."+name, report, visited)
+	}
+	for i, s := range schema.AllOf {
+		c.detectOAS32SchemaFeatures(s, prefix+".allOf["+strconv.Itoa(i)+"]", report, visited)
+	}
+	for i, s := range schema.AnyOf {
+		c.detectOAS32SchemaFeatures(s, prefix+".anyOf["+strconv.Itoa(i)+"]", report, visited)
+	}
+	for i, s := range schema.OneOf {
+		c.detectOAS32SchemaFeatures(s, prefix+".oneOf["+strconv.Itoa(i)+"]", report, visited)
+	}
+	for i, s := range schema.PrefixItems {
+		c.detectOAS32SchemaFeatures(s, prefix+".prefixItems["+strconv.Itoa(i)+"]", report, visited)
+	}
+
+	// Schema-or-bool fields always decode to *Schema, []*Schema, or bool; only the
+	// first two need walking. See the parser's promotion note.
+	for field, value := range map[string]any{
+		"additionalProperties":  schema.AdditionalProperties,
+		"items":                 schema.Items,
+		"additionalItems":       schema.AdditionalItems,
+		"unevaluatedProperties": schema.UnevaluatedProperties,
+		"unevaluatedItems":      schema.UnevaluatedItems,
+	} {
+		switch v := value.(type) {
+		case *parser.Schema:
+			c.detectOAS32SchemaFeatures(v, prefix+"."+field, report, visited)
+		case []*parser.Schema:
+			for i, s := range v {
+				c.detectOAS32SchemaFeatures(s, prefix+"."+field+"["+strconv.Itoa(i)+"]", report, visited)
+			}
+		}
+	}
+
+	for field, s := range map[string]*parser.Schema{
+		"not":           schema.Not,
+		"contains":      schema.Contains,
+		"propertyNames": schema.PropertyNames,
+		"if":            schema.If,
+		"then":          schema.Then,
+		"else":          schema.Else,
+		"contentSchema": schema.ContentSchema,
+	} {
+		c.detectOAS32SchemaFeatures(s, prefix+"."+field, report, visited)
+	}
+}

--- a/converter/oas32_features.go
+++ b/converter/oas32_features.go
@@ -279,14 +279,14 @@ func detectOAS32SecuritySchemeFeatures(scheme *parser.SecurityScheme, prefix str
 		return
 	}
 	if scheme.Flows.DeviceAuthorization != nil {
-		report(prefix+".flows", "deviceAuthorization")
+		report(prefix+".flows", oas3FlowDeviceAuthorization)
 	}
 	for name, flow := range map[string]*parser.OAuthFlow{
-		"implicit":            scheme.Flows.Implicit,
-		"password":            scheme.Flows.Password,
-		"clientCredentials":   scheme.Flows.ClientCredentials,
-		"authorizationCode":   scheme.Flows.AuthorizationCode,
-		"deviceAuthorization": scheme.Flows.DeviceAuthorization,
+		oauthFlowImplicit:           scheme.Flows.Implicit,
+		oauthFlowPassword:           scheme.Flows.Password,
+		oas3FlowClientCredentials:   scheme.Flows.ClientCredentials,
+		oas3FlowAuthorizationCode:   scheme.Flows.AuthorizationCode,
+		oas3FlowDeviceAuthorization: scheme.Flows.DeviceAuthorization,
 	} {
 		if flow != nil && flow.DeviceAuthorizationURL != "" {
 			report(prefix+".flows."+name, "deviceAuthorizationUrl")

--- a/converter/oas32_features.go
+++ b/converter/oas32_features.go
@@ -47,13 +47,19 @@ func (c *Converter) detectOAS32Features(doc *parser.OAS3Document, result *Conver
 			continue
 		}
 		tagPath := "tags[" + strconv.Itoa(i) + "]"
-		for field, present := range map[string]bool{
-			"summary": tag.Summary != "",
-			"parent":  tag.Parent != "",
-			"kind":    tag.Kind != "",
+		// An ordered slice, not a map literal: report appends to result.Issues, and
+		// Go randomizes map iteration, so a map here would reorder the output between
+		// runs for no reason.
+		for _, f := range []struct {
+			name    string
+			present bool
+		}{
+			{"summary", tag.Summary != ""},
+			{"parent", tag.Parent != ""},
+			{"kind", tag.Kind != ""},
 		} {
-			if present {
-				report(tagPath, field)
+			if f.present {
+				report(tagPath, f.name)
 			}
 		}
 	}
@@ -118,9 +124,17 @@ func (c *Converter) detectOAS32PathItemFeatures(
 		c.detectOAS32ParameterFeatures(param, prefix+".parameters["+strconv.Itoa(i)+"]", report)
 	}
 
-	// GetOperations surfaces `query` and `additionalOperations` at 3.2+, so the loop
-	// covers them without checks of their own. Both are reported as Critical where
-	// the OAS 2.0 path finds them: a lost operation is not a lost annotation.
+	// The 3.2 methods have to be reported here, not left to the loop below: that
+	// loop walks their contents, so a `query` operation carrying no 3.2-only field
+	// would convert to 3.0 with no warning at all. The OAS 2.0 path reports both as
+	// Critical of its own accord, since a lost operation is not a lost annotation.
+	if item.Query != nil {
+		report(prefix, "query")
+	}
+	if len(item.AdditionalOperations) > 0 {
+		report(prefix, "additionalOperations")
+	}
+
 	for method, op := range parser.GetOperations(item, version) {
 		if op == nil {
 			continue
@@ -281,15 +295,19 @@ func detectOAS32SecuritySchemeFeatures(scheme *parser.SecurityScheme, prefix str
 	if scheme.Flows.DeviceAuthorization != nil {
 		report(prefix+".flows", oas3FlowDeviceAuthorization)
 	}
-	for name, flow := range map[string]*parser.OAuthFlow{
-		oauthFlowImplicit:           scheme.Flows.Implicit,
-		oauthFlowPassword:           scheme.Flows.Password,
-		oas3FlowClientCredentials:   scheme.Flows.ClientCredentials,
-		oas3FlowAuthorizationCode:   scheme.Flows.AuthorizationCode,
-		oas3FlowDeviceAuthorization: scheme.Flows.DeviceAuthorization,
+	// Ordered for the same reason as the tag fields above.
+	for _, f := range []struct {
+		name string
+		flow *parser.OAuthFlow
+	}{
+		{oauthFlowImplicit, scheme.Flows.Implicit},
+		{oauthFlowPassword, scheme.Flows.Password},
+		{oas3FlowClientCredentials, scheme.Flows.ClientCredentials},
+		{oas3FlowAuthorizationCode, scheme.Flows.AuthorizationCode},
+		{oas3FlowDeviceAuthorization, scheme.Flows.DeviceAuthorization},
 	} {
-		if flow != nil && flow.DeviceAuthorizationURL != "" {
-			report(prefix+".flows."+name, "deviceAuthorizationUrl")
+		if f.flow != nil && f.flow.DeviceAuthorizationURL != "" {
+			report(prefix+".flows."+f.name, "deviceAuthorizationUrl")
 		}
 	}
 }

--- a/converter/oas32_features.go
+++ b/converter/oas32_features.go
@@ -1,5 +1,6 @@
 // oas32_features.go reports the OAS 3.2.0 fixed fields a document uses when the
 // conversion target predates 3.2.
+// https://spec.openapis.org/oas/v3.2.0.html
 
 package converter
 
@@ -13,29 +14,18 @@ import (
 // detectOAS32Features reports every OAS 3.2 fixed field the document uses, for a
 // conversion whose target version predates 3.2.
 //
-// Reporting rather than stripping is this package's established convention for a
-// field the target does not define. detectOAS3SchemaFeatures leaves `nullable`,
-// `if`, `prefixItems` and the rest in place and records an issue; convertOAS3ToOAS3
-// removes nothing at all, so even a 3.1 to 3.0 conversion keeps $defs. A field is
-// cleared only where the target's serialization structurally cannot hold it: see
-// discriminatorToStringForm, where the OAS 2.0 bare-string discriminator has
-// nowhere to put `mapping` or `defaultMapping`.
+// Reporting rather than stripping is this package's convention: detectOAS3SchemaFeatures
+// leaves `nullable`, `if`, and `prefixItems` in place and records an issue, and
+// convertOAS3ToOAS3 removes nothing at all. A field is cleared only where the target
+// cannot serialize it, as discriminatorToStringForm does for `mapping`.
 //
-// Before this ran, `query` and `additionalOperations` were the only 3.2 features
-// reported on downconversion, and only on the OAS 2.0 path. The fixed fields 3.2
-// added were emitted into a 3.0 or 3.1 document with no warning at all, which is
-// the half of issue #397 that survives once the fields are modeled: they now round
-// trip, so they reach a target that has no meaning for them.
-//
-// Severity is Warning rather than Critical throughout. These are additive
-// annotations (a name for a server, a summary for a tag) so a consumer of the
-// converted document is no worse off than before the field existed. That is
-// unlike `query` or `additionalOperations`, which describe an operation the target
-// version cannot express at all and are reported as Critical where they are found.
+// Severity is Warning because these are additive annotations, unlike `query` and
+// `additionalOperations`, which describe an operation the target cannot express and
+// are Critical where the OAS 2.0 path finds them.
 func (c *Converter) detectOAS32Features(doc *parser.OAS3Document, result *ConversionResult) {
 	target := result.TargetVersion
 
-	// define our oas32Reporter to use here and pass into downnstream functions expecting it
+	// The oas32Reporter used here and passed into the downstream detectors.
 	report := func(path, field string) {
 		c.addIssueWithContext(result, path,
 			fmt.Sprintf("'%s' is OAS 3.2+ only and has no equivalent in OAS %s", field, target),
@@ -128,11 +118,9 @@ func (c *Converter) detectOAS32PathItemFeatures(
 		c.detectOAS32ParameterFeatures(param, prefix+".parameters["+strconv.Itoa(i)+"]", report)
 	}
 
-	// GetOperations only surfaces query and additionalOperations at 3.2+, which is
-	// exactly the case this function runs in, so the 3.2 methods are covered by the
-	// loop rather than needing their own checks. They are reported as Critical
-	// where the OAS 2.0 path finds them, since an operation the target cannot
-	// express is a different kind of loss from an unusable annotation.
+	// GetOperations surfaces `query` and `additionalOperations` at 3.2+, so the loop
+	// covers them without checks of their own. Both are reported as Critical where
+	// the OAS 2.0 path finds them: a lost operation is not a lost annotation.
 	for method, op := range parser.GetOperations(item, version) {
 		if op == nil {
 			continue
@@ -153,6 +141,8 @@ func (c *Converter) detectOAS32PathItemFeatures(
 	}
 }
 
+// detectOAS32ParameterFeatures reports `in: "querystring"`, new in 3.2.
+// https://spec.openapis.org/oas/v3.2.0.html#parameter-in
 func (c *Converter) detectOAS32ParameterFeatures(param *parser.Parameter, prefix string, report oas32Reporter) {
 	if param == nil || param.Ref != "" {
 		return
@@ -176,6 +166,8 @@ func (c *Converter) detectOAS32HeaderFeatures(header *parser.Header, prefix stri
 	c.detectOAS32ContentFeatures(header.Content, prefix, report)
 }
 
+// detectOAS32ResponseFeatures reports the Response Object's `summary`.
+// https://spec.openapis.org/oas/v3.2.0.html#response-object
 func (c *Converter) detectOAS32ResponseFeatures(resp *parser.Response, prefix string, report oas32Reporter) {
 	if resp == nil || resp.Ref != "" {
 		return
@@ -195,6 +187,8 @@ func (c *Converter) detectOAS32ContentFeatures(content map[string]*parser.MediaT
 	}
 }
 
+// detectOAS32MediaTypeFeatures reports the sequential-media-type fields.
+// https://spec.openapis.org/oas/v3.2.0.html#media-type-object
 func (c *Converter) detectOAS32MediaTypeFeatures(mt *parser.MediaType, prefix string, report oas32Reporter) {
 	if mt == nil {
 		return
@@ -223,11 +217,15 @@ func (c *Converter) detectOAS32MediaTypeFeatures(mt *parser.MediaType, prefix st
 	}
 }
 
-// maxEncodingNestingDepth bounds the recursive Encoding walk. The parser decodes
-// each level into a fresh value, so a document cannot build a cyclic Encoding
-// graph, but the bound keeps a hand-assembled one from recursing without end.
+// maxEncodingNestingDepth bounds the recursive Encoding walk 3.2 introduced.
+// https://spec.openapis.org/oas/v3.2.0.html#encoding-object
+//
+// A parsed document cannot build a cyclic Encoding graph, but the bound keeps a
+// hand-assembled one from recursing without end.
 const maxEncodingNestingDepth = 100
 
+// detectOAS32EncodingFeatures reports the nesting fields 3.2 added to Encoding.
+// https://spec.openapis.org/oas/v3.2.0.html#encoding-object
 func detectOAS32EncodingFeatures(enc *parser.Encoding, prefix string, report oas32Reporter, depth int) {
 	if enc == nil || depth > maxEncodingNestingDepth {
 		return
@@ -251,6 +249,8 @@ func detectOAS32EncodingFeatures(enc *parser.Encoding, prefix string, report oas
 	}
 }
 
+// detectOAS32ExampleFeatures reports `dataValue` and `serializedValue`.
+// https://spec.openapis.org/oas/v3.2.0.html#fixed-fields-15
 func detectOAS32ExampleFeatures(ex *parser.Example, prefix string, report oas32Reporter) {
 	if ex == nil || ex.Ref != "" {
 		return
@@ -263,6 +263,8 @@ func detectOAS32ExampleFeatures(ex *parser.Example, prefix string, report oas32R
 	}
 }
 
+// detectOAS32SecuritySchemeFeatures reports the scheme and OAuth flow additions.
+// https://spec.openapis.org/oas/v3.2.0.html#security-scheme-object
 func detectOAS32SecuritySchemeFeatures(scheme *parser.SecurityScheme, prefix string, report oas32Reporter) {
 	if scheme == nil || scheme.Ref != "" {
 		return
@@ -292,12 +294,11 @@ func detectOAS32SecuritySchemeFeatures(scheme *parser.SecurityScheme, prefix str
 	}
 }
 
-// detectOAS32SchemaFeatures reports the 3.2 fields carried by a Schema Object and
-// its nested schemas.
+// detectOAS32SchemaFeatures reports `discriminator.defaultMapping` and
+// `xml.nodeType` on a Schema Object and its nested schemas.
 //
-// A schema with a $ref is skipped for the same reason walkSchemaFeatures skips
-// one: the definition it names is walked at the top level, so checking here would
-// double-report.
+// A schema with a `$ref` is skipped for the same reason walkSchemaFeatures skips
+// one: the definition it names is walked at the top level.
 func (c *Converter) detectOAS32SchemaFeatures(
 	schema *parser.Schema,
 	prefix string,
@@ -341,8 +342,8 @@ func (c *Converter) detectOAS32SchemaFeatures(
 		c.detectOAS32SchemaFeatures(s, prefix+".prefixItems["+strconv.Itoa(i)+"]", report, visited)
 	}
 
-	// Schema-or-bool fields always decode to *Schema, []*Schema, or bool; only the
-	// first two need walking. See the parser's promotion note.
+	// Schema-or-bool fields decode to *Schema, []*Schema, or bool; only the first
+	// two need walking.
 	for field, value := range map[string]any{
 		"additionalProperties":  schema.AdditionalProperties,
 		"items":                 schema.Items,

--- a/converter/oas32_features_test.go
+++ b/converter/oas32_features_test.go
@@ -1,6 +1,8 @@
 package converter
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -60,6 +62,8 @@ func TestDownconvertReportsOAS32Fields(t *testing.T) {
 				"'defaultMapping'", // Discriminator Object
 				"'nodeType'",       // XML Object
 				`'in: "querystring"'`,
+				"'query'",                // Path Item Object
+				"'additionalOperations'", // Path Item Object
 			} {
 				assert.Contains(t, joined, field,
 					"converting to %s should report the 3.2 field %s", target, field)
@@ -85,6 +89,42 @@ func TestDownconvertPreservesOAS32Fields(t *testing.T) {
 		"defaultMapping must survive a 3.x to 3.y conversion, which strips nothing")
 	assert.Equal(t, "production", doc.Servers[0].Name,
 		"a server name must survive too")
+}
+
+// TestDownconvertReportsBare32Methods pins that the 3.2 HTTP methods are reported
+// for themselves, not only when something 3.2-only is nested inside them. The walk
+// over their contents cannot see the method, so a bare `query` operation converted
+// to 3.0 previously produced no warning at all.
+func TestDownconvertReportsBare32Methods(t *testing.T) {
+	spec := `openapi: 3.2.0
+info: {title: T, version: "1.0.0"}
+paths:
+  /pets:
+    query:
+      operationId: queryPets
+      responses:
+        "200": {description: OK}
+    additionalOperations:
+      PURGE:
+        operationId: purgePets
+        responses:
+          "204": {description: No Content}
+`
+	path := filepath.Join(t.TempDir(), "bare32.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(spec), 0o600))
+
+	result, err := New().Convert(path, "3.0.3")
+	require.NoError(t, err)
+
+	var joined string
+	for _, issue := range result.Issues {
+		joined += issue.Path + ": " + issue.Message + "\n"
+	}
+
+	assert.Contains(t, joined, "'query' is OAS 3.2+ only",
+		"a query operation with no 3.2-only content must still be reported")
+	assert.Contains(t, joined, "'additionalOperations' is OAS 3.2+ only",
+		"additionalOperations must be reported for itself")
 }
 
 // TestConvertToOAS32TargetReportsNothing is the control: the fields are legal at

--- a/converter/oas32_features_test.go
+++ b/converter/oas32_features_test.go
@@ -1,0 +1,95 @@
+package converter
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erraggy/oastools/parser"
+)
+
+// The 3.2 fixed fields now round trip (issue #397), which means they now reach
+// conversion targets that have no meaning for them. This package's convention for
+// such a field is to report it and leave it in place — detectOAS3SchemaFeatures
+// does exactly that for nullable, if, and prefixItems — so these tests assert the
+// reporting, not removal.
+
+// oas32FeatureIssues converts the full-field 3.2 fixture to target and returns the
+// issue messages mentioning 3.2.
+func oas32FeatureIssues(t *testing.T, target string) []string {
+	t.Helper()
+
+	result, err := New().Convert("../testdata/oas32-all-fields.yaml", target)
+	require.NoError(t, err)
+
+	var messages []string
+	for _, issue := range result.Issues {
+		if strings.Contains(issue.Message, "OAS 3.2+ only") {
+			messages = append(messages, issue.Path+": "+issue.Message)
+		}
+	}
+	return messages
+}
+
+// TestDownconvertReportsOAS32Fields covers every fixed field OAS 3.2 added. Before
+// this ran, a 3.2 to 3.0 conversion emitted all of them with no warning at all:
+// convertOAS3ToOAS3 only bumped the version string.
+func TestDownconvertReportsOAS32Fields(t *testing.T) {
+	for _, target := range []string{"3.0.3", "3.1.0"} {
+		t.Run(target, func(t *testing.T) {
+			joined := strings.Join(oas32FeatureIssues(t, target), "\n")
+
+			for _, field := range []string{
+				"'$self'",
+				"'name'",              // Server Object
+				"'summary'",           // Tag and Response Objects
+				"'parent'",            // Tag Object
+				"'kind'",              // Tag Object
+				"'itemSchema'",        // Media Type Object
+				"'itemEncoding'",      // Media Type and Encoding Objects
+				"'prefixEncoding'",    // Media Type and Encoding Objects
+				"'encoding'",          // nested Encoding Object
+				"'dataValue'",         // Example Object
+				"'serializedValue'",   // Example Object
+				"'deprecated'",        // Security Scheme Object
+				"'oauth2MetadataUrl'", // Security Scheme Object
+				"'deviceAuthorization'",
+				"'deviceAuthorizationUrl'",
+				"'defaultMapping'", // Discriminator Object
+				"'nodeType'",       // XML Object
+				`'in: "querystring"'`,
+			} {
+				assert.Contains(t, joined, field,
+					"converting to %s should report the 3.2 field %s", target, field)
+			}
+
+			assert.Contains(t, joined, "has no equivalent in OAS "+target,
+				"the message should name the target version")
+		})
+	}
+}
+
+// TestDownconvertPreservesOAS32Fields pins that the fields are reported rather than
+// stripped, matching how detectOAS3SchemaFeatures treats nullable and prefixItems.
+// Removing them would make conversion lossy in a way no other field here is.
+func TestDownconvertPreservesOAS32Fields(t *testing.T) {
+	result, err := New().Convert("../testdata/oas32-all-fields.yaml", "3.1.0")
+	require.NoError(t, err)
+
+	doc, ok := result.Document.(*parser.OAS3Document)
+	require.True(t, ok)
+
+	assert.Equal(t, "OtherPet", doc.Components.Schemas["Pet"].Discriminator.DefaultMapping,
+		"defaultMapping must survive a 3.x to 3.y conversion, which strips nothing")
+	assert.Equal(t, "production", doc.Servers[0].Name,
+		"a server name must survive too")
+}
+
+// TestConvertToOAS32TargetReportsNothing is the control: the fields are legal at
+// 3.2, so converting between 3.2 versions must stay silent about them.
+func TestConvertToOAS32TargetReportsNothing(t *testing.T) {
+	assert.Empty(t, oas32FeatureIssues(t, "3.2.0"),
+		"nothing is lost converting a 3.2 document to 3.2")
+}

--- a/converter/oas3_to_oas2.go
+++ b/converter/oas3_to_oas2.go
@@ -93,6 +93,10 @@ func (c *Converter) convertOAS3ToOAS2(parseResult parser.ParseResult, result *Co
 		dst.Security = src.Security
 	}
 
+	// Report the 3.2 fixed fields against the source document, whose objects still
+	// carry them; the OAS 2.0 result has no field to point at for most of them.
+	c.detectOAS32Features(src, result)
+
 	// Rewrite all $ref paths from OAS 3.x to OAS 2.0 format
 	c.rewriteAllRefsOAS3ToOAS2(dst)
 

--- a/converter/oas3_to_oas2.go
+++ b/converter/oas3_to_oas2.go
@@ -327,25 +327,25 @@ func (c *Converter) convertSecuritySchemes(src *parser.OAS3Document, dst *parser
 			flowCount := 0
 			if scheme.Flows.Implicit != nil {
 				flowCount++
-				secDef.Flow = "implicit"
+				secDef.Flow = oauthFlowImplicit
 				secDef.AuthorizationURL = scheme.Flows.Implicit.AuthorizationURL
 				secDef.Scopes = scheme.Flows.Implicit.Scopes
 			}
 			if scheme.Flows.Password != nil {
 				flowCount++
-				secDef.Flow = "password"
+				secDef.Flow = oauthFlowPassword
 				secDef.TokenURL = scheme.Flows.Password.TokenURL
 				secDef.Scopes = scheme.Flows.Password.Scopes
 			}
 			if scheme.Flows.ClientCredentials != nil {
 				flowCount++
-				secDef.Flow = "application"
+				secDef.Flow = oas2FlowApplication
 				secDef.TokenURL = scheme.Flows.ClientCredentials.TokenURL
 				secDef.Scopes = scheme.Flows.ClientCredentials.Scopes
 			}
 			if scheme.Flows.AuthorizationCode != nil {
 				flowCount++
-				secDef.Flow = "accessCode"
+				secDef.Flow = oas2FlowAccessCode
 				secDef.AuthorizationURL = scheme.Flows.AuthorizationCode.AuthorizationURL
 				secDef.TokenURL = scheme.Flows.AuthorizationCode.TokenURL
 				secDef.Scopes = scheme.Flows.AuthorizationCode.Scopes

--- a/converter/ref_rewrite.go
+++ b/converter/ref_rewrite.go
@@ -168,6 +168,12 @@ func walkSchemaRefs(schema *parser.Schema, rewrite refRewriter) {
 			for key, ref := range s.Discriminator.Mapping {
 				s.Discriminator.Mapping[key] = rewrite(ref)
 			}
+			// defaultMapping (OAS 3.2+) is a schema ref on the same terms. Left
+			// alone, a downconvert would emit an OAS 2.0 document whose fallback
+			// still points into #/components/schemas/.
+			if s.Discriminator.DefaultMapping != "" {
+				s.Discriminator.DefaultMapping = rewrite(s.Discriminator.DefaultMapping)
+			}
 		}
 	})
 }

--- a/converter/schema_convert.go
+++ b/converter/schema_convert.go
@@ -61,6 +61,18 @@ func discriminatorToStringForm(c *Converter, schema *parser.Schema, result *Conv
 				"OAS 2.0 resolves the discriminator by schema name only; rename the target definitions to match the discriminator values")
 			d.Mapping = nil
 		}
+		// defaultMapping (OAS 3.2+) has no OAS 2.0 equivalent either, and unlike
+		// mapping it names a single fallback schema, so losing it changes which
+		// schema validates a payload with no discriminating value. Reported and
+		// cleared here rather than left set: the string form drops it on
+		// serialization regardless, and dropping it silently is the defect issue
+		// #397 is about.
+		if d.DefaultMapping != "" {
+			c.addIssueWithContext(result, path,
+				fmt.Sprintf("Schema discriminator uses 'defaultMapping' (%s) which has no OAS 2.0 equivalent; defaultMapping dropped", d.DefaultMapping),
+				"OAS 2.0 has no fallback for a missing or unmapped discriminator value; describe the fallback schema explicitly in the enclosing definition")
+			d.DefaultMapping = ""
+		}
 		if len(d.Extra) > 0 {
 			c.addIssueWithContext(result, path,
 				fmt.Sprintf("Schema discriminator carries extensions (%s) which have no OAS 2.0 equivalent; extensions dropped",

--- a/converter/schema_discriminator_test.go
+++ b/converter/schema_discriminator_test.go
@@ -144,3 +144,36 @@ func TestDiscriminatorFormNormalizationReachesNestedSchemas(t *testing.T) {
 	discriminatorToStringForm(New(), nested, &ConversionResult{}, "test")
 	assert.True(t, nested.Properties["pet"].AllOf[0].Discriminator.StringForm)
 }
+
+// TestConvertOAS3ToOAS2ReportsDroppedDefaultMapping covers the OAS 3.2 fallback
+// field. Unlike mapping, defaultMapping names the single schema that validates a
+// payload carrying no discriminating value, so losing it changes what the document
+// means. OAS 2.0 has no equivalent, which makes dropping it unavoidable and
+// dropping it silently a defect — see erraggy/oastools#397.
+func TestConvertOAS3ToOAS2ReportsDroppedDefaultMapping(t *testing.T) {
+	schema := &parser.Schema{
+		Type: "object",
+		Discriminator: &parser.Discriminator{
+			PropertyName:   "petType",
+			DefaultMapping: "OtherPet",
+		},
+	}
+
+	result := &ConversionResult{}
+	discriminatorToStringForm(New(), schema, result, "definitions.Pet")
+
+	var found bool
+	for _, issue := range result.Issues {
+		if strings.Contains(issue.Message, "discriminator uses 'defaultMapping'") {
+			found = true
+			assert.Contains(t, issue.Message, "OtherPet",
+				"the issue should name the schema being lost")
+			break
+		}
+	}
+	assert.True(t, found, "expected an issue reporting the dropped defaultMapping")
+
+	assert.Empty(t, schema.Discriminator.DefaultMapping,
+		"defaultMapping must be cleared, not carried into an OAS 2.0 document")
+	assert.True(t, schema.Discriminator.StringForm)
+}

--- a/fixer/generic_names.go
+++ b/fixer/generic_names.go
@@ -546,12 +546,18 @@ func toPascalCase(s string) string {
 // splitSchemaRef splits a schema $ref into its prefix and its name token, for
 // either OAS version. ok is false for a ref that names something other than a
 // local schema, an external one included.
+//
+// The prefix is matched through [pathutil.CutRefPrefix], so a ref that
+// percent-encodes the pointer separators themselves — "#%2Fcomponents%2Fschemas%2F…"
+// — splits like the raw form and yields the raw prefix. That matters because
+// [buildRefRenameMap] keys on raw prefixes: matching only the raw spelling here
+// left such a ref dangling after a rename, while prune already recognized it and
+// kept the schema alive.
 func splitSchemaRef(ref string) (prefix, name string, ok bool) {
-	if n, found := strings.CutPrefix(ref, pathutil.RefPrefixSchemas); found {
-		return pathutil.RefPrefixSchemas, n, true
-	}
-	if n, found := strings.CutPrefix(ref, pathutil.RefPrefixDefinitions); found {
-		return pathutil.RefPrefixDefinitions, n, true
+	for _, p := range [2]string{pathutil.RefPrefixSchemas, pathutil.RefPrefixDefinitions} {
+		if n, found := pathutil.CutRefPrefix(ref, p); found {
+			return p, n, true
+		}
 	}
 	return "", "", false
 }
@@ -717,11 +723,17 @@ func rewriteSchemaRefsRecursive(schema *parser.Schema, renames map[string]string
 	}
 
 	// Discriminator mapping values
-	if schema.Discriminator != nil && schema.Discriminator.Mapping != nil {
+	if schema.Discriminator != nil {
 		for key, ref := range schema.Discriminator.Mapping {
 			if newValue, ok := lookupRenamedMappingValue(ref, renames); ok {
 				schema.Discriminator.Mapping[key] = newValue
 			}
+		}
+		// defaultMapping (OAS 3.2+) names a schema exactly as a mapping value
+		// does, in either spelling, so it goes through the same lookup. Rewriting
+		// mapping without it leaves the fallback target dangling after a rename.
+		if newValue, ok := lookupRenamedMappingValue(schema.Discriminator.DefaultMapping, renames); ok {
+			schema.Discriminator.DefaultMapping = newValue
 		}
 	}
 }

--- a/fixer/generic_names_slash_test.go
+++ b/fixer/generic_names_slash_test.go
@@ -1252,3 +1252,56 @@ paths:
 	assert.NotContains(t, doc.Components.Schemas, "Orphan",
 		"matching bare names must not make every schema look referenced")
 }
+
+// TestPruneKeepsBareDiscriminatorTargetsWithSlash covers the shape this repo's own
+// generic-name fixer produces: a schema name containing "/".
+//
+// Treating "/" as evidence that a value was a pointer rather than a name deleted
+// both targets here. Only "#" marks a pointer; OAS 2.0 places no charset
+// constraint on definition keys, and "Dog[example.com/pkg.Breed]" is a name the
+// fixer emits and the discriminator tests already use as a bare mapping value.
+func TestPruneKeepsBareDiscriminatorTargetsWithSlash(t *testing.T) {
+	spec := `
+openapi: 3.2.0
+info: {title: T, version: "1.0"}
+components:
+  schemas:
+    Pet:
+      type: object
+      required: [kind]
+      properties: {kind: {type: string}}
+      discriminator:
+        propertyName: kind
+        defaultMapping: 'Other[example.com/pkg.Breed]'
+        mapping:
+          dog: 'Dog[example.com/pkg.Breed]'
+    "Dog[example.com/pkg.Breed]": {type: object}
+    "Other[example.com/pkg.Breed]": {type: object}
+    "Orphan[example.com/pkg.Breed]": {type: object}
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Pet'}
+`
+	parseResult, err := parser.ParseWithOptions(parser.WithBytes([]byte(spec)))
+	require.NoError(t, err)
+
+	f := New()
+	f.EnabledFixes = []FixType{FixTypePrunedUnusedSchema}
+	result, err := f.FixParsed(*parseResult)
+	require.NoError(t, err)
+
+	doc := result.Document.(*parser.OAS3Document)
+	assert.Contains(t, doc.Components.Schemas, "Dog[example.com/pkg.Breed]",
+		"a bare mapping value containing \"/\" must keep its schema alive")
+	assert.Contains(t, doc.Components.Schemas, "Other[example.com/pkg.Breed]",
+		"a bare defaultMapping value containing \"/\" must too")
+	assert.NotContains(t, doc.Components.Schemas, "Orphan[example.com/pkg.Breed]",
+		"an unreferenced schema with the same shape is still pruned")
+}

--- a/fixer/generic_names_slash_test.go
+++ b/fixer/generic_names_slash_test.go
@@ -570,6 +570,16 @@ func TestCanonicalSchemaRefKey(t *testing.T) {
 			want: "#/definitions/Discount%OFF",
 		},
 		{
+			name: "percent-encoded pointer separators reduce to the raw prefix",
+			ref:  "#%2Fcomponents%2Fschemas%2FPaged%5BPet%5D",
+			want: "#/components/schemas/Paged[Pet]",
+		},
+		{
+			name: "an encoded pointer whose name is doubly encoded decodes only once",
+			ref:  "#%2Fdefinitions%2FPaged%255BPet%255D",
+			want: "#/definitions/Paged%5BPet%5D",
+		},
+		{
 			name: "a non-schema ref is not a key and passes through",
 			ref:  "#/components/parameters/Limit%5Bx%5D",
 			want: "#/components/parameters/Limit%5Bx%5D",
@@ -686,6 +696,131 @@ paths:
 		"a bare name must be rewritten and stay bare")
 	assert.Equal(t, "FishOfexample.com.pkg.Breed", mapping["bareEncoded"],
 		"a bare name carrying an encoding must be rewritten too")
+}
+
+// TestFixSchemaNamesRewritesDiscriminatorDefaultMapping covers issue #397's
+// reference-bearing field: discriminator.defaultMapping (OAS 3.2+) names a schema
+// in exactly the two spellings a mapping value may use, so a rename that rewrote
+// mapping but not defaultMapping would leave the fallback target dangling.
+func TestFixSchemaNamesRewritesDiscriminatorDefaultMapping(t *testing.T) {
+	spec := `
+openapi: 3.2.0
+info: {title: T, version: "1.0"}
+components:
+  schemas:
+    Pet:
+      type: object
+      required: [kind]
+      discriminator:
+        propertyName: kind
+        defaultMapping: '#/components/schemas/Other[example.com/pkg.Breed]'
+        mapping:
+          dog: '#/components/schemas/Dog[example.com/pkg.Breed]'
+      properties:
+        kind: {type: string}
+    "Dog[example.com/pkg.Breed]": {type: object}
+    "Other[example.com/pkg.Breed]": {type: object}
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Pet'}
+`
+	result := fixSchemaNames(t, spec, GenericNamingOf)
+	doc := result.Document.(*parser.OAS3Document)
+
+	d := doc.Components.Schemas["Pet"].Discriminator
+	assert.Equal(t, pathutil.RefPrefixSchemas+"DogOfexample.com.pkg.Breed", d.Mapping["dog"],
+		"the mapping value must be rewritten")
+	assert.Equal(t, pathutil.RefPrefixSchemas+"OtherOfexample.com.pkg.Breed", d.DefaultMapping,
+		"defaultMapping must be rewritten alongside mapping")
+}
+
+// TestFixSchemaNamesRewritesBareDefaultMapping is the bare-name spelling of the
+// same field: a defaultMapping may name its target without a pointer prefix, and
+// must stay bare after the rewrite.
+func TestFixSchemaNamesRewritesBareDefaultMapping(t *testing.T) {
+	spec := `
+openapi: 3.2.0
+info: {title: T, version: "1.0"}
+components:
+  schemas:
+    Pet:
+      type: object
+      required: [kind]
+      discriminator:
+        propertyName: kind
+        defaultMapping: 'Other[example.com/pkg.Breed]'
+      properties:
+        kind: {type: string}
+    "Other[example.com/pkg.Breed]": {type: object}
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Pet'}
+`
+	result := fixSchemaNames(t, spec, GenericNamingOf)
+	doc := result.Document.(*parser.OAS3Document)
+
+	assert.Equal(t, "OtherOfexample.com.pkg.Breed",
+		doc.Components.Schemas["Pet"].Discriminator.DefaultMapping,
+		"a bare defaultMapping must be rewritten and stay bare")
+}
+
+// TestPruneKeepsDefaultMappingTarget covers the pruning side: a schema reachable
+// only through discriminator.defaultMapping is referenced, and deleting it would
+// dangle the fallback.
+func TestPruneKeepsDefaultMappingTarget(t *testing.T) {
+	spec := `
+openapi: 3.2.0
+info: {title: T, version: "1.0"}
+components:
+  schemas:
+    Pet:
+      type: object
+      required: [kind]
+      discriminator:
+        propertyName: kind
+        defaultMapping: '#/components/schemas/OtherPet'
+      properties:
+        kind: {type: string}
+    OtherPet: {type: object}
+    Orphan: {type: object}
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Pet'}
+`
+	parseResult, err := parser.ParseWithOptions(parser.WithBytes([]byte(spec)))
+	require.NoError(t, err)
+
+	f := New()
+	f.EnabledFixes = []FixType{FixTypePrunedUnusedSchema}
+	result, err := f.FixParsed(*parseResult)
+	require.NoError(t, err)
+
+	doc := result.Document.(*parser.OAS3Document)
+	assert.Contains(t, doc.Components.Schemas, "OtherPet",
+		"a schema reachable only through defaultMapping must survive pruning")
+	assert.NotContains(t, doc.Components.Schemas, "Orphan",
+		"the genuinely unreferenced schema should still be pruned")
 }
 
 // TestFixSchemaNamesKeepsLiteralPercentName covers a name that genuinely
@@ -847,6 +982,102 @@ paths:
 	assert.Zero(t, result.FixCount, "nothing should have been pruned")
 }
 
+// TestFixSchemaNamesRewritesEncodedPointerRef is the regression for issue #408.
+//
+// A generator that runs a URL escaper over a whole pointer rather than over each
+// token emits "#%2Fcomponents%2Fschemas%2F…". Pruning already recognized that
+// shape and kept the schema, but the rewrite did not, so a rename left the ref
+// pointing at a name no longer present — a dangling ref in output the fixer
+// reported as successfully fixed.
+func TestFixSchemaNamesRewritesEncodedPointerRef(t *testing.T) {
+	for _, tt := range []struct {
+		version string
+		spec    string
+	}{
+		{
+			version: "oas3",
+			spec: `
+openapi: 3.0.3
+info: {title: T, version: "1.0"}
+components:
+  schemas:
+    "Paged[Pet]": {type: object}
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: {$ref: '#%2Fcomponents%2Fschemas%2FPaged%5BPet%5D'}
+`,
+		},
+		{
+			version: "oas2",
+			spec: `
+swagger: "2.0"
+info: {title: T, version: "1.0"}
+definitions:
+  "Paged[Pet]": {type: object}
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        "200":
+          description: OK
+          schema: {$ref: '#%2Fdefinitions%2FPaged%5BPet%5D'}
+`,
+		},
+	} {
+		t.Run(tt.version, func(t *testing.T) {
+			result := fixSchemaNames(t, tt.spec, GenericNamingOf)
+
+			names := schemaNames(t, result.Document)
+			require.Contains(t, names, "PagedOfPet", "the schema should have been renamed")
+
+			assert.NotContains(t, responseSchemaRef(t, result.Document), "Paged%5BPet%5D",
+				"the ref must not still name the schema by its old name")
+			assert.Contains(t, responseSchemaRef(t, result.Document), "PagedOfPet",
+				"a ref whose pointer separators are encoded must be rewritten too")
+		})
+	}
+}
+
+// TestPruneKeepsEncodedPointerRefSchema pins the pruning half of #408. It passed
+// before the fix — appendSchemaNames already decoded the prefix — and must keep
+// passing now that it shares pathutil.CutRefPrefix with the rewrite, since a
+// prune that stops recognizing the ref would delete a referenced schema.
+func TestPruneKeepsEncodedPointerRefSchema(t *testing.T) {
+	spec := `
+swagger: "2.0"
+info: {title: T, version: "1.0"}
+definitions:
+  "Paged[Pet]": {type: object}
+paths:
+  /p:
+    get:
+      operationId: g
+      responses:
+        "200":
+          description: OK
+          schema: {$ref: '#%2Fdefinitions%2FPaged%5BPet%5D'}
+`
+	parseResult, err := parser.ParseWithOptions(parser.WithBytes([]byte(spec)))
+	require.NoError(t, err)
+
+	f := New()
+	f.EnabledFixes = []FixType{FixTypePrunedUnusedSchema}
+	result, err := f.FixParsed(*parseResult)
+	require.NoError(t, err)
+
+	doc := result.Document.(*parser.OAS2Document)
+	assert.Contains(t, doc.Definitions, "Paged[Pet]")
+	assert.Zero(t, result.FixCount, "nothing should have been pruned")
+}
+
 // TestPruneStillRemovesUnreferencedMixedEncodingSchema is the control: matching
 // more spellings must not make every schema look referenced.
 func TestPruneStillRemovesUnreferencedMixedEncodingSchema(t *testing.T) {
@@ -968,4 +1199,56 @@ paths:
 
 	assert.Equal(t, map[string]bool{pathutil.RefPrefixSchemas + "A_2FBOfPet": true}, seen,
 		"an ambiguous ref must resolve to the same schema on every run")
+}
+
+// TestPruneKeepsBareDiscriminatorTargets covers the bare spelling a discriminator
+// may use for its target.
+//
+// The spec recommends treating a mapping or defaultMapping value that is a valid
+// schema name as a schema name, so "Dog" and "#/components/schemas/Dog" name the
+// same schema. Pruning recognized only the pointer form, so a schema referenced
+// only by a bare mapping value was deleted from a legal document.
+func TestPruneKeepsBareDiscriminatorTargets(t *testing.T) {
+	spec := `
+openapi: 3.2.0
+info: {title: T, version: "1.0"}
+components:
+  schemas:
+    Pet:
+      type: object
+      required: [kind]
+      properties: {kind: {type: string}}
+      discriminator:
+        propertyName: kind
+        defaultMapping: OtherPet
+        mapping: {dog: Dog}
+    Dog: {type: object}
+    OtherPet: {type: object}
+    Orphan: {type: object}
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Pet'}
+`
+	parseResult, err := parser.ParseWithOptions(parser.WithBytes([]byte(spec)))
+	require.NoError(t, err)
+
+	f := New()
+	f.EnabledFixes = []FixType{FixTypePrunedUnusedSchema}
+	result, err := f.FixParsed(*parseResult)
+	require.NoError(t, err)
+
+	doc := result.Document.(*parser.OAS3Document)
+	assert.Contains(t, doc.Components.Schemas, "Dog",
+		"a bare mapping value names a schema and must keep it alive")
+	assert.Contains(t, doc.Components.Schemas, "OtherPet",
+		"a bare defaultMapping value must keep its schema alive too")
+	assert.NotContains(t, doc.Components.Schemas, "Orphan",
+		"matching bare names must not make every schema look referenced")
 }

--- a/fixer/prune.go
+++ b/fixer/prune.go
@@ -243,9 +243,12 @@ func appendDiscriminatorTargetNames(dst []string, value, prefix string) []string
 	}
 	dst = appendSchemaNames(dst, value, prefix)
 
-	// A pointer spelling was already expanded above; only a bare name is left to
-	// add, and a value containing "/" or "#" is not one.
-	if !strings.ContainsAny(value, "/#") && !slices.Contains(dst, value) {
+	// A pointer spelling was already expanded above, so only a bare name is left
+	// to add. "#" is the only reliable marker of a pointer: a bare schema name may
+	// legitimately contain "/", and this repo's own generic-name fixer produces
+	// exactly that shape, e.g. "Dog[example.com/pkg.Breed]". Excluding "/" here
+	// made pruning delete schemas referenced only by such a name.
+	if !strings.Contains(value, "#") && !slices.Contains(dst, value) {
 		dst = append(dst, value)
 	}
 	return dst

--- a/fixer/prune.go
+++ b/fixer/prune.go
@@ -6,7 +6,6 @@ package fixer
 
 import (
 	"fmt"
-	"net/url"
 	"slices"
 	"strings"
 
@@ -102,16 +101,13 @@ func buildReferencedSchemaSet(collector *RefCollector, schemas map[string]*parse
 // allocation-free: this runs for every $ref in the document, and almost all of
 // them are unencoded and yield a single name.
 func appendSchemaNames(dst []string, ref, prefix string) []string {
-	name, found := strings.CutPrefix(ref, prefix)
+	// Shares [pathutil.CutRefPrefix] with splitSchemaRef so a ref whose pointer
+	// separators are percent-encoded is recognized identically by pruning and by
+	// rewriting. Recognizing it in only one of the two is what made a rename leave
+	// such a ref dangling while its target survived the prune.
+	name, found := pathutil.CutRefPrefix(ref, prefix)
 	if !found {
-		// The prefix itself may be percent-encoded.
-		decoded, err := url.PathUnescape(ref)
-		if err != nil {
-			return dst
-		}
-		if name, found = strings.CutPrefix(decoded, prefix); !found {
-			return dst
-		}
+		return dst
 	}
 
 	start := len(dst)
@@ -216,9 +212,43 @@ func collectSchemaRefsRecursive(refs *[]string, schema *parser.Schema, prefix st
 	// Discriminator mapping values are references
 	if schema.Discriminator != nil {
 		for _, mappingRef := range schema.Discriminator.Mapping {
-			*refs = appendSchemaNames(*refs, mappingRef, prefix)
+			*refs = appendDiscriminatorTargetNames(*refs, mappingRef, prefix)
 		}
+		// defaultMapping (OAS 3.2+) keeps its target alive exactly as a mapping
+		// value does; omitting it would let pruning delete the fallback schema.
+		*refs = appendDiscriminatorTargetNames(*refs, schema.Discriminator.DefaultMapping, prefix)
 	}
+}
+
+// appendDiscriminatorTargetNames appends the schema names a discriminator mapping
+// or defaultMapping value could denote.
+//
+// A discriminator names its target in either of two spellings — a full pointer
+// ("#/components/schemas/Dog") or a bare schema name ("Dog") — and the spec calls
+// the second one out explicitly: "The behavior of a `mapping` value or
+// `defaultMapping` value that is both a valid schema name and a valid relative URI
+// reference is implementation-defined, but it is RECOMMENDED that it be treated as
+// a schema name."
+//
+// [appendSchemaNames] alone only recognizes the pointer spelling, because it also
+// serves real $ref values where a bare name must not match. Used on its own here
+// it made pruning delete a schema referenced only by a bare mapping value, which
+// is a legal document losing content. The bare value is appended as one more
+// candidate rather than resolved: every caller looks each name up in the schemas
+// map before acting, so a value that names no schema costs a lookup and no more —
+// the same contract appendSchemaNames documents for its own candidates.
+func appendDiscriminatorTargetNames(dst []string, value, prefix string) []string {
+	if value == "" {
+		return dst
+	}
+	dst = appendSchemaNames(dst, value, prefix)
+
+	// A pointer spelling was already expanded above; only a bare name is left to
+	// add, and a value containing "/" or "#" is not one.
+	if !strings.ContainsAny(value, "/#") && !slices.Contains(dst, value) {
+		dst = append(dst, value)
+	}
+	return dst
 }
 
 // isPathItemEmpty returns true if the path item has no operations defined.

--- a/fixer/refs.go
+++ b/fixer/refs.go
@@ -641,6 +641,11 @@ func (c *RefCollector) collectSchemaRefs(schema *parser.Schema, path string) {
 		for key, ref := range schema.Discriminator.Mapping {
 			c.addRef(ref, fmt.Sprintf("%s.discriminator.mapping.%s", path, key), RefTypeSchema)
 		}
+		// defaultMapping (OAS 3.2+) is reference-bearing on the same terms.
+		if schema.Discriminator.DefaultMapping != "" {
+			c.addRef(schema.Discriminator.DefaultMapping,
+				path+".discriminator.defaultMapping", RefTypeSchema)
+		}
 	}
 }
 

--- a/internal/codegen/decode/main.go
+++ b/internal/codegen/decode/main.go
@@ -152,7 +152,7 @@ func (x *Discriminator) decodeFromMap(m map[string]any) {}
 	oasStructTypes["Responses"] = true
 
 	// Phase 2: For each discovered type, introspect fields and classify
-	var targets []decodeTarget
+	targets := make([]decodeTarget, 0, len(targetNames))
 	for _, name := range targetNames {
 		// Responses gets a hand-written method
 		if name == "Responses" {

--- a/internal/codegen/deepcopy/main.go
+++ b/internal/codegen/deepcopy/main.go
@@ -293,14 +293,24 @@ var typeConfigs = []TypeConfig{
 			{Name: "Example", Type: "any", CopyMethod: "helper", Helper: "deepCopyJSONValue"},
 			{Name: "Examples", Type: "map[string]*Example", CopyMethod: "map", KeyType: "string", ElemType: "*Example"},
 			{Name: "Encoding", Type: "map[string]*Encoding", CopyMethod: "map", KeyType: "string", ElemType: "*Encoding"},
+			{Name: "ItemSchema", Type: "*Schema", CopyMethod: "pointer"},                              // OAS 3.2+
+			{Name: "ItemEncoding", Type: "*Encoding", CopyMethod: "pointer"},                          // OAS 3.2+
+			{Name: "PrefixEncoding", Type: "[]*Encoding", CopyMethod: "slice", ElemType: "*Encoding"}, // OAS 3.2+
 			{Name: "Extra", Type: "map[string]any", CopyMethod: "helper", Helper: "deepCopyExtensions"},
 		},
 	},
 	{
+		// Recursive as of OAS 3.2: an Encoding may nest Encoding maps and item
+		// encodings. The generated copy recurses through DeepCopy, which is
+		// unbounded — the parser cannot build a cyclic Encoding graph from a
+		// document, since each level is decoded into a fresh value.
 		Name: "Encoding",
 		Fields: []FieldConfig{
 			{Name: "Headers", Type: "map[string]*Header", CopyMethod: "map", KeyType: "string", ElemType: "*Header"},
 			{Name: "Explode", Type: "*bool", CopyMethod: "prim_pointer"},
+			{Name: "Encoding", Type: "map[string]*Encoding", CopyMethod: "map", KeyType: "string", ElemType: "*Encoding"}, // OAS 3.2+
+			{Name: "ItemEncoding", Type: "*Encoding", CopyMethod: "pointer"},                                              // OAS 3.2+
+			{Name: "PrefixEncoding", Type: "[]*Encoding", CopyMethod: "slice", ElemType: "*Encoding"},                     // OAS 3.2+
 			{Name: "Extra", Type: "map[string]any", CopyMethod: "helper", Helper: "deepCopyExtensions"},
 		},
 	},
@@ -308,6 +318,7 @@ var typeConfigs = []TypeConfig{
 		Name: "Example",
 		Fields: []FieldConfig{
 			{Name: "Value", Type: "any", CopyMethod: "helper", Helper: "deepCopyJSONValue"},
+			{Name: "DataValue", Type: "any", CopyMethod: "helper", Helper: "deepCopyJSONValue"}, // OAS 3.2+
 			{Name: "Extra", Type: "map[string]any", CopyMethod: "helper", Helper: "deepCopyExtensions"},
 		},
 	},
@@ -353,6 +364,7 @@ var typeConfigs = []TypeConfig{
 			{Name: "Password", Type: "*OAuthFlow", CopyMethod: "pointer"},
 			{Name: "ClientCredentials", Type: "*OAuthFlow", CopyMethod: "pointer"},
 			{Name: "AuthorizationCode", Type: "*OAuthFlow", CopyMethod: "pointer"},
+			{Name: "DeviceAuthorization", Type: "*OAuthFlow", CopyMethod: "pointer"}, // OAS 3.2+
 			{Name: "Extra", Type: "map[string]any", CopyMethod: "helper", Helper: "deepCopyExtensions"},
 		},
 	},

--- a/internal/mcpserver/tools_walk_headers.go
+++ b/internal/mcpserver/tools_walk_headers.go
@@ -189,6 +189,11 @@ func filterWalkHeaders(headers []*headerInfo, input walkHeadersInput) ([]*header
 		hasExtFilter = true
 	}
 
+	// Nothing to filter: skip the walk and the allocation.
+	if len(headers) == 0 {
+		return nil, nil
+	}
+
 	matched := make([]*headerInfo, 0, len(headers))
 	for _, info := range headers {
 		if input.Name != "" && !matchGlobName(info.Name, input.Name) {

--- a/internal/mcpserver/tools_walk_headers.go
+++ b/internal/mcpserver/tools_walk_headers.go
@@ -189,7 +189,7 @@ func filterWalkHeaders(headers []*headerInfo, input walkHeadersInput) ([]*header
 		hasExtFilter = true
 	}
 
-	var matched []*headerInfo
+	matched := make([]*headerInfo, 0, len(headers))
 	for _, info := range headers {
 		if input.Name != "" && !matchGlobName(info.Name, input.Name) {
 			continue

--- a/internal/mcpserver/tools_walk_operations.go
+++ b/internal/mcpserver/tools_walk_operations.go
@@ -155,6 +155,11 @@ func filterWalkOperations(ops []*walker.OperationInfo, input walkOperationsInput
 		hasExtFilter = true
 	}
 
+	// Nothing to filter: skip the walk and the allocation.
+	if len(ops) == 0 {
+		return nil, nil
+	}
+
 	matched := make([]*walker.OperationInfo, 0, len(ops))
 	for _, op := range ops {
 		if input.Method != "" && !strings.EqualFold(op.Method, input.Method) {

--- a/internal/mcpserver/tools_walk_operations.go
+++ b/internal/mcpserver/tools_walk_operations.go
@@ -155,7 +155,7 @@ func filterWalkOperations(ops []*walker.OperationInfo, input walkOperationsInput
 		hasExtFilter = true
 	}
 
-	var matched []*walker.OperationInfo
+	matched := make([]*walker.OperationInfo, 0, len(ops))
 	for _, op := range ops {
 		if input.Method != "" && !strings.EqualFold(op.Method, input.Method) {
 			continue

--- a/internal/mcpserver/tools_walk_parameters.go
+++ b/internal/mcpserver/tools_walk_parameters.go
@@ -154,6 +154,11 @@ func filterWalkParameters(params []*walker.ParameterInfo, input walkParametersIn
 		hasExtFilter = true
 	}
 
+	// Nothing to filter: skip the walk and the allocation.
+	if len(params) == 0 {
+		return nil, nil
+	}
+
 	matched := make([]*walker.ParameterInfo, 0, len(params))
 	for _, info := range params {
 		if input.In != "" && !strings.EqualFold(info.In, input.In) {

--- a/internal/mcpserver/tools_walk_parameters.go
+++ b/internal/mcpserver/tools_walk_parameters.go
@@ -154,7 +154,7 @@ func filterWalkParameters(params []*walker.ParameterInfo, input walkParametersIn
 		hasExtFilter = true
 	}
 
-	var matched []*walker.ParameterInfo
+	matched := make([]*walker.ParameterInfo, 0, len(params))
 	for _, info := range params {
 		if input.In != "" && !strings.EqualFold(info.In, input.In) {
 			continue

--- a/internal/mcpserver/tools_walk_paths.go
+++ b/internal/mcpserver/tools_walk_paths.go
@@ -149,6 +149,11 @@ func filterWalkPaths(paths []*pathInfo, input walkPathsInput) ([]*pathInfo, erro
 		hasExtFilter = true
 	}
 
+	// Nothing to filter: skip the walk and the allocation.
+	if len(paths) == 0 {
+		return nil, nil
+	}
+
 	matched := make([]*pathInfo, 0, len(paths))
 	for _, info := range paths {
 		if input.Path != "" && !matchWalkPath(info.PathTemplate, input.Path) {

--- a/internal/mcpserver/tools_walk_paths.go
+++ b/internal/mcpserver/tools_walk_paths.go
@@ -149,7 +149,7 @@ func filterWalkPaths(paths []*pathInfo, input walkPathsInput) ([]*pathInfo, erro
 		hasExtFilter = true
 	}
 
-	var matched []*pathInfo
+	matched := make([]*pathInfo, 0, len(paths))
 	for _, info := range paths {
 		if input.Path != "" && !matchWalkPath(info.PathTemplate, input.Path) {
 			continue

--- a/internal/mcpserver/tools_walk_refs.go
+++ b/internal/mcpserver/tools_walk_refs.go
@@ -141,6 +141,11 @@ func filterRefs(refs []*walker.RefInfo, input walkRefsInput) []*walker.RefInfo {
 	if input.Target == "" && input.NodeType == "" {
 		return refs
 	}
+	// Nothing to filter: skip the walk and the allocation.
+	if len(refs) == 0 {
+		return nil
+	}
+
 	filtered := make([]*walker.RefInfo, 0, len(refs))
 	for _, ref := range refs {
 		if input.Target != "" && !matchRefGlob(ref.Ref, input.Target) {

--- a/internal/mcpserver/tools_walk_refs.go
+++ b/internal/mcpserver/tools_walk_refs.go
@@ -141,7 +141,7 @@ func filterRefs(refs []*walker.RefInfo, input walkRefsInput) []*walker.RefInfo {
 	if input.Target == "" && input.NodeType == "" {
 		return refs
 	}
-	var filtered []*walker.RefInfo
+	filtered := make([]*walker.RefInfo, 0, len(refs))
 	for _, ref := range refs {
 		if input.Target != "" && !matchRefGlob(ref.Ref, input.Target) {
 			continue

--- a/internal/mcpserver/tools_walk_responses.go
+++ b/internal/mcpserver/tools_walk_responses.go
@@ -154,7 +154,7 @@ func filterWalkResponses(responses []*walker.ResponseInfo, input walkResponsesIn
 		hasExtFilter = true
 	}
 
-	var matched []*walker.ResponseInfo
+	matched := make([]*walker.ResponseInfo, 0, len(responses))
 	for _, info := range responses {
 		if input.Status != "" && !statusCodeMatches(info.StatusCode, input.Status) {
 			continue

--- a/internal/mcpserver/tools_walk_responses.go
+++ b/internal/mcpserver/tools_walk_responses.go
@@ -154,6 +154,11 @@ func filterWalkResponses(responses []*walker.ResponseInfo, input walkResponsesIn
 		hasExtFilter = true
 	}
 
+	// Nothing to filter: skip the walk and the allocation.
+	if len(responses) == 0 {
+		return nil, nil
+	}
+
 	matched := make([]*walker.ResponseInfo, 0, len(responses))
 	for _, info := range responses {
 		if input.Status != "" && !statusCodeMatches(info.StatusCode, input.Status) {

--- a/internal/mcpserver/tools_walk_schemas.go
+++ b/internal/mcpserver/tools_walk_schemas.go
@@ -170,6 +170,11 @@ func filterWalkSchemas(schemas []*walker.SchemaInfo, input walkSchemasInput) ([]
 		hasExtFilter = true
 	}
 
+	// Nothing to filter: skip the walk and the allocation.
+	if len(schemas) == 0 {
+		return nil, nil
+	}
+
 	filtered := make([]*walker.SchemaInfo, 0, len(schemas))
 	for _, info := range schemas {
 		if input.Name != "" && !matchGlobName(info.Name, input.Name) {

--- a/internal/mcpserver/tools_walk_schemas.go
+++ b/internal/mcpserver/tools_walk_schemas.go
@@ -170,7 +170,7 @@ func filterWalkSchemas(schemas []*walker.SchemaInfo, input walkSchemasInput) ([]
 		hasExtFilter = true
 	}
 
-	var filtered []*walker.SchemaInfo
+	filtered := make([]*walker.SchemaInfo, 0, len(schemas))
 	for _, info := range schemas {
 		if input.Name != "" && !matchGlobName(info.Name, input.Name) {
 			continue

--- a/internal/mcpserver/tools_walk_security.go
+++ b/internal/mcpserver/tools_walk_security.go
@@ -108,7 +108,7 @@ func filterWalkSecurity(schemes []*walker.SecuritySchemeInfo, input walkSecurity
 		hasExtFilter = true
 	}
 
-	var matched []*walker.SecuritySchemeInfo
+	matched := make([]*walker.SecuritySchemeInfo, 0, len(schemes))
 	for _, info := range schemes {
 		if input.Name != "" && !strings.EqualFold(info.Name, input.Name) {
 			continue

--- a/internal/mcpserver/tools_walk_security.go
+++ b/internal/mcpserver/tools_walk_security.go
@@ -108,6 +108,11 @@ func filterWalkSecurity(schemes []*walker.SecuritySchemeInfo, input walkSecurity
 		hasExtFilter = true
 	}
 
+	// Nothing to filter: skip the walk and the allocation.
+	if len(schemes) == 0 {
+		return nil, nil
+	}
+
 	matched := make([]*walker.SecuritySchemeInfo, 0, len(schemes))
 	for _, info := range schemes {
 		if input.Name != "" && !strings.EqualFold(info.Name, input.Name) {

--- a/internal/pathutil/refs.go
+++ b/internal/pathutil/refs.go
@@ -2,6 +2,7 @@ package pathutil
 
 import (
 	"net/url"
+	"strconv"
 	"strings"
 )
 
@@ -67,6 +68,56 @@ func DecodeRefToken(token string) string {
 		token = decoded
 	}
 	return UnescapeRefToken(token)
+}
+
+// CutRefPrefix strips a JSON Pointer prefix from a reference, tolerating a
+// reference whose pointer separators are percent-encoded, and returns the
+// remainder with its own escaping untouched.
+//
+// Generators reach that shape by running a URL escaper over a whole pointer
+// rather than over each token, so "#/components/schemas/Paged%5BPet%5D" arrives
+// as "#%2Fcomponents%2Fschemas%2FPaged%255BPet%255D". Rare, but a reference
+// spelled that way denotes exactly the same component as the raw form and has
+// to resolve to it.
+//
+// prefix is matched one decoded byte at a time rather than against a wholesale
+// [url.PathUnescape] of ref, because a wholesale decode would also decode the
+// token that follows. That token has to reach [DecodeRefToken] still escaped for
+// the exact-then-decoded lookup order to mean anything: decoding twice turns a
+// component genuinely named "Paged%5BPet%5D" into "Paged[Pet]" and stops it
+// matching itself. Keeping the decode confined to the prefix leaves
+// [DecodeRefToken] the single place a name's escaping is reversed.
+//
+// The prefix returned to the caller is the raw one it passed in, never the
+// spelling ref used, so a decoded reference lands on the same key as a raw one.
+func CutRefPrefix(ref, prefix string) (rest string, ok bool) {
+	// Fast path: almost every reference spells its prefix raw.
+	if rest, found := strings.CutPrefix(ref, prefix); found {
+		return rest, true
+	}
+	// Only a percent sequence can make the prefix match after decoding; RFC 6901
+	// escapes cannot, because "~0" and "~1" never produce "#" or "/".
+	if !strings.Contains(ref, "%") {
+		return "", false
+	}
+
+	i := 0
+	for p := 0; p < len(prefix); p++ {
+		switch {
+		case i < len(ref) && ref[i] == prefix[p]:
+			i++
+		case i+3 <= len(ref) && ref[i] == '%':
+			// ParseUint accepts either hex case, so "%2f" and "%2F" both match "/".
+			b, err := strconv.ParseUint(ref[i+1:i+3], 16, 8)
+			if err != nil || byte(b) != prefix[p] {
+				return "", false
+			}
+			i += 3
+		default:
+			return "", false
+		}
+	}
+	return ref[i:], true
 }
 
 // OAS 2.0 reference prefixes

--- a/internal/pathutil/refs_test.go
+++ b/internal/pathutil/refs_test.go
@@ -148,3 +148,123 @@ func TestDecodeRefToken(t *testing.T) {
 		})
 	}
 }
+
+// TestCutRefPrefix covers the percent-encoded pointer separators the raw
+// strings.CutPrefix path cannot see, and the boundary cases where a partially
+// decodable ref must be rejected rather than half-matched.
+func TestCutRefPrefix(t *testing.T) {
+	tests := []struct {
+		name     string
+		ref      string
+		prefix   string
+		wantRest string
+		wantOK   bool
+	}{
+		{
+			name:     "raw prefix",
+			ref:      "#/components/schemas/Pet",
+			prefix:   RefPrefixSchemas,
+			wantRest: "Pet",
+			wantOK:   true,
+		},
+		{
+			name:     "fully percent-encoded pointer",
+			ref:      "#%2Fcomponents%2Fschemas%2FPaged%5BPet%5D",
+			prefix:   RefPrefixSchemas,
+			wantRest: "Paged%5BPet%5D",
+			wantOK:   true,
+		},
+		{
+			name:     "lowercase hex decodes the same as uppercase",
+			ref:      "#%2fcomponents%2fschemas%2fPet",
+			prefix:   RefPrefixSchemas,
+			wantRest: "Pet",
+			wantOK:   true,
+		},
+		{
+			name:     "mixed raw and encoded separators",
+			ref:      "#/components%2Fschemas/Pet",
+			prefix:   RefPrefixSchemas,
+			wantRest: "Pet",
+			wantOK:   true,
+		},
+		{
+			name:     "the name keeps its own escaping, so DecodeRefToken stays the one decoder",
+			ref:      "#%2Fdefinitions%2FPaged%255BPet%255D",
+			prefix:   RefPrefixDefinitions,
+			wantRest: "Paged%255BPet%255D",
+			wantOK:   true,
+		},
+		{
+			name:     "encoded prefix for the other OAS version does not match",
+			ref:      "#%2Fdefinitions%2FPet",
+			prefix:   RefPrefixSchemas,
+			wantRest: "",
+			wantOK:   false,
+		},
+		{
+			name:     "a percent sequence that decodes to the wrong byte does not match",
+			ref:      "#%2Bcomponents%2Fschemas%2FPet",
+			prefix:   RefPrefixSchemas,
+			wantRest: "",
+			wantOK:   false,
+		},
+		{
+			name:     "an invalid percent sequence does not match",
+			ref:      "#%ZZcomponents%2Fschemas%2FPet",
+			prefix:   RefPrefixSchemas,
+			wantRest: "",
+			wantOK:   false,
+		},
+		{
+			name:     "a truncated percent sequence does not run off the end",
+			ref:      "#%2Fcomponents%2Fschemas%2",
+			prefix:   RefPrefixSchemas,
+			wantRest: "",
+			wantOK:   false,
+		},
+		{
+			name:     "a ref shorter than its prefix does not match",
+			ref:      "#/components/",
+			prefix:   RefPrefixSchemas,
+			wantRest: "",
+			wantOK:   false,
+		},
+		{
+			name:     "the bare prefix matches with an empty remainder",
+			ref:      "#%2Fcomponents%2Fschemas%2F",
+			prefix:   RefPrefixSchemas,
+			wantRest: "",
+			wantOK:   true,
+		},
+		{
+			name:     "a ref with no percent at all takes the reject path",
+			ref:      "#/definitions/Pet",
+			prefix:   RefPrefixSchemas,
+			wantRest: "",
+			wantOK:   false,
+		},
+		{
+			name:     "an external ref does not match a local prefix",
+			ref:      "other.yaml#/components/schemas/Pet",
+			prefix:   RefPrefixSchemas,
+			wantRest: "",
+			wantOK:   false,
+		},
+		{
+			name:     "an external ref with an encoded pointer still does not match",
+			ref:      "other.yaml#%2Fcomponents%2Fschemas%2FPet",
+			prefix:   RefPrefixSchemas,
+			wantRest: "",
+			wantOK:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rest, ok := CutRefPrefix(tt.ref, tt.prefix)
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.wantRest, rest)
+		})
+	}
+}

--- a/internal/schemautil/hash.go
+++ b/internal/schemautil/hash.go
@@ -225,6 +225,46 @@ func (h *SchemaHasher) hashSchema(hasher hash.Hash64, schema *parser.Schema) {
 		}
 	}
 
+	// XML
+	//
+	// XML metadata is structural, not descriptive: it decides the element name,
+	// namespace, and node kind a value serializes to, so two schemas with
+	// different XML are not interchangeable. Leaving it out of the hash put them
+	// in the same bucket, and deduplication then merged them and changed the wire
+	// format of a payload. That is the opposite case from the metadata this type's
+	// doc comment excludes: a title or description cannot change a payload.
+	//
+	// Every field is labelled so no value can be mistaken for a neighbour's, and
+	// the block is entered only for a non-nil XML object, so a schema without one
+	// hashes exactly as it did before.
+	if schema.XML != nil {
+		h.writeString(hasher, "xml:")
+		if schema.XML.Name != "" {
+			h.writeString(hasher, "name:")
+			h.writeString(hasher, schema.XML.Name)
+		}
+		if schema.XML.Namespace != "" {
+			h.writeString(hasher, "namespace:")
+			h.writeString(hasher, schema.XML.Namespace)
+		}
+		if schema.XML.Prefix != "" {
+			h.writeString(hasher, "prefix:")
+			h.writeString(hasher, schema.XML.Prefix)
+		}
+		if schema.XML.Attribute {
+			h.writeString(hasher, "attribute:true")
+		}
+		if schema.XML.Wrapped {
+			h.writeString(hasher, "wrapped:true")
+		}
+		// OAS 3.2+, and the field that supersedes attribute and wrapped, so it has
+		// to separate schemas at least as strongly as they do.
+		if schema.XML.NodeType != "" {
+			h.writeString(hasher, "nodeType:")
+			h.writeString(hasher, schema.XML.NodeType)
+		}
+	}
+
 	// Contains
 	if schema.Contains != nil {
 		h.writeString(hasher, "contains:")

--- a/internal/schemautil/hash.go
+++ b/internal/schemautil/hash.go
@@ -216,6 +216,13 @@ func (h *SchemaHasher) hashSchema(hasher hash.Hash64, schema *parser.Schema) {
 				h.writeString(hasher, schema.Discriminator.Mapping[k])
 			}
 		}
+		// OAS 3.2+. Labelled and written only when set, so a schema that does not
+		// use it hashes exactly as it did before the field existed, while two
+		// schemas that fall back to different defaults stop colliding.
+		if schema.Discriminator.DefaultMapping != "" {
+			h.writeString(hasher, "defaultMapping:")
+			h.writeString(hasher, schema.Discriminator.DefaultMapping)
+		}
 	}
 
 	// Contains

--- a/internal/schemautil/hash.go
+++ b/internal/schemautil/hash.go
@@ -202,9 +202,12 @@ func (h *SchemaHasher) hashSchema(hasher hash.Hash64, schema *parser.Schema) {
 	}
 
 	// Discriminator
+	// Every string here is length-framed. Unframed, adjacent values run together:
+	// mapping {"ab": "c"} hashed the same as {"a": "bc"}, and a mapping value could
+	// forge the defaultMapping label that follows it.
 	if schema.Discriminator != nil {
 		h.writeString(hasher, "discriminator:")
-		h.writeString(hasher, schema.Discriminator.PropertyName)
+		h.writeLabeled(hasher, "propertyName", schema.Discriminator.PropertyName)
 		if len(schema.Discriminator.Mapping) > 0 {
 			keys := make([]string, 0, len(schema.Discriminator.Mapping))
 			for k := range schema.Discriminator.Mapping {
@@ -212,16 +215,15 @@ func (h *SchemaHasher) hashSchema(hasher hash.Hash64, schema *parser.Schema) {
 			}
 			sort.Strings(keys)
 			for _, k := range keys {
-				h.writeString(hasher, k)
-				h.writeString(hasher, schema.Discriminator.Mapping[k])
+				h.writeLabeled(hasher, "map", k)
+				h.writeLabeled(hasher, "to", schema.Discriminator.Mapping[k])
 			}
 		}
 		// OAS 3.2+. Written only when set, so a schema without it hashes as it
 		// always has, while two schemas with different fallbacks stop colliding.
 		// https://spec.openapis.org/oas/v3.2.0.html#discriminator-default-mapping
 		if schema.Discriminator.DefaultMapping != "" {
-			h.writeString(hasher, "defaultMapping:")
-			h.writeString(hasher, schema.Discriminator.DefaultMapping)
+			h.writeLabeled(hasher, "defaultMapping", schema.Discriminator.DefaultMapping)
 		}
 	}
 
@@ -235,23 +237,17 @@ func (h *SchemaHasher) hashSchema(hasher hash.Hash64, schema *parser.Schema) {
 	// its neighbor's; a schema with no `xml` hashes as it always has.
 	if schema.XML != nil {
 		h.writeString(hasher, "xml:")
-		// Each value is terminated, not just labeled. writeString appends raw bytes,
-		// so unterminated values run together: name "anamespace:b" with no namespace
-		// would otherwise hash the same as name "a" with namespace "b".
+		// Length-framed via writeLabeled: writeString appends raw bytes, so an
+		// unframed name "anamespace:b" would hash the same as name "a" with
+		// namespace "b".
 		if schema.XML.Name != "" {
-			h.writeString(hasher, "name:")
-			h.writeString(hasher, schema.XML.Name)
-			h.writeString(hasher, "\x00")
+			h.writeLabeled(hasher, "name", schema.XML.Name)
 		}
 		if schema.XML.Namespace != "" {
-			h.writeString(hasher, "namespace:")
-			h.writeString(hasher, schema.XML.Namespace)
-			h.writeString(hasher, "\x00")
+			h.writeLabeled(hasher, "namespace", schema.XML.Namespace)
 		}
 		if schema.XML.Prefix != "" {
-			h.writeString(hasher, "prefix:")
-			h.writeString(hasher, schema.XML.Prefix)
-			h.writeString(hasher, "\x00")
+			h.writeLabeled(hasher, "prefix", schema.XML.Prefix)
 		}
 		if schema.XML.Attribute {
 			h.writeString(hasher, "attribute:true")
@@ -262,9 +258,7 @@ func (h *SchemaHasher) hashSchema(hasher hash.Hash64, schema *parser.Schema) {
 		// Supersedes attribute and wrapped, so it must separate schemas at least as
 		// strongly as they do.
 		if schema.XML.NodeType != "" {
-			h.writeString(hasher, "nodeType:")
-			h.writeString(hasher, schema.XML.NodeType)
-			h.writeString(hasher, "\x00")
+			h.writeLabeled(hasher, "nodeType", schema.XML.NodeType)
 		}
 	}
 
@@ -458,4 +452,18 @@ func (h *SchemaHasher) hashComposition(hasher hash.Hash64, schema *parser.Schema
 // writeString writes a string to the hash.
 func (h *SchemaHasher) writeString(hasher hash.Hash64, s string) {
 	_, _ = hasher.Write([]byte(s))
+}
+
+// writeLabeled writes a labeled value framed by its byte length, so no value can
+// be mistaken for its neighbor whatever it contains.
+//
+// A delimiter cannot do this: any sentinel byte can also appear inside a value,
+// so a NUL terminator is defeated by a name holding a NUL. The length pins where
+// the value ends, which makes the encoding injective.
+func (h *SchemaHasher) writeLabeled(hasher hash.Hash64, label, value string) {
+	h.writeString(hasher, label)
+	h.writeString(hasher, ":")
+	h.writeString(hasher, strconv.Itoa(len(value)))
+	h.writeString(hasher, ":")
+	h.writeString(hasher, value)
 }

--- a/internal/schemautil/hash.go
+++ b/internal/schemautil/hash.go
@@ -235,17 +235,23 @@ func (h *SchemaHasher) hashSchema(hasher hash.Hash64, schema *parser.Schema) {
 	// its neighbor's; a schema with no `xml` hashes as it always has.
 	if schema.XML != nil {
 		h.writeString(hasher, "xml:")
+		// Each value is terminated, not just labeled. writeString appends raw bytes,
+		// so unterminated values run together: name "anamespace:b" with no namespace
+		// would otherwise hash the same as name "a" with namespace "b".
 		if schema.XML.Name != "" {
 			h.writeString(hasher, "name:")
 			h.writeString(hasher, schema.XML.Name)
+			h.writeString(hasher, "\x00")
 		}
 		if schema.XML.Namespace != "" {
 			h.writeString(hasher, "namespace:")
 			h.writeString(hasher, schema.XML.Namespace)
+			h.writeString(hasher, "\x00")
 		}
 		if schema.XML.Prefix != "" {
 			h.writeString(hasher, "prefix:")
 			h.writeString(hasher, schema.XML.Prefix)
+			h.writeString(hasher, "\x00")
 		}
 		if schema.XML.Attribute {
 			h.writeString(hasher, "attribute:true")
@@ -258,6 +264,7 @@ func (h *SchemaHasher) hashSchema(hasher hash.Hash64, schema *parser.Schema) {
 		if schema.XML.NodeType != "" {
 			h.writeString(hasher, "nodeType:")
 			h.writeString(hasher, schema.XML.NodeType)
+			h.writeString(hasher, "\x00")
 		}
 	}
 

--- a/internal/schemautil/hash.go
+++ b/internal/schemautil/hash.go
@@ -216,27 +216,23 @@ func (h *SchemaHasher) hashSchema(hasher hash.Hash64, schema *parser.Schema) {
 				h.writeString(hasher, schema.Discriminator.Mapping[k])
 			}
 		}
-		// OAS 3.2+. Labelled and written only when set, so a schema that does not
-		// use it hashes exactly as it did before the field existed, while two
-		// schemas that fall back to different defaults stop colliding.
+		// OAS 3.2+. Written only when set, so a schema without it hashes as it
+		// always has, while two schemas with different fallbacks stop colliding.
+		// https://spec.openapis.org/oas/v3.2.0.html#discriminator-default-mapping
 		if schema.Discriminator.DefaultMapping != "" {
 			h.writeString(hasher, "defaultMapping:")
 			h.writeString(hasher, schema.Discriminator.DefaultMapping)
 		}
 	}
 
-	// XML
+	// XML is structural, not descriptive: it decides the element name, namespace,
+	// and node kind a value serializes to, unlike the title and description this
+	// type's doc comment excludes.
+	// https://spec.openapis.org/oas/v3.2.0.html#xml-object
 	//
-	// XML metadata is structural, not descriptive: it decides the element name,
-	// namespace, and node kind a value serializes to, so two schemas with
-	// different XML are not interchangeable. Leaving it out of the hash put them
-	// in the same bucket, and deduplication then merged them and changed the wire
-	// format of a payload. That is the opposite case from the metadata this type's
-	// doc comment excludes: a title or description cannot change a payload.
-	//
-	// Every field is labelled so no value can be mistaken for a neighbour's, and
-	// the block is entered only for a non-nil XML object, so a schema without one
-	// hashes exactly as it did before.
+	// Omitting it put schemas that serialize to different XML in one bucket, where
+	// deduplication merged them. Fields are labeled so no value can be mistaken for
+	// its neighbor's; a schema with no `xml` hashes as it always has.
 	if schema.XML != nil {
 		h.writeString(hasher, "xml:")
 		if schema.XML.Name != "" {
@@ -257,8 +253,8 @@ func (h *SchemaHasher) hashSchema(hasher hash.Hash64, schema *parser.Schema) {
 		if schema.XML.Wrapped {
 			h.writeString(hasher, "wrapped:true")
 		}
-		// OAS 3.2+, and the field that supersedes attribute and wrapped, so it has
-		// to separate schemas at least as strongly as they do.
+		// Supersedes attribute and wrapped, so it must separate schemas at least as
+		// strongly as they do.
 		if schema.XML.NodeType != "" {
 			h.writeString(hasher, "nodeType:")
 			h.writeString(hasher, schema.XML.NodeType)

--- a/internal/schemautil/hash_test.go
+++ b/internal/schemautil/hash_test.go
@@ -418,9 +418,10 @@ func TestHashDistinguishesXML(t *testing.T) {
 		}
 	})
 
-	// writeString appends raw bytes, so unterminated values run together. Without a
-	// terminator these two hash identically, putting different XML configurations in
-	// one deduplication bucket.
+	// writeString appends raw bytes, so values need framing or they run together.
+	// Both pairs below collided at some point: the first defeats no framing at all,
+	// the second defeats a delimiter, since any sentinel byte can appear inside a
+	// value. Only length framing separates them.
 	t.Run("adjacent xml values do not run together", func(t *testing.T) {
 		runTogether := stringWithXML(&parser.XML{Name: "anamespace:b"})
 		separate := stringWithXML(&parser.XML{Name: "a", Namespace: "b"})
@@ -428,10 +429,79 @@ func TestHashDistinguishesXML(t *testing.T) {
 			"concatenated xml values must not collide")
 	})
 
+	t.Run("a value containing the delimiter does not collide", func(t *testing.T) {
+		withNUL := stringWithXML(&parser.XML{Name: "a\x00namespace:b"})
+		separate := stringWithXML(&parser.XML{Name: "a", Namespace: "b"})
+		assert.NotEqual(t, hasher.Hash(withNUL), hasher.Hash(separate),
+			"a NUL inside a value must not forge a field boundary")
+	})
+
+	t.Run("a value containing the length framing does not collide", func(t *testing.T) {
+		forged := stringWithXML(&parser.XML{Name: "a1:bnamespace:1:c"})
+		separate := stringWithXML(&parser.XML{Name: "a", Namespace: "b"})
+		assert.NotEqual(t, hasher.Hash(forged), hasher.Hash(separate),
+			"a value imitating the framing must not collide either")
+	})
+
 	t.Run("identical xml still hashes alike", func(t *testing.T) {
 		left := stringWithXML(&parser.XML{Name: "tag", Namespace: "https://example.com/ns", NodeType: "attribute"})
 		right := stringWithXML(&parser.XML{Name: "tag", Namespace: "https://example.com/ns", NodeType: "attribute"})
 		assert.Equal(t, hasher.Hash(left), hasher.Hash(right),
 			"equal xml must not be made to differ")
+	})
+}
+
+// TestHashFramesDiscriminatorStrings covers the framing of the Discriminator
+// Object's strings.
+//
+// writeString appends raw bytes, so unframed neighbors run together. Each pair
+// below hashed identically before the discriminator block was length-framed, which
+// put semantically different discriminators in one deduplication bucket.
+func TestHashFramesDiscriminatorStrings(t *testing.T) {
+	discriminated := func(property string, mapping map[string]string, def string) *parser.Schema {
+		return &parser.Schema{
+			Type: "object",
+			Discriminator: &parser.Discriminator{
+				PropertyName:   property,
+				Mapping:        mapping,
+				DefaultMapping: def,
+			},
+		}
+	}
+
+	hasher := NewSchemaHasher()
+
+	tests := []struct {
+		name        string
+		left, right *parser.Schema
+	}{
+		{
+			name:  "a mapping key runs into its value",
+			left:  discriminated("kind", map[string]string{"ab": "c"}, ""),
+			right: discriminated("kind", map[string]string{"a": "bc"}, ""),
+		},
+		{
+			name:  "a mapping value forges the defaultMapping label",
+			left:  discriminated("kind", map[string]string{"k": "xdefaultMapping:y"}, ""),
+			right: discriminated("kind", map[string]string{"k": "x"}, "y"),
+		},
+		{
+			name:  "propertyName absorbs the first mapping key",
+			left:  discriminated("kindab", nil, ""),
+			right: discriminated("kind", map[string]string{"ab": ""}, ""),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.NotEqual(t, hasher.Hash(tt.left), hasher.Hash(tt.right),
+				"framing must keep these discriminators apart")
+		})
+	}
+
+	t.Run("identical discriminators still hash alike", func(t *testing.T) {
+		left := discriminated("kind", map[string]string{"a": "b"}, "Other")
+		right := discriminated("kind", map[string]string{"a": "b"}, "Other")
+		assert.Equal(t, hasher.Hash(left), hasher.Hash(right))
 	})
 }

--- a/internal/schemautil/hash_test.go
+++ b/internal/schemautil/hash_test.go
@@ -418,6 +418,16 @@ func TestHashDistinguishesXML(t *testing.T) {
 		}
 	})
 
+	// writeString appends raw bytes, so unterminated values run together. Without a
+	// terminator these two hash identically, putting different XML configurations in
+	// one deduplication bucket.
+	t.Run("adjacent xml values do not run together", func(t *testing.T) {
+		runTogether := stringWithXML(&parser.XML{Name: "anamespace:b"})
+		separate := stringWithXML(&parser.XML{Name: "a", Namespace: "b"})
+		assert.NotEqual(t, hasher.Hash(runTogether), hasher.Hash(separate),
+			"concatenated xml values must not collide")
+	})
+
 	t.Run("identical xml still hashes alike", func(t *testing.T) {
 		left := stringWithXML(&parser.XML{Name: "tag", Namespace: "https://example.com/ns", NodeType: "attribute"})
 		right := stringWithXML(&parser.XML{Name: "tag", Namespace: "https://example.com/ns", NodeType: "attribute"})

--- a/internal/schemautil/hash_test.go
+++ b/internal/schemautil/hash_test.go
@@ -371,3 +371,57 @@ func TestSchemaHasher_Hash_MetadataIgnored(t *testing.T) {
 
 	assert.Equal(t, hash1, hash2, "Metadata-only differences should not affect hash")
 }
+
+// TestHashDistinguishesXML covers the XML Object, which was absent from the
+// structural hash entirely.
+//
+// XML decides the element name, namespace, and node kind a value serializes to, so
+// two schemas whose XML differs describe different payloads. Hashing them alike put
+// them in one deduplication bucket, where a comparison that also ignored XML then
+// merged them: silently changing the wire format of a payload.
+func TestHashDistinguishesXML(t *testing.T) {
+	stringWithXML := func(x *parser.XML) *parser.Schema {
+		return &parser.Schema{Type: "string", XML: x}
+	}
+
+	base := stringWithXML(&parser.XML{Name: "tag"})
+
+	tests := []struct {
+		name  string
+		other *parser.Schema
+	}{
+		{"no xml at all", &parser.Schema{Type: "string"}},
+		{"different name", stringWithXML(&parser.XML{Name: "label"})},
+		{"added namespace", stringWithXML(&parser.XML{Name: "tag", Namespace: "https://example.com/ns"})},
+		{"added prefix", stringWithXML(&parser.XML{Name: "tag", Prefix: "ex"})},
+		{"attribute set", stringWithXML(&parser.XML{Name: "tag", Attribute: true})},
+		{"wrapped set", stringWithXML(&parser.XML{Name: "tag", Wrapped: true})},
+		{"nodeType set", stringWithXML(&parser.XML{Name: "tag", NodeType: "attribute"})},
+	}
+
+	hasher := NewSchemaHasher()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.NotEqual(t, hasher.Hash(base), hasher.Hash(tt.other),
+				"schemas differing only in xml must not share a structural hash")
+		})
+	}
+
+	t.Run("nodeType values are distinguished from each other", func(t *testing.T) {
+		seen := make(map[uint64]string)
+		for _, nodeType := range []string{"element", "attribute", "text", "cdata", "none"} {
+			sum := hasher.Hash(stringWithXML(&parser.XML{NodeType: nodeType}))
+			if prev, clash := seen[sum]; clash {
+				t.Errorf("nodeType %q and %q share a hash", nodeType, prev)
+			}
+			seen[sum] = nodeType
+		}
+	})
+
+	t.Run("identical xml still hashes alike", func(t *testing.T) {
+		left := stringWithXML(&parser.XML{Name: "tag", Namespace: "https://example.com/ns", NodeType: "attribute"})
+		right := stringWithXML(&parser.XML{Name: "tag", Namespace: "https://example.com/ns", NodeType: "attribute"})
+		assert.Equal(t, hasher.Hash(left), hasher.Hash(right),
+			"equal xml must not be made to differ")
+	})
+}

--- a/joiner/equivalence.go
+++ b/joiner/equivalence.go
@@ -569,6 +569,24 @@ func compareDeep(left, right *parser.Schema, path *comparePath, result *Equivale
 		path.pop()
 	}
 
+	// Compare xml
+	//
+	// XML decides the element name, namespace, and node kind a value serializes
+	// to, so two schemas whose XML differs describe different payloads and are not
+	// equivalent. Reporting them as equivalent let deduplication merge them and
+	// silently change the wire format; the missing entry in the structural hash
+	// hid it, because two such schemas rarely reached this comparison at all.
+	if !equalXMLObjects(left.XML, right.XML) {
+		path.push("xml")
+		result.Differences = append(result.Differences, SchemaDifference{
+			Path:        path.String(),
+			LeftValue:   left.XML,
+			RightValue:  right.XML,
+			Description: "xml metadata mismatch",
+		})
+		path.pop()
+	}
+
 	// Compare const
 	if !reflect.DeepEqual(left.Const, right.Const) {
 		path.push("const")
@@ -888,6 +906,26 @@ func equalTypes(left, right any) bool {
 
 	// Different types
 	return false
+}
+
+// equalXMLObjects compares two XML Objects field by field.
+//
+// A nil XML object and a present one are not equal: absent XML means the
+// serializer infers everything, which is a different payload from one that names
+// an element or picks a node type. Attribute, Wrapped, and NodeType are compared
+// independently, matching how the parser models them — nothing here derives the
+// 3.2 nodeType from the two bools it supersedes, because the 3.2 default depends
+// on the enclosing schema and cannot be computed from the XML object alone.
+func equalXMLObjects(left, right *parser.XML) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+	return left.Name == right.Name &&
+		left.Namespace == right.Namespace &&
+		left.Prefix == right.Prefix &&
+		left.Attribute == right.Attribute &&
+		left.Wrapped == right.Wrapped &&
+		left.NodeType == right.NodeType
 }
 
 func equalStringSlices(left, right []string) bool {

--- a/joiner/equivalence.go
+++ b/joiner/equivalence.go
@@ -569,13 +569,10 @@ func compareDeep(left, right *parser.Schema, path *comparePath, result *Equivale
 		path.pop()
 	}
 
-	// Compare xml
-	//
-	// XML decides the element name, namespace, and node kind a value serializes
-	// to, so two schemas whose XML differs describe different payloads and are not
-	// equivalent. Reporting them as equivalent let deduplication merge them and
-	// silently change the wire format; the missing entry in the structural hash
-	// hid it, because two such schemas rarely reached this comparison at all.
+	// Compare xml. It decides the element name, namespace, and node kind a value
+	// serializes to, so schemas whose XML differs describe different payloads.
+	// Calling them equivalent let deduplication merge them and change the wire
+	// format; the structural hash omitted xml too, so each gap hid the other.
 	if !equalXMLObjects(left.XML, right.XML) {
 		path.push("xml")
 		result.Differences = append(result.Differences, SchemaDifference{
@@ -909,13 +906,11 @@ func equalTypes(left, right any) bool {
 }
 
 // equalXMLObjects compares two XML Objects field by field.
+// https://spec.openapis.org/oas/v3.2.0.html#xml-object
 //
-// A nil XML object and a present one are not equal: absent XML means the
-// serializer infers everything, which is a different payload from one that names
-// an element or picks a node type. Attribute, Wrapped, and NodeType are compared
-// independently, matching how the parser models them — nothing here derives the
-// 3.2 nodeType from the two bools it supersedes, because the 3.2 default depends
-// on the enclosing schema and cannot be computed from the XML object alone.
+// Absent XML is not equal to present XML: inferring everything is a different
+// payload from naming an element. Attribute, Wrapped, and NodeType are compared
+// independently, matching how [parser.XML] models them.
 func equalXMLObjects(left, right *parser.XML) bool {
 	if left == nil || right == nil {
 		return left == right

--- a/joiner/equivalence_test.go
+++ b/joiner/equivalence_test.go
@@ -1395,3 +1395,61 @@ func TestEquivalenceResult_String_WithDifferences(t *testing.T) {
 	assert.Contains(t, s, "type")
 	assert.Contains(t, s, "type mismatch")
 }
+
+// TestCompareSchemas_XMLMismatch covers the XML Object, which deep comparison
+// ignored entirely.
+//
+// XML decides the element name, namespace, and node kind a value serializes to, so
+// two schemas whose XML differs describe different payloads. Reporting them as
+// equivalent let semantic deduplication merge them and silently change the wire
+// format — and the structural hash omitted XML too, so the two gaps hid each
+// other: such schemas rarely reached this comparison at all.
+func TestCompareSchemas_XMLMismatch(t *testing.T) {
+	tests := []struct {
+		name        string
+		left, right *parser.XML
+	}{
+		{"nodeType differs", &parser.XML{NodeType: "attribute"}, &parser.XML{NodeType: "text"}},
+		{"xml present vs absent", &parser.XML{Name: "tag"}, nil},
+		{"name differs", &parser.XML{Name: "tag"}, &parser.XML{Name: "label"}},
+		{"namespace differs", &parser.XML{Namespace: "https://a.example"}, &parser.XML{Namespace: "https://b.example"}},
+		{"prefix differs", &parser.XML{Prefix: "a"}, &parser.XML{Prefix: "b"}},
+		{"attribute differs", &parser.XML{Attribute: true}, &parser.XML{}},
+		{"wrapped differs", &parser.XML{Wrapped: true}, &parser.XML{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			left := &parser.Schema{Type: "string", XML: tt.left}
+			right := &parser.Schema{Type: "string", XML: tt.right}
+
+			result := CompareSchemas(left, right, EquivalenceModeDeep)
+
+			assert.False(t, result.Equivalent)
+			require.Len(t, result.Differences, 1)
+			assert.Equal(t, "xml", result.Differences[0].Path)
+			assert.Equal(t, "xml metadata mismatch", result.Differences[0].Description)
+		})
+	}
+}
+
+// TestCompareSchemas_XMLEquivalent is the control: identical XML must not be made
+// to differ, or deduplication stops consolidating schemas it always could.
+func TestCompareSchemas_XMLEquivalent(t *testing.T) {
+	xml := func() *parser.XML {
+		return &parser.XML{Name: "tag", Namespace: "https://example.com/ns", NodeType: "attribute"}
+	}
+	left := &parser.Schema{Type: "string", XML: xml()}
+	right := &parser.Schema{Type: "string", XML: xml()}
+
+	result := CompareSchemas(left, right, EquivalenceModeDeep)
+
+	assert.True(t, result.Equivalent, "identical xml must compare equal")
+	assert.Empty(t, result.Differences)
+
+	t.Run("both absent", func(t *testing.T) {
+		plainLeft := &parser.Schema{Type: "string"}
+		plainRight := &parser.Schema{Type: "string"}
+		assert.True(t, CompareSchemas(plainLeft, plainRight, EquivalenceModeDeep).Equivalent)
+	})
+}

--- a/joiner/joiner_dedupe_test.go
+++ b/joiner/joiner_dedupe_test.go
@@ -1099,3 +1099,106 @@ func TestJoiner_SemanticDeduplication_EmptyWithMetadataPreserved(t *testing.T) {
 	_, ok = oas3Doc.Components.Schemas["Placeholder"]
 	assert.True(t, ok, "Expected Placeholder empty schema to be preserved")
 }
+
+// TestJoiner_SemanticDeduplication_KeepsXMLDistinctSchemas is the end-to-end
+// regression for the XML gap: deduplication merged two schemas that serialize to
+// different XML, silently changing the wire format of every payload using them.
+//
+// Two independent holes produced it. The structural hash omitted the XML Object
+// entirely, so the schemas landed in one bucket; deep comparison also ignored it,
+// so the verification step that exists to split false positives agreed they were
+// identical. Either hole alone would have been masked by the other.
+func TestJoiner_SemanticDeduplication_KeepsXMLDistinctSchemas(t *testing.T) {
+	docWith := func(title, schemaName string, xml *parser.XML) *parser.OAS3Document {
+		return &parser.OAS3Document{
+			OpenAPI: "3.2.0",
+			Info:    &parser.Info{Title: title, Version: "1.0.0"},
+			Paths:   make(parser.Paths),
+			Components: &parser.Components{
+				Schemas: map[string]*parser.Schema{
+					schemaName: {
+						Type: "object",
+						Properties: map[string]*parser.Schema{
+							"id": {Type: "string"},
+						},
+						Required: []string{"id"},
+						XML:      xml,
+					},
+				},
+			},
+			OASVersion: parser.OASVersion320,
+		}
+	}
+
+	parsed := func(doc *parser.OAS3Document, path string) parser.ParseResult {
+		return parser.ParseResult{
+			Document:     doc,
+			Version:      "3.2.0",
+			OASVersion:   parser.OASVersion320,
+			SourcePath:   path,
+			SourceFormat: "yaml",
+		}
+	}
+
+	// Identical in every respect except the XML node kind their values serialize to.
+	results := []parser.ParseResult{
+		parsed(docWith("API 1", "AsAttribute", &parser.XML{Name: "thing", NodeType: "attribute"}), "api1.yaml"),
+		parsed(docWith("API 2", "AsElement", &parser.XML{Name: "thing", NodeType: "element"}), "api2.yaml"),
+	}
+
+	config := DefaultConfig()
+	config.SemanticDeduplication = true
+
+	joinResult, err := New(config).JoinParsed(results)
+	require.NoError(t, err)
+
+	doc, ok := joinResult.Document.(*parser.OAS3Document)
+	require.True(t, ok)
+
+	assert.Len(t, doc.Components.Schemas, 2,
+		"schemas serializing to different XML must not be consolidated")
+	assert.Contains(t, doc.Components.Schemas, "AsAttribute")
+	assert.Contains(t, doc.Components.Schemas, "AsElement")
+}
+
+// TestJoiner_SemanticDeduplication_MergesXMLIdenticalSchemas is the control:
+// distinguishing XML must not stop deduplication consolidating schemas whose XML
+// actually agrees.
+func TestJoiner_SemanticDeduplication_MergesXMLIdenticalSchemas(t *testing.T) {
+	docWith := func(title, schemaName string) *parser.OAS3Document {
+		return &parser.OAS3Document{
+			OpenAPI: "3.2.0",
+			Info:    &parser.Info{Title: title, Version: "1.0.0"},
+			Paths:   make(parser.Paths),
+			Components: &parser.Components{
+				Schemas: map[string]*parser.Schema{
+					schemaName: {
+						Type:       "object",
+						Properties: map[string]*parser.Schema{"id": {Type: "string"}},
+						Required:   []string{"id"},
+						XML:        &parser.XML{Name: "thing", NodeType: "element"},
+					},
+				},
+			},
+			OASVersion: parser.OASVersion320,
+		}
+	}
+
+	results := []parser.ParseResult{
+		{Document: docWith("API 1", "Alpha"), Version: "3.2.0", OASVersion: parser.OASVersion320, SourcePath: "api1.yaml", SourceFormat: "yaml"},
+		{Document: docWith("API 2", "Beta"), Version: "3.2.0", OASVersion: parser.OASVersion320, SourcePath: "api2.yaml", SourceFormat: "yaml"},
+	}
+
+	config := DefaultConfig()
+	config.SemanticDeduplication = true
+
+	joinResult, err := New(config).JoinParsed(results)
+	require.NoError(t, err)
+
+	doc, ok := joinResult.Document.(*parser.OAS3Document)
+	require.True(t, ok)
+
+	assert.Len(t, doc.Components.Schemas, 1,
+		"identical xml must still deduplicate")
+	assert.Contains(t, doc.Components.Schemas, "Alpha", "alphabetically first name is canonical")
+}

--- a/joiner/rewriter.go
+++ b/joiner/rewriter.go
@@ -219,13 +219,23 @@ func (r *SchemaRewriter) rewriteSchema(schema *parser.Schema) {
 	r.rewriteSchema(schema.Else)
 
 	// Rewrite discriminator mappings
-	if schema.Discriminator != nil && schema.Discriminator.Mapping != nil {
+	if schema.Discriminator != nil {
 		for key, value := range schema.Discriminator.Mapping {
 			// Handle full $ref paths first, then bare schema names if not matched
 			if newRef, exists := r.refMap[value]; exists {
 				schema.Discriminator.Mapping[key] = newRef
 			} else if newName, exists := r.bareNameMap[value]; exists {
 				schema.Discriminator.Mapping[key] = newName
+			}
+		}
+		// defaultMapping (OAS 3.2+) names a schema in the same two spellings, so
+		// it is resolved the same way. A join that renames the fallback's target
+		// without rewriting this produces a dangling reference.
+		if value := schema.Discriminator.DefaultMapping; value != "" {
+			if newRef, exists := r.refMap[value]; exists {
+				schema.Discriminator.DefaultMapping = newRef
+			} else if newName, exists := r.bareNameMap[value]; exists {
+				schema.Discriminator.DefaultMapping = newName
 			}
 		}
 	}

--- a/parser/common.go
+++ b/parser/common.go
@@ -47,6 +47,16 @@ type Tag struct {
 	Name         string        `yaml:"name" json:"name"`
 	Description  string        `yaml:"description,omitempty" json:"description,omitempty"`
 	ExternalDocs *ExternalDocs `yaml:"externalDocs,omitempty" json:"externalDocs,omitempty"`
+
+	// Summary is a short display name for the tag (OAS 3.2+).
+	Summary string `yaml:"summary,omitempty" json:"summary,omitempty"` // OAS 3.2+
+	// Parent names another tag this one nests under, forming a tag hierarchy
+	// (OAS 3.2+). The value is a tag name, not a reference.
+	Parent string `yaml:"parent,omitempty" json:"parent,omitempty"` // OAS 3.2+
+	// Kind classifies how tooling should treat the tag, e.g. "nav" or "badge"
+	// (OAS 3.2+).
+	Kind string `yaml:"kind,omitempty" json:"kind,omitempty"` // OAS 3.2+
+
 	// Extra captures specification extensions (fields starting with "x-")
 	Extra map[string]any `yaml:",inline" json:"-"`
 }
@@ -56,6 +66,11 @@ type Server struct {
 	URL         string                    `yaml:"url" json:"url"`
 	Description string                    `yaml:"description,omitempty" json:"description,omitempty"`
 	Variables   map[string]ServerVariable `yaml:"variables,omitempty" json:"variables,omitempty"`
+
+	// Name is a short identifier for the server, unique among the servers of the
+	// document it appears in (OAS 3.2+).
+	Name string `yaml:"name,omitempty" json:"name,omitempty"` // OAS 3.2+
+
 	// Extra captures specification extensions (fields starting with "x-")
 	Extra map[string]any `yaml:",inline" json:"-"`
 }

--- a/parser/common_equals.go
+++ b/parser/common_equals.go
@@ -119,6 +119,18 @@ func equalTag(a, b *Tag) bool {
 	if !equalExternalDocs(a.ExternalDocs, b.ExternalDocs) {
 		return false
 	}
+
+	// OAS 3.2+
+	if a.Summary != b.Summary {
+		return false
+	}
+	if a.Parent != b.Parent {
+		return false
+	}
+	if a.Kind != b.Kind {
+		return false
+	}
+
 	if !equalMapStringAny(a.Extra, b.Extra) {
 		return false
 	}
@@ -152,6 +164,12 @@ func equalServer(a, b *Server) bool {
 	if !equalServerVariableMap(a.Variables, b.Variables) {
 		return false
 	}
+
+	// OAS 3.2+
+	if a.Name != b.Name {
+		return false
+	}
+
 	if !equalMapStringAny(a.Extra, b.Extra) {
 		return false
 	}

--- a/parser/common_json.go
+++ b/parser/common_json.go
@@ -156,6 +156,9 @@ func (t *Tag) MarshalJSON() ([]byte, error) {
 	}
 	jsonhelpers.SetIfNotEmpty(m, jsonKeyDescription, t.Description)
 	jsonhelpers.SetIfNotNil(m, "externalDocs", t.ExternalDocs)
+	jsonhelpers.SetIfNotEmpty(m, "summary", t.Summary)
+	jsonhelpers.SetIfNotEmpty(m, "parent", t.Parent)
+	jsonhelpers.SetIfNotEmpty(m, "kind", t.Kind)
 
 	// Merge in Extra fields and marshal
 	return jsonhelpers.MarshalWithExtras(m, t.Extra)
@@ -189,6 +192,7 @@ func (s *Server) MarshalJSON() ([]byte, error) {
 	}
 	jsonhelpers.SetIfNotEmpty(m, jsonKeyDescription, s.Description)
 	jsonhelpers.SetIfMapNotEmpty(m, "variables", s.Variables)
+	jsonhelpers.SetIfNotEmpty(m, jsonKeyName, s.Name)
 
 	// Merge in Extra fields and marshal
 	return jsonhelpers.MarshalWithExtras(m, s.Extra)

--- a/parser/constants.go
+++ b/parser/constants.go
@@ -4,6 +4,13 @@ package parser
 const (
 	// ParamInQuery indicates the parameter is passed in the query string
 	ParamInQuery = "query"
+	// ParamInQueryString indicates the parameter is the entire query string,
+	// described as a single value (OAS 3.2+).
+	//
+	// Distinct from ParamInQuery, and mutually exclusive with it: a querystring
+	// parameter describes the whole query string, so it cannot coexist with a
+	// parameter describing one member of it. See the OAS 3.2 Parameter Object.
+	ParamInQueryString = "querystring"
 	// ParamInHeader indicates the parameter is passed in a request header
 	ParamInHeader = "header"
 	// ParamInPath indicates the parameter is part of the URL path

--- a/parser/deep_dive.md
+++ b/parser/deep_dive.md
@@ -46,6 +46,30 @@ The parser automatically detects format from:
 2. Content inspection (JSON starts with `{` or `[`)
 3. Defaults to YAML if unknown
 
+### Unknown Fields Differ by Format
+
+Every parser struct carries an `Extra` map tagged ``yaml:",inline" json:"-"``, and
+the two halves of that tag do not do the same job:
+
+| Format | Unknown field | Result |
+|---|---|---|
+| YAML | any key the struct does not model | **preserved** — the inline map captures every unknown key |
+| JSON | `x-` extension | **preserved** — repopulated by `ExtractExtensions` |
+| JSON | anything else | **dropped** — `ExtractExtensions` keeps only `x-` prefixed keys |
+
+So a field oastools does not model survives a YAML round trip and is lost on a
+JSON one. YAML preserving it is incidental rather than designed: the inline map is
+simply indiscriminate.
+
+This matters when a document uses a specification field newer than the parser. All
+OAS 2.0 through 3.2.0 fixed fields are modeled, so a conformant document is not
+affected today — but a field added by a future OAS revision will round trip in
+YAML and disappear from JSON until it is modeled here. If you are relying on
+oastools to round trip a document containing fields it does not model, use YAML.
+
+Note that `Extra` holds only what the struct does not model; a field with a Go
+field of its own round trips identically in both formats.
+
 ### Discriminator Dialects
 
 OAS 2.0 spells a Schema Object's discriminator as a bare string naming the

--- a/parser/oas32_roundtrip_test.go
+++ b/parser/oas32_roundtrip_test.go
@@ -1,0 +1,348 @@
+package parser
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v4"
+)
+
+// The two fixtures are the same document in the two formats. Both are asserted
+// against the same expectations, which is the point: issue #397 was that the
+// formats disagreed, and no per-format test could have caught it.
+const (
+	oas32FixtureYAML = "../testdata/oas32-all-fields.yaml"
+	oas32FixtureJSON = "../testdata/oas32-all-fields.json"
+)
+
+// assertOAS32FieldsPresent asserts every fixed field OAS 3.2.0 added over 3.1.1
+// is populated, per the audit in issue #397.
+//
+// Deliberately one function applied to every parsed form of the document —
+// fixture, re-parsed output, cross-format conversion — rather than assertions
+// spread across the tests. The original defect was that a field survived one path
+// and vanished on another, so any check that does not run identically on both
+// paths could have passed while the bug was live.
+func assertOAS32FieldsPresent(t *testing.T, doc *OAS3Document) {
+	t.Helper()
+
+	// Server Object
+	require.Len(t, doc.Servers, 1)
+	assert.Equal(t, "production", doc.Servers[0].Name, "servers[0].name")
+
+	// Tag Object
+	require.NotEmpty(t, doc.Tags)
+	pets := doc.Tags[0]
+	assert.Equal(t, "Pet operations", pets.Summary, "tags[0].summary")
+	assert.Equal(t, "root", pets.Parent, "tags[0].parent")
+	assert.Equal(t, "nav", pets.Kind, "tags[0].kind")
+
+	// Response Object
+	get := doc.Paths["/pets"].Get
+	require.NotNil(t, get)
+	resp := get.Responses.Codes["200"]
+	require.NotNil(t, resp)
+	assert.Equal(t, "Pets, or the default shape", resp.Summary, "response.summary")
+
+	// Media Type Object: sequential media type fields
+	jsonl := resp.Content["application/jsonl"]
+	require.NotNil(t, jsonl, "application/jsonl media type")
+	require.NotNil(t, jsonl.ItemSchema, "mediaType.itemSchema")
+	assert.Equal(t, "#/components/schemas/Pet", jsonl.ItemSchema.Ref, "mediaType.itemSchema.$ref")
+	require.NotNil(t, jsonl.ItemEncoding, "mediaType.itemEncoding")
+	assert.Equal(t, "application/json", jsonl.ItemEncoding.ContentType)
+	require.Len(t, jsonl.PrefixEncoding, 1, "mediaType.prefixEncoding")
+	assert.Equal(t, "application/json", jsonl.PrefixEncoding[0].ContentType)
+
+	// Encoding Object: recursive as of 3.2
+	multipart := resp.Content["multipart/form-data"]
+	require.NotNil(t, multipart)
+	meta := multipart.Encoding["meta"]
+	require.NotNil(t, meta, "encoding.meta")
+	require.NotNil(t, meta.Encoding["nested"], "encoding.meta.encoding.nested")
+	assert.Equal(t, "text/plain", meta.Encoding["nested"].ContentType)
+	require.NotNil(t, meta.ItemEncoding, "encoding.meta.itemEncoding")
+	assert.Equal(t, "text/plain", meta.ItemEncoding.ContentType)
+	require.Len(t, meta.PrefixEncoding, 1, "encoding.meta.prefixEncoding")
+	assert.Equal(t, "text/plain", meta.PrefixEncoding[0].ContentType)
+
+	// Parameter Object: in: "querystring"
+	post := doc.Paths["/pets"].Post
+	require.NotNil(t, post)
+	require.Len(t, post.Parameters, 1)
+	assert.Equal(t, ParamInQueryString, post.Parameters[0].In, "parameter.in")
+
+	require.NotNil(t, doc.Components)
+
+	// Discriminator Object
+	pet := doc.Components.Schemas["Pet"]
+	require.NotNil(t, pet)
+	require.NotNil(t, pet.Discriminator)
+	assert.Equal(t, "OtherPet", pet.Discriminator.DefaultMapping, "discriminator.defaultMapping")
+
+	// XML Object
+	tag := pet.Properties["tag"]
+	require.NotNil(t, tag)
+	require.NotNil(t, tag.XML)
+	assert.Equal(t, "attribute", tag.XML.NodeType, "xml.nodeType")
+
+	// Example Object
+	ex := doc.Components.Examples["withData"]
+	require.NotNil(t, ex)
+	assert.NotNil(t, ex.DataValue, "example.dataValue")
+	assert.Equal(t, `{"petType":"dog"}`, ex.SerializedValue, "example.serializedValue")
+
+	// Security Scheme Object and the OAuth flow objects
+	oauth := doc.Components.SecuritySchemes["oauth"]
+	require.NotNil(t, oauth)
+	assert.True(t, oauth.Deprecated, "securityScheme.deprecated")
+	assert.Equal(t, "https://auth.example.com/.well-known/oauth-authorization-server",
+		oauth.OAuth2MetadataURL, "securityScheme.oauth2MetadataUrl")
+	require.NotNil(t, oauth.Flows)
+	device := oauth.Flows.DeviceAuthorization
+	require.NotNil(t, device, "oauthFlows.deviceAuthorization")
+	assert.Equal(t, "https://auth.example.com/device",
+		device.DeviceAuthorizationURL, "oauthFlow.deviceAuthorizationUrl")
+}
+
+// parseOAS32Fixture parses one of the fixtures and returns its document.
+func parseOAS32Fixture(t *testing.T, path string) *OAS3Document {
+	t.Helper()
+
+	src, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	result, err := ParseWithOptions(WithBytes(src), WithValidateStructure(true))
+	require.NoError(t, err, "fixture should parse")
+
+	doc, ok := result.OAS3Document()
+	require.True(t, ok)
+	return doc
+}
+
+// TestOAS32AllFieldsParse is the decode half of issue #397: the fields have to
+// reach the struct at all, from either format.
+func TestOAS32AllFieldsParse(t *testing.T) {
+	for name, path := range map[string]string{"yaml": oas32FixtureYAML, "json": oas32FixtureJSON} {
+		t.Run(name, func(t *testing.T) {
+			assertOAS32FieldsPresent(t, parseOAS32Fixture(t, path))
+		})
+	}
+}
+
+// TestOAS32AllFieldsSurviveRoundTrip is the encode half, and the regression for
+// the issue's headline symptom: "oastools fix on a valid OAS 3.2 JSON document
+// deletes spec-conformant content and reports success."
+//
+// Marshaling with encoding/json and go.yaml.in/yaml directly is what the CLI does
+// when it writes output, so this exercises the same serialization the reported
+// command did.
+func TestOAS32AllFieldsSurviveRoundTrip(t *testing.T) {
+	t.Run("json", func(t *testing.T) {
+		doc := parseOAS32Fixture(t, oas32FixtureJSON)
+
+		out, err := json.MarshalIndent(doc, "", "  ")
+		require.NoError(t, err)
+
+		result, err := ParseWithOptions(WithBytes(out), WithValidateStructure(true))
+		require.NoError(t, err, "re-emitted JSON should parse")
+		reparsed, ok := result.OAS3Document()
+		require.True(t, ok)
+
+		assertOAS32FieldsPresent(t, reparsed)
+	})
+
+	t.Run("yaml", func(t *testing.T) {
+		doc := parseOAS32Fixture(t, oas32FixtureYAML)
+
+		out, err := yaml.Marshal(doc)
+		require.NoError(t, err)
+
+		result, err := ParseWithOptions(WithBytes(out), WithValidateStructure(true))
+		require.NoError(t, err, "re-emitted YAML should parse")
+		reparsed, ok := result.OAS3Document()
+		require.True(t, ok)
+
+		assertOAS32FieldsPresent(t, reparsed)
+	})
+}
+
+// TestOAS32AllFieldsRoundTripWithoutExtensions covers the marshaling path the
+// fixture cannot reach on its own.
+//
+// Every object in the fixture carries an "x-" extension, which sends each type
+// down its slow MarshalJSON path — the one that hand-builds a map[string]any.
+// Clearing Extra sends the same document down the fast path, which delegates to
+// the struct tags instead. Both paths must emit every field; a field added to the
+// struct but not to the map builder passes here and fails above, and one added to
+// neither fails in both.
+func TestOAS32AllFieldsRoundTripWithoutExtensions(t *testing.T) {
+	doc := parseOAS32Fixture(t, oas32FixtureJSON)
+	stripOAS32Extensions(doc)
+
+	out, err := json.MarshalIndent(doc, "", "  ")
+	require.NoError(t, err)
+	assert.NotContains(t, string(out), `"x-`,
+		"extensions should have been cleared, so this exercises the fast marshal path")
+
+	result, err := ParseWithOptions(WithBytes(out), WithValidateStructure(true))
+	require.NoError(t, err)
+	reparsed, ok := result.OAS3Document()
+	require.True(t, ok)
+
+	assertOAS32FieldsPresent(t, reparsed)
+}
+
+// stripOAS32Extensions clears Extra on every object the fixture puts an extension
+// on, so the document marshals through the fast path.
+func stripOAS32Extensions(doc *OAS3Document) {
+	for _, s := range doc.Servers {
+		s.Extra = nil
+	}
+	for _, tag := range doc.Tags {
+		tag.Extra = nil
+	}
+
+	resp := doc.Paths["/pets"].Get.Responses.Codes["200"]
+	resp.Extra = nil
+	for _, mt := range resp.Content {
+		mt.Extra = nil
+		if mt.ItemEncoding != nil {
+			mt.ItemEncoding.Extra = nil
+		}
+		for _, enc := range mt.PrefixEncoding {
+			enc.Extra = nil
+		}
+		for _, enc := range mt.Encoding {
+			enc.Extra = nil
+			for _, nested := range enc.Encoding {
+				nested.Extra = nil
+			}
+		}
+	}
+
+	pet := doc.Components.Schemas["Pet"]
+	pet.Discriminator.Extra = nil
+	pet.Properties["tag"].XML.Extra = nil
+	doc.Components.Examples["withData"].Extra = nil
+
+	oauth := doc.Components.SecuritySchemes["oauth"]
+	oauth.Extra = nil
+	oauth.Flows.Extra = nil
+	oauth.Flows.DeviceAuthorization.Extra = nil
+}
+
+// TestOAS32FormatsAgree pins that neither format is privileged: the same document
+// written as YAML and as JSON must parse to equal documents.
+//
+// This is the assertion the issue's root-cause analysis calls for. Before the fix
+// the YAML fixture kept the 3.2 fields in its inline Extra map while the JSON one
+// discarded them, so the two parsed to different documents while both "worked".
+func TestOAS32FormatsAgree(t *testing.T) {
+	fromYAML := parseOAS32Fixture(t, oas32FixtureYAML)
+	fromJSON := parseOAS32Fixture(t, oas32FixtureJSON)
+
+	assert.True(t, fromYAML.Equals(fromJSON),
+		"the same document in YAML and JSON must parse to equal documents")
+}
+
+// TestOAS32DeepCopyPreservesNewFields covers the generated DeepCopy methods,
+// which are a third path a new field has to be wired into — the deepcopy
+// generator is driven by a hand-maintained field table, not by the structs, so a
+// pointer, slice, or map field added to a struct alone is silently shallow-copied.
+func TestOAS32DeepCopyPreservesNewFields(t *testing.T) {
+	original := parseOAS32Fixture(t, oas32FixtureYAML)
+	clone := original.DeepCopy()
+
+	assertOAS32FieldsPresent(t, clone)
+	assert.True(t, original.Equals(clone), "a deep copy must equal its original")
+
+	// Mutating the clone's nested 3.2 structures must not reach the original, or
+	// the copy is shallow and the two share state.
+	cloneJSONL := clone.Paths["/pets"].Get.Responses.Codes["200"].Content["application/jsonl"]
+	cloneJSONL.ItemSchema.Ref = "#/components/schemas/Mutated"
+	cloneJSONL.ItemEncoding.ContentType = "text/mutated"
+	cloneJSONL.PrefixEncoding[0].ContentType = "text/mutated"
+	clone.Components.SecuritySchemes["oauth"].Flows.DeviceAuthorization.DeviceAuthorizationURL = "https://mutated"
+
+	originalJSONL := original.Paths["/pets"].Get.Responses.Codes["200"].Content["application/jsonl"]
+	assert.Equal(t, "#/components/schemas/Pet", originalJSONL.ItemSchema.Ref)
+	assert.Equal(t, "application/json", originalJSONL.ItemEncoding.ContentType)
+	assert.Equal(t, "application/json", originalJSONL.PrefixEncoding[0].ContentType)
+	assert.Equal(t, "https://auth.example.com/device",
+		original.Components.SecuritySchemes["oauth"].Flows.DeviceAuthorization.DeviceAuthorizationURL)
+}
+
+// TestQueryStringLocationVersionGate covers the parser's own enforcement of the
+// version that introduced in: "querystring". It is the parser's job rather than
+// the validator's because an unrecognized `in` value is a structural problem, and
+// the parser already owns the list of legal locations.
+func TestQueryStringLocationVersionGate(t *testing.T) {
+	spec := func(version string) string {
+		return `
+openapi: "` + version + `"
+info: {title: T, version: "1.0.0"}
+paths:
+  /search:
+    get:
+      operationId: search
+      parameters:
+        - name: q
+          in: querystring
+          content:
+            application/x-www-form-urlencoded:
+              schema: {type: object}
+      responses:
+        "200": {description: OK}
+`
+	}
+
+	// Structure validation reports through ParseResult.Errors rather than the
+	// returned error, which is reserved for a document that could not be decoded
+	// at all.
+	structureErrors := func(t *testing.T, version string) []string {
+		t.Helper()
+
+		result, err := ParseWithOptions(WithBytes([]byte(spec(version))), WithValidateStructure(true))
+		require.NoError(t, err, "the document should still decode")
+
+		messages := make([]string, 0, len(result.Errors))
+		for _, e := range result.Errors {
+			messages = append(messages, e.Error())
+		}
+		return messages
+	}
+
+	t.Run("accepted at 3.2", func(t *testing.T) {
+		for _, msg := range structureErrors(t, "3.2.0") {
+			assert.NotContains(t, msg, "querystring",
+				"querystring is a legal location at 3.2 and must not be reported")
+		}
+
+		result, err := ParseWithOptions(WithBytes([]byte(spec("3.2.0"))), WithValidateStructure(true))
+		require.NoError(t, err)
+		doc, ok := result.OAS3Document()
+		require.True(t, ok)
+		assert.Equal(t, ParamInQueryString, doc.Paths["/search"].Get.Parameters[0].In)
+	})
+
+	for _, version := range []string{"3.0.3", "3.1.0"} {
+		t.Run("rejected at "+version, func(t *testing.T) {
+			errs := structureErrors(t, version)
+
+			var found bool
+			for _, msg := range errs {
+				if strings.Contains(msg, "querystring") && strings.Contains(msg, "not a valid parameter location") {
+					found = true
+					break
+				}
+			}
+			assert.True(t, found,
+				"querystring predates %s and must be reported as an invalid location; got: %v", version, errs)
+		})
+	}
+}

--- a/parser/oas32_roundtrip_test.go
+++ b/parser/oas32_roundtrip_test.go
@@ -48,15 +48,26 @@ func assertOAS32FieldsPresent(t *testing.T, doc *OAS3Document) {
 	require.NotNil(t, resp)
 	assert.Equal(t, "Pets, or the default shape", resp.Summary, "response.summary")
 
-	// Media Type Object: sequential media type fields
+	// Media Type Object: itemSchema describes each item of a sequential media type.
 	jsonl := resp.Content["application/jsonl"]
 	require.NotNil(t, jsonl, "application/jsonl media type")
 	require.NotNil(t, jsonl.ItemSchema, "mediaType.itemSchema")
 	assert.Equal(t, "#/components/schemas/Pet", jsonl.ItemSchema.Ref, "mediaType.itemSchema.$ref")
-	require.NotNil(t, jsonl.ItemEncoding, "mediaType.itemEncoding")
-	assert.Equal(t, "application/json", jsonl.ItemEncoding.ContentType)
-	require.Len(t, jsonl.PrefixEncoding, 1, "mediaType.prefixEncoding")
-	assert.Equal(t, "application/json", jsonl.PrefixEncoding[0].ContentType)
+
+	// itemEncoding and prefixEncoding only apply to a multipart media type.
+	mixed := resp.Content["multipart/mixed"]
+	require.NotNil(t, mixed, "multipart/mixed media type")
+	require.NotNil(t, mixed.ItemEncoding, "mediaType.itemEncoding")
+	assert.Equal(t, "application/json", mixed.ItemEncoding.ContentType)
+	require.Len(t, mixed.PrefixEncoding, 1, "mediaType.prefixEncoding")
+	assert.Equal(t, "application/json", mixed.PrefixEncoding[0].ContentType)
+
+	// Path Item Object: the two methods 3.2 added.
+	require.NotNil(t, doc.Paths["/pets"].Query, "pathItem.query")
+	assert.Equal(t, "queryPets", doc.Paths["/pets"].Query.OperationID)
+	purge := doc.Paths["/pets"].AdditionalOperations["PURGE"]
+	require.NotNil(t, purge, "pathItem.additionalOperations.PURGE")
+	assert.Equal(t, "purgePets", purge.OperationID)
 
 	// Encoding Object: recursive as of 3.2
 	multipart := resp.Content["multipart/form-data"]
@@ -263,16 +274,20 @@ func TestOAS32DeepCopyPreservesNewFields(t *testing.T) {
 
 	// Mutating the clone's nested 3.2 structures must not reach the original, or
 	// the copy is shallow and the two share state.
-	cloneJSONL := clone.Paths["/pets"].Get.Responses.Codes["200"].Content["application/jsonl"]
-	cloneJSONL.ItemSchema.Ref = "#/components/schemas/Mutated"
-	cloneJSONL.ItemEncoding.ContentType = "text/mutated"
-	cloneJSONL.PrefixEncoding[0].ContentType = "text/mutated"
+	cloneContent := clone.Paths["/pets"].Get.Responses.Codes["200"].Content
+	cloneContent["application/jsonl"].ItemSchema.Ref = "#/components/schemas/Mutated"
+	cloneContent["multipart/mixed"].ItemEncoding.ContentType = "text/mutated"
+	cloneContent["multipart/mixed"].PrefixEncoding[0].ContentType = "text/mutated"
+	clone.Paths["/pets"].Query.OperationID = "mutated"
+	clone.Paths["/pets"].AdditionalOperations["PURGE"].OperationID = "mutated"
 	clone.Components.SecuritySchemes["oauth"].Flows.DeviceAuthorization.DeviceAuthorizationURL = "https://mutated"
 
-	originalJSONL := original.Paths["/pets"].Get.Responses.Codes["200"].Content["application/jsonl"]
-	assert.Equal(t, "#/components/schemas/Pet", originalJSONL.ItemSchema.Ref)
-	assert.Equal(t, "application/json", originalJSONL.ItemEncoding.ContentType)
-	assert.Equal(t, "application/json", originalJSONL.PrefixEncoding[0].ContentType)
+	originalContent := original.Paths["/pets"].Get.Responses.Codes["200"].Content
+	assert.Equal(t, "#/components/schemas/Pet", originalContent["application/jsonl"].ItemSchema.Ref)
+	assert.Equal(t, "application/json", originalContent["multipart/mixed"].ItemEncoding.ContentType)
+	assert.Equal(t, "application/json", originalContent["multipart/mixed"].PrefixEncoding[0].ContentType)
+	assert.Equal(t, "queryPets", original.Paths["/pets"].Query.OperationID)
+	assert.Equal(t, "purgePets", original.Paths["/pets"].AdditionalOperations["PURGE"].OperationID)
 	assert.Equal(t, "https://auth.example.com/device",
 		original.Components.SecuritySchemes["oauth"].Flows.DeviceAuthorization.DeviceAuthorizationURL)
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1101,8 +1101,17 @@ func (p *Parser) validateOAS3Parameter(param *Parameter, opPath string, index in
 			ParamInPath:   true,
 			ParamInCookie: true,
 		}
+		// "querystring" is OAS 3.2+ only. Gated here rather than accepted
+		// unconditionally so a 3.0 or 3.1 document using it is still rejected;
+		// the constraints that come with it (content required, at most one, no
+		// sibling in: query) are the validator's, not the parser's.
+		locations := "query, header, path, or cookie"
+		if v, ok := ParseVersion(version); ok && v >= OASVersion320 {
+			validLocations[ParamInQueryString] = true
+			locations = "query, querystring, header, path, or cookie"
+		}
 		if !validLocations[param.In] {
-			errors = append(errors, fmt.Errorf("oas %s: invalid value for '%s.in': \"%s\" is not a valid parameter location (must be query, header, path, or cookie)", version, paramPath, param.In))
+			errors = append(errors, fmt.Errorf("oas %s: invalid value for '%s.in': \"%s\" is not a valid parameter location (must be %s)", version, paramPath, param.In, locations))
 		}
 	}
 

--- a/parser/paths.go
+++ b/parser/paths.go
@@ -146,9 +146,10 @@ type Link struct {
 
 // MediaType provides schema and examples for the media type (OAS 3.0+)
 //
-// The three OAS 3.2 fields describe sequential media types — a stream of items
-// such as JSON Lines or multipart — where the schema and encoding apply to each
-// item rather than to the payload as a whole.
+// The three OAS 3.2 fields describe sequential media types (a stream of items such
+// as JSON Lines or multipart), where the schema and encoding apply to each item
+// rather than to the payload as a whole.
+// https://spec.openapis.org/oas/v3.2.0.html#media-type-object
 type MediaType struct {
 	Schema   *Schema              `yaml:"schema,omitempty" json:"schema,omitempty"`
 	Example  any                  `yaml:"example,omitempty" json:"example,omitempty"`
@@ -176,15 +177,15 @@ type Example struct {
 	Value         any    `yaml:"value,omitempty" json:"value,omitempty"`
 	ExternalValue string `yaml:"externalValue,omitempty" json:"externalValue,omitempty"`
 
-	// DataValue holds the example as structured data, replacing Value in OAS 3.2
-	// where the distinction from SerializedValue matters (OAS 3.2+).
+	// DataValue holds the example as structured data, superseding Value (OAS 3.2+).
+	// https://spec.openapis.org/oas/v3.2.0.html#example-data-value
 	//
-	// Mutually exclusive with Value: "If this field is present, value MUST be
-	// absent." Enforced by the validator, not here — a parser that rejected one of
-	// the two could not round-trip a document to report the problem.
+	// Its exclusivity with Value is enforced by the validator, not here: a parser
+	// that rejected the pair could not round trip the document to report it.
 	DataValue any `yaml:"dataValue,omitempty" json:"dataValue,omitempty"` // OAS 3.2+
-	// SerializedValue holds the example already serialized for its media type
-	// (OAS 3.2+). Mutually exclusive with Value on the same terms as DataValue.
+	// SerializedValue holds the example already serialized for its media type,
+	// excluding Value and ExternalValue (OAS 3.2+).
+	// https://spec.openapis.org/oas/v3.2.0.html#example-serialized-value
 	SerializedValue string `yaml:"serializedValue,omitempty" json:"serializedValue,omitempty"` // OAS 3.2+
 
 	// Extra captures specification extensions (fields starting with "x-")
@@ -192,11 +193,11 @@ type Example struct {
 }
 
 // Encoding defines encoding for a specific property (OAS 3.0+)
+// https://spec.openapis.org/oas/v3.2.0.html#encoding-object
 //
-// OAS 3.2 makes this type recursive: an encoding may describe the encoding of its
-// own nested properties or sequence items. Anything walking an Encoding must
-// recurse through Encoding, ItemEncoding, and PrefixEncoding, and guard against
-// a cycle the way the schema walkers do.
+// OAS 3.2 makes this type recursive: an encoding may describe its own nested
+// properties or sequence items. Anything walking an Encoding must recurse through
+// Encoding, ItemEncoding, and PrefixEncoding.
 type Encoding struct {
 	ContentType   string             `yaml:"contentType,omitempty" json:"contentType,omitempty"`
 	Headers       map[string]*Header `yaml:"headers,omitempty" json:"headers,omitempty"`

--- a/parser/paths.go
+++ b/parser/paths.go
@@ -116,6 +116,11 @@ type Response struct {
 	Headers     map[string]*Header    `yaml:"headers,omitempty" json:"headers,omitempty"`
 	Content     map[string]*MediaType `yaml:"content,omitempty" json:"content,omitempty"` // OAS 3.0+
 	Links       map[string]*Link      `yaml:"links,omitempty" json:"links,omitempty"`     // OAS 3.0+
+
+	// Summary is a short description of the response, alongside the longer
+	// Description (OAS 3.2+).
+	Summary string `yaml:"summary,omitempty" json:"summary,omitempty"` // OAS 3.2+
+
 	// OAS 2.0 specific
 	Schema   *Schema        `yaml:"schema,omitempty" json:"schema,omitempty"`     // OAS 2.0
 	Examples map[string]any `yaml:"examples,omitempty" json:"examples,omitempty"` // OAS 2.0
@@ -140,11 +145,25 @@ type Link struct {
 }
 
 // MediaType provides schema and examples for the media type (OAS 3.0+)
+//
+// The three OAS 3.2 fields describe sequential media types — a stream of items
+// such as JSON Lines or multipart — where the schema and encoding apply to each
+// item rather than to the payload as a whole.
 type MediaType struct {
 	Schema   *Schema              `yaml:"schema,omitempty" json:"schema,omitempty"`
 	Example  any                  `yaml:"example,omitempty" json:"example,omitempty"`
 	Examples map[string]*Example  `yaml:"examples,omitempty" json:"examples,omitempty"`
 	Encoding map[string]*Encoding `yaml:"encoding,omitempty" json:"encoding,omitempty"`
+
+	// ItemSchema describes each item of a sequential media type (OAS 3.2+).
+	ItemSchema *Schema `yaml:"itemSchema,omitempty" json:"itemSchema,omitempty"` // OAS 3.2+
+	// ItemEncoding describes how each item of a sequential media type is encoded
+	// (OAS 3.2+).
+	ItemEncoding *Encoding `yaml:"itemEncoding,omitempty" json:"itemEncoding,omitempty"` // OAS 3.2+
+	// PrefixEncoding describes the encoding of the leading items of a sequential
+	// media type positionally, the way prefixItems does for a schema (OAS 3.2+).
+	PrefixEncoding []*Encoding `yaml:"prefixEncoding,omitempty" json:"prefixEncoding,omitempty"` // OAS 3.2+
+
 	// Extra captures specification extensions (fields starting with "x-")
 	Extra map[string]any `yaml:",inline" json:"-"`
 }
@@ -156,17 +175,43 @@ type Example struct {
 	Description   string `yaml:"description,omitempty" json:"description,omitempty"`
 	Value         any    `yaml:"value,omitempty" json:"value,omitempty"`
 	ExternalValue string `yaml:"externalValue,omitempty" json:"externalValue,omitempty"`
+
+	// DataValue holds the example as structured data, replacing Value in OAS 3.2
+	// where the distinction from SerializedValue matters (OAS 3.2+).
+	//
+	// Mutually exclusive with Value: "If this field is present, value MUST be
+	// absent." Enforced by the validator, not here — a parser that rejected one of
+	// the two could not round-trip a document to report the problem.
+	DataValue any `yaml:"dataValue,omitempty" json:"dataValue,omitempty"` // OAS 3.2+
+	// SerializedValue holds the example already serialized for its media type
+	// (OAS 3.2+). Mutually exclusive with Value on the same terms as DataValue.
+	SerializedValue string `yaml:"serializedValue,omitempty" json:"serializedValue,omitempty"` // OAS 3.2+
+
 	// Extra captures specification extensions (fields starting with "x-")
 	Extra map[string]any `yaml:",inline" json:"-"`
 }
 
 // Encoding defines encoding for a specific property (OAS 3.0+)
+//
+// OAS 3.2 makes this type recursive: an encoding may describe the encoding of its
+// own nested properties or sequence items. Anything walking an Encoding must
+// recurse through Encoding, ItemEncoding, and PrefixEncoding, and guard against
+// a cycle the way the schema walkers do.
 type Encoding struct {
 	ContentType   string             `yaml:"contentType,omitempty" json:"contentType,omitempty"`
 	Headers       map[string]*Header `yaml:"headers,omitempty" json:"headers,omitempty"`
 	Style         string             `yaml:"style,omitempty" json:"style,omitempty"`
 	Explode       *bool              `yaml:"explode,omitempty" json:"explode,omitempty"`
 	AllowReserved bool               `yaml:"allowReserved,omitempty" json:"allowReserved,omitempty"`
+
+	// Encoding describes the encoding of nested properties (OAS 3.2+).
+	Encoding map[string]*Encoding `yaml:"encoding,omitempty" json:"encoding,omitempty"` // OAS 3.2+
+	// ItemEncoding describes the encoding of each item of a sequence (OAS 3.2+).
+	ItemEncoding *Encoding `yaml:"itemEncoding,omitempty" json:"itemEncoding,omitempty"` // OAS 3.2+
+	// PrefixEncoding describes the encoding of the leading items of a sequence
+	// positionally (OAS 3.2+).
+	PrefixEncoding []*Encoding `yaml:"prefixEncoding,omitempty" json:"prefixEncoding,omitempty"` // OAS 3.2+
+
 	// Extra captures specification extensions (fields starting with "x-")
 	Extra map[string]any `yaml:",inline" json:"-"`
 }

--- a/parser/paths_equals.go
+++ b/parser/paths_equals.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"maps"
+	"slices"
 
 	"github.com/erraggy/oastools/internal/equalutil"
 )
@@ -243,6 +244,11 @@ func equalResponse(a, b *Response) bool {
 		return false
 	}
 
+	// OAS 3.2+
+	if a.Summary != b.Summary {
+		return false
+	}
+
 	// Extensions
 	if !equalMapStringAny(a.Extra, b.Extra) {
 		return false
@@ -366,6 +372,17 @@ func equalMediaType(a, b *MediaType) bool {
 		return false
 	}
 
+	// OAS 3.2+ sequential media type fields
+	if !a.ItemSchema.Equals(b.ItemSchema) {
+		return false
+	}
+	if !equalEncoding(a.ItemEncoding, b.ItemEncoding) {
+		return false
+	}
+	if !equalEncodingSlice(a.PrefixEncoding, b.PrefixEncoding) {
+		return false
+	}
+
 	// Extensions
 	if !equalMapStringAny(a.Extra, b.Extra) {
 		return false
@@ -409,6 +426,14 @@ func equalExample(a, b *Example) bool {
 
 	// Any field
 	if !equalJSONValue(a.Value, b.Value) {
+		return false
+	}
+
+	// OAS 3.2+
+	if a.SerializedValue != b.SerializedValue {
+		return false
+	}
+	if !equalJSONValue(a.DataValue, b.DataValue) {
 		return false
 	}
 
@@ -462,6 +487,19 @@ func equalEncoding(a, b *Encoding) bool {
 		return false
 	}
 
+	// OAS 3.2+ nested encodings. Recursive, and safely so: the parser decodes
+	// each level into a fresh value, so an Encoding graph from a document is a
+	// tree and cannot cycle back on itself.
+	if !equalEncodingMap(a.Encoding, b.Encoding) {
+		return false
+	}
+	if !equalEncoding(a.ItemEncoding, b.ItemEncoding) {
+		return false
+	}
+	if !equalEncodingSlice(a.PrefixEncoding, b.PrefixEncoding) {
+		return false
+	}
+
 	// Extensions
 	if !equalMapStringAny(a.Extra, b.Extra) {
 		return false
@@ -474,4 +512,11 @@ func equalEncoding(a, b *Encoding) bool {
 // Nil and empty maps are considered equal.
 func equalEncodingMap(a, b map[string]*Encoding) bool {
 	return maps.EqualFunc(a, b, equalEncoding)
+}
+
+// equalEncodingSlice compares two []*Encoding slices for equality.
+// Order-sensitive, because prefixEncoding is positional. Nil and empty slices
+// are considered equal.
+func equalEncodingSlice(a, b []*Encoding) bool {
+	return slices.EqualFunc(a, b, equalEncoding)
 }

--- a/parser/paths_equals.go
+++ b/parser/paths_equals.go
@@ -487,9 +487,13 @@ func equalEncoding(a, b *Encoding) bool {
 		return false
 	}
 
-	// OAS 3.2+ nested encodings. Recursive, and safely so: the parser decodes
-	// each level into a fresh value, so an Encoding graph from a document is a
-	// tree and cannot cycle back on itself.
+	// OAS 3.2+ nested encodings. Recursive, and deliberately without the
+	// visited-pair guard [Schema.equalsWithVisited] carries: a Schema graph can
+	// cycle for a real document, because $ref resolution makes schemas share
+	// pointers, while an Encoding is only ever reached by decoding a fresh value
+	// per level. A cyclic Encoding is therefore unreachable by parsing and can only
+	// be hand-assembled; guarding it would cost an allocation on every media type
+	// comparison to defend against input the parser cannot produce.
 	if !equalEncodingMap(a.Encoding, b.Encoding) {
 		return false
 	}

--- a/parser/paths_json.go
+++ b/parser/paths_json.go
@@ -119,6 +119,7 @@ func (r *Response) MarshalJSON() ([]byte, error) {
 	jsonhelpers.SetIfMapNotEmpty(m, "links", r.Links)
 	jsonhelpers.SetIfNotNil(m, "schema", r.Schema)
 	jsonhelpers.SetIfMapNotEmpty(m, "examples", r.Examples)
+	jsonhelpers.SetIfNotEmpty(m, "summary", r.Summary)
 
 	// Merge in Extra fields and marshal
 	return jsonhelpers.MarshalWithExtras(m, r.Extra)
@@ -188,6 +189,9 @@ func (mt *MediaType) MarshalJSON() ([]byte, error) {
 	jsonhelpers.SetIfNotNil(m, "example", mt.Example)
 	jsonhelpers.SetIfMapNotEmpty(m, "examples", mt.Examples)
 	jsonhelpers.SetIfMapNotEmpty(m, "encoding", mt.Encoding)
+	jsonhelpers.SetIfNotNil(m, "itemSchema", mt.ItemSchema)
+	jsonhelpers.SetIfNotNil(m, "itemEncoding", mt.ItemEncoding)
+	jsonhelpers.SetIfSliceNotEmpty(m, "prefixEncoding", mt.PrefixEncoding)
 
 	// Merge in Extra fields and marshal
 	return jsonhelpers.MarshalWithExtras(m, mt.Extra)
@@ -222,6 +226,8 @@ func (e *Example) MarshalJSON() ([]byte, error) {
 	jsonhelpers.SetIfNotEmpty(m, jsonKeyDescription, e.Description)
 	jsonhelpers.SetIfNotNil(m, "value", e.Value)
 	jsonhelpers.SetIfNotEmpty(m, "externalValue", e.ExternalValue)
+	jsonhelpers.SetIfNotNil(m, "dataValue", e.DataValue)
+	jsonhelpers.SetIfNotEmpty(m, "serializedValue", e.SerializedValue)
 
 	// Merge in Extra fields and marshal
 	return jsonhelpers.MarshalWithExtras(m, e.Extra)
@@ -256,6 +262,9 @@ func (e *Encoding) MarshalJSON() ([]byte, error) {
 	jsonhelpers.SetIfNotEmpty(m, "style", e.Style)
 	jsonhelpers.SetIfNotNil(m, "explode", e.Explode)
 	jsonhelpers.SetIfTrue(m, "allowReserved", e.AllowReserved)
+	jsonhelpers.SetIfMapNotEmpty(m, "encoding", e.Encoding)
+	jsonhelpers.SetIfNotNil(m, "itemEncoding", e.ItemEncoding)
+	jsonhelpers.SetIfSliceNotEmpty(m, "prefixEncoding", e.PrefixEncoding)
 
 	// Merge in Extra fields and marshal
 	return jsonhelpers.MarshalWithExtras(m, e.Extra)

--- a/parser/schema.go
+++ b/parser/schema.go
@@ -110,7 +110,22 @@ type Schema struct {
 type Discriminator struct {
 	PropertyName string            `yaml:"propertyName" json:"propertyName"`
 	Mapping      map[string]string `yaml:"mapping,omitempty" json:"mapping,omitempty"` // OAS 3.0+ only
-	Extra        map[string]any    `yaml:",inline" json:"-"`
+
+	// DefaultMapping names the schema to use when the discriminating property is
+	// absent, or present with a value no Mapping key covers.
+	//
+	// It is reference-bearing in exactly the way a Mapping value is: the value is
+	// either a schema name or a URI reference. Every pass that rewrites Mapping —
+	// joining documents, renaming schemas, converting between versions — must
+	// rewrite this alongside it, or the rewrite produces a dangling reference here
+	// while reporting success.
+	//
+	// The spec makes it conditionally required: when the discriminating property is
+	// optional, the Discriminator Object MUST include defaultMapping. That is a
+	// validator rule rather than a parser one, since presence of the property in
+	// `required` is only knowable from the enclosing schema.
+	DefaultMapping string         `yaml:"defaultMapping,omitempty" json:"defaultMapping,omitempty"` // OAS 3.2+
+	Extra          map[string]any `yaml:",inline" json:"-"`
 
 	// StringForm reports that this discriminator came from — and should be
 	// written back as — the OAS 2.0 bare-string form (`discriminator: petType`)
@@ -124,11 +139,32 @@ type Discriminator struct {
 }
 
 // XML represents metadata for XML encoding (OAS 2.0+)
+//
+// NodeType supersedes Attribute and Wrapped in OAS 3.2, and is modeled beside
+// them rather than derived from either. See the field's own comment for why.
 type XML struct {
-	Name      string         `yaml:"name,omitempty" json:"name,omitempty"`
-	Namespace string         `yaml:"namespace,omitempty" json:"namespace,omitempty"`
-	Prefix    string         `yaml:"prefix,omitempty" json:"prefix,omitempty"`
-	Attribute bool           `yaml:"attribute,omitempty" json:"attribute,omitempty"`
-	Wrapped   bool           `yaml:"wrapped,omitempty" json:"wrapped,omitempty"`
-	Extra     map[string]any `yaml:",inline" json:"-"`
+	Name      string `yaml:"name,omitempty" json:"name,omitempty"`
+	Namespace string `yaml:"namespace,omitempty" json:"namespace,omitempty"`
+	Prefix    string `yaml:"prefix,omitempty" json:"prefix,omitempty"`
+	Attribute bool   `yaml:"attribute,omitempty" json:"attribute,omitempty"`
+	Wrapped   bool   `yaml:"wrapped,omitempty" json:"wrapped,omitempty"`
+
+	// NodeType selects the XML node a schema maps to: "element", "attribute",
+	// "text", "cdata", or "none". It supersedes Attribute and Wrapped.
+	//
+	// Deliberately an independent field, not a third spelling reconciled with the
+	// two bools. Collapsing the two representations into one is what made
+	// discriminator's dual dialect need StringForm to stay lossless (#394), and
+	// here it would be worse than lossy: the 3.2 default for nodeType is not a
+	// constant, it depends on the enclosing schema — "none" when the schema is a
+	// $ref or $dynamicRef, or holds certain types — and an XML object cannot see
+	// its schema from here. Synthesizing a value would therefore mean inventing one
+	// that the document did not state and that this type cannot compute correctly.
+	//
+	// Keeping them independent means each survives a round trip exactly as written,
+	// and no document gains a field it did not have. Reconciling a document that
+	// sets both is the validator's job, which is where the OAS version is known.
+	NodeType string `yaml:"nodeType,omitempty" json:"nodeType,omitempty"` // OAS 3.2+
+
+	Extra map[string]any `yaml:",inline" json:"-"`
 }

--- a/parser/schema.go
+++ b/parser/schema.go
@@ -112,18 +112,16 @@ type Discriminator struct {
 	Mapping      map[string]string `yaml:"mapping,omitempty" json:"mapping,omitempty"` // OAS 3.0+ only
 
 	// DefaultMapping names the schema to use when the discriminating property is
-	// absent, or present with a value no Mapping key covers.
+	// absent, or holds a value no Mapping key covers (OAS 3.2+).
+	// https://spec.openapis.org/oas/v3.2.0.html#discriminator-default-mapping
 	//
-	// It is reference-bearing in exactly the way a Mapping value is: the value is
-	// either a schema name or a URI reference. Every pass that rewrites Mapping —
-	// joining documents, renaming schemas, converting between versions — must
-	// rewrite this alongside it, or the rewrite produces a dangling reference here
-	// while reporting success.
+	// Reference-bearing exactly as a Mapping value is: a schema name or a URI
+	// reference. Every pass that rewrites Mapping (joining, renaming, converting)
+	// must rewrite this too, or leave a dangling reference while reporting success.
 	//
-	// The spec makes it conditionally required: when the discriminating property is
-	// optional, the Discriminator Object MUST include defaultMapping. That is a
-	// validator rule rather than a parser one, since presence of the property in
-	// `required` is only knowable from the enclosing schema.
+	// Its conditional requirement is a validator rule, not a parser one: whether the
+	// discriminating property is optional is only knowable from the enclosing
+	// schema.
 	DefaultMapping string         `yaml:"defaultMapping,omitempty" json:"defaultMapping,omitempty"` // OAS 3.2+
 	Extra          map[string]any `yaml:",inline" json:"-"`
 
@@ -139,9 +137,10 @@ type Discriminator struct {
 }
 
 // XML represents metadata for XML encoding (OAS 2.0+)
+// https://spec.openapis.org/oas/v3.2.0.html#xml-object
 //
-// NodeType supersedes Attribute and Wrapped in OAS 3.2, and is modeled beside
-// them rather than derived from either. See the field's own comment for why.
+// NodeType supersedes Attribute and Wrapped in OAS 3.2 and is modeled beside them
+// rather than derived from either. See the field's own comment for why.
 type XML struct {
 	Name      string `yaml:"name,omitempty" json:"name,omitempty"`
 	Namespace string `yaml:"namespace,omitempty" json:"namespace,omitempty"`
@@ -149,21 +148,15 @@ type XML struct {
 	Attribute bool   `yaml:"attribute,omitempty" json:"attribute,omitempty"`
 	Wrapped   bool   `yaml:"wrapped,omitempty" json:"wrapped,omitempty"`
 
-	// NodeType selects the XML node a schema maps to: "element", "attribute",
-	// "text", "cdata", or "none". It supersedes Attribute and Wrapped.
+	// NodeType selects the XML node a schema maps to, superseding Attribute and
+	// Wrapped (OAS 3.2+).
+	// https://spec.openapis.org/oas/v3.2.0.html#xml-node-type
 	//
-	// Deliberately an independent field, not a third spelling reconciled with the
-	// two bools. Collapsing the two representations into one is what made
-	// discriminator's dual dialect need StringForm to stay lossless (#394), and
-	// here it would be worse than lossy: the 3.2 default for nodeType is not a
-	// constant, it depends on the enclosing schema — "none" when the schema is a
-	// $ref or $dynamicRef, or holds certain types — and an XML object cannot see
-	// its schema from here. Synthesizing a value would therefore mean inventing one
-	// that the document did not state and that this type cannot compute correctly.
-	//
-	// Keeping them independent means each survives a round trip exactly as written,
-	// and no document gains a field it did not have. Reconciling a document that
-	// sets both is the validator's job, which is where the OAS version is known.
+	// Deliberately independent of those two bools rather than reconciled with them.
+	// Its default depends on the enclosing Schema Object, which an XML Object cannot
+	// see, so deriving a value here would invent one the document never stated.
+	// Keeping them independent lets each survive a round trip as written; the spec
+	// forbids setting both, and the validator enforces that.
 	NodeType string `yaml:"nodeType,omitempty" json:"nodeType,omitempty"` // OAS 3.2+
 
 	Extra map[string]any `yaml:",inline" json:"-"`

--- a/parser/schema_equals.go
+++ b/parser/schema_equals.go
@@ -325,6 +325,13 @@ func equalDiscriminator(a, b *Discriminator) bool {
 	if !equalMapStringString(a.Mapping, b.Mapping) {
 		return false
 	}
+
+	// OAS 3.2+. Unlike StringForm this is meaning, not spelling: two
+	// discriminators that fall back to different schemas are different.
+	if a.DefaultMapping != b.DefaultMapping {
+		return false
+	}
+
 	if !equalMapStringAny(a.Extra, b.Extra) {
 		return false
 	}
@@ -360,6 +367,13 @@ func equalXML(a, b *XML) bool {
 	if a.Wrapped != b.Wrapped {
 		return false
 	}
+
+	// OAS 3.2+. Compared independently of Attribute and Wrapped, matching how
+	// the field is modeled: nothing here derives one spelling from the other.
+	if a.NodeType != b.NodeType {
+		return false
+	}
+
 	if !equalMapStringAny(a.Extra, b.Extra) {
 		return false
 	}

--- a/parser/schema_json.go
+++ b/parser/schema_json.go
@@ -178,6 +178,7 @@ func (d *Discriminator) MarshalJSON() ([]byte, error) {
 		"propertyName": d.PropertyName, // Required field, always include
 	}
 	jsonhelpers.SetIfNotNil(m, "mapping", d.Mapping)
+	jsonhelpers.SetIfNotEmpty(m, "defaultMapping", d.DefaultMapping)
 
 	// Merge in Extra fields and marshal
 	return jsonhelpers.MarshalWithExtras(m, d.Extra)
@@ -231,6 +232,7 @@ func (x *XML) MarshalJSON() ([]byte, error) {
 	jsonhelpers.SetIfNotEmpty(m, "prefix", x.Prefix)
 	jsonhelpers.SetIfTrue(m, "attribute", x.Attribute)
 	jsonhelpers.SetIfTrue(m, "wrapped", x.Wrapped)
+	jsonhelpers.SetIfNotEmpty(m, "nodeType", x.NodeType)
 
 	// Merge in Extra fields and marshal
 	return jsonhelpers.MarshalWithExtras(m, x.Extra)

--- a/parser/security.go
+++ b/parser/security.go
@@ -30,17 +30,28 @@ type SecurityScheme struct {
 	// Type: openIdConnect (OAS 3.0+)
 	OpenIDConnectURL string `yaml:"openIdConnectUrl,omitempty" json:"openIdConnectUrl,omitempty"`
 
+	// Deprecated marks the scheme as no longer recommended for use (OAS 3.2+).
+	Deprecated bool `yaml:"deprecated,omitempty" json:"deprecated,omitempty"` // OAS 3.2+
+	// OAuth2MetadataURL points at the OAuth 2.0 Authorization Server Metadata
+	// document for the scheme (OAS 3.2+).
+	OAuth2MetadataURL string `yaml:"oauth2MetadataUrl,omitempty" json:"oauth2MetadataUrl,omitempty"` // OAS 3.2+
+
 	// Extra captures specification extensions (fields starting with "x-")
 	Extra map[string]any `yaml:",inline" json:"-"`
 }
 
 // OAuthFlows allows configuration of the supported OAuth Flows (OAS 3.0+)
 type OAuthFlows struct {
-	Implicit          *OAuthFlow     `yaml:"implicit,omitempty" json:"implicit,omitempty"`
-	Password          *OAuthFlow     `yaml:"password,omitempty" json:"password,omitempty"`
-	ClientCredentials *OAuthFlow     `yaml:"clientCredentials,omitempty" json:"clientCredentials,omitempty"`
-	AuthorizationCode *OAuthFlow     `yaml:"authorizationCode,omitempty" json:"authorizationCode,omitempty"`
-	Extra             map[string]any `yaml:",inline" json:"-"`
+	Implicit          *OAuthFlow `yaml:"implicit,omitempty" json:"implicit,omitempty"`
+	Password          *OAuthFlow `yaml:"password,omitempty" json:"password,omitempty"`
+	ClientCredentials *OAuthFlow `yaml:"clientCredentials,omitempty" json:"clientCredentials,omitempty"`
+	AuthorizationCode *OAuthFlow `yaml:"authorizationCode,omitempty" json:"authorizationCode,omitempty"`
+
+	// DeviceAuthorization configures the OAuth 2.0 Device Authorization Grant
+	// (RFC 8628) flow (OAS 3.2+).
+	DeviceAuthorization *OAuthFlow `yaml:"deviceAuthorization,omitempty" json:"deviceAuthorization,omitempty"` // OAS 3.2+
+
+	Extra map[string]any `yaml:",inline" json:"-"`
 }
 
 // OAuthFlow represents configuration for a single OAuth flow (OAS 3.0+)
@@ -49,5 +60,10 @@ type OAuthFlow struct {
 	TokenURL         string            `yaml:"tokenUrl,omitempty" json:"tokenUrl,omitempty"`
 	RefreshURL       string            `yaml:"refreshUrl,omitempty" json:"refreshUrl,omitempty"`
 	Scopes           map[string]string `yaml:"scopes" json:"scopes"`
-	Extra            map[string]any    `yaml:",inline" json:"-"`
+
+	// DeviceAuthorizationURL is the device authorization endpoint, required by the
+	// deviceAuthorization flow (OAS 3.2+).
+	DeviceAuthorizationURL string `yaml:"deviceAuthorizationUrl,omitempty" json:"deviceAuthorizationUrl,omitempty"` // OAS 3.2+
+
+	Extra map[string]any `yaml:",inline" json:"-"`
 }

--- a/parser/security_equals.go
+++ b/parser/security_equals.go
@@ -76,6 +76,14 @@ func equalSecurityScheme(a, b *SecurityScheme) bool {
 		return false
 	}
 
+	// OAS 3.2+
+	if a.Deprecated != b.Deprecated {
+		return false
+	}
+	if a.OAuth2MetadataURL != b.OAuth2MetadataURL {
+		return false
+	}
+
 	// Struct pointers
 	if !equalOAuthFlows(a.Flows, b.Flows) {
 		return false
@@ -126,6 +134,11 @@ func equalOAuthFlows(a, b *OAuthFlows) bool {
 		return false
 	}
 
+	// OAS 3.2+
+	if !equalOAuthFlow(a.DeviceAuthorization, b.DeviceAuthorization) {
+		return false
+	}
+
 	// Extensions
 	if !equalMapStringAny(a.Extra, b.Extra) {
 		return false
@@ -151,6 +164,11 @@ func equalOAuthFlow(a, b *OAuthFlow) bool {
 		return false
 	}
 	if a.RefreshURL != b.RefreshURL {
+		return false
+	}
+
+	// OAS 3.2+
+	if a.DeviceAuthorizationURL != b.DeviceAuthorizationURL {
 		return false
 	}
 

--- a/parser/security_json.go
+++ b/parser/security_json.go
@@ -59,6 +59,12 @@ func (ss *SecurityScheme) MarshalJSON() ([]byte, error) {
 	if ss.OpenIDConnectURL != "" {
 		m["openIdConnectUrl"] = ss.OpenIDConnectURL
 	}
+	if ss.Deprecated {
+		m["deprecated"] = ss.Deprecated
+	}
+	if ss.OAuth2MetadataURL != "" {
+		m["oauth2MetadataUrl"] = ss.OAuth2MetadataURL
+	}
 
 	// Add Extra fields (spec extensions must start with "x-")
 	for k, v := range ss.Extra {
@@ -106,6 +112,9 @@ func (of *OAuthFlows) MarshalJSON() ([]byte, error) {
 	if of.AuthorizationCode != nil {
 		m["authorizationCode"] = of.AuthorizationCode
 	}
+	if of.DeviceAuthorization != nil {
+		m["deviceAuthorization"] = of.DeviceAuthorization
+	}
 
 	// Add Extra fields (spec extensions must start with "x-")
 	for k, v := range of.Extra {
@@ -152,6 +161,9 @@ func (of *OAuthFlow) MarshalJSON() ([]byte, error) {
 	}
 	// Scopes is required, always include
 	m["scopes"] = of.Scopes
+	if of.DeviceAuthorizationURL != "" {
+		m["deviceAuthorizationUrl"] = of.DeviceAuthorizationURL
+	}
 
 	// Add Extra fields (spec extensions must start with "x-")
 	for k, v := range of.Extra {

--- a/parser/zz_generated_decode.go
+++ b/parser/zz_generated_decode.go
@@ -130,6 +130,7 @@ func (x *Contact) decodeFromMap(m map[string]any) {
 func (x *Discriminator) decodeFromMap(m map[string]any) {
 	x.PropertyName, _ = m["propertyName"].(string)
 	x.Mapping = mapGetStringMap(m, "mapping")
+	x.DefaultMapping, _ = m["defaultMapping"].(string)
 	x.Extra = extractExtensionsFromMap(m)
 }
 
@@ -148,6 +149,30 @@ func (x *Encoding) decodeFromMap(m map[string]any) {
 	x.Style, _ = m["style"].(string)
 	x.Explode = mapGetBoolPtr(m, "explode")
 	x.AllowReserved, _ = m["allowReserved"].(bool)
+	if sub, ok := m["encoding"].(map[string]any); ok {
+		x.Encoding = make(map[string]*Encoding, len(sub))
+		for k, v := range sub {
+			if vm, ok := v.(map[string]any); ok {
+				elem := new(Encoding)
+				elem.decodeFromMap(vm)
+				x.Encoding[k] = elem
+			}
+		}
+	}
+	if sub, ok := m["itemEncoding"].(map[string]any); ok {
+		x.ItemEncoding = new(Encoding)
+		x.ItemEncoding.decodeFromMap(sub)
+	}
+	if arr, ok := m["prefixEncoding"].([]any); ok {
+		x.PrefixEncoding = make([]*Encoding, 0, len(arr))
+		for _, item := range arr {
+			if sub, ok := item.(map[string]any); ok {
+				elem := new(Encoding)
+				elem.decodeFromMap(sub)
+				x.PrefixEncoding = append(x.PrefixEncoding, elem)
+			}
+		}
+	}
 	x.Extra = extractExtensionsFromMap(m)
 }
 
@@ -157,6 +182,8 @@ func (x *Example) decodeFromMap(m map[string]any) {
 	x.Description, _ = m["description"].(string)
 	x.Value = m["value"]
 	x.ExternalValue, _ = m["externalValue"].(string)
+	x.DataValue = m["dataValue"]
+	x.SerializedValue, _ = m["serializedValue"].(string)
 	x.Extra = extractExtensionsFromMap(m)
 }
 
@@ -315,6 +342,24 @@ func (x *MediaType) decodeFromMap(m map[string]any) {
 			}
 		}
 	}
+	if sub, ok := m["itemSchema"].(map[string]any); ok {
+		x.ItemSchema = new(Schema)
+		x.ItemSchema.decodeFromMap(sub)
+	}
+	if sub, ok := m["itemEncoding"].(map[string]any); ok {
+		x.ItemEncoding = new(Encoding)
+		x.ItemEncoding.decodeFromMap(sub)
+	}
+	if arr, ok := m["prefixEncoding"].([]any); ok {
+		x.PrefixEncoding = make([]*Encoding, 0, len(arr))
+		for _, item := range arr {
+			if sub, ok := item.(map[string]any); ok {
+				elem := new(Encoding)
+				elem.decodeFromMap(sub)
+				x.PrefixEncoding = append(x.PrefixEncoding, elem)
+			}
+		}
+	}
 	x.Extra = extractExtensionsFromMap(m)
 }
 
@@ -452,6 +497,7 @@ func (x *OAuthFlow) decodeFromMap(m map[string]any) {
 	x.TokenURL, _ = m["tokenUrl"].(string)
 	x.RefreshURL, _ = m["refreshUrl"].(string)
 	x.Scopes = mapGetStringMap(m, "scopes")
+	x.DeviceAuthorizationURL, _ = m["deviceAuthorizationUrl"].(string)
 	x.Extra = extractExtensionsFromMap(m)
 }
 
@@ -471,6 +517,10 @@ func (x *OAuthFlows) decodeFromMap(m map[string]any) {
 	if sub, ok := m["authorizationCode"].(map[string]any); ok {
 		x.AuthorizationCode = new(OAuthFlow)
 		x.AuthorizationCode.decodeFromMap(sub)
+	}
+	if sub, ok := m["deviceAuthorization"].(map[string]any); ok {
+		x.DeviceAuthorization = new(OAuthFlow)
+		x.DeviceAuthorization.decodeFromMap(sub)
 	}
 	x.Extra = extractExtensionsFromMap(m)
 }
@@ -721,6 +771,7 @@ func (x *Response) decodeFromMap(m map[string]any) {
 			}
 		}
 	}
+	x.Summary, _ = m["summary"].(string)
 	if sub, ok := m["schema"].(map[string]any); ok {
 		x.Schema = new(Schema)
 		x.Schema.decodeFromMap(sub)
@@ -919,6 +970,8 @@ func (x *SecurityScheme) decodeFromMap(m map[string]any) {
 	x.TokenURL, _ = m["tokenUrl"].(string)
 	x.Scopes = mapGetStringMap(m, "scopes")
 	x.OpenIDConnectURL, _ = m["openIdConnectUrl"].(string)
+	x.Deprecated, _ = m["deprecated"].(bool)
+	x.OAuth2MetadataURL, _ = m["oauth2MetadataUrl"].(string)
 	x.Extra = extractExtensionsFromMap(m)
 }
 
@@ -935,6 +988,7 @@ func (x *Server) decodeFromMap(m map[string]any) {
 			}
 		}
 	}
+	x.Name, _ = m["name"].(string)
 	x.Extra = extractExtensionsFromMap(m)
 }
 
@@ -952,6 +1006,9 @@ func (x *Tag) decodeFromMap(m map[string]any) {
 		x.ExternalDocs = new(ExternalDocs)
 		x.ExternalDocs.decodeFromMap(sub)
 	}
+	x.Summary, _ = m["summary"].(string)
+	x.Parent, _ = m["parent"].(string)
+	x.Kind, _ = m["kind"].(string)
 	x.Extra = extractExtensionsFromMap(m)
 }
 
@@ -961,6 +1018,7 @@ func (x *XML) decodeFromMap(m map[string]any) {
 	x.Prefix, _ = m["prefix"].(string)
 	x.Attribute, _ = m["attribute"].(bool)
 	x.Wrapped, _ = m["wrapped"].(bool)
+	x.NodeType, _ = m["nodeType"].(string)
 	x.Extra = extractExtensionsFromMap(m)
 }
 

--- a/parser/zz_generated_deepcopy.go
+++ b/parser/zz_generated_deepcopy.go
@@ -182,6 +182,28 @@ func (in *Encoding) DeepCopyInto(out *Encoding) {
 		*out.Explode = *in.Explode
 	}
 
+	if in.Encoding != nil {
+		out.Encoding = make(map[string]*Encoding, len(in.Encoding))
+		for k, v := range in.Encoding {
+			if v != nil {
+				out.Encoding[k] = v.DeepCopy()
+			}
+		}
+	}
+
+	if in.ItemEncoding != nil {
+		out.ItemEncoding = in.ItemEncoding.DeepCopy()
+	}
+
+	if in.PrefixEncoding != nil {
+		out.PrefixEncoding = make([]*Encoding, len(in.PrefixEncoding))
+		for i, v := range in.PrefixEncoding {
+			if v != nil {
+				out.PrefixEncoding[i] = v.DeepCopy()
+			}
+		}
+	}
+
 	out.Extra = deepCopyExtensions(in.Extra)
 }
 
@@ -200,6 +222,8 @@ func (in *Example) DeepCopyInto(out *Example) {
 	*out = *in
 
 	out.Value = deepCopyJSONValue(in.Value)
+
+	out.DataValue = deepCopyJSONValue(in.DataValue)
 
 	out.Extra = deepCopyExtensions(in.Extra)
 }
@@ -475,6 +499,23 @@ func (in *MediaType) DeepCopyInto(out *MediaType) {
 		}
 	}
 
+	if in.ItemSchema != nil {
+		out.ItemSchema = in.ItemSchema.DeepCopy()
+	}
+
+	if in.ItemEncoding != nil {
+		out.ItemEncoding = in.ItemEncoding.DeepCopy()
+	}
+
+	if in.PrefixEncoding != nil {
+		out.PrefixEncoding = make([]*Encoding, len(in.PrefixEncoding))
+		for i, v := range in.PrefixEncoding {
+			if v != nil {
+				out.PrefixEncoding[i] = v.DeepCopy()
+			}
+		}
+	}
+
 	out.Extra = deepCopyExtensions(in.Extra)
 }
 
@@ -674,6 +715,10 @@ func (in *OAuthFlows) DeepCopyInto(out *OAuthFlows) {
 
 	if in.AuthorizationCode != nil {
 		out.AuthorizationCode = in.AuthorizationCode.DeepCopy()
+	}
+
+	if in.DeviceAuthorization != nil {
+		out.DeviceAuthorization = in.DeviceAuthorization.DeepCopy()
 	}
 
 	out.Extra = deepCopyExtensions(in.Extra)

--- a/testdata/oas32-all-fields.json
+++ b/testdata/oas32-all-fields.json
@@ -1,0 +1,181 @@
+{
+  "$self": "https://example.com/api/openapi.yaml",
+  "components": {
+    "examples": {
+      "withData": {
+        "dataValue": {
+          "petType": "dog"
+        },
+        "serializedValue": "{\"petType\":\"dog\"}",
+        "summary": "Structured form only",
+        "x-example-ext": "keep"
+      }
+    },
+    "schemas": {
+      "Dog": {
+        "type": "object"
+      },
+      "OtherPet": {
+        "type": "object"
+      },
+      "Pet": {
+        "discriminator": {
+          "defaultMapping": "OtherPet",
+          "mapping": {
+            "dog": "Dog"
+          },
+          "propertyName": "petType",
+          "x-discriminator-ext": "keep"
+        },
+        "properties": {
+          "petType": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string",
+            "xml": {
+              "name": "tag",
+              "nodeType": "attribute",
+              "x-xml-ext": "keep"
+            }
+          }
+        },
+        "required": [
+          "petType"
+        ],
+        "type": "object"
+      }
+    },
+    "securitySchemes": {
+      "oauth": {
+        "deprecated": true,
+        "flows": {
+          "deviceAuthorization": {
+            "deviceAuthorizationUrl": "https://auth.example.com/device",
+            "scopes": {
+              "read": "Read access"
+            },
+            "tokenUrl": "https://auth.example.com/token",
+            "x-oauth-flow-ext": "keep"
+          },
+          "x-oauth-flows-ext": "keep"
+        },
+        "oauth2MetadataUrl": "https://auth.example.com/.well-known/oauth-authorization-server",
+        "type": "oauth2",
+        "x-security-scheme-ext": "keep"
+      }
+    }
+  },
+  "info": {
+    "title": "OAS 3.2 full field set",
+    "version": "1.0.0"
+  },
+  "openapi": "3.2.0",
+  "paths": {
+    "/pets": {
+      "get": {
+        "operationId": "listPets",
+        "responses": {
+          "200": {
+            "content": {
+              "application/jsonl": {
+                "itemEncoding": {
+                  "contentType": "application/json",
+                  "x-item-encoding-ext": "keep"
+                },
+                "itemSchema": {
+                  "$ref": "#/components/schemas/Pet"
+                },
+                "prefixEncoding": [
+                  {
+                    "contentType": "application/json",
+                    "x-prefix-encoding-ext": "keep"
+                  }
+                ],
+                "x-media-type-ext": "keep"
+              },
+              "multipart/form-data": {
+                "encoding": {
+                  "meta": {
+                    "contentType": "application/json",
+                    "encoding": {
+                      "nested": {
+                        "contentType": "text/plain",
+                        "x-nested-encoding-ext": "keep"
+                      }
+                    },
+                    "itemEncoding": {
+                      "contentType": "text/plain"
+                    },
+                    "prefixEncoding": [
+                      {
+                        "contentType": "text/plain"
+                      }
+                    ],
+                    "x-encoding-ext": "keep"
+                  }
+                },
+                "schema": {
+                  "properties": {
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "A list of pets",
+            "summary": "Pets, or the default shape",
+            "x-response-ext": "keep"
+          }
+        }
+      },
+      "post": {
+        "operationId": "searchPets",
+        "parameters": [
+          {
+            "content": {
+              "application/x-www-form-urlencoded": {
+                "schema": {
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "in": "querystring",
+            "name": "q"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No content"
+          }
+        }
+      }
+    }
+  },
+  "servers": [
+    {
+      "name": "production",
+      "url": "https://api.example.com",
+      "x-server-ext": "keep"
+    }
+  ],
+  "tags": [
+    {
+      "kind": "nav",
+      "name": "pets",
+      "parent": "root",
+      "summary": "Pet operations",
+      "x-tag-ext": "keep"
+    },
+    {
+      "name": "root"
+    }
+  ]
+}

--- a/testdata/oas32-all-fields.json
+++ b/testdata/oas32-all-fields.json
@@ -27,6 +27,14 @@
           "propertyName": "petType",
           "x-discriminator-ext": "keep"
         },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/Dog"
+          },
+          {
+            "$ref": "#/components/schemas/OtherPet"
+          }
+        ],
         "properties": {
           "petType": {
             "type": "string"
@@ -73,25 +81,25 @@
   "openapi": "3.2.0",
   "paths": {
     "/pets": {
+      "additionalOperations": {
+        "PURGE": {
+          "operationId": "purgePets",
+          "responses": {
+            "204": {
+              "description": "Purged"
+            }
+          }
+        }
+      },
       "get": {
         "operationId": "listPets",
         "responses": {
           "200": {
             "content": {
               "application/jsonl": {
-                "itemEncoding": {
-                  "contentType": "application/json",
-                  "x-item-encoding-ext": "keep"
-                },
                 "itemSchema": {
                   "$ref": "#/components/schemas/Pet"
                 },
-                "prefixEncoding": [
-                  {
-                    "contentType": "application/json",
-                    "x-prefix-encoding-ext": "keep"
-                  }
-                ],
                 "x-media-type-ext": "keep"
               },
               "multipart/form-data": {
@@ -123,6 +131,21 @@
                   },
                   "type": "object"
                 }
+              },
+              "multipart/mixed": {
+                "itemEncoding": {
+                  "contentType": "application/json",
+                  "x-item-encoding-ext": "keep"
+                },
+                "itemSchema": {
+                  "$ref": "#/components/schemas/Pet"
+                },
+                "prefixEncoding": [
+                  {
+                    "contentType": "application/json",
+                    "x-prefix-encoding-ext": "keep"
+                  }
+                ]
               }
             },
             "description": "A list of pets",
@@ -154,6 +177,23 @@
         "responses": {
           "204": {
             "description": "No content"
+          }
+        }
+      },
+      "query": {
+        "operationId": "queryPets",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Matching pets"
           }
         }
       }

--- a/testdata/oas32-all-fields.yaml
+++ b/testdata/oas32-all-fields.yaml
@@ -1,0 +1,126 @@
+# Exercises every fixed field OAS 3.2.0 added over 3.1.1, as audited in issue
+# #397. The companion oas32-all-fields.json is the same document in JSON, so the
+# round-trip test can prove the two formats agree — the original defect was that
+# YAML preserved these fields incidentally (via the inline Extra map) while JSON
+# dropped them.
+#
+# Every object carrying a 3.2 field also carries an "x-" extension. That is
+# deliberate: each type marshals through two paths, a fast one driven by struct
+# tags and a slow one that hand-builds a map when Extra is non-empty. Only a
+# non-empty Extra reaches the slow path, which is where a newly added field is
+# most easily forgotten.
+openapi: 3.2.0
+$self: https://example.com/api/openapi.yaml
+info:
+  title: OAS 3.2 full field set
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+    name: production
+    x-server-ext: keep
+tags:
+  - name: pets
+    summary: Pet operations
+    parent: root
+    kind: nav
+    x-tag-ext: keep
+  - name: root
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        "200":
+          description: A list of pets
+          summary: Pets, or the default shape
+          x-response-ext: keep
+          content:
+            application/jsonl:
+              itemSchema:
+                $ref: "#/components/schemas/Pet"
+              itemEncoding:
+                contentType: application/json
+                x-item-encoding-ext: keep
+              prefixEncoding:
+                - contentType: application/json
+                  x-prefix-encoding-ext: keep
+              x-media-type-ext: keep
+            multipart/form-data:
+              schema:
+                type: object
+                properties:
+                  meta:
+                    type: object
+              encoding:
+                meta:
+                  contentType: application/json
+                  encoding:
+                    nested:
+                      contentType: text/plain
+                      x-nested-encoding-ext: keep
+                  itemEncoding:
+                    contentType: text/plain
+                  prefixEncoding:
+                    - contentType: text/plain
+                  x-encoding-ext: keep
+    post:
+      operationId: searchPets
+      parameters:
+        - name: q
+          in: querystring
+          content:
+            application/x-www-form-urlencoded:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+      responses:
+        "204":
+          description: No content
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - petType
+      properties:
+        petType:
+          type: string
+        tag:
+          type: string
+          xml:
+            name: tag
+            nodeType: attribute
+            x-xml-ext: keep
+      discriminator:
+        propertyName: petType
+        defaultMapping: OtherPet
+        mapping:
+          dog: Dog
+        x-discriminator-ext: keep
+    Dog:
+      type: object
+    OtherPet:
+      type: object
+  examples:
+    withData:
+      summary: Structured form only
+      dataValue:
+        petType: dog
+      serializedValue: '{"petType":"dog"}'
+      x-example-ext: keep
+  securitySchemes:
+    oauth:
+      type: oauth2
+      deprecated: true
+      oauth2MetadataUrl: https://auth.example.com/.well-known/oauth-authorization-server
+      x-security-scheme-ext: keep
+      flows:
+        deviceAuthorization:
+          deviceAuthorizationUrl: https://auth.example.com/device
+          tokenUrl: https://auth.example.com/token
+          scopes:
+            read: Read access
+          x-oauth-flow-ext: keep
+        x-oauth-flows-ext: keep

--- a/testdata/oas32-all-fields.yaml
+++ b/testdata/oas32-all-fields.yaml
@@ -38,13 +38,18 @@ paths:
             application/jsonl:
               itemSchema:
                 $ref: "#/components/schemas/Pet"
+              x-media-type-ext: keep
+            # itemEncoding and prefixEncoding SHALL only apply to a multipart media
+            # type, so they live here rather than on the sequential one above.
+            multipart/mixed:
+              itemSchema:
+                $ref: "#/components/schemas/Pet"
               itemEncoding:
                 contentType: application/json
                 x-item-encoding-ext: keep
               prefixEncoding:
                 - contentType: application/json
                   x-prefix-encoding-ext: keep
-              x-media-type-ext: keep
             multipart/form-data:
               schema:
                 type: object
@@ -63,6 +68,22 @@ paths:
                   prefixEncoding:
                     - contentType: text/plain
                   x-encoding-ext: keep
+    query:
+      operationId: queryPets
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        "200":
+          description: Matching pets
+    additionalOperations:
+      PURGE:
+        operationId: purgePets
+        responses:
+          "204":
+            description: Purged
     post:
       operationId: searchPets
       parameters:
@@ -93,6 +114,9 @@ components:
             name: tag
             nodeType: attribute
             x-xml-ext: keep
+      oneOf:
+        - $ref: "#/components/schemas/Dog"
+        - $ref: "#/components/schemas/OtherPet"
       discriminator:
         propertyName: petType
         defaultMapping: OtherPet

--- a/validator/component_path_items_test.go
+++ b/validator/component_path_items_test.go
@@ -1,0 +1,456 @@
+package validator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erraggy/oastools/parser"
+)
+
+// validationWarnings mirrors validationErrors for the warning severity, which is
+// collected in a separate slice on the result. It exists for the negative
+// assertion these tests turn on: the path-template checks must stay out of
+// components.pathItems, and those report warnings rather than errors.
+func validationWarnings(t *testing.T, spec string) []string {
+	t.Helper()
+	return warningsWithStrict(t, spec, false)
+}
+
+// warningsWithStrict is validationWarnings with StrictMode selectable, because
+// the response-status-code arm of validateResponseStatusCodes is only reachable
+// as a warning: the parser's own decoder rejects a malformed status code as a
+// construct error before any document carrying one reaches the validator, so the
+// strict-mode non-standard-code and missing-2xx warnings are what prove the
+// responses check runs at all for a given call site.
+func warningsWithStrict(t *testing.T, spec string, strict bool) []string {
+	t.Helper()
+
+	p := parser.New()
+	p.ValidateStructure = false
+	parseResult, err := p.ParseBytes([]byte(spec))
+	require.NoError(t, err, "test spec should parse")
+
+	v := New()
+	v.IncludeWarnings = true
+	v.StrictMode = strict
+	result, err := v.ValidateParsed(*parseResult)
+	require.NoError(t, err)
+
+	messages := make([]string, 0, len(result.Warnings))
+	for _, w := range result.Warnings {
+		messages = append(messages, w.Path+": "+w.Message)
+	}
+	return messages
+}
+
+// TestComponentPathItemsOperationsAreValidated covers the first half of issue
+// #392: operations under components.pathItems never reached
+// validateOAS3Operation, so they skipped every check operations under paths and
+// webhooks get. A reusable path item is reached by $ref and describes real
+// operations, so the same defects must be reported there.
+func TestComponentPathItemsOperationsAreValidated(t *testing.T) {
+	tests := []struct {
+		name       string
+		spec       string
+		wantErrors []string
+	}{
+		{
+			name: "request body with no content",
+			spec: `
+openapi: 3.1.0
+info: {title: T, version: "1.0.0"}
+paths: {}
+components:
+  pathItems:
+    Shared:
+      post:
+        operationId: sharedPost
+        requestBody:
+          description: no content object at all
+        responses:
+          "201": {description: Created}
+`,
+			wantErrors: []string{
+				"components.pathItems.Shared.post.requestBody: RequestBody must have a content object with at least one media type",
+			},
+		},
+		{
+			name: "schema defect inside a request body media type",
+			spec: `
+openapi: 3.1.0
+info: {title: T, version: "1.0.0"}
+paths: {}
+components:
+  pathItems:
+    Shared:
+      post:
+        operationId: sharedPost
+        requestBody:
+          content:
+            application/json:
+              schema: {type: string, enum: [1]}
+        responses:
+          "201": {description: Created}
+`,
+			wantErrors: []string{
+				"components.pathItems.Shared.post.requestBody.content.application/json.schema.enum[0]: Enum value must be a string",
+			},
+		},
+		{
+			name: "invalid media type in a request body",
+			spec: `
+openapi: 3.1.0
+info: {title: T, version: "1.0.0"}
+paths: {}
+components:
+  pathItems:
+    Shared:
+      post:
+        operationId: sharedPost
+        requestBody:
+          content:
+            "not a media type": {schema: {type: object}}
+        responses:
+          "201": {description: Created}
+`,
+			wantErrors: []string{
+				`components.pathItems.Shared.post.requestBody.content.not a media type: Invalid media type: not a media type`,
+			},
+		},
+		{
+			name: "path parameter missing required: true",
+			spec: `
+openapi: 3.1.0
+info: {title: T, version: "1.0.0"}
+paths: {}
+components:
+  pathItems:
+    Shared:
+      parameters:
+        - {name: id, in: path, schema: {type: string}}
+      get:
+        operationId: sharedGet
+        responses:
+          "200": {description: OK}
+`,
+			wantErrors: []string{
+				"components.pathItems.Shared.parameters[0]: Path parameters must have required: true",
+			},
+		},
+		{
+			name: "a well-formed reusable path item is clean",
+			spec: `
+openapi: 3.1.0
+info: {title: T, version: "1.0.0"}
+paths: {}
+components:
+  pathItems:
+    Shared:
+      parameters:
+        - {name: id, in: path, required: true, schema: {type: string}}
+      post:
+        operationId: sharedPost
+        requestBody:
+          content:
+            application/json: {schema: {type: object}}
+        responses:
+          "201": {description: Created}
+`,
+			wantErrors: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertErrorsMatch(t, validationErrors(t, tt.spec), tt.wantErrors)
+		})
+	}
+}
+
+// TestComponentPathItemsResponsesAreValidated covers the responses half of #392
+// separately, because validateResponseStatusCodes only ever reports warnings for
+// a document that parses: a malformed code is rejected by the parser's decoder
+// first. Strict mode's non-standard-code and missing-2xx warnings are therefore
+// the observable proof that the check reaches these operations.
+func TestComponentPathItemsResponsesAreValidated(t *testing.T) {
+	spec := `
+openapi: 3.1.0
+info: {title: T, version: "1.0.0"}
+paths: {}
+components:
+  pathItems:
+    Shared:
+      get:
+        operationId: sharedGet
+        summary: reusable
+        responses:
+          "299": {description: valid format, not a standard code}
+      delete:
+        operationId: sharedDelete
+        summary: no success response
+        responses:
+          "404": {description: Not Found}
+`
+	warnings := strings.Join(warningsWithStrict(t, spec, true), "\n")
+
+	assert.Contains(t, warnings,
+		"components.pathItems.Shared.get.responses.299: Non-standard HTTP status code: 299")
+	assert.Contains(t, warnings,
+		"components.pathItems.Shared.delete.responses: Operation should define at least one successful response")
+}
+
+// TestComponentPathItemsSkipPathTemplateChecks pins the exclusion #392 states
+// explicitly. A reusable path item has no path field, so the Paths-Object-scoped
+// rule that a path parameter's name match a template expression cannot apply;
+// running warnUnusedPathParams here would warn about every well-formed path
+// parameter instead of finding a defect. Webhooks are excluded for the same
+// reason, and are asserted alongside so the two stay consistent.
+func TestComponentPathItemsSkipPathTemplateChecks(t *testing.T) {
+	spec := `
+openapi: 3.1.0
+info: {title: T, version: "1.0.0"}
+paths: {}
+webhooks:
+  onEvent:
+    parameters:
+      - {name: hookId, in: path, required: true, schema: {type: string}}
+    post:
+      operationId: onEventPost
+      requestBody:
+        content:
+          application/json: {schema: {type: object}}
+      responses:
+        "200": {description: OK}
+components:
+  pathItems:
+    Shared:
+      parameters:
+        - {name: id, in: path, required: true, schema: {type: string}}
+      get:
+        operationId: sharedGet
+        summary: reusable
+        responses:
+          "200": {description: OK}
+`
+	for _, warning := range validationWarnings(t, spec) {
+		assert.NotContains(t, warning, "not used in path template",
+			"a reusable path item and a webhook have no path template, so a well-formed "+
+				"path parameter in either must not be warned about")
+	}
+	assertErrorsMatch(t, validationErrors(t, spec), nil)
+}
+
+// TestComponentPathItemsDuplicateOperationIds covers the operationId decision
+// #392 asks to settle: each components.pathItems entry counts exactly once,
+// however many places $ref it and whether or not anything does.
+func TestComponentPathItemsDuplicateOperationIds(t *testing.T) {
+	tests := []struct {
+		name       string
+		spec       string
+		wantErrors []string
+	}{
+		{
+			// The sweep runs after paths, so the collision is reported at the
+			// components site — where a rename belongs, since the path is the
+			// live operation.
+			name: "collides with an operation under paths",
+			spec: `
+openapi: 3.1.0
+info: {title: T, version: "1.0.0"}
+paths:
+  /pets:
+    get:
+      operationId: shared
+      responses:
+        "200": {description: OK}
+components:
+  pathItems:
+    Shared:
+      get:
+        operationId: shared
+        responses:
+          "200": {description: OK}
+`,
+			wantErrors: []string{
+				"components.pathItems.Shared.get: Duplicate operationId 'shared' (first seen at paths./pets.get)",
+			},
+		},
+		{
+			// Names are swept in sorted order, so "B" is always the one reported
+			// as the duplicate rather than whichever map iteration reached first.
+			name: "two reusable path items collide, reported in sorted name order",
+			spec: `
+openapi: 3.1.0
+info: {title: T, version: "1.0.0"}
+paths: {}
+components:
+  pathItems:
+    B:
+      get:
+        operationId: shared
+        responses:
+          "200": {description: OK}
+    A:
+      get:
+        operationId: shared
+        responses:
+          "200": {description: OK}
+`,
+			wantErrors: []string{
+				"components.pathItems.B.get: Duplicate operationId 'shared' (first seen at components.pathItems.A.get)",
+			},
+		},
+		{
+			// The self-collision hazard the issue raises. Path item $refs are
+			// preserved verbatim rather than resolved in place, so the use sites
+			// carry no operations and the single declaration is counted once.
+			name: "one reusable path item referenced from several places does not collide with itself",
+			spec: `
+openapi: 3.1.0
+info: {title: T, version: "1.0.0"}
+paths:
+  /a:
+    $ref: '#/components/pathItems/Shared'
+  /b:
+    $ref: '#/components/pathItems/Shared'
+webhooks:
+  onEvent:
+    $ref: '#/components/pathItems/Shared'
+components:
+  pathItems:
+    Shared:
+      get:
+        operationId: sharedGet
+        responses:
+          "200": {description: OK}
+`,
+			wantErrors: nil,
+		},
+		{
+			// An entry nothing references arguably describes nothing, but an
+			// operationId duplicating a live one is a latent defect one $ref from
+			// mattering, so it is reported.
+			name: "an unreferenced reusable path item is still counted",
+			spec: `
+openapi: 3.1.0
+info: {title: T, version: "1.0.0"}
+paths:
+  /pets:
+    get:
+      operationId: shared
+      responses:
+        "200": {description: OK}
+components:
+  pathItems:
+    NeverReferenced:
+      get:
+        operationId: shared
+        responses:
+          "200": {description: OK}
+`,
+			wantErrors: []string{
+				"components.pathItems.NeverReferenced.get: Duplicate operationId 'shared' (first seen at paths./pets.get)",
+			},
+		},
+		{
+			name: "distinct operationIds across paths and reusable path items are clean",
+			spec: `
+openapi: 3.1.0
+info: {title: T, version: "1.0.0"}
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        "200": {description: OK}
+components:
+  pathItems:
+    Shared:
+      get:
+        operationId: sharedGet
+        responses:
+          "200": {description: OK}
+`,
+			wantErrors: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertErrorsMatch(t, validationErrors(t, tt.spec), tt.wantErrors)
+		})
+	}
+}
+
+// TestComponentPathItemsSortedOrderIsStable runs the sorted-order case enough
+// times to fail if the sweep ever ranges the map directly. A single run passes
+// by chance roughly half the time, which is what makes the ordering guarantee
+// worth pinning separately from the collision itself.
+func TestComponentPathItemsSortedOrderIsStable(t *testing.T) {
+	spec := `
+openapi: 3.1.0
+info: {title: T, version: "1.0.0"}
+paths: {}
+components:
+  pathItems:
+    B:
+      get:
+        operationId: shared
+        responses:
+          "200": {description: OK}
+    A:
+      get:
+        operationId: shared
+        responses:
+          "200": {description: OK}
+    C:
+      get:
+        operationId: shared
+        responses:
+          "200": {description: OK}
+`
+	for range 50 {
+		errs := validationErrors(t, spec)
+		require.Len(t, errs, 2, "A wins the id; B and C are the duplicates")
+		joined := strings.Join(errs, "\n")
+		assert.Contains(t, joined, "components.pathItems.B.get: Duplicate operationId 'shared' (first seen at components.pathItems.A.get)")
+		assert.Contains(t, joined, "components.pathItems.C.get: Duplicate operationId 'shared' (first seen at components.pathItems.A.get)")
+	}
+}
+
+// TestComponentPathItemsAdditionalOperationsAreValidated covers the OAS 3.2
+// methods, which GetOperations only surfaces at 3.2+. Validating the fixed
+// methods while skipping query and additionalOperations would leave the same
+// blind spot for exactly the operations most likely to be hand-written.
+func TestComponentPathItemsAdditionalOperationsAreValidated(t *testing.T) {
+	spec := `
+openapi: 3.2.0
+info: {title: T, version: "1.0.0"}
+paths: {}
+components:
+  pathItems:
+    Shared:
+      query:
+        operationId: sharedQuery
+        requestBody:
+          description: no content
+        responses:
+          "200": {description: OK}
+      additionalOperations:
+        PURGE:
+          operationId: sharedPurge
+          requestBody:
+            content:
+              application/json:
+                schema: {type: string, enum: [1]}
+          responses:
+            "200": {description: OK}
+`
+	assertErrorsMatch(t, validationErrors(t, spec), []string{
+		"components.pathItems.Shared.query.requestBody: RequestBody must have a content object with at least one media type",
+		"components.pathItems.Shared.PURGE.requestBody.content.application/json.schema.enum[0]: Enum value must be a string",
+	})
+}

--- a/validator/oas3.go
+++ b/validator/oas3.go
@@ -2,6 +2,7 @@ package validator
 
 import (
 	"fmt"
+	"maps"
 	"slices"
 	"strconv"
 	"strings"
@@ -54,6 +55,9 @@ func (v *Validator) validateOAS3(doc *parser.OAS3Document, result *ValidationRes
 	// Validate webhooks (OAS 3.1+)
 	v.validateOAS3Webhooks(doc, result, baseURL)
 
+	// Validate reusable path items (OAS 3.1+)
+	v.validateOAS3ComponentPathItems(doc, result, baseURL)
+
 	// Validate path parameters match path templates
 	v.validateOAS3PathParameterConsistency(doc, result, baseURL)
 
@@ -62,6 +66,9 @@ func (v *Validator) validateOAS3(doc *parser.OAS3Document, result *ValidationRes
 
 	// Validate duplicate operationIds
 	v.validateOAS3OperationIds(doc, result, baseURL)
+
+	// Validate the OAS 3.2 cross-field constraints (see oas32.go)
+	v.validateOAS32Document(doc, result)
 
 	// Validate all $ref values point to valid components
 	v.validateOAS3Refs(doc, result, baseURL)
@@ -105,6 +112,45 @@ func (v *Validator) validateOAS3OperationIds(doc *parser.OAS3Document, result *V
 		operations := parser.GetOperations(pathItem, doc.OASVersion)
 
 		v.checkDuplicateOperationIds(operations, "webhooks", webhookName, operationIds, result, baseURL)
+	}
+
+	// Check reusable path items (OAS 3.1+).
+	//
+	// The spec requires an operationId to be "unique among all operations
+	// described in the API", which needs a decision here rather than a mechanical
+	// extension of the sweep above. The rule adopted is: each components.pathItems
+	// entry is counted exactly once, however many places $ref it, and whether or
+	// not anything does.
+	//
+	// Counting once rather than once per use site is what "described in the API"
+	// reduces to for this parser. A path item $ref is preserved verbatim rather
+	// than resolved in place, so a use site under paths or webhooks carries no
+	// operations of its own and cannot double-count against the declaration.
+	// Resolving first and counting each site instead would make a path item
+	// referenced from two places collide with itself, which is not a defect in the
+	// document.
+	//
+	// Counting an entry nothing references is deliberate. It arguably describes
+	// nothing, so it is not strictly bound by the uniqueness rule, but an
+	// operationId duplicating a live one is a latent defect one $ref away from
+	// mattering, and reporting it costs a document that never adds that $ref
+	// nothing but a rename.
+	//
+	// Swept after paths and webhooks so a collision with either is reported at the
+	// components site, where the fix belongs, and in sorted name order so a
+	// collision between two reusable path items names the same one of the pair on
+	// every run instead of alternating with map order.
+	if doc.Components != nil {
+		for _, name := range slices.Sorted(maps.Keys(doc.Components.PathItems)) {
+			pathItem := doc.Components.PathItems[name]
+			if pathItem == nil {
+				continue
+			}
+
+			operations := parser.GetOperations(pathItem, doc.OASVersion)
+
+			v.checkDuplicateOperationIds(operations, "components.pathItems", name, operationIds, result, baseURL)
+		}
 	}
 }
 
@@ -187,6 +233,10 @@ func (v *Validator) validateOAS3Paths(doc *parser.OAS3Document, result *Validati
 
 		// Validate each operation
 		operations := parser.GetOperations(pathItem, doc.OASVersion)
+
+		// The OAS 3.2 traversal rules ride along on the operations map this pass
+		// already built, rather than taking a traversal of their own (see oas32.go).
+		v.validateOAS32PathItem(pathItem, pathPrefix, doc.OASVersion, operations, result)
 
 		for method, op := range operations {
 			if op == nil {
@@ -504,6 +554,8 @@ func (v *Validator) validateOAS3Webhooks(doc *parser.OAS3Document, result *Valid
 		// Validate each operation in the webhook
 		operations := parser.GetOperations(pathItem, doc.OASVersion)
 
+		v.validateOAS32PathItem(pathItem, pathPrefix, doc.OASVersion, operations, result)
+
 		for method, op := range operations {
 			if op == nil {
 				continue
@@ -511,6 +563,59 @@ func (v *Validator) validateOAS3Webhooks(doc *parser.OAS3Document, result *Valid
 
 			opPath := pathPrefix + "." + method
 			v.validateOAS3Operation(op, opPath, result, baseURL)
+		}
+	}
+}
+
+// validateOAS3ComponentPathItems validates the reusable path items under
+// components.pathItems (OAS 3.1+).
+//
+// A reusable path item is reached by $ref from webhooks, from paths, or from
+// another path item, and describes operations as genuine as any other, so its
+// operations get the same operation-level validation as those under paths and
+// webhooks. Before this ran, only the component *names* were checked
+// (checkComponentNames) and nothing inside them was: a request body with no
+// content, or a malformed response status code, went unreported.
+//
+// Deliberately excluded: the path-template consistency checks
+// (reportUndeclaredPathParams and warnUnusedPathParams). The spec scopes the
+// parameter name rule to the Paths Object —
+//
+//	If in is "path", the name field MUST correspond to a single template
+//	expression occurring within the path field in the Paths Object.
+//
+// — and a reusable path item has no path field of its own, so running those here
+// would warn about every well-formed path parameter. Webhooks are excluded for
+// the same reason.
+//
+// [Validator.validatePathParamsRequired] is not a template check and does apply:
+// required: true is a property of the parameter alone, independent of any path.
+func (v *Validator) validateOAS3ComponentPathItems(doc *parser.OAS3Document, result *ValidationResult, baseURL string) {
+	if doc.Components == nil || len(doc.Components.PathItems) == 0 {
+		return
+	}
+
+	for name, pathItem := range doc.Components.PathItems {
+		if pathItem == nil {
+			continue
+		}
+
+		prefix := "components.pathItems." + name
+
+		// Path-item parameters apply to every operation in the item, so they are
+		// checked once here rather than once per operation — the same requirement
+		// validatePathParamsRequired documents for its callers.
+		v.validatePathParamsRequired(pathItem.Parameters, prefix, result, baseURL)
+
+		operations := parser.GetOperations(pathItem, doc.OASVersion)
+
+		v.validateOAS32PathItem(pathItem, prefix, doc.OASVersion, operations, result)
+
+		for method, op := range operations {
+			if op == nil {
+				continue
+			}
+			v.validateOAS3Operation(op, prefix+"."+method, result, baseURL)
 		}
 	}
 }

--- a/validator/oas3.go
+++ b/validator/oas3.go
@@ -116,30 +116,25 @@ func (v *Validator) validateOAS3OperationIds(doc *parser.OAS3Document, result *V
 
 	// Check reusable path items (OAS 3.1+).
 	//
-	// The spec requires an operationId to be "unique among all operations
-	// described in the API", which needs a decision here rather than a mechanical
-	// extension of the sweep above. The rule adopted is: each components.pathItems
-	// entry is counted exactly once, however many places $ref it, and whether or
-	// not anything does.
+	// `operationId` must be unique among all operations described in the API:
+	// https://spec.openapis.org/oas/v3.2.0.html#operation-id
 	//
-	// Counting once rather than once per use site is what "described in the API"
-	// reduces to for this parser. A path item $ref is preserved verbatim rather
-	// than resolved in place, so a use site under paths or webhooks carries no
-	// operations of its own and cannot double-count against the declaration.
-	// Resolving first and counting each site instead would make a path item
-	// referenced from two places collide with itself, which is not a defect in the
-	// document.
+	// Applying that to `components.pathItems` is a decision, so it is recorded
+	// here: each entry counts exactly once, however many places `$ref` it, and
+	// whether or not anything does.
 	//
-	// Counting an entry nothing references is deliberate. It arguably describes
-	// nothing, so it is not strictly bound by the uniqueness rule, but an
-	// operationId duplicating a live one is a latent defect one $ref away from
-	// mattering, and reporting it costs a document that never adds that $ref
-	// nothing but a rename.
+	// Once rather than per use site, because a path item `$ref` is preserved
+	// verbatim rather than resolved in place. A use site carries no operations of
+	// its own, so it cannot double-count against the declaration, and counting
+	// resolved sites instead would make a twice-referenced path item collide with
+	// itself.
 	//
-	// Swept after paths and webhooks so a collision with either is reported at the
-	// components site, where the fix belongs, and in sorted name order so a
-	// collision between two reusable path items names the same one of the pair on
-	// every run instead of alternating with map order.
+	// An unreferenced entry counts too. It describes nothing today, but an
+	// `operationId` duplicating a live one is one `$ref` away from mattering.
+	//
+	// Swept last so a collision with `paths` or `webhooks` is reported at the
+	// components site, and in sorted name order so the same one of a colliding
+	// pair is named on every run.
 	if doc.Components != nil {
 		for _, name := range slices.Sorted(maps.Keys(doc.Components.PathItems)) {
 			pathItem := doc.Components.PathItems[name]
@@ -579,17 +574,15 @@ func (v *Validator) validateOAS3Webhooks(doc *parser.OAS3Document, result *Valid
 //
 // Deliberately excluded: the path-template consistency checks
 // (reportUndeclaredPathParams and warnUnusedPathParams). The spec scopes the
-// parameter name rule to the Paths Object —
+// `name` rule for `in: "path"` to a template expression in the Paths Object:
+// https://spec.openapis.org/oas/v3.2.0.html#parameter-name
 //
-//	If in is "path", the name field MUST correspond to a single template
-//	expression occurring within the path field in the Paths Object.
-//
-// — and a reusable path item has no path field of its own, so running those here
+// A reusable path item has no `path` of its own, so running those checks here
 // would warn about every well-formed path parameter. Webhooks are excluded for
 // the same reason.
 //
 // [Validator.validatePathParamsRequired] is not a template check and does apply:
-// required: true is a property of the parameter alone, independent of any path.
+// `required: true` is a property of the parameter alone.
 func (v *Validator) validateOAS3ComponentPathItems(doc *parser.OAS3Document, result *ValidationResult, baseURL string) {
 	if doc.Components == nil || len(doc.Components.PathItems) == 0 {
 		return

--- a/validator/oas32.go
+++ b/validator/oas32.go
@@ -1,0 +1,507 @@
+// oas32.go implements the OAS 3.2.0 constraints that are more than presence
+// checks — the rules where a field's legality depends on a sibling field, on the
+// document's version, or on another parameter in the same effective list.
+//
+// Every rule here is quoted from versions/3.2.0.md in OAI/OpenAPI-Specification
+// at the site that enforces it, because several of them read as though they were
+// warnings and are in fact MUST NOTs.
+
+package validator
+
+import (
+	"fmt"
+	"slices"
+	"strconv"
+
+	"github.com/erraggy/oastools/parser"
+)
+
+// oas32SpecRef is the base URL for the 3.2.0 spec, used for every rule in this
+// file. The rules only exist at 3.2, so unlike the version-varying checks
+// elsewhere there is nothing to select between.
+const oas32SpecRef = "https://spec.openapis.org/oas/v3.2.0.html"
+
+// xmlNodeTypes is the closed set the XML Object's nodeType may take:
+//
+//	One of `element`, `attribute`, `text`, `cdata`, or `none`
+//
+// Quoted from the XML Object's fixed fields table. The default is deliberately
+// not modeled — it is "none if $ref, $dynamicRef, or type: "array" is present in
+// the Schema Object containing the XML Object, and element otherwise", which
+// depends on the enclosing schema rather than on the XML Object.
+var xmlNodeTypes = []string{"element", "attribute", "text", "cdata", "none"}
+
+// oas32TraversalApplies reports whether the traversal-driven 3.2 rules are worth
+// walking the document for.
+//
+// Gated on the version because these rules read Example.dataValue,
+// Example.serializedValue, and in: "querystring" — fields OAS 3.2 introduced. A
+// pre-3.2 document cannot legally carry any of them, and walking every media
+// type, header, and encoding of such a document to say so is not free: the walk
+// builds a JSON path string per operation, response, and media type it passes,
+// which measured as roughly a 20% increase in validator allocations across every
+// document size. Skipping it keeps 3.0 and 3.1 documents at exactly their
+// previous cost.
+//
+// What that gives up is narrow. `in: "querystring"` below 3.2 is already rejected
+// by the parser's structure validation, so nothing is lost there. A pre-3.2
+// document carrying dataValue or serializedValue goes unreported by these rules —
+// an unknown field for its version, which is the parser's business rather than a
+// cross-field constraint. The schema-level 3.2 rules keep their version checks,
+// because validateSchema already visits every schema and they cost a nil test.
+func oas32TraversalApplies(version parser.OASVersion) bool {
+	return !version.IsValid() || version >= parser.OASVersion320
+}
+
+// validateOAS32Document runs the 3.2 cross-field rules that are not reachable
+// from schema validation.
+//
+// The schema-level rules (XML nodeType, discriminator defaultMapping) hang off
+// validateSchema instead, so they reach every schema the validator already
+// visits rather than needing a second traversal of their own.
+//
+// The Example and querystring rules do need a traversal — the validator has
+// never visited Example Objects, and the querystring rules need a path item's
+// parameters together with each operation's. They share one pass over the path
+// items rather than taking a pass each, because [parser.GetOperations] builds a
+// map per call and this package already calls it three times per path item.
+// Maps are ranged directly rather than in sorted order for the same reason:
+// sorting every map in the document allocates on every document to make error
+// ordering deterministic in the rare document that has an error, and the
+// surrounding validator ranges doc.Paths directly for exactly this reason.
+func (v *Validator) validateOAS32Document(doc *parser.OAS3Document, result *ValidationResult) {
+	if !oas32TraversalApplies(doc.OASVersion) || doc.Components == nil {
+		return
+	}
+	c := doc.Components
+
+	for name, ex := range c.Examples {
+		v.validateExampleValueExclusivity(ex, "components.examples."+name, result)
+	}
+	for name, param := range c.Parameters {
+		prefix := "components.parameters." + name
+		v.visitParameterExamples(param, prefix, result)
+		// A parameter definition gets its declaration-site rules only: which
+		// operations reference it is not knowable from here, so the interaction
+		// rules are left to the use sites.
+		v.validateQueryStringParam(param, prefix, result)
+	}
+	for name, header := range c.Headers {
+		v.visitHeaderExamples(header, "components.headers."+name, result)
+	}
+	for name, rb := range c.RequestBodies {
+		if rb != nil {
+			v.visitContentExamples(rb.Content, "components.requestBodies."+name, result)
+		}
+	}
+	for name, resp := range c.Responses {
+		v.visitResponseExamples(resp, "components.responses."+name, result)
+	}
+	for name, mt := range c.MediaTypes {
+		v.visitMediaTypeExamples(mt, "components.mediaTypes."+name, result)
+	}
+}
+
+// validateOAS32PathItem applies the traversal-driven 3.2 rules — Example Object
+// exclusivity and the in: "querystring" constraints — to one path item.
+//
+// ops and version are passed in rather than derived here because every caller is
+// a pass that already holds both. [parser.GetOperations] allocates a map per call, and this
+// package already calls it three times per path item; a fourth traversal of its
+// own measured as roughly a 20% increase in validator allocations on a large
+// document, for rules that fire on almost none.
+func (v *Validator) validateOAS32PathItem(
+	item *parser.PathItem,
+	prefix string,
+	version parser.OASVersion,
+	ops map[string]*parser.Operation,
+	result *ValidationResult,
+) {
+	if item == nil || !oas32TraversalApplies(version) {
+		return
+	}
+
+	for i, param := range item.Parameters {
+		paramPath := prefix + ".parameters[" + strconv.Itoa(i) + "]"
+		v.visitParameterExamples(param, paramPath, result)
+		v.validateQueryStringParam(param, paramPath, result)
+	}
+
+	// Reported against the path item so a conflict wholly inside its own
+	// parameter list is not repeated for every operation it contains.
+	itemQueryString, itemQuery := countQueryLocations(item.Parameters)
+	v.reportQueryStringConflicts(itemQueryString, itemQuery, prefix, result)
+
+	for method, op := range ops {
+		if op == nil {
+			continue
+		}
+		opPath := prefix + "." + method
+
+		for i, param := range op.Parameters {
+			paramPath := opPath + ".parameters[" + strconv.Itoa(i) + "]"
+			v.visitParameterExamples(param, paramPath, result)
+			v.validateQueryStringParam(param, paramPath, result)
+		}
+
+		if opQueryString, opQuery := countQueryLocations(op.Parameters); opQueryString > 0 || opQuery > 0 {
+			// Skipped when the operation declares neither, since any defect in the
+			// path item's own list was already reported above.
+			v.reportQueryStringConflicts(itemQueryString+opQueryString, itemQuery+opQuery, opPath, result)
+		}
+
+		if op.RequestBody != nil {
+			v.visitContentExamples(op.RequestBody.Content, opPath+".requestBody", result)
+		}
+		if op.Responses != nil {
+			for code, resp := range op.Responses.Codes {
+				v.visitResponseExamples(resp, opPath+".responses."+code, result)
+			}
+		}
+	}
+}
+
+// =============================================================================
+// Example Object: dataValue / serializedValue exclusivity
+// =============================================================================
+
+// validateExampleValueExclusivity enforces the Example Object's mutual-exclusion
+// rules, quoted from the 3.2.0 fixed fields table:
+//
+//	dataValue        — "If this field is present, `value` MUST be absent."
+//	serializedValue  — "If this field is present, `value`, and `externalValue`
+//	                    MUST be absent."
+//	externalValue    — "If this field is present, `serializedValue` and `value`
+//	                    MUST be absent."
+//
+// dataValue and serializedValue together are explicitly fine — the spec's own
+// Example Object example sets both — so no rule pairs those two.
+//
+// Reached only for a 3.2+ document (or one whose version could not be
+// recognized): [oas32TraversalApplies] gates the walk that finds these objects,
+// so there is no pre-3.2 branch to take here.
+func (v *Validator) validateExampleValueExclusivity(ex *parser.Example, path string, result *ValidationResult) {
+	if ex == nil {
+		return
+	}
+	// A pure $ref alias carries no sibling fields; the definition it names is
+	// checked in its own right. Mirrors validateOAS3RequestBody.
+	if ex.Ref != "" {
+		return
+	}
+
+	hasData := ex.DataValue != nil
+	hasSerialized := ex.SerializedValue != ""
+
+	if !hasData && !hasSerialized {
+		return
+	}
+
+	if hasData && ex.Value != nil {
+		v.addError(result, path,
+			"Example must not have both dataValue and value; dataValue requires value to be absent",
+			withSpecRef(oas32SpecRef+"#example-object"),
+			withField("dataValue"),
+		)
+	}
+	if hasSerialized && ex.Value != nil {
+		v.addError(result, path,
+			"Example must not have both serializedValue and value; serializedValue requires value to be absent",
+			withSpecRef(oas32SpecRef+"#example-object"),
+			withField("serializedValue"),
+		)
+	}
+	if hasSerialized && ex.ExternalValue != "" {
+		v.addError(result, path,
+			"Example must not have both serializedValue and externalValue; serializedValue requires externalValue to be absent",
+			withSpecRef(oas32SpecRef+"#example-object"),
+			withField("serializedValue"),
+		)
+	}
+}
+
+func (v *Validator) visitParameterExamples(param *parser.Parameter, prefix string, result *ValidationResult) {
+	if param == nil {
+		return
+	}
+	for name, ex := range param.Examples {
+		v.validateExampleValueExclusivity(ex, prefix+".examples."+name, result)
+	}
+	v.visitContentExamples(param.Content, prefix, result)
+}
+
+func (v *Validator) visitHeaderExamples(header *parser.Header, prefix string, result *ValidationResult) {
+	if header == nil {
+		return
+	}
+	for name, ex := range header.Examples {
+		v.validateExampleValueExclusivity(ex, prefix+".examples."+name, result)
+	}
+	v.visitContentExamples(header.Content, prefix, result)
+}
+
+func (v *Validator) visitResponseExamples(resp *parser.Response, prefix string, result *ValidationResult) {
+	if resp == nil {
+		return
+	}
+	v.visitContentExamples(resp.Content, prefix, result)
+	for name, header := range resp.Headers {
+		v.visitHeaderExamples(header, prefix+".headers."+name, result)
+	}
+}
+
+func (v *Validator) visitContentExamples(content map[string]*parser.MediaType, prefix string, result *ValidationResult) {
+	for mediaType, mt := range content {
+		v.visitMediaTypeExamples(mt, prefix+".content."+mediaType, result)
+	}
+}
+
+func (v *Validator) visitMediaTypeExamples(mt *parser.MediaType, prefix string, result *ValidationResult) {
+	if mt == nil {
+		return
+	}
+	for name, ex := range mt.Examples {
+		v.validateExampleValueExclusivity(ex, prefix+".examples."+name, result)
+	}
+	// Encoding Objects carry Headers, which carry Examples. Reached through the
+	// OAS 3.2 nested encodings too, since an Encoding may now contain Encodings.
+	for name, enc := range mt.Encoding {
+		v.visitEncodingExamples(enc, prefix+".encoding."+name, result, 0)
+	}
+	v.visitEncodingExamples(mt.ItemEncoding, prefix+".itemEncoding", result, 0)
+	for i, enc := range mt.PrefixEncoding {
+		v.visitEncodingExamples(enc, prefix+".prefixEncoding["+strconv.Itoa(i)+"]", result, 0)
+	}
+}
+
+// maxEncodingNestingDepth bounds the OAS 3.2 recursive Encoding traversal.
+//
+// The parser decodes each level into a fresh value, so a document cannot produce
+// a cyclic Encoding graph — but a depth bound costs nothing and keeps a
+// hand-assembled document from recursing without end.
+const maxEncodingNestingDepth = 100
+
+func (v *Validator) visitEncodingExamples(enc *parser.Encoding, prefix string, result *ValidationResult, depth int) {
+	if enc == nil || depth > maxEncodingNestingDepth {
+		return
+	}
+	for name, header := range enc.Headers {
+		v.visitHeaderExamples(header, prefix+".headers."+name, result)
+	}
+	for name, nested := range enc.Encoding {
+		v.visitEncodingExamples(nested, prefix+".encoding."+name, result, depth+1)
+	}
+	v.visitEncodingExamples(enc.ItemEncoding, prefix+".itemEncoding", result, depth+1)
+	for i, nested := range enc.PrefixEncoding {
+		v.visitEncodingExamples(nested, prefix+".prefixEncoding["+strconv.Itoa(i)+"]", result, depth+1)
+	}
+}
+
+// =============================================================================
+// Parameter Object: in: "querystring"
+// =============================================================================
+
+// countQueryLocations counts the querystring and query parameters in one list.
+// A $ref parameter contributes to neither: its `in` lives on the definition, and
+// guessing would report a conflict that may not exist.
+func countQueryLocations(params []*parser.Parameter) (queryString, query int) {
+	for _, param := range params {
+		if param == nil || param.Ref != "" {
+			continue
+		}
+		switch param.In {
+		case parser.ParamInQueryString:
+			queryString++
+		case parser.ParamInQuery:
+			query++
+		}
+	}
+	return queryString, query
+}
+
+// reportQueryStringConflicts reports the two interaction rules for one effective
+// parameter list.
+func (v *Validator) reportQueryStringConflicts(queryString, query int, prefix string, result *ValidationResult) {
+	if queryString > 1 {
+		v.addError(result, prefix,
+			fmt.Sprintf("A querystring parameter must not appear more than once, but %d were found", queryString),
+			withSpecRef(oas32SpecRef+"#parameter-object"),
+			withField("parameters"),
+		)
+	}
+	if queryString > 0 && query > 0 {
+		v.addError(result, prefix,
+			"A querystring parameter must not appear alongside any 'in: query' parameter "+
+				"in the same operation or its path item",
+			withSpecRef(oas32SpecRef+"#parameter-object"),
+			withField("parameters"),
+		)
+	}
+}
+
+// validateQueryStringParam enforces the rules a single querystring parameter must
+// satisfy on its own: that it is described with `content` rather than `schema`.
+//
+// The `schema` prohibition is stated in the spec under "Fixed Fields for use with
+// `schema`" — "These fields MUST NOT be used with in: "querystring"" — and covers
+// style, explode, and allowReserved alongside schema itself.
+//
+// The version this location was introduced in is enforced by the parser's
+// structure validation, which rejects in: "querystring" outright below 3.2, so
+// there is nothing to re-report here.
+func (v *Validator) validateQueryStringParam(param *parser.Parameter, path string, result *ValidationResult) {
+	if param == nil || param.Ref != "" || param.In != parser.ParamInQueryString {
+		return
+	}
+
+	if len(param.Content) == 0 {
+		v.addError(result, path,
+			"A querystring parameter must be specified using the content field",
+			withSpecRef(oas32SpecRef+"#parameter-object"),
+			withField("content"),
+		)
+	}
+	if param.Schema != nil {
+		v.addError(result, path,
+			"A querystring parameter must not use schema; the entire query string is described with content",
+			withSpecRef(oas32SpecRef+"#parameter-object"),
+			withField("schema"),
+		)
+	}
+	// style, explode, and allowReserved are listed under "Fixed Fields for use
+	// with `schema`" alongside schema itself, so the same prohibition covers them.
+	for _, f := range []struct {
+		name    string
+		present bool
+	}{
+		{"style", param.Style != ""},
+		{"explode", param.Explode != nil},
+		{"allowReserved", param.AllowReserved},
+	} {
+		if !f.present {
+			continue
+		}
+		v.addError(result, path,
+			fmt.Sprintf("A querystring parameter must not use %s; that field is for use with schema", f.name),
+			withSpecRef(oas32SpecRef+"#parameter-object"),
+			withField(f.name),
+		)
+	}
+}
+
+// =============================================================================
+// Schema-level rules: XML nodeType, Discriminator defaultMapping
+// =============================================================================
+
+// validateOAS32SchemaFields runs the 3.2 rules that belong to a Schema Object, so
+// they reach every schema validateSchema already visits.
+func (v *Validator) validateOAS32SchemaFields(schema *parser.Schema, path string, result *ValidationResult) {
+	v.validateXMLNodeType(schema, path, result)
+	v.validateDiscriminatorDefaultMapping(schema, path, result)
+}
+
+// validateXMLNodeType enforces the XML Object's nodeType rules.
+//
+// Both bools it supersedes are a hard conflict, not a style preference — the
+// fixed fields table says of each: "If `nodeType` is present, this field MUST NOT
+// be present." That is what makes modeling nodeType as an independent field
+// correct rather than lazy: a document may legally set the bools *or* nodeType,
+// never both, so there is no case where one has to be derived from the other.
+func (v *Validator) validateXMLNodeType(schema *parser.Schema, path string, result *ValidationResult) {
+	if schema.XML == nil || schema.XML.NodeType == "" {
+		return
+	}
+	xmlPath := path + ".xml"
+
+	if v.oasVersion.IsValid() && v.oasVersion < parser.OASVersion320 {
+		v.addError(result, xmlPath,
+			fmt.Sprintf("XML nodeType is only supported in OAS 3.2+, but document is version %s", v.oasVersion),
+			withSpecRef(oas32SpecRef+"#xml-object"),
+			withField("nodeType"),
+			withValue(schema.XML.NodeType),
+		)
+		return
+	}
+
+	if !slices.Contains(xmlNodeTypes, schema.XML.NodeType) {
+		v.addError(result, xmlPath,
+			fmt.Sprintf("Invalid XML nodeType %q; must be one of element, attribute, text, cdata, none", schema.XML.NodeType),
+			withSpecRef(oas32SpecRef+"#xml-object"),
+			withField("nodeType"),
+			withValue(schema.XML.NodeType),
+		)
+	}
+
+	if schema.XML.Attribute {
+		v.addError(result, xmlPath,
+			"XML attribute must not be present when nodeType is present; use nodeType: attribute instead",
+			withSpecRef(oas32SpecRef+"#xml-object"),
+			withField("attribute"),
+		)
+	}
+	if schema.XML.Wrapped {
+		v.addError(result, xmlPath,
+			"XML wrapped must not be present when nodeType is present; use nodeType: element instead",
+			withSpecRef(oas32SpecRef+"#xml-object"),
+			withField("wrapped"),
+		)
+	}
+}
+
+// validateDiscriminatorDefaultMapping enforces the conditional requirement the
+// 3.2 spec places on defaultMapping:
+//
+//	The discriminating property MAY be defined as required or optional, but when
+//	defined as an optional property the Discriminator Object MUST include a
+//	`defaultMapping` field […]
+//
+// Reported only when this schema itself declares the discriminating property and
+// omits it from `required`, which is the case where "defined as an optional
+// property" is locally provable. When the property is declared in the subschemas
+// of a oneOf/anyOf instead — the more common shape — its optionality is a property
+// of those subschemas, and reporting from here would mean guessing. Staying
+// silent loses findings; guessing invents them, and a false "must include
+// defaultMapping" on a correct document is the worse failure.
+//
+// Below 3.2 the field does not exist, so a document carrying it is reported as a
+// version error rather than checked.
+func (v *Validator) validateDiscriminatorDefaultMapping(schema *parser.Schema, path string, result *ValidationResult) {
+	d := schema.Discriminator
+	if d == nil {
+		return
+	}
+
+	if d.DefaultMapping != "" {
+		if v.oasVersion.IsValid() && v.oasVersion < parser.OASVersion320 {
+			v.addError(result, path+".discriminator",
+				fmt.Sprintf("discriminator defaultMapping is only supported in OAS 3.2+, but document is version %s", v.oasVersion),
+				withSpecRef(oas32SpecRef+"#discriminator-object"),
+				withField("defaultMapping"),
+				withValue(d.DefaultMapping),
+			)
+		}
+		return
+	}
+
+	if !v.oasVersion.IsValid() || v.oasVersion < parser.OASVersion320 {
+		return
+	}
+	if d.PropertyName == "" {
+		// Missing propertyName is reported elsewhere; without it there is no
+		// property whose optionality could be assessed.
+		return
+	}
+	if _, declared := schema.Properties[d.PropertyName]; !declared {
+		return
+	}
+	if slices.Contains(schema.Required, d.PropertyName) {
+		return
+	}
+
+	v.addError(result, path+".discriminator",
+		fmt.Sprintf("Discriminator must include defaultMapping because the discriminating property '%s' is optional", d.PropertyName),
+		withSpecRef(oas32SpecRef+"#discriminator-object"),
+		withField("defaultMapping"),
+		withValue(d.PropertyName),
+	)
+}

--- a/validator/oas32.go
+++ b/validator/oas32.go
@@ -1,10 +1,9 @@
-// oas32.go implements the OAS 3.2.0 constraints that are more than presence
-// checks — the rules where a field's legality depends on a sibling field, on the
-// document's version, or on another parameter in the same effective list.
+// oas32.go implements the OAS 3.2.0 constraints that depend on more than a
+// field's presence: a sibling field, the document version, or another parameter
+// in the same effective list.
 //
-// Every rule here is quoted from versions/3.2.0.md in OAI/OpenAPI-Specification
-// at the site that enforces it, because several of them read as though they were
-// warnings and are in fact MUST NOTs.
+// Each rule links to the section of the specification that states it rather than
+// restating it here. https://spec.openapis.org/oas/v3.2.0.html
 
 package validator
 
@@ -16,59 +15,33 @@ import (
 	"github.com/erraggy/oastools/parser"
 )
 
-// oas32SpecRef is the base URL for the 3.2.0 spec, used for every rule in this
-// file. The rules only exist at 3.2, so unlike the version-varying checks
-// elsewhere there is nothing to select between.
+// oas32SpecRef is the OAS 3.2.0 specification. Every rule in this file exists
+// only at 3.2, so there is no version to select between.
 const oas32SpecRef = "https://spec.openapis.org/oas/v3.2.0.html"
 
-// xmlNodeTypes is the closed set the XML Object's nodeType may take:
+// xmlNodeTypes is the closed set `nodeType` accepts.
+// https://spec.openapis.org/oas/v3.2.0.html#xml-node-type
 //
-//	One of `element`, `attribute`, `text`, `cdata`, or `none`
-//
-// Quoted from the XML Object's fixed fields table. The default is deliberately
-// not modeled — it is "none if $ref, $dynamicRef, or type: "array" is present in
-// the Schema Object containing the XML Object, and element otherwise", which
-// depends on the enclosing schema rather than on the XML Object.
+// Its default is not modeled: the default depends on the enclosing Schema Object,
+// which an XML Object cannot see.
 var xmlNodeTypes = []string{"element", "attribute", "text", "cdata", "none"}
 
-// oas32TraversalApplies reports whether the traversal-driven 3.2 rules are worth
-// walking the document for.
+// oas32TraversalApplies reports whether the traversal-driven 3.2 rules apply.
 //
-// Gated on the version because these rules read Example.dataValue,
-// Example.serializedValue, and in: "querystring" — fields OAS 3.2 introduced. A
-// pre-3.2 document cannot legally carry any of them, and walking every media
-// type, header, and encoding of such a document to say so is not free: the walk
-// builds a JSON path string per operation, response, and media type it passes,
-// which measured as roughly a 20% increase in validator allocations across every
-// document size. Skipping it keeps 3.0 and 3.1 documents at exactly their
-// previous cost.
-//
-// What that gives up is narrow. `in: "querystring"` below 3.2 is already rejected
-// by the parser's structure validation, so nothing is lost there. A pre-3.2
-// document carrying dataValue or serializedValue goes unreported by these rules —
-// an unknown field for its version, which is the parser's business rather than a
-// cross-field constraint. The schema-level 3.2 rules keep their version checks,
-// because validateSchema already visits every schema and they cost a nil test.
+// They read fields 3.2 introduced, and the walk is not free: it builds a JSON path
+// per operation, response, and media type it passes, which ungated cost roughly
+// 20% more validator allocations on every document. An unrecognized version counts
+// as in scope, so a document the parser could not classify is still checked.
 func oas32TraversalApplies(version parser.OASVersion) bool {
 	return !version.IsValid() || version >= parser.OASVersion320
 }
 
-// validateOAS32Document runs the 3.2 cross-field rules that are not reachable
-// from schema validation.
+// validateOAS32Document runs the 3.2 rules over the Components sections. Path
+// items go through [Validator.validateOAS32PathItem], called from the passes that
+// already hold their operations map.
 //
-// The schema-level rules (XML nodeType, discriminator defaultMapping) hang off
-// validateSchema instead, so they reach every schema the validator already
-// visits rather than needing a second traversal of their own.
-//
-// The Example and querystring rules do need a traversal — the validator has
-// never visited Example Objects, and the querystring rules need a path item's
-// parameters together with each operation's. They share one pass over the path
-// items rather than taking a pass each, because [parser.GetOperations] builds a
-// map per call and this package already calls it three times per path item.
-// Maps are ranged directly rather than in sorted order for the same reason:
-// sorting every map in the document allocates on every document to make error
-// ordering deterministic in the rare document that has an error, and the
-// surrounding validator ranges doc.Paths directly for exactly this reason.
+// The schema-level rules hang off validateSchema instead, which already visits
+// every schema.
 func (v *Validator) validateOAS32Document(doc *parser.OAS3Document, result *ValidationResult) {
 	if !oas32TraversalApplies(doc.OASVersion) || doc.Components == nil {
 		return
@@ -81,9 +54,8 @@ func (v *Validator) validateOAS32Document(doc *parser.OAS3Document, result *Vali
 	for name, param := range c.Parameters {
 		prefix := "components.parameters." + name
 		v.visitParameterExamples(param, prefix, result)
-		// A parameter definition gets its declaration-site rules only: which
-		// operations reference it is not knowable from here, so the interaction
-		// rules are left to the use sites.
+		// Declaration-site rules only: which operations reference this definition is
+		// not knowable here, so the interaction rules are left to the use sites.
 		v.validateQueryStringParam(param, prefix, result)
 	}
 	for name, header := range c.Headers {
@@ -102,14 +74,10 @@ func (v *Validator) validateOAS32Document(doc *parser.OAS3Document, result *Vali
 	}
 }
 
-// validateOAS32PathItem applies the traversal-driven 3.2 rules — Example Object
-// exclusivity and the in: "querystring" constraints — to one path item.
-//
-// ops and version are passed in rather than derived here because every caller is
-// a pass that already holds both. [parser.GetOperations] allocates a map per call, and this
-// package already calls it three times per path item; a fourth traversal of its
-// own measured as roughly a 20% increase in validator allocations on a large
-// document, for rules that fire on almost none.
+// validateOAS32PathItem applies the Example and `querystring` rules to one path
+// item. ops and version come from the caller because every caller already holds
+// them; building another operations map here cost roughly 20% more validator
+// allocations, for rules that fire on almost no document.
 func (v *Validator) validateOAS32PathItem(
 	item *parser.PathItem,
 	prefix string,
@@ -165,21 +133,14 @@ func (v *Validator) validateOAS32PathItem(
 // Example Object: dataValue / serializedValue exclusivity
 // =============================================================================
 
-// validateExampleValueExclusivity enforces the Example Object's mutual-exclusion
-// rules, quoted from the 3.2.0 fixed fields table:
+// validateExampleValueExclusivity enforces the Example Object's mutual exclusions:
+// `dataValue` and `serializedValue` each forbid `value`, and `serializedValue`
+// also forbids `externalValue`.
+// https://spec.openapis.org/oas/v3.2.0.html#fixed-fields-15
 //
-//	dataValue        — "If this field is present, `value` MUST be absent."
-//	serializedValue  — "If this field is present, `value`, and `externalValue`
-//	                    MUST be absent."
-//	externalValue    — "If this field is present, `serializedValue` and `value`
-//	                    MUST be absent."
-//
-// dataValue and serializedValue together are explicitly fine — the spec's own
-// Example Object example sets both — so no rule pairs those two.
-//
-// Reached only for a 3.2+ document (or one whose version could not be
-// recognized): [oas32TraversalApplies] gates the walk that finds these objects,
-// so there is no pre-3.2 branch to take here.
+// `dataValue` with `serializedValue` is legal, so no rule pairs those two.
+// [oas32TraversalApplies] gates the walk that reaches here, so there is no
+// pre-3.2 branch to take.
 func (v *Validator) validateExampleValueExclusivity(ex *parser.Example, path string, result *ValidationResult) {
 	if ex == nil {
 		return
@@ -200,21 +161,21 @@ func (v *Validator) validateExampleValueExclusivity(ex *parser.Example, path str
 	if hasData && ex.Value != nil {
 		v.addError(result, path,
 			"Example must not have both dataValue and value; dataValue requires value to be absent",
-			withSpecRef(oas32SpecRef+"#example-object"),
+			withSpecRef(oas32SpecRef+"#fixed-fields-15"),
 			withField("dataValue"),
 		)
 	}
 	if hasSerialized && ex.Value != nil {
 		v.addError(result, path,
 			"Example must not have both serializedValue and value; serializedValue requires value to be absent",
-			withSpecRef(oas32SpecRef+"#example-object"),
+			withSpecRef(oas32SpecRef+"#fixed-fields-15"),
 			withField("serializedValue"),
 		)
 	}
 	if hasSerialized && ex.ExternalValue != "" {
 		v.addError(result, path,
 			"Example must not have both serializedValue and externalValue; serializedValue requires externalValue to be absent",
-			withSpecRef(oas32SpecRef+"#example-object"),
+			withSpecRef(oas32SpecRef+"#fixed-fields-15"),
 			withField("serializedValue"),
 		)
 	}
@@ -263,8 +224,8 @@ func (v *Validator) visitMediaTypeExamples(mt *parser.MediaType, prefix string, 
 	for name, ex := range mt.Examples {
 		v.validateExampleValueExclusivity(ex, prefix+".examples."+name, result)
 	}
-	// Encoding Objects carry Headers, which carry Examples. Reached through the
-	// OAS 3.2 nested encodings too, since an Encoding may now contain Encodings.
+	// Encoding Objects carry Headers, which carry Examples, including through the
+	// nested encodings 3.2 added.
 	for name, enc := range mt.Encoding {
 		v.visitEncodingExamples(enc, prefix+".encoding."+name, result, 0)
 	}
@@ -274,11 +235,9 @@ func (v *Validator) visitMediaTypeExamples(mt *parser.MediaType, prefix string, 
 	}
 }
 
-// maxEncodingNestingDepth bounds the OAS 3.2 recursive Encoding traversal.
-//
-// The parser decodes each level into a fresh value, so a document cannot produce
-// a cyclic Encoding graph — but a depth bound costs nothing and keeps a
-// hand-assembled document from recursing without end.
+// maxEncodingNestingDepth bounds the recursive Encoding traversal 3.2 introduced.
+// A parsed document cannot build a cyclic Encoding graph, but the bound keeps a
+// hand-assembled one from recursing without end.
 const maxEncodingNestingDepth = 100
 
 func (v *Validator) visitEncodingExamples(enc *parser.Encoding, prefix string, result *ValidationResult, depth int) {
@@ -301,8 +260,8 @@ func (v *Validator) visitEncodingExamples(enc *parser.Encoding, prefix string, r
 // Parameter Object: in: "querystring"
 // =============================================================================
 
-// countQueryLocations counts the querystring and query parameters in one list.
-// A $ref parameter contributes to neither: its `in` lives on the definition, and
+// countQueryLocations counts the `querystring` and `query` parameters in one list.
+// A `$ref` parameter counts as neither: its `in` lives on the definition, and
 // guessing would report a conflict that may not exist.
 func countQueryLocations(params []*parser.Parameter) (queryString, query int) {
 	for _, param := range params {
@@ -319,13 +278,14 @@ func countQueryLocations(params []*parser.Parameter) (queryString, query int) {
 	return queryString, query
 }
 
-// reportQueryStringConflicts reports the two interaction rules for one effective
-// parameter list.
+// reportQueryStringConflicts reports the two `querystring` interaction rules for
+// one effective parameter list: at most one, and never alongside `in: "query"`.
+// https://spec.openapis.org/oas/v3.2.0.html#parameter-in
 func (v *Validator) reportQueryStringConflicts(queryString, query int, prefix string, result *ValidationResult) {
 	if queryString > 1 {
 		v.addError(result, prefix,
 			fmt.Sprintf("A querystring parameter must not appear more than once, but %d were found", queryString),
-			withSpecRef(oas32SpecRef+"#parameter-object"),
+			withSpecRef(oas32SpecRef+"#parameter-in"),
 			withField("parameters"),
 		)
 	}
@@ -333,22 +293,18 @@ func (v *Validator) reportQueryStringConflicts(queryString, query int, prefix st
 		v.addError(result, prefix,
 			"A querystring parameter must not appear alongside any 'in: query' parameter "+
 				"in the same operation or its path item",
-			withSpecRef(oas32SpecRef+"#parameter-object"),
+			withSpecRef(oas32SpecRef+"#parameter-in"),
 			withField("parameters"),
 		)
 	}
 }
 
-// validateQueryStringParam enforces the rules a single querystring parameter must
-// satisfy on its own: that it is described with `content` rather than `schema`.
+// validateQueryStringParam enforces what an `in: "querystring"` parameter must
+// satisfy on its own: described with `content`, and none of the schema-form fields
+// present.
+// https://spec.openapis.org/oas/v3.2.0.html#fixed-fields-for-use-with-schema
 //
-// The `schema` prohibition is stated in the spec under "Fixed Fields for use with
-// `schema`" — "These fields MUST NOT be used with in: "querystring"" — and covers
-// style, explode, and allowReserved alongside schema itself.
-//
-// The version this location was introduced in is enforced by the parser's
-// structure validation, which rejects in: "querystring" outright below 3.2, so
-// there is nothing to re-report here.
+// The version gate belongs to the parser, which rejects the location below 3.2.
 func (v *Validator) validateQueryStringParam(param *parser.Parameter, path string, result *ValidationResult) {
 	if param == nil || param.Ref != "" || param.In != parser.ParamInQueryString {
 		return
@@ -357,19 +313,19 @@ func (v *Validator) validateQueryStringParam(param *parser.Parameter, path strin
 	if len(param.Content) == 0 {
 		v.addError(result, path,
 			"A querystring parameter must be specified using the content field",
-			withSpecRef(oas32SpecRef+"#parameter-object"),
+			withSpecRef(oas32SpecRef+"#fixed-fields-for-use-with-schema"),
 			withField("content"),
 		)
 	}
 	if param.Schema != nil {
 		v.addError(result, path,
 			"A querystring parameter must not use schema; the entire query string is described with content",
-			withSpecRef(oas32SpecRef+"#parameter-object"),
+			withSpecRef(oas32SpecRef+"#fixed-fields-for-use-with-schema"),
 			withField("schema"),
 		)
 	}
-	// style, explode, and allowReserved are listed under "Fixed Fields for use
-	// with `schema`" alongside schema itself, so the same prohibition covers them.
+	// Listed alongside `schema` in the section linked above, so the same
+	// prohibition covers them.
 	for _, f := range []struct {
 		name    string
 		present bool
@@ -383,7 +339,7 @@ func (v *Validator) validateQueryStringParam(param *parser.Parameter, path strin
 		}
 		v.addError(result, path,
 			fmt.Sprintf("A querystring parameter must not use %s; that field is for use with schema", f.name),
-			withSpecRef(oas32SpecRef+"#parameter-object"),
+			withSpecRef(oas32SpecRef+"#fixed-fields-for-use-with-schema"),
 			withField(f.name),
 		)
 	}
@@ -400,13 +356,12 @@ func (v *Validator) validateOAS32SchemaFields(schema *parser.Schema, path string
 	v.validateDiscriminatorDefaultMapping(schema, path, result)
 }
 
-// validateXMLNodeType enforces the XML Object's nodeType rules.
+// validateXMLNodeType enforces the XML Object's `nodeType` rules: a value from the
+// closed set, and neither `attribute` nor `wrapped` present alongside it.
+// https://spec.openapis.org/oas/v3.2.0.html#xml-node-type
 //
-// Both bools it supersedes are a hard conflict, not a style preference — the
-// fixed fields table says of each: "If `nodeType` is present, this field MUST NOT
-// be present." That is what makes modeling nodeType as an independent field
-// correct rather than lazy: a document may legally set the bools *or* nodeType,
-// never both, so there is no case where one has to be derived from the other.
+// The two bools are a MUST NOT rather than a preference, which is why the parser
+// models `nodeType` beside them instead of deriving one from the other.
 func (v *Validator) validateXMLNodeType(schema *parser.Schema, path string, result *ValidationResult) {
 	if schema.XML == nil || schema.XML.NodeType == "" {
 		return
@@ -416,7 +371,7 @@ func (v *Validator) validateXMLNodeType(schema *parser.Schema, path string, resu
 	if v.oasVersion.IsValid() && v.oasVersion < parser.OASVersion320 {
 		v.addError(result, xmlPath,
 			fmt.Sprintf("XML nodeType is only supported in OAS 3.2+, but document is version %s", v.oasVersion),
-			withSpecRef(oas32SpecRef+"#xml-object"),
+			withSpecRef(oas32SpecRef+"#xml-node-type"),
 			withField("nodeType"),
 			withValue(schema.XML.NodeType),
 		)
@@ -426,7 +381,7 @@ func (v *Validator) validateXMLNodeType(schema *parser.Schema, path string, resu
 	if !slices.Contains(xmlNodeTypes, schema.XML.NodeType) {
 		v.addError(result, xmlPath,
 			fmt.Sprintf("Invalid XML nodeType %q; must be one of element, attribute, text, cdata, none", schema.XML.NodeType),
-			withSpecRef(oas32SpecRef+"#xml-object"),
+			withSpecRef(oas32SpecRef+"#xml-node-type"),
 			withField("nodeType"),
 			withValue(schema.XML.NodeType),
 		)
@@ -435,36 +390,29 @@ func (v *Validator) validateXMLNodeType(schema *parser.Schema, path string, resu
 	if schema.XML.Attribute {
 		v.addError(result, xmlPath,
 			"XML attribute must not be present when nodeType is present; use nodeType: attribute instead",
-			withSpecRef(oas32SpecRef+"#xml-object"),
+			withSpecRef(oas32SpecRef+"#xml-attribute"),
 			withField("attribute"),
 		)
 	}
 	if schema.XML.Wrapped {
 		v.addError(result, xmlPath,
 			"XML wrapped must not be present when nodeType is present; use nodeType: element instead",
-			withSpecRef(oas32SpecRef+"#xml-object"),
+			withSpecRef(oas32SpecRef+"#xml-wrapped"),
 			withField("wrapped"),
 		)
 	}
 }
 
-// validateDiscriminatorDefaultMapping enforces the conditional requirement the
-// 3.2 spec places on defaultMapping:
+// validateDiscriminatorDefaultMapping enforces that an optional discriminating
+// property requires `defaultMapping`.
+// https://spec.openapis.org/oas/v3.2.0.html#discriminator-default-mapping
 //
-//	The discriminating property MAY be defined as required or optional, but when
-//	defined as an optional property the Discriminator Object MUST include a
-//	`defaultMapping` field […]
+// Reported only where "optional" is locally provable: this schema declares the
+// property and omits it from `required`. When the property lives in `oneOf` or
+// `anyOf` subschemas instead, reporting from here would be a guess, and a false
+// report on a correct document is the worse failure.
 //
-// Reported only when this schema itself declares the discriminating property and
-// omits it from `required`, which is the case where "defined as an optional
-// property" is locally provable. When the property is declared in the subschemas
-// of a oneOf/anyOf instead — the more common shape — its optionality is a property
-// of those subschemas, and reporting from here would mean guessing. Staying
-// silent loses findings; guessing invents them, and a false "must include
-// defaultMapping" on a correct document is the worse failure.
-//
-// Below 3.2 the field does not exist, so a document carrying it is reported as a
-// version error rather than checked.
+// Below 3.2 the field does not exist, so its presence is a version error.
 func (v *Validator) validateDiscriminatorDefaultMapping(schema *parser.Schema, path string, result *ValidationResult) {
 	d := schema.Discriminator
 	if d == nil {
@@ -475,7 +423,7 @@ func (v *Validator) validateDiscriminatorDefaultMapping(schema *parser.Schema, p
 		if v.oasVersion.IsValid() && v.oasVersion < parser.OASVersion320 {
 			v.addError(result, path+".discriminator",
 				fmt.Sprintf("discriminator defaultMapping is only supported in OAS 3.2+, but document is version %s", v.oasVersion),
-				withSpecRef(oas32SpecRef+"#discriminator-object"),
+				withSpecRef(oas32SpecRef+"#discriminator-default-mapping"),
 				withField("defaultMapping"),
 				withValue(d.DefaultMapping),
 			)
@@ -500,7 +448,7 @@ func (v *Validator) validateDiscriminatorDefaultMapping(schema *parser.Schema, p
 
 	v.addError(result, path+".discriminator",
 		fmt.Sprintf("Discriminator must include defaultMapping because the discriminating property '%s' is optional", d.PropertyName),
-		withSpecRef(oas32SpecRef+"#discriminator-object"),
+		withSpecRef(oas32SpecRef+"#discriminator-default-mapping"),
 		withField("defaultMapping"),
 		withValue(d.PropertyName),
 	)

--- a/validator/oas32_test.go
+++ b/validator/oas32_test.go
@@ -1,0 +1,687 @@
+package validator
+
+import (
+	"testing"
+)
+
+// TestOAS32ExampleValueExclusivity covers the Example Object rules from issue
+// #397 item 4. These are the constraints the issue flags as "a validation rule,
+// not just a field": dataValue and serializedValue each forbid siblings.
+func TestOAS32ExampleValueExclusivity(t *testing.T) {
+	tests := []struct {
+		name       string
+		spec       string
+		wantErrors []string
+	}{
+		{
+			name: "dataValue with value",
+			spec: `
+openapi: 3.2.0
+info: {title: T, version: "1.0.0"}
+paths: {}
+components:
+  examples:
+    bad:
+      dataValue: {a: 1}
+      value: {a: 1}
+`,
+			wantErrors: []string{
+				"components.examples.bad: Example must not have both dataValue and value",
+			},
+		},
+		{
+			name: "serializedValue with value",
+			spec: `
+openapi: 3.2.0
+info: {title: T, version: "1.0.0"}
+paths: {}
+components:
+  examples:
+    bad:
+      serializedValue: "a=1"
+      value: {a: 1}
+`,
+			wantErrors: []string{
+				"components.examples.bad: Example must not have both serializedValue and value",
+			},
+		},
+		{
+			name: "serializedValue with externalValue",
+			spec: `
+openapi: 3.2.0
+info: {title: T, version: "1.0.0"}
+paths: {}
+components:
+  examples:
+    bad:
+      serializedValue: "a=1"
+      externalValue: https://example.com/example.txt
+`,
+			wantErrors: []string{
+				"components.examples.bad: Example must not have both serializedValue and externalValue",
+			},
+		},
+		{
+			// The spec's own Example Object example sets both, so no rule may pair
+			// these two. A check that rejected the combination would flag correct
+			// documents.
+			name: "dataValue with serializedValue is legal",
+			spec: `
+openapi: 3.2.0
+info: {title: T, version: "1.0.0"}
+paths: {}
+components:
+  examples:
+    good:
+      dataValue: {a: 1}
+      serializedValue: '{"a":1}'
+`,
+			wantErrors: nil,
+		},
+		{
+			// The traversal that finds Example Objects is gated on 3.2 — see
+			// oas32TraversalApplies for why paying it on every 3.0/3.1 document is
+			// not worth catching a field those versions do not define. A pre-3.2
+			// document carrying dataValue therefore gets no error from this rule.
+			name: "the rules do not run below 3.2",
+			spec: `
+openapi: 3.1.0
+info: {title: T, version: "1.0.0"}
+paths: {}
+components:
+  examples:
+    tooEarly:
+      dataValue: {a: 1}
+      value: {a: 1}
+`,
+			wantErrors: nil,
+		},
+		{
+			// Reached only through the media-type traversal, not through
+			// components.examples, so it proves the traversal covers nested sites.
+			name: "an example inside a response media type is reached",
+			spec: `
+openapi: 3.2.0
+info: {title: T, version: "1.0.0"}
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: {type: object}
+              examples:
+                bad:
+                  dataValue: {a: 1}
+                  value: {a: 1}
+`,
+			wantErrors: []string{
+				"paths./pets.get.responses.200.content.application/json.examples.bad: " +
+					"Example must not have both dataValue and value",
+			},
+		},
+		{
+			// Deepest reachable site: an example on a header of a nested encoding,
+			// which only exists because OAS 3.2 made Encoding recursive.
+			name: "an example under a nested encoding header is reached",
+			spec: `
+openapi: 3.2.0
+info: {title: T, version: "1.0.0"}
+paths:
+  /upload:
+    post:
+      operationId: upload
+      requestBody:
+        content:
+          multipart/form-data:
+            schema: {type: object}
+            encoding:
+              meta:
+                contentType: application/json
+                encoding:
+                  nested:
+                    contentType: text/plain
+                    headers:
+                      X-Trace:
+                        schema: {type: string}
+                        examples:
+                          bad:
+                            dataValue: abc
+                            value: abc
+      responses:
+        "204": {description: No Content}
+`,
+			wantErrors: []string{
+				"paths./upload.post.requestBody.content.multipart/form-data.encoding.meta." +
+					"encoding.nested.headers.X-Trace.examples.bad: " +
+					"Example must not have both dataValue and value",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertErrorsMatch(t, validationErrors(t, tt.spec), tt.wantErrors)
+		})
+	}
+}
+
+// TestOAS32XMLNodeType covers the XML Object rules. The coexistence rules are
+// errors rather than warnings because the 3.2 fixed fields table says of both
+// attribute and wrapped: "If nodeType is present, this field MUST NOT be
+// present."
+func TestOAS32XMLNodeType(t *testing.T) {
+	tests := []struct {
+		name       string
+		spec       string
+		wantErrors []string
+	}{
+		{
+			name: "nodeType with attribute",
+			spec: `
+openapi: 3.2.0
+info: {title: T, version: "1.0.0"}
+paths: {}
+components:
+  schemas:
+    Pet:
+      type: string
+      xml: {nodeType: attribute, attribute: true}
+`,
+			wantErrors: []string{
+				"components.schemas.Pet.xml: XML attribute must not be present when nodeType is present",
+			},
+		},
+		{
+			name: "nodeType with wrapped",
+			spec: `
+openapi: 3.2.0
+info: {title: T, version: "1.0.0"}
+paths: {}
+components:
+  schemas:
+    Pets:
+      type: array
+      items: {type: string}
+      xml: {nodeType: element, wrapped: true}
+`,
+			wantErrors: []string{
+				"components.schemas.Pets.xml: XML wrapped must not be present when nodeType is present",
+			},
+		},
+		{
+			name: "invalid nodeType value",
+			spec: `
+openapi: 3.2.0
+info: {title: T, version: "1.0.0"}
+paths: {}
+components:
+  schemas:
+    Pet:
+      type: string
+      xml: {nodeType: elemental}
+`,
+			wantErrors: []string{
+				`components.schemas.Pet.xml: Invalid XML nodeType "elemental"`,
+			},
+		},
+		{
+			name: "nodeType is rejected before 3.2",
+			spec: `
+openapi: 3.1.0
+info: {title: T, version: "1.0.0"}
+paths: {}
+components:
+  schemas:
+    Pet:
+      type: string
+      xml: {nodeType: attribute}
+`,
+			wantErrors: []string{
+				"components.schemas.Pet.xml: XML nodeType is only supported in OAS 3.2+",
+			},
+		},
+		{
+			name: "each legal nodeType value is accepted",
+			spec: `
+openapi: 3.2.0
+info: {title: T, version: "1.0.0"}
+paths: {}
+components:
+  schemas:
+    A: {type: string, xml: {nodeType: element}}
+    B: {type: string, xml: {nodeType: attribute}}
+    C: {type: string, xml: {nodeType: text}}
+    D: {type: string, xml: {nodeType: cdata}}
+    E: {type: string, xml: {nodeType: none}}
+`,
+			wantErrors: nil,
+		},
+		{
+			// The deprecated bools remain legal on their own — nothing here makes
+			// a pre-3.2 document invalid.
+			name: "attribute and wrapped without nodeType stay legal",
+			spec: `
+openapi: 3.2.0
+info: {title: T, version: "1.0.0"}
+paths: {}
+components:
+  schemas:
+    Pets:
+      type: array
+      items: {type: string}
+      xml: {wrapped: true}
+`,
+			wantErrors: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertErrorsMatch(t, validationErrors(t, tt.spec), tt.wantErrors)
+		})
+	}
+}
+
+// TestOAS32DiscriminatorDefaultMapping covers the conditional requirement:
+// "when defined as an optional property the Discriminator Object MUST include a
+// defaultMapping field".
+//
+// The controls matter more than the positive case here. The rule is only reported
+// where optionality is locally provable, so the cases that must stay silent are
+// what keep it from firing on correct documents.
+func TestOAS32DiscriminatorDefaultMapping(t *testing.T) {
+	tests := []struct {
+		name       string
+		spec       string
+		wantErrors []string
+	}{
+		{
+			name: "optional discriminating property without defaultMapping",
+			spec: `
+openapi: 3.2.0
+info: {title: T, version: "1.0.0"}
+paths: {}
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        petType: {type: string}
+      discriminator:
+        propertyName: petType
+`,
+			wantErrors: []string{
+				"components.schemas.Pet.discriminator: Discriminator must include defaultMapping " +
+					"because the discriminating property 'petType' is optional",
+			},
+		},
+		{
+			name: "required discriminating property needs no defaultMapping",
+			spec: `
+openapi: 3.2.0
+info: {title: T, version: "1.0.0"}
+paths: {}
+components:
+  schemas:
+    Pet:
+      type: object
+      required: [petType]
+      properties:
+        petType: {type: string}
+      discriminator:
+        propertyName: petType
+`,
+			wantErrors: nil,
+		},
+		{
+			name: "optional property with defaultMapping is satisfied",
+			spec: `
+openapi: 3.2.0
+info: {title: T, version: "1.0.0"}
+paths: {}
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        petType: {type: string}
+      discriminator:
+        propertyName: petType
+        defaultMapping: OtherPet
+    OtherPet: {type: object}
+`,
+			wantErrors: nil,
+		},
+		{
+			// The common oneOf shape: the discriminating property is declared in
+			// the subschemas, so its optionality is not knowable here. Staying
+			// silent is deliberate — guessing would flag correct documents.
+			name: "property declared only in subschemas is not reported",
+			spec: `
+openapi: 3.2.0
+info: {title: T, version: "1.0.0"}
+paths: {}
+components:
+  schemas:
+    Pet:
+      oneOf:
+        - $ref: '#/components/schemas/Dog'
+      discriminator:
+        propertyName: petType
+    Dog:
+      type: object
+      required: [petType]
+      properties:
+        petType: {type: string}
+`,
+			wantErrors: nil,
+		},
+		{
+			name: "defaultMapping is rejected before 3.2",
+			spec: `
+openapi: 3.1.0
+info: {title: T, version: "1.0.0"}
+paths: {}
+components:
+  schemas:
+    Pet:
+      type: object
+      required: [petType]
+      properties:
+        petType: {type: string}
+      discriminator:
+        propertyName: petType
+        defaultMapping: OtherPet
+    OtherPet: {type: object}
+`,
+			wantErrors: []string{
+				"components.schemas.Pet.discriminator: discriminator defaultMapping is only supported in OAS 3.2+",
+			},
+		},
+		{
+			// A 3.0/3.1 document with an optional discriminating property must not
+			// be told to add a field its version does not have.
+			name: "the requirement does not apply before 3.2",
+			spec: `
+openapi: 3.1.0
+info: {title: T, version: "1.0.0"}
+paths: {}
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        petType: {type: string}
+      discriminator:
+        propertyName: petType
+`,
+			wantErrors: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertErrorsMatch(t, validationErrors(t, tt.spec), tt.wantErrors)
+		})
+	}
+}
+
+// TestOAS32QueryStringParam covers the three constraints on in: "querystring",
+// including the path-item interaction the spec spells out as "in the same
+// operation (or in the operation's path-item)".
+func TestOAS32QueryStringParam(t *testing.T) {
+	tests := []struct {
+		name       string
+		spec       string
+		wantErrors []string
+	}{
+		{
+			name: "querystring with content is legal",
+			spec: `
+openapi: 3.2.0
+info: {title: T, version: "1.0.0"}
+paths:
+  /search:
+    get:
+      operationId: search
+      parameters:
+        - name: q
+          in: querystring
+          content:
+            application/x-www-form-urlencoded:
+              schema: {type: object}
+      responses:
+        "200": {description: OK}
+`,
+			wantErrors: nil,
+		},
+		{
+			name: "querystring using schema instead of content",
+			spec: `
+openapi: 3.2.0
+info: {title: T, version: "1.0.0"}
+paths:
+  /search:
+    get:
+      operationId: search
+      parameters:
+        - name: q
+          in: querystring
+          schema: {type: string}
+      responses:
+        "200": {description: OK}
+`,
+			wantErrors: []string{
+				"paths./search.get.parameters[0]: A querystring parameter must be specified using the content field",
+				"paths./search.get.parameters[0]: A querystring parameter must not use schema",
+			},
+		},
+		{
+			name: "querystring with style is rejected",
+			spec: `
+openapi: 3.2.0
+info: {title: T, version: "1.0.0"}
+paths:
+  /search:
+    get:
+      operationId: search
+      parameters:
+        - name: q
+          in: querystring
+          style: form
+          content:
+            application/x-www-form-urlencoded:
+              schema: {type: object}
+      responses:
+        "200": {description: OK}
+`,
+			wantErrors: []string{
+				"paths./search.get.parameters[0]: A querystring parameter must not use style",
+			},
+		},
+		{
+			name: "two querystring parameters in one operation",
+			spec: `
+openapi: 3.2.0
+info: {title: T, version: "1.0.0"}
+paths:
+  /search:
+    get:
+      operationId: search
+      parameters:
+        - name: a
+          in: querystring
+          content:
+            application/x-www-form-urlencoded: {schema: {type: object}}
+        - name: b
+          in: querystring
+          content:
+            application/x-www-form-urlencoded: {schema: {type: object}}
+      responses:
+        "200": {description: OK}
+`,
+			wantErrors: []string{
+				"paths./search.get: A querystring parameter must not appear more than once, but 2 were found",
+			},
+		},
+		{
+			name: "querystring alongside query in the same operation",
+			spec: `
+openapi: 3.2.0
+info: {title: T, version: "1.0.0"}
+paths:
+  /search:
+    get:
+      operationId: search
+      parameters:
+        - name: a
+          in: querystring
+          content:
+            application/x-www-form-urlencoded: {schema: {type: object}}
+        - name: limit
+          in: query
+          schema: {type: integer}
+      responses:
+        "200": {description: OK}
+`,
+			wantErrors: []string{
+				"paths./search.get: A querystring parameter must not appear alongside any 'in: query' parameter",
+			},
+		},
+		{
+			// The interaction the spec's "or in the operation's path-item" clause
+			// exists for: neither list contains both, but the effective list does.
+			name: "path-item query with operation querystring conflicts",
+			spec: `
+openapi: 3.2.0
+info: {title: T, version: "1.0.0"}
+paths:
+  /search:
+    parameters:
+      - name: limit
+        in: query
+        schema: {type: integer}
+    get:
+      operationId: search
+      parameters:
+        - name: a
+          in: querystring
+          content:
+            application/x-www-form-urlencoded: {schema: {type: object}}
+      responses:
+        "200": {description: OK}
+`,
+			wantErrors: []string{
+				"paths./search.get: A querystring parameter must not appear alongside any 'in: query' parameter",
+			},
+		},
+		{
+			// A conflict wholly inside the path item's own list is reported once
+			// against the path item, not repeated for each of its operations.
+			name: "a path-item-only conflict is reported once",
+			spec: `
+openapi: 3.2.0
+info: {title: T, version: "1.0.0"}
+paths:
+  /search:
+    parameters:
+      - name: limit
+        in: query
+        schema: {type: integer}
+      - name: a
+        in: querystring
+        content:
+          application/x-www-form-urlencoded: {schema: {type: object}}
+    get:
+      operationId: search
+      responses:
+        "200": {description: OK}
+    post:
+      operationId: searchPost
+      responses:
+        "200": {description: OK}
+`,
+			wantErrors: []string{
+				"paths./search: A querystring parameter must not appear alongside any 'in: query' parameter",
+			},
+		},
+		{
+			// These tests parse with ValidateStructure disabled, so the parser's own
+			// rejection of in: "querystring" below 3.2 does not fire here and the
+			// validator's 3.2 rules are gated off. TestQueryStringLocationVersionGate
+			// covers the version enforcement on the normal parse path.
+			name: "the querystring rules do not run below 3.2",
+			spec: `
+openapi: 3.1.0
+info: {title: T, version: "1.0.0"}
+paths:
+  /search:
+    get:
+      operationId: search
+      parameters:
+        - name: q
+          in: querystring
+          schema: {type: string}
+      responses:
+        "200": {description: OK}
+`,
+			wantErrors: nil,
+		},
+		{
+			// Plain query parameters must be unaffected — the rule only triggers
+			// when a querystring parameter is present.
+			name: "several query parameters without querystring stay legal",
+			spec: `
+openapi: 3.2.0
+info: {title: T, version: "1.0.0"}
+paths:
+  /search:
+    get:
+      operationId: search
+      parameters:
+        - name: limit
+          in: query
+          schema: {type: integer}
+        - name: offset
+          in: query
+          schema: {type: integer}
+      responses:
+        "200": {description: OK}
+`,
+			wantErrors: nil,
+		},
+		{
+			name: "querystring in a reusable path item is checked too",
+			spec: `
+openapi: 3.2.0
+info: {title: T, version: "1.0.0"}
+paths: {}
+components:
+  pathItems:
+    Search:
+      get:
+        operationId: search
+        parameters:
+          - name: q
+            in: querystring
+            schema: {type: string}
+        responses:
+          "200": {description: OK}
+`,
+			wantErrors: []string{
+				"components.pathItems.Search.get.parameters[0]: A querystring parameter must be specified using the content field",
+				"components.pathItems.Search.get.parameters[0]: A querystring parameter must not use schema",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertErrorsMatch(t, validationErrors(t, tt.spec), tt.wantErrors)
+		})
+	}
+}

--- a/validator/schema.go
+++ b/validator/schema.go
@@ -63,6 +63,9 @@ func (v *Validator) validateSchemaWithVisited(schema *parser.Schema, path string
 	// Validate the discriminator meets the varying requirements of each OAS version
 	v.validateDiscriminatorForm(schema, path, result)
 
+	// Validate the OAS 3.2 schema-level fields (xml.nodeType, discriminator.defaultMapping)
+	v.validateOAS32SchemaFields(schema, path, result)
+
 	// Validate required fields
 	v.validateRequiredFields(schema, path, result)
 


### PR DESCRIPTION
## Summary

- Model all 19 OAS [3.2.0](https://spec.openapis.org/oas/v3.2.0.html) fixed fields across 11 objects, which JSON documents were silently losing on round trip
- Validate operations under `components.pathItems`, which previously received no validation at all
- Match `$ref`s whose JSON-Pointer prefix is percent-encoded, so a schema rename no longer leaves them dangling

## Changes

**parser** — the 19 fields, each documented with a link to the section that defines it rather than a restatement of it. Both JSON marshal paths were updated: a field added to the struct alone still vanishes from any object that also carries an `x-` extension, because a non-empty `Extra` sends the type down a hand-built map instead of its struct tags.

**validator** — operation-level rules for `components.pathItems`, and the 3.2 constraints that are more than presence checks:

| Rule | Specification |
|---|---|
| `dataValue`/`serializedValue` exclusivity | [Example Object](https://spec.openapis.org/oas/v3.2.0.html#fixed-fields-15) |
| `nodeType` excludes `attribute` and `wrapped` | [XML Object](https://spec.openapis.org/oas/v3.2.0.html#xml-node-type) |
| `defaultMapping` required for an optional discriminating property | [Discriminator Object](https://spec.openapis.org/oas/v3.2.0.html#discriminator-default-mapping) |
| `in: "querystring"` needs `content`, at most once, never beside `in: "query"` | [Parameter Object](https://spec.openapis.org/oas/v3.2.0.html#parameter-in), [fields for use with schema](https://spec.openapis.org/oas/v3.2.0.html#fixed-fields-for-use-with-schema) |

The `operationId` uniqueness decision for reusable path items is documented at the sweep site: each declaration counts once, however many places `$ref` it.

**fixer, joiner, converter** — `discriminator.defaultMapping` is reference-bearing, so all five rewrite paths handle it alongside `mapping`, and pruning now recognizes the bare-name spelling both fields may use.

**internal/schemautil, joiner** — the XML Object is hashed and compared.

## Context

#397 began as one missing field. Auditing the rest of the 3.2.0 delta against 3.1.1 showed that only four 3.2 features had ever landed — `$self`, `components.mediaTypes`, `additionalOperations`, and `query` — and that 19 fixed fields across 11 objects were unmodeled. Unmodeled fields survive a YAML round trip by accident, because the inline `Extra` map is indiscriminate, and are destroyed on the JSON path, so `oastools fix` deleted spec-conformant content from a valid document and reported success.

Modeling them exposed three further problems, each fixed here:

1. **Downconversion went silent.** Once the fields round trip, they reach targets that have no meaning for them. Only `query` and `additionalOperations` were ever reported, and only when converting to 2.0; a 3.2 to 3.0 conversion emitted every other 3.2 field with no warning. They are now reported and preserved, matching how `nullable`, `if`, and `prefixItems` are already handled.

2. **`defaultMapping` is a reference.** It names a schema exactly as a `mapping` value does, so joining, renaming, and converting all had to learn it or produce dangling references while reporting success.

3. **Deduplication merged schemas that serialize to different XML.** The structural hash omitted the XML Object entirely and the deep comparison ignored it too, so the two gaps hid each other: schemas landed in one bucket, and the verification step that exists to split false positives agreed they were identical. Both halves are fixed, with an end-to-end regression in `joiner`.

Auditing the third of these turned up more than XML: `joiner` ignores 29 of the 65 fields on `parser.Schema`, and six of them merge non-equivalent schemas today. That and the missing version gates are filed rather than expanded into this PR.

## Testing

- Round-trip fixtures in `testdata/oas32-all-fields.{yaml,json}`: the same document in both formats, asserted to parse equal and to survive re-serialization. Every object carries an `x-` extension so the slow marshal path is the one under test, with a companion case that strips them to exercise the fast path.
- Regression tests written to fail without each fix, verified by reverting the fix and observing the failure.
- Generators re-run and confirmed to reproduce the committed output byte for byte.
- Validator benchmarks confirm allocations are unchanged for 3.0 and 3.1 documents (5403 allocs/op on the large fixture, against 5400 before).
- [x] All tests pass (`make check`) — 9368 tests
- [x] Security scan clean (`govulncheck`)

## Related Issues

Fixes #397
Fixes #392
Fixes #408

Follow-ups filed while working on these, deliberately out of scope: #410, #411