### PR TITLE
fix(validator): report OAS 3.2 fields used by documents that predate them

### DIFF
--- a/validator/oas3.go
+++ b/validator/oas3.go
@@ -69,6 +69,7 @@ func (v *Validator) validateOAS3(doc *parser.OAS3Document, result *ValidationRes
 
 	// Validate the OAS 3.2 cross-field constraints (see oas32.go)
 	v.validateOAS32Document(doc, result)
+	v.validateOAS32FieldsNotYetIntroduced(doc, result)
 
 	// Validate all $ref values point to valid components
 	v.validateOAS3Refs(doc, result, baseURL)

--- a/validator/oas32_gate.go
+++ b/validator/oas32_gate.go
@@ -1,7 +1,7 @@
 // oas32_gate.go reports OAS 3.2.0 fixed fields used by a document that predates
-// them. The rules in oas32.go run at 3.2 and above, where these fields are legal;
-// this file is the complement, running below 3.2 where their presence is itself
-// the defect. Issue #411 has the field inventory.
+// them — the complement of oas32.go, which runs at 3.2 and above where the same
+// fields are legal. Issue #411 has the inventory; each report below deep-links
+// the object that owns the field.
 //
 // https://spec.openapis.org/oas/v3.2.0.html
 
@@ -15,30 +15,41 @@ import (
 	"github.com/erraggy/oastools/parser"
 )
 
-// oas32FieldGateApplies reports whether a document is old enough for the 3.2
-// fixed fields to be errors. The exact complement of [oas32TraversalApplies]: an
-// unrecognized version is checked by the 3.2 rules and left alone here, since
-// calling a field too new requires a version for it to be too new than.
+// oas32FieldGateApplies reports whether a document predates the 3.2 fixed fields.
+// The exact complement of [oas32TraversalApplies], which keeps the unrecognized
+// versions: calling a field too new needs a version to measure it against.
 func oas32FieldGateApplies(version parser.OASVersion) bool {
 	return version.IsValid() && version < parser.OASVersion320
 }
 
-// gateSeg is one path segment. A negative index marks the segment as unindexed,
-// which defers formatting the number until there is something to report.
+// Each field's report links the object that defines it, so the error says where
+// to read rather than restating the specification here.
+const (
+	refOpenAPI        = oas32SpecRef + "#openapi-object"
+	refComponents     = oas32SpecRef + "#components-object"
+	refPathItem       = oas32SpecRef + "#path-item-object"
+	refTag            = oas32SpecRef + "#tag-object"
+	refServer         = oas32SpecRef + "#server-object"
+	refResponse       = oas32SpecRef + "#response-object"
+	refMediaType      = oas32SpecRef + "#media-type-object"
+	refEncoding       = oas32SpecRef + "#encoding-object"
+	refExample        = oas32SpecRef + "#example-object"
+	refSecurityScheme = oas32SpecRef + "#security-scheme-object"
+	refOAuthFlows     = oas32SpecRef + "#oauth-flows-object"
+	refOAuthFlow      = oas32SpecRef + "#oauth-flow-object"
+)
+
+// gateSeg is one path segment. A negative index means unindexed, so the number is
+// formatted only when there is something to report.
 type gateSeg struct {
 	name  string
 	index int
 }
 
-// gatePath accumulates a JSON path without building one.
-//
-// The walk below reaches every media type, encoding and example in the document
-// — the traversal [oas32TraversalApplies] declines to pay for at 3.0 and 3.1,
-// measured at roughly 20% more validator allocations when path strings are built
-// eagerly. Concatenating nothing keeps that cost off the common document:
-// segments push and pop by value, and the join happens only where a violation is
-// reported. Almost no pre-3.2 document carries a 3.2 field, so almost no document
-// reaches it at all.
+// gatePath accumulates a JSON path without building one. Building it eagerly cost
+// roughly 20% more validator allocations — see [oas32TraversalApplies] — so
+// segments push and pop by value and the join happens only where a violation is
+// reported, which on a real pre-3.2 document is nowhere.
 type gatePath struct {
 	segs []gateSeg
 }
@@ -71,16 +82,12 @@ func (p *gatePath) String() string {
 	return b.String()
 }
 
-// maxPathItemNestingDepth bounds the recursive Path Item traversal. A callback
-// holds path items, whose operations hold callbacks, so the graph can close a
-// loop. A parsed document cannot build one — the same reasoning as
-// [maxEncodingNestingDepth] — but ValidateParsed takes a caller-supplied
-// document, and a hand-assembled cycle should not recurse without end.
+// maxPathItemNestingDepth bounds the recursive Path Item traversal, which a
+// callback can close into a loop. Same reasoning as [maxEncodingNestingDepth]: a
+// parsed document cannot build one, but ValidateParsed takes the caller's.
 const maxPathItemNestingDepth = 100
 
-// oas32Gate carries the walk state. The version and result travel on the struct
-// rather than through every signature, since every method needs both and none
-// changes either.
+// oas32Gate carries the walk state, so it stays off every method signature.
 type oas32Gate struct {
 	v       *Validator
 	version parser.OASVersion
@@ -93,15 +100,13 @@ type oas32Gate struct {
 // validateOAS32FieldsNotYetIntroduced reports every 3.2 fixed field found in a
 // pre-3.2 document. Conversion already reports these when downgrading a target
 // (`detectOAS32Features`), so validation staying silent on the result was the
-// inconsistency worth closing.
+// inconsistency #411 set out to close.
 func (v *Validator) validateOAS32FieldsNotYetIntroduced(doc *parser.OAS3Document, result *ValidationResult) {
 	if doc == nil || !oas32FieldGateApplies(doc.OASVersion) {
 		return
 	}
-	// Sized past the deepest path the walk builds — components, section, name,
-	// method, responses, code, content, media type, encoding — so the segment
-	// stack does not reallocate as it grows. That growth was the walk's only
-	// measured allocation: three or four per document, whatever its size.
+	// Sized past the deepest path the walk builds, so the segment stack does not
+	// reallocate. Its growth was the walk's only measured allocation.
 	g := &oas32Gate{
 		v:       v,
 		version: doc.OASVersion,
@@ -109,11 +114,9 @@ func (v *Validator) validateOAS32FieldsNotYetIntroduced(doc *parser.OAS3Document
 		path:    gatePath{segs: make([]gateSeg, 0, 16)},
 	}
 
-	// The walk ranges over maps, whose order Go randomizes, so the same document
-	// reported its errors in a different order on each run. Sorting the errors
-	// afterwards rather than sorting every map's keys during the walk keeps the
-	// cost where the disorder is: a clean document sorts an empty range and
-	// allocates nothing, which is the whole point of the lazy path above.
+	// Map order is randomized, so the same document reported its errors in a
+	// different order each run. Sorting afterwards rather than sorting every map's
+	// keys during the walk leaves a clean document sorting an empty range.
 	first := len(result.Errors)
 	g.document(doc)
 	added := result.Errors[first:]
@@ -125,26 +128,25 @@ func (v *Validator) validateOAS32FieldsNotYetIntroduced(doc *parser.OAS3Document
 	})
 }
 
-// report names the field and the version that does not have it.
-func (g *oas32Gate) report(field string) {
+// report names the field, the version lacking it, and the object defining it.
+func (g *oas32Gate) report(field, ref string) {
 	g.v.addError(g.result, g.path.String(),
 		field+" was introduced in OpenAPI 3.2.0, but this document declares "+g.version.String(),
-		withSpecRef(oas32SpecRef),
+		withSpecRef(ref),
 		withField(field),
 	)
 }
 
-// reportIn pushes one segment, reports, and pops. For the common case of a field
-// sitting directly under the object the walk is already positioned on.
-func (g *oas32Gate) reportIn(segment, field string) {
+// reportIn reports a field sitting directly under the object the walk is on.
+func (g *oas32Gate) reportIn(segment, field, ref string) {
 	g.path.push(segment)
-	g.report(field)
+	g.report(field, ref)
 	g.path.pop()
 }
 
 func (g *oas32Gate) document(doc *parser.OAS3Document) {
 	if doc.Self != "" {
-		g.reportIn("$self", "$self")
+		g.reportIn("$self", "$self", refOpenAPI)
 	}
 
 	g.servers(doc.Servers)
@@ -155,13 +157,13 @@ func (g *oas32Gate) document(doc *parser.OAS3Document) {
 		}
 		g.path.pushIndex("tags", i)
 		if tag.Summary != "" {
-			g.reportIn("summary", "summary")
+			g.reportIn("summary", "summary", refTag)
 		}
 		if tag.Parent != "" {
-			g.reportIn("parent", "parent")
+			g.reportIn("parent", "parent", refTag)
 		}
 		if tag.Kind != "" {
-			g.reportIn("kind", "kind")
+			g.reportIn("kind", "kind", refTag)
 		}
 		g.path.pop()
 	}
@@ -193,7 +195,7 @@ func (g *oas32Gate) components(c *parser.Components) {
 	defer g.path.pop()
 
 	if len(c.MediaTypes) > 0 {
-		g.reportIn("mediaTypes", "mediaTypes")
+		g.reportIn("mediaTypes", "mediaTypes", refComponents)
 	}
 
 	walkNamedIn(g, "pathItems", c.PathItems, g.pathItem)
@@ -244,22 +246,19 @@ func (g *oas32Gate) pathItem(item *parser.PathItem) {
 	defer func() { g.depth-- }()
 
 	if item.Query != nil {
-		g.reportIn("query", "query")
+		g.reportIn("query", "query", refPathItem)
 	}
 	if len(item.AdditionalOperations) > 0 {
-		g.reportIn("additionalOperations", "additionalOperations")
+		g.reportIn("additionalOperations", "additionalOperations", refPathItem)
 	}
 
 	g.servers(item.Servers)
 	g.parameters(item.Parameters)
 
-	// Listed rather than taken from [parser.GetOperations], which is version-aware:
-	// below 3.2 it omits query and additionalOperations, the two this pass exists to
-	// find. Asking it for the 3.2 set instead would allocate a map per path item,
-	// which is the eager work the lazy path above avoids.
-	//
-	// The 3.2-only operations are walked too: their contents are equally illegal
-	// here, and reporting only the container would hide a 3.2 field nested inside.
+	// Listed rather than taken from [parser.GetOperations], which below 3.2 omits
+	// query and additionalOperations — the two this pass exists to find. The
+	// 3.2-only operations are walked, not just reported, or a field nested inside
+	// one would go unseen.
 	g.operationIn("get", item.Get)
 	g.operationIn("put", item.Put)
 	g.operationIn("post", item.Post)
@@ -312,8 +311,9 @@ func (g *oas32Gate) operationIn(method string, op *parser.Operation) {
 	walkNamedIn(g, "callbacks", op.Callbacks, g.callback)
 }
 
-// callback walks the path items a Callback Object holds, which carry `query` and
-// `additionalOperations` like any other.
+// callback walks the path items a [Callback Object] holds.
+//
+// [Callback Object]: https://spec.openapis.org/oas/v3.2.0.html#callback-object
 func (g *oas32Gate) callback(cb *parser.Callback) {
 	if cb == nil {
 		return
@@ -330,21 +330,22 @@ func (g *oas32Gate) response(resp *parser.Response) {
 		return
 	}
 	if resp.Summary != "" {
-		g.reportIn("summary", "summary")
+		g.reportIn("summary", "summary", refResponse)
 	}
 	g.content(resp.Content)
 	g.walkHeaders(resp.Headers)
 	walkNamedIn(g, "links", resp.Links, g.link)
 }
 
-// link reaches the one Server Object that is not part of a servers list, so its
-// `name` is checked here rather than in [oas32Gate.servers].
+// link reaches the one [Server Object] that is not part of a servers list.
+//
+// [Server Object]: https://spec.openapis.org/oas/v3.2.0.html#server-object
 func (g *oas32Gate) link(l *parser.Link) {
 	if l == nil || l.Server == nil || l.Server.Name == "" {
 		return
 	}
 	g.path.push("server")
-	g.reportIn("name", "name")
+	g.reportIn("name", "name", refServer)
 	g.path.pop()
 }
 
@@ -369,13 +370,13 @@ func (g *oas32Gate) mediaType(mt *parser.MediaType) {
 		return
 	}
 	if mt.ItemSchema != nil {
-		g.reportIn("itemSchema", "itemSchema")
+		g.reportIn("itemSchema", "itemSchema", refMediaType)
 	}
 	if mt.ItemEncoding != nil {
-		g.reportIn("itemEncoding", "itemEncoding")
+		g.reportIn("itemEncoding", "itemEncoding", refMediaType)
 	}
 	if len(mt.PrefixEncoding) > 0 {
-		g.reportIn("prefixEncoding", "prefixEncoding")
+		g.reportIn("prefixEncoding", "prefixEncoding", refMediaType)
 	}
 
 	g.examples(mt.Examples)
@@ -393,8 +394,7 @@ func (g *oas32Gate) mediaType(mt *parser.MediaType) {
 	}
 }
 
-// encodings walks a named encoding map. Shared by Media Type and Encoding, which
-// both carry one.
+// encodings walks a named encoding map, which Media Type and Encoding both hold.
 func (g *oas32Gate) encodings(encodings map[string]*parser.Encoding, depth int) {
 	if len(encodings) == 0 {
 		return
@@ -408,21 +408,22 @@ func (g *oas32Gate) encodings(encodings map[string]*parser.Encoding, depth int) 
 	g.path.pop()
 }
 
-// encoding recurses through the Encoding graph 3.2 introduced. depth mirrors the
-// bound on [Validator.visitEncodingExamples]: a parsed document cannot build a
-// cycle, but a hand-assembled one should not recurse without end.
+// encoding recurses through the [Encoding Object] graph 3.2 introduced. depth
+// mirrors the bound on [Validator.visitEncodingExamples].
+//
+// [Encoding Object]: https://spec.openapis.org/oas/v3.2.0.html#encoding-object
 func (g *oas32Gate) encoding(enc *parser.Encoding, depth int) {
 	if enc == nil || depth > maxEncodingNestingDepth {
 		return
 	}
 	if len(enc.Encoding) > 0 {
-		g.reportIn("encoding", "encoding")
+		g.reportIn("encoding", "encoding", refEncoding)
 	}
 	if enc.ItemEncoding != nil {
-		g.reportIn("itemEncoding", "itemEncoding")
+		g.reportIn("itemEncoding", "itemEncoding", refEncoding)
 	}
 	if len(enc.PrefixEncoding) > 0 {
-		g.reportIn("prefixEncoding", "prefixEncoding")
+		g.reportIn("prefixEncoding", "prefixEncoding", refEncoding)
 	}
 
 	g.walkHeaders(enc.Headers)
@@ -442,18 +443,17 @@ func (g *oas32Gate) encoding(enc *parser.Encoding, depth int) {
 }
 
 // example tests the zero value because the parser has nothing else to test: a
-// present-but-null dataValue is indistinguishable from an absent one. Matches
-// [Validator.validateExampleValueExclusivity], which has the same limit. Issue
-// #421 covers giving the parser a way to tell them apart.
+// present-but-null dataValue is indistinguishable from an absent one, the same
+// limit [Validator.validateExampleValueExclusivity] has. Issue #421 tracks it.
 func (g *oas32Gate) example(ex *parser.Example) {
 	if ex == nil {
 		return
 	}
 	if ex.DataValue != nil {
-		g.reportIn("dataValue", "dataValue")
+		g.reportIn("dataValue", "dataValue", refExample)
 	}
 	if ex.SerializedValue != "" {
-		g.reportIn("serializedValue", "serializedValue")
+		g.reportIn("serializedValue", "serializedValue", refExample)
 	}
 }
 
@@ -498,7 +498,7 @@ func (g *oas32Gate) servers(servers []*parser.Server) {
 			continue
 		}
 		g.path.pushIndex("servers", i)
-		g.reportIn("name", "name")
+		g.reportIn("name", "name", refServer)
 		g.path.pop()
 	}
 }
@@ -508,10 +508,10 @@ func (g *oas32Gate) securityScheme(scheme *parser.SecurityScheme) {
 		return
 	}
 	if scheme.Deprecated {
-		g.reportIn("deprecated", "deprecated")
+		g.reportIn("deprecated", "deprecated", refSecurityScheme)
 	}
 	if scheme.OAuth2MetadataURL != "" {
-		g.reportIn("oauth2MetadataUrl", "oauth2MetadataUrl")
+		g.reportIn("oauth2MetadataUrl", "oauth2MetadataUrl", refSecurityScheme)
 	}
 	if scheme.Flows == nil {
 		return
@@ -519,7 +519,7 @@ func (g *oas32Gate) securityScheme(scheme *parser.SecurityScheme) {
 
 	g.path.push("flows")
 	if scheme.Flows.DeviceAuthorization != nil {
-		g.reportIn("deviceAuthorization", "deviceAuthorization")
+		g.reportIn("deviceAuthorization", "deviceAuthorization", refOAuthFlows)
 	}
 	g.oauthFlowIn("implicit", scheme.Flows.Implicit)
 	g.oauthFlowIn("password", scheme.Flows.Password)
@@ -534,6 +534,6 @@ func (g *oas32Gate) oauthFlowIn(name string, flow *parser.OAuthFlow) {
 		return
 	}
 	g.path.push(name)
-	g.reportIn("deviceAuthorizationUrl", "deviceAuthorizationUrl")
+	g.reportIn("deviceAuthorizationUrl", "deviceAuthorizationUrl", refOAuthFlow)
 	g.path.pop()
 }

--- a/validator/oas32_gate.go
+++ b/validator/oas32_gate.go
@@ -1,0 +1,539 @@
+// oas32_gate.go reports OAS 3.2.0 fixed fields used by a document that predates
+// them. The rules in oas32.go run at 3.2 and above, where these fields are legal;
+// this file is the complement, running below 3.2 where their presence is itself
+// the defect. Issue #411 has the field inventory.
+//
+// https://spec.openapis.org/oas/v3.2.0.html
+
+package validator
+
+import (
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/erraggy/oastools/parser"
+)
+
+// oas32FieldGateApplies reports whether a document is old enough for the 3.2
+// fixed fields to be errors. The exact complement of [oas32TraversalApplies]: an
+// unrecognized version is checked by the 3.2 rules and left alone here, since
+// calling a field too new requires a version for it to be too new than.
+func oas32FieldGateApplies(version parser.OASVersion) bool {
+	return version.IsValid() && version < parser.OASVersion320
+}
+
+// gateSeg is one path segment. A negative index marks the segment as unindexed,
+// which defers formatting the number until there is something to report.
+type gateSeg struct {
+	name  string
+	index int
+}
+
+// gatePath accumulates a JSON path without building one.
+//
+// The walk below reaches every media type, encoding and example in the document
+// — the traversal [oas32TraversalApplies] declines to pay for at 3.0 and 3.1,
+// measured at roughly 20% more validator allocations when path strings are built
+// eagerly. Concatenating nothing keeps that cost off the common document:
+// segments push and pop by value, and the join happens only where a violation is
+// reported. Almost no pre-3.2 document carries a 3.2 field, so almost no document
+// reaches it at all.
+type gatePath struct {
+	segs []gateSeg
+}
+
+func (p *gatePath) push(name string) {
+	p.segs = append(p.segs, gateSeg{name: name, index: -1})
+}
+
+func (p *gatePath) pushIndex(name string, index int) {
+	p.segs = append(p.segs, gateSeg{name: name, index: index})
+}
+
+func (p *gatePath) pop() {
+	p.segs = p.segs[:len(p.segs)-1]
+}
+
+func (p *gatePath) String() string {
+	var b strings.Builder
+	for i, s := range p.segs {
+		if i > 0 {
+			b.WriteByte('.')
+		}
+		b.WriteString(s.name)
+		if s.index >= 0 {
+			b.WriteByte('[')
+			b.WriteString(strconv.Itoa(s.index))
+			b.WriteByte(']')
+		}
+	}
+	return b.String()
+}
+
+// maxPathItemNestingDepth bounds the recursive Path Item traversal. A callback
+// holds path items, whose operations hold callbacks, so the graph can close a
+// loop. A parsed document cannot build one — the same reasoning as
+// [maxEncodingNestingDepth] — but ValidateParsed takes a caller-supplied
+// document, and a hand-assembled cycle should not recurse without end.
+const maxPathItemNestingDepth = 100
+
+// oas32Gate carries the walk state. The version and result travel on the struct
+// rather than through every signature, since every method needs both and none
+// changes either.
+type oas32Gate struct {
+	v       *Validator
+	version parser.OASVersion
+	result  *ValidationResult
+	path    gatePath
+	// depth counts nested path items, not path segments.
+	depth int
+}
+
+// validateOAS32FieldsNotYetIntroduced reports every 3.2 fixed field found in a
+// pre-3.2 document. Conversion already reports these when downgrading a target
+// (`detectOAS32Features`), so validation staying silent on the result was the
+// inconsistency worth closing.
+func (v *Validator) validateOAS32FieldsNotYetIntroduced(doc *parser.OAS3Document, result *ValidationResult) {
+	if doc == nil || !oas32FieldGateApplies(doc.OASVersion) {
+		return
+	}
+	// Sized past the deepest path the walk builds — components, section, name,
+	// method, responses, code, content, media type, encoding — so the segment
+	// stack does not reallocate as it grows. That growth was the walk's only
+	// measured allocation: three or four per document, whatever its size.
+	g := &oas32Gate{
+		v:       v,
+		version: doc.OASVersion,
+		result:  result,
+		path:    gatePath{segs: make([]gateSeg, 0, 16)},
+	}
+
+	// The walk ranges over maps, whose order Go randomizes, so the same document
+	// reported its errors in a different order on each run. Sorting the errors
+	// afterwards rather than sorting every map's keys during the walk keeps the
+	// cost where the disorder is: a clean document sorts an empty range and
+	// allocates nothing, which is the whole point of the lazy path above.
+	first := len(result.Errors)
+	g.document(doc)
+	added := result.Errors[first:]
+	slices.SortStableFunc(added, func(a, b ValidationError) int {
+		if c := strings.Compare(a.Path, b.Path); c != 0 {
+			return c
+		}
+		return strings.Compare(a.Field, b.Field)
+	})
+}
+
+// report names the field and the version that does not have it.
+func (g *oas32Gate) report(field string) {
+	g.v.addError(g.result, g.path.String(),
+		field+" was introduced in OpenAPI 3.2.0, but this document declares "+g.version.String(),
+		withSpecRef(oas32SpecRef),
+		withField(field),
+	)
+}
+
+// reportIn pushes one segment, reports, and pops. For the common case of a field
+// sitting directly under the object the walk is already positioned on.
+func (g *oas32Gate) reportIn(segment, field string) {
+	g.path.push(segment)
+	g.report(field)
+	g.path.pop()
+}
+
+func (g *oas32Gate) document(doc *parser.OAS3Document) {
+	if doc.Self != "" {
+		g.reportIn("$self", "$self")
+	}
+
+	g.servers(doc.Servers)
+
+	for i, tag := range doc.Tags {
+		if tag == nil {
+			continue
+		}
+		g.path.pushIndex("tags", i)
+		if tag.Summary != "" {
+			g.reportIn("summary", "summary")
+		}
+		if tag.Parent != "" {
+			g.reportIn("parent", "parent")
+		}
+		if tag.Kind != "" {
+			g.reportIn("kind", "kind")
+		}
+		g.path.pop()
+	}
+
+	g.path.push("paths")
+	for name, item := range doc.Paths {
+		g.path.push(name)
+		g.pathItem(item)
+		g.path.pop()
+	}
+	g.path.pop()
+
+	g.path.push("webhooks")
+	for name, item := range doc.Webhooks {
+		g.path.push(name)
+		g.pathItem(item)
+		g.path.pop()
+	}
+	g.path.pop()
+
+	g.components(doc.Components)
+}
+
+func (g *oas32Gate) components(c *parser.Components) {
+	if c == nil {
+		return
+	}
+	g.path.push("components")
+	defer g.path.pop()
+
+	if len(c.MediaTypes) > 0 {
+		g.reportIn("mediaTypes", "mediaTypes")
+	}
+
+	walkNamedIn(g, "pathItems", c.PathItems, g.pathItem)
+	walkNamedIn(g, "mediaTypes", c.MediaTypes, g.mediaType)
+	walkNamedIn(g, "examples", c.Examples, g.example)
+	walkNamedIn(g, "responses", c.Responses, g.response)
+	walkNamedIn(g, "parameters", c.Parameters, g.parameter)
+	walkNamedIn(g, "headers", c.Headers, g.header)
+	walkNamedIn(g, "securitySchemes", c.SecuritySchemes, g.securityScheme)
+	walkNamedIn(g, "links", c.Links, g.link)
+	walkNamedIn(g, "callbacks", c.Callbacks, g.callback)
+
+	g.path.push("requestBodies")
+	for name, rb := range c.RequestBodies {
+		if rb == nil {
+			continue
+		}
+		g.path.push(name)
+		g.content(rb.Content)
+		g.path.pop()
+	}
+	g.path.pop()
+}
+
+// walkNamedIn visits a named map under one segment. Generic so the component
+// sections do not each repeat the push/pop.
+func walkNamedIn[T any](g *oas32Gate, section string, items map[string]*T, visit func(*T)) {
+	if len(items) == 0 {
+		return
+	}
+	g.path.push(section)
+	for name, item := range items {
+		if item == nil {
+			continue
+		}
+		g.path.push(name)
+		visit(item)
+		g.path.pop()
+	}
+	g.path.pop()
+}
+
+func (g *oas32Gate) pathItem(item *parser.PathItem) {
+	if item == nil || g.depth >= maxPathItemNestingDepth {
+		return
+	}
+	g.depth++
+	defer func() { g.depth-- }()
+
+	if item.Query != nil {
+		g.reportIn("query", "query")
+	}
+	if len(item.AdditionalOperations) > 0 {
+		g.reportIn("additionalOperations", "additionalOperations")
+	}
+
+	g.servers(item.Servers)
+	g.parameters(item.Parameters)
+
+	// Listed rather than taken from [parser.GetOperations], which is version-aware:
+	// below 3.2 it omits query and additionalOperations, the two this pass exists to
+	// find. Asking it for the 3.2 set instead would allocate a map per path item,
+	// which is the eager work the lazy path above avoids.
+	//
+	// The 3.2-only operations are walked too: their contents are equally illegal
+	// here, and reporting only the container would hide a 3.2 field nested inside.
+	g.operationIn("get", item.Get)
+	g.operationIn("put", item.Put)
+	g.operationIn("post", item.Post)
+	g.operationIn("delete", item.Delete)
+	g.operationIn("options", item.Options)
+	g.operationIn("head", item.Head)
+	g.operationIn("patch", item.Patch)
+	g.operationIn("trace", item.Trace)
+	g.operationIn("query", item.Query)
+
+	if len(item.AdditionalOperations) > 0 {
+		g.path.push("additionalOperations")
+		for method, op := range item.AdditionalOperations {
+			g.operationIn(method, op)
+		}
+		g.path.pop()
+	}
+}
+
+func (g *oas32Gate) operationIn(method string, op *parser.Operation) {
+	if op == nil {
+		return
+	}
+	g.path.push(method)
+	defer g.path.pop()
+
+	g.servers(op.Servers)
+	g.parameters(op.Parameters)
+
+	if op.RequestBody != nil {
+		g.path.push("requestBody")
+		g.content(op.RequestBody.Content)
+		g.path.pop()
+	}
+	if op.Responses != nil {
+		g.path.push("responses")
+		if op.Responses.Default != nil {
+			g.path.push("default")
+			g.response(op.Responses.Default)
+			g.path.pop()
+		}
+		for code, resp := range op.Responses.Codes {
+			g.path.push(code)
+			g.response(resp)
+			g.path.pop()
+		}
+		g.path.pop()
+	}
+
+	walkNamedIn(g, "callbacks", op.Callbacks, g.callback)
+}
+
+// callback walks the path items a Callback Object holds, which carry `query` and
+// `additionalOperations` like any other.
+func (g *oas32Gate) callback(cb *parser.Callback) {
+	if cb == nil {
+		return
+	}
+	for expr, item := range *cb {
+		g.path.push(expr)
+		g.pathItem(item)
+		g.path.pop()
+	}
+}
+
+func (g *oas32Gate) response(resp *parser.Response) {
+	if resp == nil {
+		return
+	}
+	if resp.Summary != "" {
+		g.reportIn("summary", "summary")
+	}
+	g.content(resp.Content)
+	g.walkHeaders(resp.Headers)
+	walkNamedIn(g, "links", resp.Links, g.link)
+}
+
+// link reaches the one Server Object that is not part of a servers list, so its
+// `name` is checked here rather than in [oas32Gate.servers].
+func (g *oas32Gate) link(l *parser.Link) {
+	if l == nil || l.Server == nil || l.Server.Name == "" {
+		return
+	}
+	g.path.push("server")
+	g.reportIn("name", "name")
+	g.path.pop()
+}
+
+func (g *oas32Gate) content(content map[string]*parser.MediaType) {
+	if len(content) == 0 {
+		return
+	}
+	g.path.push("content")
+	for name, mt := range content {
+		if mt == nil {
+			continue
+		}
+		g.path.push(name)
+		g.mediaType(mt)
+		g.path.pop()
+	}
+	g.path.pop()
+}
+
+func (g *oas32Gate) mediaType(mt *parser.MediaType) {
+	if mt == nil {
+		return
+	}
+	if mt.ItemSchema != nil {
+		g.reportIn("itemSchema", "itemSchema")
+	}
+	if mt.ItemEncoding != nil {
+		g.reportIn("itemEncoding", "itemEncoding")
+	}
+	if len(mt.PrefixEncoding) > 0 {
+		g.reportIn("prefixEncoding", "prefixEncoding")
+	}
+
+	g.examples(mt.Examples)
+	g.encodings(mt.Encoding, 0)
+
+	if mt.ItemEncoding != nil {
+		g.path.push("itemEncoding")
+		g.encoding(mt.ItemEncoding, 0)
+		g.path.pop()
+	}
+	for i, nested := range mt.PrefixEncoding {
+		g.path.pushIndex("prefixEncoding", i)
+		g.encoding(nested, 0)
+		g.path.pop()
+	}
+}
+
+// encodings walks a named encoding map. Shared by Media Type and Encoding, which
+// both carry one.
+func (g *oas32Gate) encodings(encodings map[string]*parser.Encoding, depth int) {
+	if len(encodings) == 0 {
+		return
+	}
+	g.path.push("encoding")
+	for name, enc := range encodings {
+		g.path.push(name)
+		g.encoding(enc, depth)
+		g.path.pop()
+	}
+	g.path.pop()
+}
+
+// encoding recurses through the Encoding graph 3.2 introduced. depth mirrors the
+// bound on [Validator.visitEncodingExamples]: a parsed document cannot build a
+// cycle, but a hand-assembled one should not recurse without end.
+func (g *oas32Gate) encoding(enc *parser.Encoding, depth int) {
+	if enc == nil || depth > maxEncodingNestingDepth {
+		return
+	}
+	if len(enc.Encoding) > 0 {
+		g.reportIn("encoding", "encoding")
+	}
+	if enc.ItemEncoding != nil {
+		g.reportIn("itemEncoding", "itemEncoding")
+	}
+	if len(enc.PrefixEncoding) > 0 {
+		g.reportIn("prefixEncoding", "prefixEncoding")
+	}
+
+	g.walkHeaders(enc.Headers)
+
+	g.encodings(enc.Encoding, depth+1)
+
+	if enc.ItemEncoding != nil {
+		g.path.push("itemEncoding")
+		g.encoding(enc.ItemEncoding, depth+1)
+		g.path.pop()
+	}
+	for i, nested := range enc.PrefixEncoding {
+		g.path.pushIndex("prefixEncoding", i)
+		g.encoding(nested, depth+1)
+		g.path.pop()
+	}
+}
+
+// example tests the zero value because the parser has nothing else to test: a
+// present-but-null dataValue is indistinguishable from an absent one. Matches
+// [Validator.validateExampleValueExclusivity], which has the same limit. Issue
+// #421 covers giving the parser a way to tell them apart.
+func (g *oas32Gate) example(ex *parser.Example) {
+	if ex == nil {
+		return
+	}
+	if ex.DataValue != nil {
+		g.reportIn("dataValue", "dataValue")
+	}
+	if ex.SerializedValue != "" {
+		g.reportIn("serializedValue", "serializedValue")
+	}
+}
+
+func (g *oas32Gate) examples(examples map[string]*parser.Example) {
+	walkNamedIn(g, "examples", examples, g.example)
+}
+
+func (g *oas32Gate) parameter(param *parser.Parameter) {
+	if param == nil {
+		return
+	}
+	g.examples(param.Examples)
+	g.content(param.Content)
+}
+
+func (g *oas32Gate) parameters(params []*parser.Parameter) {
+	for i, param := range params {
+		if param == nil {
+			continue
+		}
+		g.path.pushIndex("parameters", i)
+		g.parameter(param)
+		g.path.pop()
+	}
+}
+
+func (g *oas32Gate) header(header *parser.Header) {
+	if header == nil {
+		return
+	}
+	g.examples(header.Examples)
+	g.content(header.Content)
+}
+
+func (g *oas32Gate) walkHeaders(headers map[string]*parser.Header) {
+	walkNamedIn(g, "headers", headers, g.header)
+}
+
+func (g *oas32Gate) servers(servers []*parser.Server) {
+	for i, server := range servers {
+		if server == nil || server.Name == "" {
+			continue
+		}
+		g.path.pushIndex("servers", i)
+		g.reportIn("name", "name")
+		g.path.pop()
+	}
+}
+
+func (g *oas32Gate) securityScheme(scheme *parser.SecurityScheme) {
+	if scheme == nil {
+		return
+	}
+	if scheme.Deprecated {
+		g.reportIn("deprecated", "deprecated")
+	}
+	if scheme.OAuth2MetadataURL != "" {
+		g.reportIn("oauth2MetadataUrl", "oauth2MetadataUrl")
+	}
+	if scheme.Flows == nil {
+		return
+	}
+
+	g.path.push("flows")
+	if scheme.Flows.DeviceAuthorization != nil {
+		g.reportIn("deviceAuthorization", "deviceAuthorization")
+	}
+	g.oauthFlowIn("implicit", scheme.Flows.Implicit)
+	g.oauthFlowIn("password", scheme.Flows.Password)
+	g.oauthFlowIn("clientCredentials", scheme.Flows.ClientCredentials)
+	g.oauthFlowIn("authorizationCode", scheme.Flows.AuthorizationCode)
+	g.oauthFlowIn("deviceAuthorization", scheme.Flows.DeviceAuthorization)
+	g.path.pop()
+}
+
+func (g *oas32Gate) oauthFlowIn(name string, flow *parser.OAuthFlow) {
+	if flow == nil || flow.DeviceAuthorizationURL == "" {
+		return
+	}
+	g.path.push(name)
+	g.reportIn("deviceAuthorizationUrl", "deviceAuthorizationUrl")
+	g.path.pop()
+}

--- a/validator/oas32_gate_test.go
+++ b/validator/oas32_gate_test.go
@@ -1,0 +1,724 @@
+package validator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erraggy/oastools/parser"
+)
+
+// gateMarker identifies an error raised by the version gate rather than by any
+// other rule. Downgrading a 3.2 document produces plenty of unrelated errors, so
+// the tests below select on this rather than on the total count.
+const gateMarker = "was introduced in OpenAPI 3.2.0"
+
+// gateErrors validates the document and returns the gate's errors, in the order
+// reported. A nil parse error is not a clean parse — collected errors ride on
+// Errors — so both are checked before the document reaches the validator.
+func gateErrors(t *testing.T, spec string) []ValidationError {
+	t.Helper()
+
+	p := parser.New()
+	parsed, err := p.ParseBytes([]byte(spec))
+	require.NoError(t, err)
+	require.Empty(t, parsed.Errors)
+
+	result, err := New().ValidateParsed(*parsed)
+	require.NoError(t, err)
+
+	var gate []ValidationError
+	for _, e := range result.Errors {
+		if strings.Contains(e.Message, gateMarker) {
+			gate = append(gate, e)
+		}
+	}
+	return gate
+}
+
+// gateFields keys the gate's error paths by field.
+func gateFields(t *testing.T, spec string) map[string][]string {
+	t.Helper()
+
+	found := make(map[string][]string)
+	for _, e := range gateErrors(t, spec) {
+		found[e.Field] = append(found[e.Field], e.Path)
+	}
+	return found
+}
+
+// gatePaths lists the gate's error paths, in the order reported.
+func gatePaths(t *testing.T, spec string) []string {
+	t.Helper()
+
+	errs := gateErrors(t, spec)
+	if len(errs) == 0 {
+		return nil
+	}
+	paths := make([]string, 0, len(errs))
+	for _, e := range errs {
+		paths = append(paths, e.Path)
+	}
+	return paths
+}
+
+// TestOAS32FieldGate_ReportsEachField covers issue #411's inventory one field at a
+// time, so a failure names the field that lost its gate rather than a count.
+//
+// Each case is a whole document because the gate reads the declared version, and
+// the version is the thing under test.
+func TestOAS32FieldGate_ReportsEachField(t *testing.T) {
+	tests := []struct {
+		name      string
+		spec      string
+		wantField string
+		wantPath  string
+	}{
+		{
+			name: "$self on the OpenAPI Object",
+			spec: `
+openapi: 3.0.3
+info: {title: T, version: "1.0.0"}
+$self: https://example.com/spec
+paths: {}
+`,
+			wantField: "$self",
+			wantPath:  "$self",
+		},
+		{
+			name: "mediaTypes on the Components Object",
+			spec: `
+openapi: 3.0.3
+info: {title: T, version: "1.0.0"}
+paths: {}
+components:
+  mediaTypes:
+    application/json:
+      schema: {type: object}
+`,
+			wantField: "mediaTypes",
+			wantPath:  "components.mediaTypes",
+		},
+		{
+			name: "query on a Path Item",
+			spec: `
+openapi: 3.0.3
+info: {title: T, version: "1.0.0"}
+paths:
+  /pets:
+    query:
+      operationId: queryPets
+      responses:
+        "200": {description: OK}
+`,
+			wantField: "query",
+			wantPath:  "paths./pets.query",
+		},
+		{
+			name: "additionalOperations on a Path Item",
+			spec: `
+openapi: 3.0.3
+info: {title: T, version: "1.0.0"}
+paths:
+  /pets:
+    additionalOperations:
+      PURGE:
+        operationId: purgePets
+        responses:
+          "200": {description: OK}
+`,
+			wantField: "additionalOperations",
+			wantPath:  "paths./pets.additionalOperations",
+		},
+		{
+			name: "summary on a Tag",
+			spec: `
+openapi: 3.0.3
+info: {title: T, version: "1.0.0"}
+tags:
+  - name: pets
+    summary: Pet operations
+paths: {}
+`,
+			wantField: "summary",
+			wantPath:  "tags[0].summary",
+		},
+		{
+			name: "parent on a Tag",
+			spec: `
+openapi: 3.0.3
+info: {title: T, version: "1.0.0"}
+tags:
+  - name: pets
+    parent: root
+paths: {}
+`,
+			wantField: "parent",
+			wantPath:  "tags[0].parent",
+		},
+		{
+			name: "kind on a Tag",
+			spec: `
+openapi: 3.0.3
+info: {title: T, version: "1.0.0"}
+tags:
+  - name: pets
+    kind: nav
+paths: {}
+`,
+			wantField: "kind",
+			wantPath:  "tags[0].kind",
+		},
+		{
+			name: "name on a Server",
+			spec: `
+openapi: 3.0.3
+info: {title: T, version: "1.0.0"}
+servers:
+  - url: https://api.example.com
+    name: production
+paths: {}
+`,
+			wantField: "name",
+			wantPath:  "servers[0].name",
+		},
+		{
+			// The one Server Object that is not part of a servers list. Missed by the
+			// converter's detector too, which walks only the document's own servers.
+			name: "name on a Server inside a Link",
+			spec: `
+openapi: 3.0.3
+info: {title: T, version: "1.0.0"}
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        "200":
+          description: OK
+          links:
+            self:
+              operationId: listPets
+              server:
+                url: https://api.example.com
+                name: production
+`,
+			wantField: "name",
+			wantPath:  "paths./pets.get.responses.200.links.self.server.name",
+		},
+		{
+			name: "name on a Server inside a component Link",
+			spec: `
+openapi: 3.0.3
+info: {title: T, version: "1.0.0"}
+paths: {}
+components:
+  links:
+    shared:
+      operationId: listPets
+      server:
+        url: https://api.example.com
+        name: staging
+`,
+			wantField: "name",
+			wantPath:  "components.links.shared.server.name",
+		},
+		{
+			name: "summary on a Response",
+			spec: `
+openapi: 3.0.3
+info: {title: T, version: "1.0.0"}
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        "200":
+          description: OK
+          summary: A pet
+`,
+			wantField: "summary",
+			wantPath:  "paths./pets.get.responses.200.summary",
+		},
+		{
+			name: "itemSchema on a Media Type",
+			spec: `
+openapi: 3.0.3
+info: {title: T, version: "1.0.0"}
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              itemSchema: {type: object}
+`,
+			wantField: "itemSchema",
+			wantPath:  "paths./pets.get.responses.200.content.application/json.itemSchema",
+		},
+		{
+			name: "itemEncoding on a Media Type",
+			spec: `
+openapi: 3.0.3
+info: {title: T, version: "1.0.0"}
+paths:
+  /pets:
+    post:
+      operationId: addPet
+      requestBody:
+        content:
+          multipart/mixed:
+            itemEncoding: {contentType: application/json}
+      responses:
+        "200": {description: OK}
+`,
+			wantField: "itemEncoding",
+			wantPath:  "paths./pets.post.requestBody.content.multipart/mixed.itemEncoding",
+		},
+		{
+			name: "prefixEncoding on a Media Type",
+			spec: `
+openapi: 3.0.3
+info: {title: T, version: "1.0.0"}
+paths:
+  /pets:
+    post:
+      operationId: addPet
+      requestBody:
+        content:
+          multipart/mixed:
+            prefixEncoding:
+              - contentType: application/json
+      responses:
+        "200": {description: OK}
+`,
+			wantField: "prefixEncoding",
+			wantPath:  "paths./pets.post.requestBody.content.multipart/mixed.prefixEncoding",
+		},
+		{
+			name: "encoding nested in an Encoding",
+			spec: `
+openapi: 3.0.3
+info: {title: T, version: "1.0.0"}
+paths:
+  /pets:
+    post:
+      operationId: addPet
+      requestBody:
+        content:
+          multipart/form-data:
+            encoding:
+              profile:
+                encoding:
+                  avatar: {contentType: image/png}
+      responses:
+        "200": {description: OK}
+`,
+			wantField: "encoding",
+			wantPath:  "paths./pets.post.requestBody.content.multipart/form-data.encoding.profile.encoding",
+		},
+		{
+			name: "encoding nested inside a Media Type itemEncoding",
+			spec: `
+openapi: 3.0.3
+info: {title: T, version: "1.0.0"}
+paths: {}
+components:
+  requestBodies:
+    body:
+      content:
+        multipart/mixed:
+          itemEncoding:
+            contentType: application/json
+            encoding:
+              nested: {contentType: image/png}
+`,
+			wantField: "encoding",
+			wantPath:  "components.requestBodies.body.content.multipart/mixed.itemEncoding.encoding",
+		},
+		{
+			name: "itemEncoding nested inside a Media Type prefixEncoding entry",
+			spec: `
+openapi: 3.0.3
+info: {title: T, version: "1.0.0"}
+paths: {}
+components:
+  requestBodies:
+    body:
+      content:
+        multipart/mixed:
+          prefixEncoding:
+            - contentType: application/json
+              itemEncoding: {contentType: image/png}
+`,
+			wantField: "itemEncoding",
+			wantPath:  "components.requestBodies.body.content.multipart/mixed.prefixEncoding[0].itemEncoding",
+		},
+		{
+			name: "dataValue on an Example",
+			spec: `
+openapi: 3.0.3
+info: {title: T, version: "1.0.0"}
+paths: {}
+components:
+  examples:
+    pet:
+      dataValue: {name: Fido}
+`,
+			wantField: "dataValue",
+			wantPath:  "components.examples.pet.dataValue",
+		},
+		{
+			name: "serializedValue on an Example",
+			spec: `
+openapi: 3.0.3
+info: {title: T, version: "1.0.0"}
+paths: {}
+components:
+  examples:
+    pet:
+      serializedValue: '{"name":"Fido"}'
+`,
+			wantField: "serializedValue",
+			wantPath:  "components.examples.pet.serializedValue",
+		},
+		{
+			name: "deprecated on a Security Scheme",
+			spec: `
+openapi: 3.0.3
+info: {title: T, version: "1.0.0"}
+paths: {}
+components:
+  securitySchemes:
+    key:
+      type: apiKey
+      name: X-Key
+      in: header
+      deprecated: true
+`,
+			wantField: "deprecated",
+			wantPath:  "components.securitySchemes.key.deprecated",
+		},
+		{
+			name: "oauth2MetadataUrl on a Security Scheme",
+			spec: `
+openapi: 3.0.3
+info: {title: T, version: "1.0.0"}
+paths: {}
+components:
+  securitySchemes:
+    key:
+      type: apiKey
+      name: X-Key
+      in: header
+      oauth2MetadataUrl: https://auth.example.com/meta
+`,
+			wantField: "oauth2MetadataUrl",
+			wantPath:  "components.securitySchemes.key.oauth2MetadataUrl",
+		},
+		{
+			name: "deviceAuthorization on OAuth Flows",
+			spec: `
+openapi: 3.0.3
+info: {title: T, version: "1.0.0"}
+paths: {}
+components:
+  securitySchemes:
+    oauth:
+      type: oauth2
+      flows:
+        deviceAuthorization:
+          tokenUrl: https://auth.example.com/token
+          scopes: {read: Read}
+`,
+			wantField: "deviceAuthorization",
+			wantPath:  "components.securitySchemes.oauth.flows.deviceAuthorization",
+		},
+		{
+			name: "deviceAuthorizationUrl on an OAuth Flow",
+			spec: `
+openapi: 3.0.3
+info: {title: T, version: "1.0.0"}
+paths: {}
+components:
+  securitySchemes:
+    oauth:
+      type: oauth2
+      flows:
+        deviceAuthorization:
+          deviceAuthorizationUrl: https://auth.example.com/device
+          tokenUrl: https://auth.example.com/token
+          scopes: {read: Read}
+`,
+			wantField: "deviceAuthorizationUrl",
+			wantPath:  "components.securitySchemes.oauth.flows.deviceAuthorization.deviceAuthorizationUrl",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			found := gateFields(t, tt.spec)
+			require.Contains(t, found, tt.wantField,
+				"%s is an OAS 3.2 field but a 3.0.3 document using it reported nothing; reported: %v",
+				tt.wantField, found)
+			assert.Contains(t, found[tt.wantField], tt.wantPath,
+				"the error should point at the field's own location")
+			// Exactly once. Several of these field names also spell a field that is
+			// legal before 3.2 — a Media Type's own `encoding`, a Tag's `name` — so a
+			// membership check alone would pass a gate that reported the legal one too.
+			assert.Len(t, found[tt.wantField], 1,
+				"%s should be reported once, at %s; got %v", tt.wantField, tt.wantPath, found[tt.wantField])
+		})
+	}
+}
+
+// TestOAS32FieldGate_SilentAtAndAbove32 is the other half: at 3.2 these fields are
+// legal, so the gate must not fire. Without this the suite would pass with a gate
+// that reported the fields unconditionally.
+func TestOAS32FieldGate_SilentAtAndAbove32(t *testing.T) {
+	spec := `
+openapi: 3.2.0
+info: {title: T, version: "1.0.0"}
+$self: https://example.com/spec
+servers:
+  - url: https://api.example.com
+    name: production
+tags:
+  - name: pets
+    summary: Pet operations
+    parent: root
+    kind: nav
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        "200":
+          description: OK
+          summary: A pet
+          content:
+            application/json:
+              itemSchema: {type: object}
+`
+	assert.Empty(t, gateFields(t, spec),
+		"every field here is legal at 3.2.0, so none should be gated")
+}
+
+// TestOAS32FieldGate_AppliesAt31 pins the boundary. 3.1 is the version most likely
+// to be mistaken for new enough, since it postdates most of the OAS 3.x surface.
+func TestOAS32FieldGate_AppliesAt31(t *testing.T) {
+	spec := `
+openapi: 3.1.0
+info: {title: T, version: "1.0.0"}
+$self: https://example.com/spec
+paths: {}
+`
+	assert.Contains(t, gateFields(t, spec), "$self",
+		"$self arrived in 3.2, so a 3.1 document using it is still too early")
+}
+
+// TestOAS32FieldGate_PathItemFieldsWhereverPathItemsAppear covers the exception
+// issue #411 calls out: `query` was reported only under `paths`, and
+// `additionalOperations` nowhere. A path item appears in four places.
+func TestOAS32FieldGate_PathItemFieldsWhereverPathItemsAppear(t *testing.T) {
+	tests := []struct {
+		name string
+		// container is the YAML above the path item, ending with the key that owns
+		// it. indent is how deep that path item's own fields sit.
+		container string
+		indent    int
+		wantPath  string
+	}{
+		{
+			name: "under paths",
+			container: `
+paths:
+  /pets:`,
+			indent:   4,
+			wantPath: "paths./pets",
+		},
+		{
+			name: "under webhooks",
+			container: `
+paths: {}
+webhooks:
+  petEvent:`,
+			indent:   4,
+			wantPath: "webhooks.petEvent",
+		},
+		{
+			name: "under components.pathItems",
+			container: `
+paths: {}
+components:
+  pathItems:
+    shared:`,
+			indent:   6,
+			wantPath: "components.pathItems.shared",
+		},
+		{
+			name: "inside a component callback",
+			container: `
+paths: {}
+components:
+  callbacks:
+    onEvent:
+      '{$request.body#/url}':`,
+			indent:   8,
+			wantPath: "components.callbacks.onEvent.{$request.body#/url}",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := "openapi: 3.1.0\ninfo: {title: T, version: \"1.0.0\"}" +
+				tt.container + pathItemFields(tt.indent)
+
+			found := gateFields(t, spec)
+			assert.Contains(t, found["query"], tt.wantPath+".query",
+				"query should be reported wherever a path item appears")
+			assert.Contains(t, found["additionalOperations"], tt.wantPath+".additionalOperations",
+				"additionalOperations should be reported wherever a path item appears")
+		})
+	}
+}
+
+// pathItemFields renders a path item's two OAS 3.2 operation fields at the given
+// indent. Built from an indent rather than reindented from a fixed template: a
+// template shifted by exact-whitespace replacement silently produced sibling keys
+// instead of nested ones, and the test passed for the wrong reason until the
+// paths were checked.
+func pathItemFields(indent int) string {
+	pad := strings.Repeat(" ", indent)
+	return "\n" + pad + "query:" +
+		"\n" + pad + "  operationId: itemQuery" +
+		"\n" + pad + "  responses:" +
+		"\n" + pad + `    "200": {description: OK}` +
+		"\n" + pad + "additionalOperations:" +
+		"\n" + pad + "  PURGE:" +
+		"\n" + pad + "    operationId: itemPurge" +
+		"\n" + pad + "    responses:" +
+		"\n" + pad + `      "200": {description: OK}` + "\n"
+}
+
+// TestOAS32FieldGate_ReportsFieldsNestedInsideA32Operation covers the operations
+// the gate reports as containers. Stopping at the container would hide a 3.2 field
+// nested inside one.
+func TestOAS32FieldGate_ReportsFieldsNestedInsideA32Operation(t *testing.T) {
+	spec := `
+openapi: 3.1.0
+info: {title: T, version: "1.0.0"}
+paths:
+  /pets:
+    query:
+      operationId: queryPets
+      responses:
+        "200":
+          description: OK
+          summary: Nested inside a query operation
+`
+	found := gateFields(t, spec)
+	assert.Contains(t, found["query"], "paths./pets.query")
+	assert.Contains(t, found["summary"], "paths./pets.query.responses.200.summary",
+		"a 3.2 field inside a 3.2-only operation should be reported in its own right")
+}
+
+// TestOAS32GatePartitionsVersionsWithTraversal pins the two predicates against each
+// other. They divide the version space: oas32TraversalApplies runs the rules that
+// exist at 3.2, oas32FieldGateApplies reports the fields that do not exist before
+// it. A version answering true or false to both would be checked twice or not at
+// all.
+func TestOAS32GatePartitionsVersionsWithTraversal(t *testing.T) {
+	versions := []parser.OASVersion{
+		parser.OASVersion20,
+		parser.OASVersion300,
+		parser.OASVersion303,
+		parser.OASVersion304,
+		parser.OASVersion310,
+		parser.OASVersion311,
+		parser.OASVersion312,
+		parser.OASVersion320,
+	}
+
+	for _, version := range versions {
+		t.Run(version.String(), func(t *testing.T) {
+			assert.NotEqual(t, oas32TraversalApplies(version), oas32FieldGateApplies(version),
+				"exactly one of the two 3.2 passes must claim %s", version)
+		})
+	}
+
+	// An unclassifiable version is the deliberate exception: it is treated as new
+	// enough for the rules, and never reported for using a field, since there is no
+	// version to call the field newer than.
+	var unknown parser.OASVersion
+	require.False(t, unknown.IsValid(), "the zero version should not be valid")
+	assert.True(t, oas32TraversalApplies(unknown))
+	assert.False(t, oas32FieldGateApplies(unknown))
+}
+
+// TestOAS32FieldGate_ErrorOrderIsDeterministic pins the ordering.
+//
+// The walk ranges over maps, and Go randomizes that order, so the same document
+// reported its errors in a different order on each run — six distinct orderings
+// in eight runs of the eight-path document below. Anything diffing validator
+// output across runs saw phantom changes.
+//
+// The gate sorts the errors it added rather than sorting each map's keys during
+// the walk, so a clean document sorts an empty range and pays nothing.
+func TestOAS32FieldGate_ErrorOrderIsDeterministic(t *testing.T) {
+	var spec strings.Builder
+	spec.WriteString("openapi: 3.0.3\ninfo: {title: T, version: \"1.0.0\"}\npaths:\n")
+	for _, name := range []string{"a", "b", "c", "d", "e", "f", "g", "h"} {
+		spec.WriteString("  /" + name + ":\n    query:\n      operationId: q" + name +
+			"\n      responses:\n        \"200\": {description: OK}\n")
+	}
+
+	first := gatePaths(t, spec.String())
+	require.Len(t, first, 8, "each path should report its query")
+
+	// Repeated rather than compared against a hardcoded list: the assertion is that
+	// the order does not move, not that it is any particular order.
+	for range 12 {
+		assert.Equal(t, first, gatePaths(t, spec.String()),
+			"the same document must report its errors in the same order every run")
+	}
+
+	assert.IsIncreasing(t, first, "sorted by path, so the order is predictable and not merely stable")
+}
+
+// TestOAS32FieldGate_BoundsCyclicPathItems covers the one graph the walk cannot
+// treat as a tree. A Callback Object holds path items, whose operations hold
+// callbacks, so the two can point at each other.
+//
+// A parsed document cannot build that cycle, but ValidateParsed takes a document
+// from the caller, and before the bound this recursed until the stack gave out.
+// Constructed by hand because that is precisely the case that reaches it.
+func TestOAS32FieldGate_BoundsCyclicPathItems(t *testing.T) {
+	item := &parser.PathItem{}
+	callback := parser.Callback{"loop": item}
+	item.Get = &parser.Operation{
+		Callbacks: map[string]*parser.Callback{"cycle": &callback},
+	}
+	// A 3.2 field, so each pass round the loop has something to report and the
+	// bound is observable rather than merely survived.
+	item.Query = &parser.Operation{}
+
+	doc := &parser.OAS3Document{
+		OpenAPI:    "3.0.3",
+		Info:       &parser.Info{Title: "T", Version: "1.0.0"},
+		Paths:      parser.Paths{"/a": item},
+		OASVersion: parser.OASVersion303,
+	}
+
+	result := &ValidationResult{}
+	require.NotPanics(t, func() {
+		New().validateOAS32FieldsNotYetIntroduced(doc, result)
+	})
+	assert.Len(t, result.Errors, maxPathItemNestingDepth,
+		"the walk should stop at the nesting bound, having reported once per level")
+}

--- a/validator/oas32_gate_test.go
+++ b/validator/oas32_gate_test.go
@@ -49,6 +49,17 @@ func gateFields(t *testing.T, spec string) map[string][]string {
 	return found
 }
 
+// gateSpecRefs keys the gate's spec references by the path they were reported at.
+func gateSpecRefs(t *testing.T, spec string) map[string]string {
+	t.Helper()
+
+	refs := make(map[string]string)
+	for _, e := range gateErrors(t, spec) {
+		refs[e.Path] = e.SpecRef
+	}
+	return refs
+}
+
 // gatePaths lists the gate's error paths, in the order reported.
 func gatePaths(t *testing.T, spec string) []string {
 	t.Helper()
@@ -65,16 +76,18 @@ func gatePaths(t *testing.T, spec string) []string {
 }
 
 // TestOAS32FieldGate_ReportsEachField covers issue #411's inventory one field at a
-// time, so a failure names the field that lost its gate rather than a count.
-//
-// Each case is a whole document because the gate reads the declared version, and
-// the version is the thing under test.
+// time, so a failure names the field that lost its gate rather than a count. Each
+// case is a whole document because the declared version is what the gate reads.
 func TestOAS32FieldGate_ReportsEachField(t *testing.T) {
 	tests := []struct {
 		name      string
 		spec      string
 		wantField string
 		wantPath  string
+		// wantRef is the object that defines the field, which is not always the
+		// object the field is spelled on: deviceAuthorizationUrl sits inside an OAuth
+		// Flow, deviceAuthorization on the OAuth Flows that holds it.
+		wantRef string
 	}{
 		{
 			name: "$self on the OpenAPI Object",
@@ -86,6 +99,7 @@ paths: {}
 `,
 			wantField: "$self",
 			wantPath:  "$self",
+			wantRef:   "https://spec.openapis.org/oas/v3.2.0.html#openapi-object",
 		},
 		{
 			name: "mediaTypes on the Components Object",
@@ -100,6 +114,7 @@ components:
 `,
 			wantField: "mediaTypes",
 			wantPath:  "components.mediaTypes",
+			wantRef:   "https://spec.openapis.org/oas/v3.2.0.html#components-object",
 		},
 		{
 			name: "query on a Path Item",
@@ -115,6 +130,7 @@ paths:
 `,
 			wantField: "query",
 			wantPath:  "paths./pets.query",
+			wantRef:   "https://spec.openapis.org/oas/v3.2.0.html#path-item-object",
 		},
 		{
 			name: "additionalOperations on a Path Item",
@@ -131,6 +147,7 @@ paths:
 `,
 			wantField: "additionalOperations",
 			wantPath:  "paths./pets.additionalOperations",
+			wantRef:   "https://spec.openapis.org/oas/v3.2.0.html#path-item-object",
 		},
 		{
 			name: "summary on a Tag",
@@ -144,6 +161,7 @@ paths: {}
 `,
 			wantField: "summary",
 			wantPath:  "tags[0].summary",
+			wantRef:   "https://spec.openapis.org/oas/v3.2.0.html#tag-object",
 		},
 		{
 			name: "parent on a Tag",
@@ -157,6 +175,7 @@ paths: {}
 `,
 			wantField: "parent",
 			wantPath:  "tags[0].parent",
+			wantRef:   "https://spec.openapis.org/oas/v3.2.0.html#tag-object",
 		},
 		{
 			name: "kind on a Tag",
@@ -170,6 +189,7 @@ paths: {}
 `,
 			wantField: "kind",
 			wantPath:  "tags[0].kind",
+			wantRef:   "https://spec.openapis.org/oas/v3.2.0.html#tag-object",
 		},
 		{
 			name: "name on a Server",
@@ -183,6 +203,7 @@ paths: {}
 `,
 			wantField: "name",
 			wantPath:  "servers[0].name",
+			wantRef:   "https://spec.openapis.org/oas/v3.2.0.html#server-object",
 		},
 		{
 			// The one Server Object that is not part of a servers list. Missed by the
@@ -207,6 +228,7 @@ paths:
 `,
 			wantField: "name",
 			wantPath:  "paths./pets.get.responses.200.links.self.server.name",
+			wantRef:   "https://spec.openapis.org/oas/v3.2.0.html#server-object",
 		},
 		{
 			name: "name on a Server inside a component Link",
@@ -224,6 +246,7 @@ components:
 `,
 			wantField: "name",
 			wantPath:  "components.links.shared.server.name",
+			wantRef:   "https://spec.openapis.org/oas/v3.2.0.html#server-object",
 		},
 		{
 			name: "summary on a Response",
@@ -241,6 +264,7 @@ paths:
 `,
 			wantField: "summary",
 			wantPath:  "paths./pets.get.responses.200.summary",
+			wantRef:   "https://spec.openapis.org/oas/v3.2.0.html#response-object",
 		},
 		{
 			name: "itemSchema on a Media Type",
@@ -260,6 +284,7 @@ paths:
 `,
 			wantField: "itemSchema",
 			wantPath:  "paths./pets.get.responses.200.content.application/json.itemSchema",
+			wantRef:   "https://spec.openapis.org/oas/v3.2.0.html#media-type-object",
 		},
 		{
 			name: "itemEncoding on a Media Type",
@@ -279,6 +304,7 @@ paths:
 `,
 			wantField: "itemEncoding",
 			wantPath:  "paths./pets.post.requestBody.content.multipart/mixed.itemEncoding",
+			wantRef:   "https://spec.openapis.org/oas/v3.2.0.html#media-type-object",
 		},
 		{
 			name: "prefixEncoding on a Media Type",
@@ -299,6 +325,7 @@ paths:
 `,
 			wantField: "prefixEncoding",
 			wantPath:  "paths./pets.post.requestBody.content.multipart/mixed.prefixEncoding",
+			wantRef:   "https://spec.openapis.org/oas/v3.2.0.html#media-type-object",
 		},
 		{
 			name: "encoding nested in an Encoding",
@@ -321,6 +348,7 @@ paths:
 `,
 			wantField: "encoding",
 			wantPath:  "paths./pets.post.requestBody.content.multipart/form-data.encoding.profile.encoding",
+			wantRef:   "https://spec.openapis.org/oas/v3.2.0.html#encoding-object",
 		},
 		{
 			name: "encoding nested inside a Media Type itemEncoding",
@@ -340,6 +368,7 @@ components:
 `,
 			wantField: "encoding",
 			wantPath:  "components.requestBodies.body.content.multipart/mixed.itemEncoding.encoding",
+			wantRef:   "https://spec.openapis.org/oas/v3.2.0.html#encoding-object",
 		},
 		{
 			name: "itemEncoding nested inside a Media Type prefixEncoding entry",
@@ -358,6 +387,7 @@ components:
 `,
 			wantField: "itemEncoding",
 			wantPath:  "components.requestBodies.body.content.multipart/mixed.prefixEncoding[0].itemEncoding",
+			wantRef:   "https://spec.openapis.org/oas/v3.2.0.html#encoding-object",
 		},
 		{
 			name: "dataValue on an Example",
@@ -372,6 +402,7 @@ components:
 `,
 			wantField: "dataValue",
 			wantPath:  "components.examples.pet.dataValue",
+			wantRef:   "https://spec.openapis.org/oas/v3.2.0.html#example-object",
 		},
 		{
 			name: "serializedValue on an Example",
@@ -386,6 +417,7 @@ components:
 `,
 			wantField: "serializedValue",
 			wantPath:  "components.examples.pet.serializedValue",
+			wantRef:   "https://spec.openapis.org/oas/v3.2.0.html#example-object",
 		},
 		{
 			name: "deprecated on a Security Scheme",
@@ -403,6 +435,7 @@ components:
 `,
 			wantField: "deprecated",
 			wantPath:  "components.securitySchemes.key.deprecated",
+			wantRef:   "https://spec.openapis.org/oas/v3.2.0.html#security-scheme-object",
 		},
 		{
 			name: "oauth2MetadataUrl on a Security Scheme",
@@ -420,6 +453,7 @@ components:
 `,
 			wantField: "oauth2MetadataUrl",
 			wantPath:  "components.securitySchemes.key.oauth2MetadataUrl",
+			wantRef:   "https://spec.openapis.org/oas/v3.2.0.html#security-scheme-object",
 		},
 		{
 			name: "deviceAuthorization on OAuth Flows",
@@ -438,6 +472,7 @@ components:
 `,
 			wantField: "deviceAuthorization",
 			wantPath:  "components.securitySchemes.oauth.flows.deviceAuthorization",
+			wantRef:   "https://spec.openapis.org/oas/v3.2.0.html#oauth-flows-object",
 		},
 		{
 			name: "deviceAuthorizationUrl on an OAuth Flow",
@@ -457,6 +492,7 @@ components:
 `,
 			wantField: "deviceAuthorizationUrl",
 			wantPath:  "components.securitySchemes.oauth.flows.deviceAuthorization.deviceAuthorizationUrl",
+			wantRef:   "https://spec.openapis.org/oas/v3.2.0.html#oauth-flow-object",
 		},
 	}
 
@@ -473,6 +509,8 @@ components:
 			// membership check alone would pass a gate that reported the legal one too.
 			assert.Len(t, found[tt.wantField], 1,
 				"%s should be reported once, at %s; got %v", tt.wantField, tt.wantPath, found[tt.wantField])
+			assert.Equal(t, tt.wantRef, gateSpecRefs(t, tt.spec)[tt.wantPath],
+				"the error should link the object that defines %s", tt.wantField)
 		})
 	}
 }
@@ -589,10 +627,9 @@ components:
 }
 
 // pathItemFields renders a path item's two OAS 3.2 operation fields at the given
-// indent. Built from an indent rather than reindented from a fixed template: a
-// template shifted by exact-whitespace replacement silently produced sibling keys
-// instead of nested ones, and the test passed for the wrong reason until the
-// paths were checked.
+// indent. Built from an indent rather than reindenting a fixed template, which
+// silently produced sibling keys instead of nested ones and passed for the wrong
+// reason until the paths were checked.
 func pathItemFields(indent int) string {
 	pad := strings.Repeat(" ", indent)
 	return "\n" + pad + "query:" +
@@ -628,11 +665,9 @@ paths:
 		"a 3.2 field inside a 3.2-only operation should be reported in its own right")
 }
 
-// TestOAS32GatePartitionsVersionsWithTraversal pins the two predicates against each
-// other. They divide the version space: oas32TraversalApplies runs the rules that
-// exist at 3.2, oas32FieldGateApplies reports the fields that do not exist before
-// it. A version answering true or false to both would be checked twice or not at
-// all.
+// TestOAS32GatePartitionsVersionsWithTraversal pins the two predicates against
+// each other: they divide the version space, so a version answering the same to
+// both would be checked twice or not at all.
 func TestOAS32GatePartitionsVersionsWithTraversal(t *testing.T) {
 	versions := []parser.OASVersion{
 		parser.OASVersion20,
@@ -661,15 +696,9 @@ func TestOAS32GatePartitionsVersionsWithTraversal(t *testing.T) {
 	assert.False(t, oas32FieldGateApplies(unknown))
 }
 
-// TestOAS32FieldGate_ErrorOrderIsDeterministic pins the ordering.
-//
-// The walk ranges over maps, and Go randomizes that order, so the same document
-// reported its errors in a different order on each run — six distinct orderings
-// in eight runs of the eight-path document below. Anything diffing validator
-// output across runs saw phantom changes.
-//
-// The gate sorts the errors it added rather than sorting each map's keys during
-// the walk, so a clean document sorts an empty range and pays nothing.
+// TestOAS32FieldGate_ErrorOrderIsDeterministic pins the ordering. Map order is
+// randomized, so this document reported six distinct orderings in eight runs, and
+// anything diffing validator output saw phantom changes.
 func TestOAS32FieldGate_ErrorOrderIsDeterministic(t *testing.T) {
 	var spec strings.Builder
 	spec.WriteString("openapi: 3.0.3\ninfo: {title: T, version: \"1.0.0\"}\npaths:\n")
@@ -692,12 +721,11 @@ func TestOAS32FieldGate_ErrorOrderIsDeterministic(t *testing.T) {
 }
 
 // TestOAS32FieldGate_BoundsCyclicPathItems covers the one graph the walk cannot
-// treat as a tree. A Callback Object holds path items, whose operations hold
-// callbacks, so the two can point at each other.
+// treat as a tree — a [Callback Object] holds path items whose operations hold
+// callbacks. Hand-built because a parsed document cannot close that loop, and
+// ValidateParsed takes the caller's; before the bound this exhausted the stack.
 //
-// A parsed document cannot build that cycle, but ValidateParsed takes a document
-// from the caller, and before the bound this recursed until the stack gave out.
-// Constructed by hand because that is precisely the case that reaches it.
+// [Callback Object]: https://spec.openapis.org/oas/v3.2.0.html#callback-object
 func TestOAS32FieldGate_BoundsCyclicPathItems(t *testing.T) {
 	item := &parser.PathItem{}
 	callback := parser.Callback{"loop": item}

--- a/validator/oas32_test.go
+++ b/validator/oas32_test.go
@@ -81,9 +81,14 @@ components:
 		{
 			// The traversal that finds Example Objects is gated on 3.2 — see
 			// oas32TraversalApplies for why paying it on every 3.0/3.1 document is
-			// not worth catching a field those versions do not define. A pre-3.2
-			// document carrying dataValue therefore gets no error from this rule.
-			name: "the rules do not run below 3.2",
+			// not worth catching a field those versions do not define. So the
+			// exclusivity rule stays silent here even though dataValue and value are
+			// set together.
+			//
+			// What reports instead is the version gate: below 3.2 the defect is not
+			// that dataValue conflicts with value, it is that dataValue does not
+			// exist yet. Issue #411 covers that pass.
+			name: "the exclusivity rules do not run below 3.2, but the field is still too early",
 			spec: `
 openapi: 3.1.0
 info: {title: T, version: "1.0.0"}
@@ -94,7 +99,9 @@ components:
       dataValue: {a: 1}
       value: {a: 1}
 `,
-			wantErrors: nil,
+			wantErrors: []string{
+				"components.examples.tooEarly.dataValue: dataValue was introduced in OpenAPI 3.2.0",
+			},
 		},
 		{
 			// Reached only through the media-type traversal, not through


### PR DESCRIPTION
A document declaring `openapi: 3.0.3` could use fields that did not exist until 3.2 and validate clean. ✅ on a document that is not.

Conversion already reported them, so `oastools convert -t 3.0.3` warned about a field while `oastools validate` on the result did not. That inconsistency is what this closes.

Fixes #411

## The inventory

| Object | Fields |
|---|---|
| OpenAPI | `$self` |
| Components | `mediaTypes` |
| Path Item | `query`, `additionalOperations` |
| Tag | `summary`, `parent`, `kind` |
| Server | `name` |
| Response | `summary` |
| Media Type | `itemSchema`, `itemEncoding`, `prefixEncoding` |
| Encoding | `encoding`, `itemEncoding`, `prefixEncoding` |
| Example | `dataValue`, `serializedValue` |
| Security Scheme | `deprecated`, `oauth2MetadataUrl` |
| OAuth Flows / Flow | `deviceAuthorization`, `deviceAuthorizationUrl` |

`query` and `additionalOperations` are reported wherever a path item appears — `paths`, `webhooks`, `components.pathItems` and callbacks — not only under `paths`.

`xml.nodeType` and `discriminator.defaultMapping` are deliberately **not** here: `validateOAS32SchemaFields` already gates them, and adding them would double-report.

## Two predicates that partition the version space

`oas32FieldGateApplies` is the exact complement of `oas32TraversalApplies`. One runs the rules that exist at 3.2; the other reports the fields that do not exist before it. An unclassifiable version stays with the permissive path, since calling a field too new needs a version for it to be too new *than*. A test asserts exactly one of the two claims every version — a document checked twice, or not at all, fails it.

## Cost

The walk reaches every media type, encoding and example — the traversal `oas32TraversalApplies` declines to pay for at 3.0 and 3.1, measured at roughly 20% more allocations when path strings are built eagerly. That cost is *path construction*, not traversal: Go's map and slice iteration allocate nothing. So segments push onto a preallocated stack and the join happens only where a violation is reported, which on a real 3.0 document is nowhere.

| | baseline | with the gate |
|---|---|---|
| SmallOAS3 | 2211 | 2212 |
| MediumOAS3 | 18905 | 18906 |
| LargeOAS3 | 213072 | 213073 |
| SmallOAS2 | 2179 | 2179 |
| MediumOAS2 | 17359 | 17358 |

One allocation, constant in document size. LargeOAS3 has 213k allocations and the gate adds one.

## Also fixed here

Both found by review, both verified by reproduction before fixing:

- **Non-deterministic error order.** The walk ranges over maps, so the same document reported its errors in a different order every run — six orderings in eight runs. Sorting each map's keys during the walk would have reintroduced exactly the eager work the design avoids, so the pass sorts the errors it added instead: a clean document sorts an empty range.
- **Unbounded recursion.** A Callback Object holds path items whose operations hold callbacks, the one loop the walk cannot treat as a tree. A parsed document cannot build it, but `ValidateParsed` takes a document from the caller, and a hand-assembled cycle recursed until the stack gave out. Bounded at 100 nested path items, matching `maxEncodingNestingDepth`.

## Verification

Every test was run twice, once with the code and once without:

| Suite | Without |
|---|---|
| Field inventory, path-item locations, nesting | 22 subtests fail |
| Callback walk and nested encodings | 4 subtests fail |
| Deterministic ordering | fails |
| Cyclic path items | never terminates |

Each table case asserts its field is reported **exactly once**. Several of these names also spell something legal before 3.2 — a Media Type's own `encoding`, a Tag's `name` — so a membership check alone would pass a gate that reported the legal one too.

`TestOAS32ExampleValueExclusivity`'s pre-3.2 case changes expectation: the exclusivity rule still does not run there, but the field is now reported for arriving early.

## Every error deep-links its object

A second commit fixes something the first got wrong: all 23 reports pointed at the spec's front page rather than the section defining the field, leaving the reader to search a 670KB document.

Each now links the object that owns the field. Two pairs share a spelling across different objects, which is where a copy-pasted anchor would go unnoticed:

| Field | Links |
|---|---|
| `summary` on a Tag | `#tag-object` |
| `summary` on a Response | `#response-object` |
| `deviceAuthorization` | `#oauth-flows-object` |
| `deviceAuthorizationUrl` | `#oauth-flow-object` |

The expected link is pinned per field, so mislinking a Response `summary` to the Tag Object fails the table. All twelve anchors were checked against the published spec rather than assumed.

The links also replaced the prose that named those objects, which is where most of the transcribed specification detail lived — comments drop from 68 to 53 lines in `oas32_gate.go` and 68 to 56 in its test. What stays is the reasoning no specification carries: why the gate guards centrally, why errors are sorted afterwards rather than the maps during the walk, and why `parser.GetOperations` cannot serve here.

## Follow-ups filed

- #420 — the converter's own detector misses a Link Object's `server.name`, and `testdata/oas32-all-fields.yaml` has no `components.mediaTypes` despite claiming to cover every 3.2 field
- #421 — a present-but-null `dataValue` is indistinguishable from an absent one, so both this gate and the pre-existing exclusivity rule miss it

## Checks

`make check` green — no lint or gopls findings. CodeRabbit CLI: three findings on the first pass (two major) and five on the second, all addressed or skipped with reasoning recorded in the code; a final pass returned **zero**.
