### PR TITLE
fix(joiner): stop the nil-schema panic in deep comparison

### DIFF
--- a/internal/driftguard/equivalence_test.go
+++ b/internal/driftguard/equivalence_test.go
@@ -67,3 +67,101 @@ func TestEqualsReadsEveryStructuralSchemaField(t *testing.T) {
 		})
 	}
 }
+
+// TestDeepComparisonSurvivesNilNestedSchemas covers the class behind issue #417
+// rather than the individual sites that issue lists. Populating every
+// nested-schema field with a nil in turn is what keeps the next nested walk added
+// from reintroducing it.
+func TestDeepComparisonSurvivesNilNestedSchemas(t *testing.T) {
+	// Both schemas carry a type and a property so neither is the empty schema,
+	// which compareDeep rejects for unrelated reasons.
+	base := func() *parser.Schema {
+		return &parser.Schema{
+			Type:       "object",
+			Properties: map[string]*parser.Schema{"p": {Type: "string"}},
+		}
+	}
+	present := &parser.Schema{Type: "string"}
+
+	// Every Schema field that can hold a nested schema, by the shape that holds it.
+	nilIn := map[string]func(*parser.Schema, bool){
+		"properties":            func(s *parser.Schema, nilled bool) { s.Properties = schemaMapEntry(nilled, present) },
+		"patternProperties":     func(s *parser.Schema, nilled bool) { s.PatternProperties = schemaMapEntry(nilled, present) },
+		"dependentSchemas":      func(s *parser.Schema, nilled bool) { s.DependentSchemas = schemaMapEntry(nilled, present) },
+		"$defs":                 func(s *parser.Schema, nilled bool) { s.Defs = schemaMapEntry(nilled, present) },
+		"allOf":                 func(s *parser.Schema, nilled bool) { s.AllOf = schemaSliceEntry(nilled, present) },
+		"anyOf":                 func(s *parser.Schema, nilled bool) { s.AnyOf = schemaSliceEntry(nilled, present) },
+		"oneOf":                 func(s *parser.Schema, nilled bool) { s.OneOf = schemaSliceEntry(nilled, present) },
+		"prefixItems":           func(s *parser.Schema, nilled bool) { s.PrefixItems = schemaSliceEntry(nilled, present) },
+		"not":                   func(s *parser.Schema, nilled bool) { s.Not = schemaPointer(nilled, present) },
+		"contains":              func(s *parser.Schema, nilled bool) { s.Contains = schemaPointer(nilled, present) },
+		"propertyNames":         func(s *parser.Schema, nilled bool) { s.PropertyNames = schemaPointer(nilled, present) },
+		"if":                    func(s *parser.Schema, nilled bool) { s.If = schemaPointer(nilled, present) },
+		"then":                  func(s *parser.Schema, nilled bool) { s.Then = schemaPointer(nilled, present) },
+		"else":                  func(s *parser.Schema, nilled bool) { s.Else = schemaPointer(nilled, present) },
+		"contentSchema":         func(s *parser.Schema, nilled bool) { s.ContentSchema = schemaPointer(nilled, present) },
+		"items":                 func(s *parser.Schema, nilled bool) { s.Items = schemaOrBool(nilled, present) },
+		"additionalItems":       func(s *parser.Schema, nilled bool) { s.AdditionalItems = schemaOrBool(nilled, present) },
+		"additionalProperties":  func(s *parser.Schema, nilled bool) { s.AdditionalProperties = schemaOrBool(nilled, present) },
+		"unevaluatedItems":      func(s *parser.Schema, nilled bool) { s.UnevaluatedItems = schemaOrBool(nilled, present) },
+		"unevaluatedProperties": func(s *parser.Schema, nilled bool) { s.UnevaluatedProperties = schemaOrBool(nilled, present) },
+	}
+
+	for field, set := range nilIn {
+		t.Run(field, func(t *testing.T) {
+			nilled, populated := base(), base()
+			set(nilled, true)
+			set(populated, false)
+
+			// The assertion is that these return at all. A panic here is the bug.
+			assert.NotPanics(t, func() {
+				result := joiner.CompareSchemas(nilled, populated, joiner.EquivalenceModeDeep)
+				assert.False(t, result.Equivalent,
+					"a nil %s against a populated one is a difference", field)
+			})
+
+			assert.NotPanics(t, func() {
+				bothNil := base()
+				set(bothNil, true)
+				other := base()
+				set(other, true)
+				assert.True(t, joiner.CompareSchemas(bothNil, other, joiner.EquivalenceModeDeep).Equivalent,
+					"two schemas both holding a nil %s are equivalent", field)
+			})
+		})
+	}
+}
+
+// schemaMapEntry returns a one-entry schema map whose value is nil or present.
+func schemaMapEntry(nilled bool, present *parser.Schema) map[string]*parser.Schema {
+	if nilled {
+		return map[string]*parser.Schema{"a": nil}
+	}
+	return map[string]*parser.Schema{"a": present}
+}
+
+// schemaSliceEntry returns a one-element schema slice holding nil or present.
+func schemaSliceEntry(nilled bool, present *parser.Schema) []*parser.Schema {
+	if nilled {
+		return []*parser.Schema{nil}
+	}
+	return []*parser.Schema{present}
+}
+
+// schemaPointer returns nil or present.
+func schemaPointer(nilled bool, present *parser.Schema) *parser.Schema {
+	if nilled {
+		return nil
+	}
+	return present
+}
+
+// schemaOrBool returns a typed nil or a present schema, in the `any` a
+// schema-or-bool field is declared as. A typed nil is the shape that passes an
+// interface nil check and still dereferences to nothing.
+func schemaOrBool(nilled bool, present *parser.Schema) any {
+	if nilled {
+		return (*parser.Schema)(nil)
+	}
+	return present
+}

--- a/joiner/equivalence.go
+++ b/joiner/equivalence.go
@@ -510,18 +510,10 @@ func compareSchemaMaps(
 	}
 	path.push(field)
 	for name, leftValue := range left {
-		// compareDeep dereferences both operands with no nil guard of its own, and a
-		// map may hold a nil value for a present key: `patternProperties: {"^a": }`
-		// parses that way.
-		rightValue := right[name]
-		if leftValue == nil || rightValue == nil {
-			if (leftValue == nil) != (rightValue == nil) {
-				result.record(path, name, leftValue != nil, rightValue != nil, field+" entry presence mismatch")
-			}
-			continue
-		}
+		// A nil entry needs no guard here: compareDeep checks its own operands and
+		// records at this path.
 		path.push(name)
-		compareDeep(leftValue, rightValue, path, result, visited, compareDocs)
+		compareDeep(leftValue, right[name], path, result, visited, compareDocs)
 		path.pop()
 	}
 	path.pop()
@@ -762,6 +754,23 @@ func compareShallow(left, right *parser.Schema, path *comparePath, result *Equiv
 
 // compareDeep recursively compares all schema properties
 func compareDeep(left, right *parser.Schema, path *comparePath, result *EquivalenceResult, visited map[pointerPair]bool, compareDocs bool) {
+	// Everything below dereferences both operands, and a nested schema can
+	// legitimately be nil. Guarded here rather than at the fourteen call sites so a
+	// new nested walk cannot miss it, and recorded at the caller's path, which
+	// already names the field. Issue #417 has the reachable cases; #416 spot-fixed
+	// two of them before this replaced that approach.
+	if left == nil || right == nil {
+		if left != right {
+			result.Differences = append(result.Differences, SchemaDifference{
+				Path:        path.String(),
+				LeftValue:   left != nil,
+				RightValue:  right != nil,
+				Description: "schema presence mismatch",
+			})
+		}
+		return
+	}
+
 	// Check for circular references
 	pair := pointerPair{
 		left:  reflect.ValueOf(left).Pointer(),
@@ -1273,14 +1282,8 @@ func compareSchemaOrBool(field string, left, right any, path *comparePath, resul
 	leftSchema, leftIsSchema := left.(*parser.Schema)
 	rightSchema, rightIsSchema := right.(*parser.Schema)
 	if leftIsSchema && rightIsSchema {
-		// A typed nil passes the interface nil checks above and asserts cleanly, so
-		// the pointer itself has to be tested before compareDeep dereferences it.
-		if leftSchema == nil || rightSchema == nil {
-			if leftSchema != rightSchema {
-				result.record(path, field, leftSchema != nil, rightSchema != nil, field+" presence mismatch")
-			}
-			return
-		}
+		// A typed nil passes the interface nil checks above and asserts cleanly.
+		// compareDeep catches it and records at this path.
 		path.push(field)
 		compareDeep(leftSchema, rightSchema, path, result, visited, compareDocs)
 		path.pop()

--- a/joiner/equivalence_test.go
+++ b/joiner/equivalence_test.go
@@ -1462,6 +1462,12 @@ func TestCompareSchemas_XMLEquivalent(t *testing.T) {
 // nested walk has to keep nils away from it. `patternProperties: {"^a": }` parses
 // to a nil entry, and a caller can store a typed nil `(*parser.Schema)(nil)` in
 // additionalItems, which passes an interface nil check and asserts cleanly.
+// Issues #416 and #417 have the rest.
+//
+// Cases are one-directional except for properties, which is checked both ways
+// because compareSchemaMaps ranges over the left map alone. The guard itself is
+// symmetric, so the remaining fields would report the same verdict at the same
+// path reversed.
 func TestCompareSchemas_NilNestedSchemas(t *testing.T) {
 	base := func() map[string]*parser.Schema {
 		return map[string]*parser.Schema{"p": {Type: "string"}}
@@ -1491,6 +1497,65 @@ func TestCompareSchemas_NilNestedSchemas(t *testing.T) {
 			name:       "both entries nil",
 			left:       &parser.Schema{Type: "object", Properties: base(), Defs: map[string]*parser.Schema{"A": nil}},
 			right:      &parser.Schema{Type: "object", Properties: base(), Defs: map[string]*parser.Schema{"A": nil}},
+			equivalent: true,
+		},
+		{
+			name: "nil properties entry against a present one",
+			left: &parser.Schema{Type: "object", Properties: map[string]*parser.Schema{
+				"p": {Type: "string"}, "name": nil}},
+			right: &parser.Schema{Type: "object", Properties: map[string]*parser.Schema{
+				"p": {Type: "string"}, "name": {Type: "string"}}},
+			equivalent: false,
+			wantPath:   "properties.name",
+		},
+		{
+			name: "present properties entry against a nil one",
+			left: &parser.Schema{Type: "object", Properties: map[string]*parser.Schema{
+				"p": {Type: "string"}, "name": {Type: "string"}}},
+			right: &parser.Schema{Type: "object", Properties: map[string]*parser.Schema{
+				"p": {Type: "string"}, "name": nil}},
+			equivalent: false,
+			wantPath:   "properties.name",
+		},
+		{
+			name:       "nil dependentSchemas entry against a present one",
+			left:       &parser.Schema{Type: "object", Properties: base(), DependentSchemas: map[string]*parser.Schema{"a": nil}},
+			right:      &parser.Schema{Type: "object", Properties: base(), DependentSchemas: map[string]*parser.Schema{"a": {Type: "string"}}},
+			equivalent: false,
+			wantPath:   "dependentSchemas.a",
+		},
+		{
+			name:       "nil allOf element against a present one",
+			left:       &parser.Schema{Type: "object", Properties: base(), AllOf: []*parser.Schema{nil}},
+			right:      &parser.Schema{Type: "object", Properties: base(), AllOf: []*parser.Schema{{Type: "string"}}},
+			equivalent: false,
+			wantPath:   "allOf.[0]",
+		},
+		{
+			name:       "nil anyOf element against a present one",
+			left:       &parser.Schema{Type: "object", Properties: base(), AnyOf: []*parser.Schema{nil}},
+			right:      &parser.Schema{Type: "object", Properties: base(), AnyOf: []*parser.Schema{{Type: "string"}}},
+			equivalent: false,
+			wantPath:   "anyOf.[0]",
+		},
+		{
+			name:       "nil oneOf element against a present one",
+			left:       &parser.Schema{Type: "object", Properties: base(), OneOf: []*parser.Schema{nil}},
+			right:      &parser.Schema{Type: "object", Properties: base(), OneOf: []*parser.Schema{{Type: "string"}}},
+			equivalent: false,
+			wantPath:   "oneOf.[0]",
+		},
+		{
+			name:       "nil prefixItems element against a present one",
+			left:       &parser.Schema{Type: "array", Properties: base(), PrefixItems: []*parser.Schema{nil}},
+			right:      &parser.Schema{Type: "array", Properties: base(), PrefixItems: []*parser.Schema{{Type: "string"}}},
+			equivalent: false,
+			wantPath:   "prefixItems.[0]",
+		},
+		{
+			name:       "both allOf elements nil",
+			left:       &parser.Schema{Type: "object", Properties: base(), AllOf: []*parser.Schema{nil}},
+			right:      &parser.Schema{Type: "object", Properties: base(), AllOf: []*parser.Schema{nil}},
 			equivalent: true,
 		},
 		{

--- a/joiner/nil_schema_regression_test.go
+++ b/joiner/nil_schema_regression_test.go
@@ -1,0 +1,87 @@
+package joiner
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erraggy/oastools/parser"
+)
+
+// TestSemanticDedup_NilPropertyValue is the regression for issue #417, at the
+// level it was reported: a valid document, parsed, joined with semantic
+// deduplication. That issue covers why both documents have to carry the same nil
+// before the comparison ever reaches it.
+//
+// Parsed rather than hand-built, since the point is that an ordinary document
+// produces this shape without the caller doing anything unusual.
+func TestSemanticDedup_NilPropertyValue(t *testing.T) {
+	specA := []byte(`
+openapi: 3.1.0
+info:
+  title: API a
+  version: "1.0.0"
+paths: {}
+components:
+  schemas:
+    Thinga:
+      type: object
+      properties:
+        name:
+`)
+	specB := []byte(`
+openapi: 3.1.0
+info:
+  title: API b
+  version: "1.0.0"
+paths: {}
+components:
+  schemas:
+    Thingb:
+      type: object
+      properties:
+        name:
+`)
+
+	// A nil error does not mean a clean parse: collected errors ride on Errors,
+	// which JoinParsed rejects. Checked here so a bad fixture reports as one.
+	p := parser.New()
+	docA, err := p.ParseBytes(specA)
+	require.NoError(t, err)
+	require.Empty(t, docA.Errors)
+	docB, err := p.ParseBytes(specB)
+	require.NoError(t, err)
+	require.Empty(t, docB.Errors)
+
+	// Distinct source paths, so the join does not warn about generic names and
+	// bury the thing under test.
+	docA.SourcePath = "crash-a.yaml"
+	docB.SourcePath = "crash-b.yaml"
+
+	parsedA, ok := docA.OAS3Document()
+	require.True(t, ok)
+	schemas := parsedA.Components.Schemas
+	require.Contains(t, schemas, "Thinga")
+	require.Contains(t, schemas["Thinga"].Properties, "name",
+		"the parse must keep the empty property as a present key, or this test proves nothing")
+	require.Nil(t, schemas["Thinga"].Properties["name"],
+		"the empty property must parse to a nil schema, or this test proves nothing")
+
+	j := New(JoinerConfig{SemanticDeduplication: true})
+
+	// Before the guard moved into compareDeep this panicked rather than failing.
+	var result *JoinResult
+	require.NotPanics(t, func() {
+		result, err = j.JoinParsed([]parser.ParseResult{*docA, *docB})
+	})
+	require.NoError(t, err)
+	joinedDoc, ok := result.Document.(*parser.OAS3Document)
+	require.True(t, ok)
+
+	// The two schemas are genuinely equivalent, so deduplication should still do
+	// its job: surviving the nil is not the same as treating it as a difference.
+	joined := joinedDoc.Components.Schemas
+	assert.Len(t, joined, 1,
+		"two identical schemas differing only in name should deduplicate to one")
+}


### PR DESCRIPTION
`oastools join --semantic-dedup` panicked on a valid document. 💥

```yaml
components:
  schemas:
    Thing:
      type: object
      properties:
        name:
```

`properties: {name:}` is legal YAML and parses to a present key with a nil value. `compareDeep` dereferenced both operands immediately, so comparing two such schemas segfaulted.

Fixes #417

## The fix

`CompareSchemasWithOptions` guards its own two arguments, but nothing re-guarded the recursion — so all fourteen nested walks that can produce a nil were exposed. #416 patched two of them where they were found; that approach makes correctness something each *future* nested walk has to re-derive.

One guard at the top of `compareDeep` instead, and the two spot fixes revert to plain calls. A nil against a present schema is recorded as a difference at the caller's path, which already names the field or entry, so diagnostics land exactly where they did before. Two nils are equivalent.

The `*Schema` pointer fields — `not`, `if`, `then`, `else`, `contains`, `propertyNames`, `contentSchema` — each carry their own presence check with a field-specific message and are untouched. They aren't the bug, and rewriting them would change existing diagnostic strings for no correctness gain. The central guard sits under them as a backstop. That seven-fold duplication is what #418 is filed for.

## Verification

Every test here was run twice — once with the fix, once with it stripped out:

| Suite | Without the fix |
|---|---|
| `internal/driftguard` nested-nil cases | 13 of 20 fail |
| `joiner` public-API table | panics |
| `join --semantic-dedup` CLI repro | segfault |

A test that has never been observed failing asserts that the code compiles, not that the bug is fixed — and `assert.NotPanics` is especially prone to passing vacuously, since a function that returns early for the wrong reason also doesn't panic.

The seven that pass without the fix are precisely the pointer fields listed above, which confirms the boundary rather than undermining it.

## Coverage

- **[internal/driftguard](internal/driftguard/equivalence_test.go)** — all 20 nested-schema fields populated with a nil in turn, so the *class* can't return via a field added later
- **[joiner/equivalence_test.go](joiner/equivalence_test.go)** — 8 rows added to the table #416 started, covering the sites #417 names with their exact diagnostic paths
- **[joiner/nil_schema_regression_test.go](joiner/nil_schema_regression_test.go)** — the reported scenario end to end: parse → join → dedup

The integration test parses real YAML rather than building structs, because the claim under test is that an *ordinary document* produces this shape. It asserts the nil parse actually happened before asserting anything else, so it can't silently stop covering the bug if parsing changes. Dedup still consolidates the two schemas to one — surviving a nil is not the same as treating it as a difference.

## Checks

`make check` green — 10243 tests, no lint or gopls findings. CodeRabbit CLI run pre-push: no critical or warning findings; one minor applied, one skipped with the reasoning recorded in the test file.