### PR TITLE
fix(ci): pin golangci-lint to one version, and fail corpus downloads loudly

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,7 +30,8 @@ jobs:
 
     - name: Install dependencies
       run: |
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh \
+          | sh -s -- -b $(go env GOPATH)/bin "$(grep '^GOLANGCI_VERSION=' Makefile | cut -d= -f2)"
         go install gotest.tools/gotestsum@latest
 
     - name: Run Check (Tidy, Format, Lint, Test)

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,7 +20,11 @@ jobs:
         with:
           go-version: '1.25'
           cache: true
+      # The version comes from the Makefile so it cannot drift from `make lint`.
+      - name: Read pinned golangci-lint version
+        id: lint-version
+        run: echo "version=$(grep '^GOLANGCI_VERSION=' Makefile | cut -d= -f2)" >> "$GITHUB_OUTPUT"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
+          version: ${{ steps.lint-version.outputs.version }}

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,11 @@ MAIN_PATH=./cmd/oastools
 BENCH_DIR=benchmarks
 BENCH_TIME=5s
 
+# The golangci-lint version this repository is checked against. CI installs this
+# exact version in both workflows, so `make lint` and CI cannot disagree. Bumping
+# it is a deliberate, reviewable change; see issue #413 for why it is pinned.
+GOLANGCI_VERSION=v2.12.2
+
 # Allow go commands to automatically download the toolchain version declared in
 # go.mod when the local Go binary is older. This is the portable alternative to
 # pinning GOROOT/PATH to a specific SDK path.
@@ -152,12 +157,26 @@ count-benchmarks:
 .PHONY: lint
 lint:
 	@echo "Running linter..."
-	@if command -v golangci-lint >/dev/null 2>&1; then \
-		golangci-lint run ./...; \
-	else \
-		echo "golangci-lint not installed. Install it from https://golangci-lint.run/usage/install/"; \
+	@if ! command -v golangci-lint >/dev/null 2>&1; then \
+		echo "golangci-lint not installed. Install $(GOLANGCI_VERSION) with:"; \
+		echo "  make lint-install"; \
 		exit 1; \
 	fi
+	@installed=$$(golangci-lint --version 2>/dev/null | grep -oE 'version [0-9]+\.[0-9]+\.[0-9]+' | cut -d' ' -f2); \
+	if [ "v$$installed" != "$(GOLANGCI_VERSION)" ]; then \
+		echo "golangci-lint v$$installed is installed, but this repository pins $(GOLANGCI_VERSION)."; \
+		echo "Findings will not match CI. Install the pinned version with:"; \
+		echo "  make lint-install"; \
+		exit 1; \
+	fi
+	@golangci-lint run ./...
+
+## lint-install: Install the pinned golangci-lint version
+.PHONY: lint-install
+lint-install:
+	@echo "Installing golangci-lint $(GOLANGCI_VERSION)..."
+	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh \
+		| sh -s -- -b $$(go env GOPATH)/bin $(GOLANGCI_VERSION)
 
 ## fmt: Format code
 .PHONY: fmt
@@ -441,25 +460,25 @@ corpus-download:
 	@echo "Downloading corpus specifications..."
 	@mkdir -p testdata/corpus
 	@echo "  Downloading Petstore (OAS 2.0)..."
-	@curl -sL -o testdata/corpus/petstore-swagger.json "https://petstore.swagger.io/v2/swagger.json"
+	@curl -sSL --fail -o testdata/corpus/petstore-swagger.json "https://petstore.swagger.io/v2/swagger.json"
 	@echo "  Downloading DigitalOcean (OAS 3.0.0, bundled)..."
-	@curl -sL -o testdata/corpus/digitalocean-public.v2.yaml "https://api-engineering.nyc3.digitaloceanspaces.com/spec-ci/DigitalOcean-public.v2.yaml"
+	@curl -sSL --fail -o testdata/corpus/digitalocean-public.v2.yaml "https://api-engineering.nyc3.digitaloceanspaces.com/spec-ci/DigitalOcean-public.v2.yaml"
 	@echo "  Downloading Asana (OAS 3.0.0)..."
-	@curl -sL -o testdata/corpus/asana-oas.yaml "https://raw.githubusercontent.com/Asana/openapi/master/defs/asana_oas.yaml"
+	@curl -sSL --fail -o testdata/corpus/asana-oas.yaml "https://raw.githubusercontent.com/Asana/openapi/master/defs/asana_oas.yaml"
 	@echo "  Downloading Google Maps (OAS 3.0.3)..."
-	@curl -sL -o testdata/corpus/google-maps-platform.json "https://raw.githubusercontent.com/googlemaps/openapi-specification/main/dist/google-maps-platform-openapi3.json"
+	@curl -sSL --fail -o testdata/corpus/google-maps-platform.json "https://raw.githubusercontent.com/googlemaps/openapi-specification/main/dist/google-maps-platform-openapi3.json"
 	@echo "  Downloading US NWS (OAS 3.0.3)..."
-	@curl -sL -o testdata/corpus/nws-openapi.json "https://api.weather.gov/openapi.json"
+	@curl -sSL --fail -o testdata/corpus/nws-openapi.json "https://api.weather.gov/openapi.json"
 	@echo "  Downloading Plaid (OAS 3.0.0)..."
-	@curl -sL -o testdata/corpus/plaid-2020-09-14.yml "https://raw.githubusercontent.com/plaid/plaid-openapi/master/2020-09-14.yml"
+	@curl -sSL --fail -o testdata/corpus/plaid-2020-09-14.yml "https://raw.githubusercontent.com/plaid/plaid-openapi/master/2020-09-14.yml"
 	@echo "  Downloading Discord (OAS 3.1.0)..."
-	@curl -sL -o testdata/corpus/discord-openapi.json "https://raw.githubusercontent.com/discord/discord-api-spec/main/specs/openapi.json"
+	@curl -sSL --fail -o testdata/corpus/discord-openapi.json "https://raw.githubusercontent.com/discord/discord-api-spec/main/specs/openapi.json"
 	@echo "  Downloading GitHub (OAS 3.0.3)..."
-	@curl -sL -o testdata/corpus/github-api.json "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json"
+	@curl -sSL --fail -o testdata/corpus/github-api.json "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json"
 	@echo "  Downloading Stripe (OAS 3.0.0, large)..."
-	@curl -sL -o testdata/corpus/stripe-spec3.json "https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json"
+	@curl -sSL --fail -o testdata/corpus/stripe-spec3.json "https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json"
 	@echo "  Downloading Microsoft Graph (OAS 3.0.4, large)..."
-	@curl -sL -o testdata/corpus/msgraph-openapi.yaml "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/openapi/v1.0/openapi.yaml"
+	@curl -sSL --fail -o testdata/corpus/msgraph-openapi.yaml "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/openapi/v1.0/openapi.yaml"
 	@echo "Corpus download complete!"
 	@echo ""
 	@ls -lh testdata/corpus/


### PR DESCRIPTION
## Summary

- Pin golangci-lint in one place, consumed by `make lint` and both CI workflows, so local checks predict CI
- Refuse to lint with a mismatched version instead of silently producing different findings
- Add `--fail` to the corpus downloads so an HTTP error aborts rather than writing the error body as a spec

## Changes

**One pinned version.** `GOLANGCI_VERSION` in the Makefile is the source; `golangci-lint.yml` and `go.yml` both read it out of the Makefile rather than restating it, so the three cannot drift apart again.

**`make lint` fails closed.** It previously ran whatever was on `PATH`:

```
$ make lint
golangci-lint v2.7.2 is installed, but this repository pins v2.12.2.
Findings will not match CI. Install the pinned version with:
  make lint-install
```

**`--fail` on all ten corpus downloads.** Demonstrated against a 404:

| | exit | file written |
|---|---|---|
| `curl -sL` | 0 | yes, containing `404: Not Found` |
| `curl -sSL --fail` | 22 | no |

## Context

#412 passed `make check` locally and failed CI on `goconst`. The cause was version drift: the newer linter tallies occurrences in `_test.go` files that `.golangci.yml` excludes from reporting, so the same code produced 2 occurrences locally and 6 in CI. Nothing in the repository pinned a version, and two of the three resolutions tracked "latest", so the result could change between runs with no repository change at all.

The Google Maps 404 in #391 has since resolved upstream, so this is prevention rather than repair: without `--fail`, the next transient error silently poisons the corpus again, and the failure surfaces as a misleading parser error.

Verified at the pinned version before committing to it: **0 issues**, so no cleanup rides along.

## Testing

- `make lint` refuses on a mismatched version, and passes once `make lint-install` runs
- `--fail` behavior confirmed against a real 404 (above)
- [x] All tests pass (`make check`) — 9378 tests
- [x] Linter clean at the pinned version

## Related Issues

Fixes #413
Fixes #391