### PR TITLE
fix(converter): report a Link Object's server name, and cover mediaTypes

### DIFF
--- a/converter/oas32_features.go
+++ b/converter/oas32_features.go
@@ -6,7 +6,9 @@ package converter
 
 import (
 	"fmt"
+	"slices"
 	"strconv"
+	"strings"
 
 	"github.com/erraggy/oastools/parser"
 )
@@ -24,6 +26,24 @@ import (
 // are Critical where the OAS 2.0 path finds them.
 func (c *Converter) detectOAS32Features(doc *parser.OAS3Document, result *ConversionResult) {
 	target := result.TargetVersion
+
+	// The section walks below range over maps, and Go randomizes that order, so the
+	// same document reported these issues in a different order on each run — four
+	// orderings in eight runs of the full-field fixture. Sorting what this pass
+	// appended costs one sort of a short slice and leaves the walks readable, where
+	// ordering every map's keys would allocate on documents that report nothing.
+	// The ordered-slice comment on the Tag fields below is the same concern, caught
+	// earlier and solved locally.
+	first := len(result.Issues)
+	defer func() {
+		added := result.Issues[first:]
+		slices.SortStableFunc(added, func(a, b ConversionIssue) int {
+			if n := strings.Compare(a.Path, b.Path); n != 0 {
+				return n
+			}
+			return strings.Compare(a.Message, b.Message)
+		})
+	}()
 
 	// The oas32Reporter used here and passed into the downstream detectors.
 	report := func(path, field string) {

--- a/converter/oas32_features.go
+++ b/converter/oas32_features.go
@@ -79,6 +79,11 @@ func (c *Converter) detectOAS32Features(doc *parser.OAS3Document, result *Conver
 	if len(comp.MediaTypes) > 0 {
 		report("components.mediaTypes", "mediaTypes")
 	}
+	for name, mt := range comp.MediaTypes {
+		// The section is 3.2-only, but so is anything 3.2 added inside it, and
+		// reporting only the container would understate what the target loses.
+		c.detectOAS32MediaTypeFeatures(mt, "components.mediaTypes."+name, report)
+	}
 	for name, item := range comp.PathItems {
 		c.detectOAS32PathItemFeatures(item, "components.pathItems."+name, doc.OASVersion, report)
 	}
@@ -104,6 +109,9 @@ func (c *Converter) detectOAS32Features(doc *parser.OAS3Document, result *Conver
 	}
 	for name, scheme := range comp.SecuritySchemes {
 		detectOAS32SecuritySchemeFeatures(scheme, "components.securitySchemes."+name, report)
+	}
+	for name, link := range comp.Links {
+		detectOAS32LinkFeatures(link, "components.links."+name, report)
 	}
 }
 
@@ -192,6 +200,21 @@ func (c *Converter) detectOAS32ResponseFeatures(resp *parser.Response, prefix st
 	c.detectOAS32ContentFeatures(resp.Content, prefix, report)
 	for name, header := range resp.Headers {
 		c.detectOAS32HeaderFeatures(header, prefix+".headers."+name, report)
+	}
+	for name, link := range resp.Links {
+		detectOAS32LinkFeatures(link, prefix+".links."+name, report)
+	}
+}
+
+// detectOAS32LinkFeatures reports the `name` of the one Server Object that is not
+// part of a servers list.
+// https://spec.openapis.org/oas/v3.2.0.html#link-object
+func detectOAS32LinkFeatures(link *parser.Link, prefix string, report oas32Reporter) {
+	if link == nil || link.Ref != "" {
+		return
+	}
+	if link.Server != nil && link.Server.Name != "" {
+		report(prefix+".server", "name")
 	}
 }
 

--- a/converter/oas32_features_test.go
+++ b/converter/oas32_features_test.go
@@ -152,6 +152,7 @@ func TestDownconvertReportsAmbiguousFieldsAtTheirLocation(t *testing.T) {
 				// name, on each of the two kinds of Server Object
 				"servers[0]: 'name'",
 				"components.links.petById.server: 'name'",
+				"paths./pets.get.responses.200.links.firstPet.server: 'name'",
 				// summary, on a Tag and on a Response
 				"tags[0]: 'summary'",
 				"paths./pets.get.responses.200: 'summary'",

--- a/converter/oas32_features_test.go
+++ b/converter/oas32_features_test.go
@@ -146,7 +146,7 @@ func TestConvertToOAS32TargetReportsNothing(t *testing.T) {
 func TestDownconvertReportsAmbiguousFieldsAtTheirLocation(t *testing.T) {
 	for _, target := range []string{"3.0.3", "3.1.0"} {
 		t.Run(target, func(t *testing.T) {
-			joined := strings.Join(oas32FeatureIssues(t, target), "\n")
+			issues := oas32FeatureIssues(t, target)
 
 			for _, want := range []string{
 				// name, on each of the two kinds of Server Object
@@ -158,10 +158,14 @@ func TestDownconvertReportsAmbiguousFieldsAtTheirLocation(t *testing.T) {
 				// the Components section that is itself 3.2-only, and what is inside it:
 				// reporting only the container would understate what the target loses
 				"components.mediaTypes: 'mediaTypes'",
-				"components.mediaTypes.application/jsonl: 'itemSchema'",
+				"components.mediaTypes.PetStream: 'itemSchema'",
 			} {
-				assert.Contains(t, joined, want,
-					"converting to %s should report %s at that location", target, want)
+				// Matched per issue rather than against the joined text: every path here
+				// is a prefix of some other path in the document, so a substring search
+				// over one blob would let a nested report satisfy its parent's assertion.
+				assert.True(t, slices.ContainsFunc(issues, func(issue string) bool {
+					return strings.HasPrefix(issue, want+" ")
+				}), "converting to %s should report %s at that location; got %v", target, want, issues)
 			}
 		})
 	}

--- a/converter/oas32_features_test.go
+++ b/converter/oas32_features_test.go
@@ -3,6 +3,7 @@ package converter
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -164,4 +165,32 @@ func TestDownconvertReportsAmbiguousFieldsAtTheirLocation(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestDownconvertIssueOrderIsDeterministic pins the ordering.
+//
+// The section walks range over maps, so the full-field fixture reported these
+// issues in four distinct orderings across eight runs. Anything diffing conversion
+// output between runs saw changes that were not there.
+func TestDownconvertIssueOrderIsDeterministic(t *testing.T) {
+	first := oas32FeatureIssues(t, "3.0.3")
+	require.NotEmpty(t, first)
+
+	// Repeated rather than compared against a fixed list: the assertion is that the
+	// order holds, not that it is any particular order.
+	for range 12 {
+		assert.Equal(t, first, oas32FeatureIssues(t, "3.0.3"),
+			"the same document must report its issues in the same order every run")
+	}
+
+	// Asserted on the sort key itself, not the rendered "path: message" line: '.'
+	// sorts before ':', so a parent path and its child render out of order while
+	// their paths are sorted correctly.
+	paths := make([]string, 0, len(first))
+	for _, issue := range first {
+		path, _, _ := strings.Cut(issue, ": ")
+		paths = append(paths, path)
+	}
+	assert.True(t, slices.IsSorted(paths),
+		"sorted by path, so the order is predictable and not merely stable: %v", paths)
 }

--- a/converter/oas32_features_test.go
+++ b/converter/oas32_features_test.go
@@ -45,7 +45,8 @@ func TestDownconvertReportsOAS32Fields(t *testing.T) {
 
 			for _, field := range []string{
 				"'$self'",
-				"'name'",              // Server Object
+				"'mediaTypes'",        // Components Object
+				"'name'",              // Server Object, including a Link's own
 				"'summary'",           // Tag and Response Objects
 				"'parent'",            // Tag Object
 				"'kind'",              // Tag Object
@@ -132,4 +133,35 @@ paths:
 func TestConvertToOAS32TargetReportsNothing(t *testing.T) {
 	assert.Empty(t, oas32FeatureIssues(t, "3.2.0"),
 		"nothing is lost converting a 3.2 document to 3.2")
+}
+
+// TestDownconvertReportsAmbiguousFieldsAtTheirLocation pins where a field is
+// reported, not only that its name appears somewhere.
+//
+// TestDownconvertReportsOAS32Fields checks field names, which is enough for a name
+// used once. It is not enough for `name` and `summary`, each of which several
+// objects carry: `name` was already reported for the document's own servers, so
+// that test passed for the whole time a Link Object's server went unreported.
+func TestDownconvertReportsAmbiguousFieldsAtTheirLocation(t *testing.T) {
+	for _, target := range []string{"3.0.3", "3.1.0"} {
+		t.Run(target, func(t *testing.T) {
+			joined := strings.Join(oas32FeatureIssues(t, target), "\n")
+
+			for _, want := range []string{
+				// name, on each of the two kinds of Server Object
+				"servers[0]: 'name'",
+				"components.links.petById.server: 'name'",
+				// summary, on a Tag and on a Response
+				"tags[0]: 'summary'",
+				"paths./pets.get.responses.200: 'summary'",
+				// the Components section that is itself 3.2-only, and what is inside it:
+				// reporting only the container would understate what the target loses
+				"components.mediaTypes: 'mediaTypes'",
+				"components.mediaTypes.application/jsonl: 'itemSchema'",
+			} {
+				assert.Contains(t, joined, want,
+					"converting to %s should report %s at that location", target, want)
+			}
+		})
+	}
 }

--- a/parser/oas32_roundtrip_test.go
+++ b/parser/oas32_roundtrip_test.go
@@ -114,6 +114,15 @@ func assertOAS32FieldsPresent(t *testing.T, doc *OAS3Document) {
 	assert.Equal(t, "#/components/schemas/Pet", sharedMediaType.ItemSchema.Ref,
 		"components.mediaTypes[].itemSchema.$ref")
 
+	// A Link Object reached through a Response, not through Components: the
+	// converter walks the two separately, so one working proves nothing about the
+	// other.
+	respLink := resp.Links["firstPet"]
+	require.NotNil(t, respLink, "response.links")
+	require.NotNil(t, respLink.Server, "response.links[].server")
+	assert.Equal(t, "response-link-server", respLink.Server.Name,
+		"response.links[].server.name")
+
 	// Link Object, whose server is the one Server Object outside a servers list
 	link := doc.Components.Links["petById"]
 	require.NotNil(t, link)
@@ -260,6 +269,12 @@ func stripOAS32Extensions(doc *OAS3Document) {
 		mt.Extra = nil
 	}
 	for _, link := range doc.Components.Links {
+		link.Extra = nil
+		if link.Server != nil {
+			link.Server.Extra = nil
+		}
+	}
+	for _, link := range doc.Paths["/pets"].Get.Responses.Codes["200"].Links {
 		link.Extra = nil
 		if link.Server != nil {
 			link.Server.Extra = nil

--- a/parser/oas32_roundtrip_test.go
+++ b/parser/oas32_roundtrip_test.go
@@ -108,14 +108,18 @@ func assertOAS32FieldsPresent(t *testing.T, doc *OAS3Document) {
 	assert.Equal(t, `{"petType":"dog"}`, ex.SerializedValue, "example.serializedValue")
 
 	// Components Object
-	sharedMediaType := doc.Components.MediaTypes["application/jsonl"]
+	sharedMediaType := doc.Components.MediaTypes["PetStream"]
 	require.NotNil(t, sharedMediaType, "components.mediaTypes")
-	assert.NotNil(t, sharedMediaType.ItemSchema, "components.mediaTypes[].itemSchema")
+	require.NotNil(t, sharedMediaType.ItemSchema, "components.mediaTypes[].itemSchema")
+	assert.Equal(t, "#/components/schemas/Pet", sharedMediaType.ItemSchema.Ref,
+		"components.mediaTypes[].itemSchema.$ref")
 
 	// Link Object, whose server is the one Server Object outside a servers list
 	link := doc.Components.Links["petById"]
 	require.NotNil(t, link)
+	assert.Equal(t, "listPets", link.OperationID, "link.operationId")
 	require.NotNil(t, link.Server, "link.server")
+	assert.Equal(t, "https://api.example.com", link.Server.URL, "link.server.url")
 	assert.Equal(t, "link-server", link.Server.Name, "link.server.name")
 
 	// Security Scheme Object and the OAuth flow objects

--- a/parser/oas32_roundtrip_test.go
+++ b/parser/oas32_roundtrip_test.go
@@ -107,6 +107,17 @@ func assertOAS32FieldsPresent(t *testing.T, doc *OAS3Document) {
 	assert.NotNil(t, ex.DataValue, "example.dataValue")
 	assert.Equal(t, `{"petType":"dog"}`, ex.SerializedValue, "example.serializedValue")
 
+	// Components Object
+	sharedMediaType := doc.Components.MediaTypes["application/jsonl"]
+	require.NotNil(t, sharedMediaType, "components.mediaTypes")
+	assert.NotNil(t, sharedMediaType.ItemSchema, "components.mediaTypes[].itemSchema")
+
+	// Link Object, whose server is the one Server Object outside a servers list
+	link := doc.Components.Links["petById"]
+	require.NotNil(t, link)
+	require.NotNil(t, link.Server, "link.server")
+	assert.Equal(t, "link-server", link.Server.Name, "link.server.name")
+
 	// Security Scheme Object and the OAuth flow objects
 	oauth := doc.Components.SecuritySchemes["oauth"]
 	require.NotNil(t, oauth)
@@ -240,6 +251,16 @@ func stripOAS32Extensions(doc *OAS3Document) {
 	pet.Discriminator.Extra = nil
 	pet.Properties["tag"].XML.Extra = nil
 	doc.Components.Examples["withData"].Extra = nil
+
+	for _, mt := range doc.Components.MediaTypes {
+		mt.Extra = nil
+	}
+	for _, link := range doc.Components.Links {
+		link.Extra = nil
+		if link.Server != nil {
+			link.Server.Extra = nil
+		}
+	}
 
 	oauth := doc.Components.SecuritySchemes["oauth"]
 	oauth.Extra = nil

--- a/testdata/oas32-all-fields.json
+++ b/testdata/oas32-all-fields.json
@@ -11,6 +11,25 @@
         "x-example-ext": "keep"
       }
     },
+    "links": {
+      "petById": {
+        "operationId": "listPets",
+        "server": {
+          "name": "link-server",
+          "url": "https://api.example.com",
+          "x-server-ext": "keep"
+        },
+        "x-link-ext": "keep"
+      }
+    },
+    "mediaTypes": {
+      "application/jsonl": {
+        "itemSchema": {
+          "$ref": "#/components/schemas/Pet"
+        },
+        "x-media-type-ext": "keep"
+      }
+    },
     "schemas": {
       "Dog": {
         "type": "object"

--- a/testdata/oas32-all-fields.json
+++ b/testdata/oas32-all-fields.json
@@ -168,6 +168,16 @@
               }
             },
             "description": "A list of pets",
+            "links": {
+              "firstPet": {
+                "operationId": "listPets",
+                "server": {
+                  "name": "response-link-server",
+                  "url": "https://api.example.com",
+                  "x-response-link-server-ext": "keep"
+                }
+              }
+            },
             "summary": "Pets, or the default shape",
             "x-response-ext": "keep"
           }

--- a/testdata/oas32-all-fields.json
+++ b/testdata/oas32-all-fields.json
@@ -23,7 +23,7 @@
       }
     },
     "mediaTypes": {
-      "application/jsonl": {
+      "PetStream": {
         "itemSchema": {
           "$ref": "#/components/schemas/Pet"
         },

--- a/testdata/oas32-all-fields.yaml
+++ b/testdata/oas32-all-fields.yaml
@@ -134,6 +134,19 @@ components:
         petType: dog
       serializedValue: '{"petType":"dog"}'
       x-example-ext: keep
+  mediaTypes:
+    application/jsonl:
+      itemSchema:
+        $ref: "#/components/schemas/Pet"
+      x-media-type-ext: keep
+  links:
+    petById:
+      operationId: listPets
+      server:
+        url: https://api.example.com
+        name: link-server
+        x-server-ext: keep
+      x-link-ext: keep
   securitySchemes:
     oauth:
       type: oauth2

--- a/testdata/oas32-all-fields.yaml
+++ b/testdata/oas32-all-fields.yaml
@@ -33,6 +33,13 @@ paths:
         "200":
           description: A list of pets
           summary: Pets, or the default shape
+          links:
+            firstPet:
+              operationId: listPets
+              server:
+                url: https://api.example.com
+                name: response-link-server
+                x-response-link-server-ext: keep
           x-response-ext: keep
           content:
             application/jsonl:

--- a/testdata/oas32-all-fields.yaml
+++ b/testdata/oas32-all-fields.yaml
@@ -135,7 +135,7 @@ components:
       serializedValue: '{"petType":"dog"}'
       x-example-ext: keep
   mediaTypes:
-    application/jsonl:
+    PetStream:
       itemSchema:
         $ref: "#/components/schemas/Pet"
       x-media-type-ext: keep

--- a/validator/oas32_test.go
+++ b/validator/oas32_test.go
@@ -1,7 +1,11 @@
 package validator
 
 import (
+	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestOAS32ExampleValueExclusivity covers the Example Object rules from issue
@@ -689,6 +693,34 @@ components:
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assertErrorsMatch(t, validationErrors(t, tt.spec), tt.wantErrors)
+		})
+	}
+}
+
+// TestOAS32AllFieldsFixtureIsValid pins that the shared 3.2 fixture is a valid
+// document.
+//
+// parser and converter both build on it, and both reach it through the parser's
+// structure validation, which does not check the Components key charset. So a
+// `components.mediaTypes` key of `application/jsonl` passed every test in both
+// packages while making the fixture an invalid document.
+//
+// That key is the easy mistake to make twice: the same string is legal as a
+// `content` key, which the fixture still uses, because there it names a media
+// type. Under `components` it names a component, and the allowlist has no slash.
+// The check lives here because parser cannot import validator.
+//
+// https://spec.openapis.org/oas/v3.2.0.html#components-object
+func TestOAS32AllFieldsFixtureIsValid(t *testing.T) {
+	for _, path := range []string{
+		"../testdata/oas32-all-fields.yaml",
+		"../testdata/oas32-all-fields.json",
+	} {
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			result, err := New().Validate(path)
+			require.NoError(t, err)
+			assert.Empty(t, result.Errors,
+				"the full-field fixture must itself be a valid OAS 3.2 document")
 		})
 	}
 }


### PR DESCRIPTION
The validator reports `server.name` inside a Link Object as of #422; the converter did not. That is the same validate/convert inconsistency #411 existed to close, pointing the other way. 🔁

Fixes #420

## What was wrong

`detectOAS32Features` walked only `doc.Servers`, so the one Server Object that is **not** part of a servers list went unreported:

```yaml
links:
  self:
    operationId: listPets
    server:
      url: https://api.example.com
      name: production   # OAS 3.2+, silently dropped on downconvert
```

The section walk also reported `components.mediaTypes` as a container without walking into it, so a 3.2 field on a media type defined there was lost.

## The fixture claimed more than it covered

`testdata/oas32-all-fields.yaml` says it exercises "every fixed field OAS 3.2.0 added over 3.1.1". It had no `components.mediaTypes` — the field arrived with #416 and the fixture was never extended — so neither `parser/oas32_roundtrip_test.go` nor the converter's feature test proved anything about it.

Adding that section is what exposed the container gap above, and adding a Link with a named server gives the fix something to check. Both files are regenerated from one source so they stay the same document; I reproduced the existing JSON byte-for-byte before changing anything.

## The test could not have caught the bug it was for

`TestDownconvertReportsOAS32Fields` asserts field *names*. `'name'` was already reported for the document's own servers, so it passed for the entire time a Link's server went unreported — I verified this by removing the fix and watching it stay green.

A second test pins the **location** for every field name that more than one object carries: `name` on both kinds of Server Object, `summary` on a Tag and on a Response, and `mediaTypes` with its contents. Matched per issue rather than against one joined blob, since every path here is a prefix of another.

## Two things found along the way

**An invalid fixture.** `application/jsonl` is not a legal Components key — the spec requires every Components fixed field to use `^[a-zA-Z0-9\.\-_]+$`, and the key names a *component*, not a media type. `oastools validate` reported it immediately; nothing had ever run the validator on the fixture, because parser and converter both reach it through the parser's structure validation, which does not check the key charset. A test in `validator` now asserts the fixture validates clean — it has to live there, since `parser` cannot import `validator`. The same string remains legal, and present, as a `content` key.

**Non-deterministic output** (own commit, pre-existing). The section walks range over maps, so the fixture reported its issues in four distinct orderings across eight runs. The file already had the concern solved locally — the Tag fields are an ordered slice with a comment saying why — but the section walks never got the same treatment. Sorting what the pass appended matches the validator's gate in #411, so `validate` and `convert` now agree on order as well as inventory. Fixed here rather than filed because the Link and mediaTypes walks add two more map ranges to it.

## Parity

Converting the full fixture to 3.0.3 and validating the result now report the same inventory. The only fields the converter reports and the validator does not are `defaultMapping`, `nodeType` and `in: "querystring"`, which reach the validator through their own rules. Nothing is validator-only.

## Follow-up filed

#423 — the schema-level 3.2 rules never reach response content or parameter schemas, in **either** package. Pre-existing, spans two packages, so kept out of this PR. Found while verifying a review finding here.

## Checks

`make check` green. CodeRabbit CLI across three passes: 5 findings, then 1, then 3 — each applied or skipped with the reason verified by reproduction, including two skips where the requested change was already covered (`TestComponentNameCharset/mediaTypes/rejects_slash` already exists) or would have contradicted the file's design.