### PR TITLE
fix(validator,converter): validate every schema, not only two positions

### DIFF
--- a/converter/oas32_features.go
+++ b/converter/oas32_features.go
@@ -262,6 +262,12 @@ func (c *Converter) detectOAS32MediaTypeFeatures(mt *parser.MediaType, prefix st
 	for name, ex := range mt.Examples {
 		detectOAS32ExampleFeatures(ex, prefix+".examples."+name, report)
 	}
+	// The ordinary schema as well as the 3.2 itemSchema beside it: only itemSchema
+	// was walked, so a 3.2 field in the schema every 3.0 document already has went
+	// unreported. Issue #423.
+	if mt.Schema != nil {
+		c.detectOAS32SchemaFeatures(mt.Schema, prefix+".schema", report, make(map[*parser.Schema]bool))
+	}
 	if mt.ItemSchema != nil {
 		c.detectOAS32SchemaFeatures(mt.ItemSchema, prefix+".itemSchema", report, make(map[*parser.Schema]bool))
 	}

--- a/converter/oas32_features_test.go
+++ b/converter/oas32_features_test.go
@@ -158,6 +158,10 @@ func TestDownconvertReportsAmbiguousFieldsAtTheirLocation(t *testing.T) {
 				"paths./pets.get.responses.200: 'summary'",
 				// the Components section that is itself 3.2-only, and what is inside it:
 				// reporting only the container would understate what the target loses
+				// nodeType, on a components schema and on an inline one: the schema
+				// rules reached components.schemas and the request body alone
+				"components.schemas.Pet.properties.tag.xml: 'nodeType'",
+				"paths./pets.get.responses.200.content.multipart/form-data.schema.properties.meta.xml: 'nodeType'",
 				"components.mediaTypes: 'mediaTypes'",
 				"components.mediaTypes.PetStream: 'itemSchema'",
 			} {

--- a/internal/corpusutil/corpus.go
+++ b/internal/corpusutil/corpus.go
@@ -73,13 +73,21 @@ var Corpus = []SpecInfo{
 		SizeBytes:      405_000,
 	},
 	{
-		Name:           "GoogleMaps",
-		Filename:       "google-maps-platform.json",
-		URL:            "https://raw.githubusercontent.com/googlemaps/openapi-specification/main/dist/google-maps-platform-openapi3.json",
-		OASVersion:     "3.0.3",
-		Format:         formatJSON,
-		ExpectedValid:  true, // Now valid after fixing $ref parameter validation (was 228 false positives)
-		ExpectedErrors: 0,
+		Name:       "GoogleMaps",
+		Filename:   "google-maps-platform.json",
+		URL:        "https://raw.githubusercontent.com/googlemaps/openapi-specification/main/dist/google-maps-platform-openapi3.json",
+		OASVersion: "3.0.3",
+		Format:     formatJSON,
+		// Invalid again as of #423, and correctly so. Two parameters declare
+		// `"type": "string"` with `"enum": [0, 1, 2, 3, 4]`, five integers in a
+		// string-typed enum. The spec's own description says the values "range
+		// between 0 and 4", so the type is the mistake, not the enum.
+		//
+		// It read as valid only because parameter schemas were never validated:
+		// validateSchema was reached from the request body and components.schemas
+		// alone. The earlier note below is still true of the $ref work it describes.
+		ExpectedValid:  false, // Was true after $ref parameter validation removed 228 false positives
+		ExpectedErrors: 10,
 		IsLarge:        false,
 		SizeBytes:      500_000,
 	},

--- a/parser/oas32_roundtrip_test.go
+++ b/parser/oas32_roundtrip_test.go
@@ -107,6 +107,19 @@ func assertOAS32FieldsPresent(t *testing.T, doc *OAS3Document) {
 	assert.NotNil(t, ex.DataValue, "example.dataValue")
 	assert.Equal(t, `{"petType":"dog"}`, ex.SerializedValue, "example.serializedValue")
 
+	// An inline schema in a media type, not one under components.schemas
+	formData := resp.Content["multipart/form-data"]
+	require.NotNil(t, formData)
+	require.NotNil(t, formData.Schema)
+	metaProp := formData.Schema.Properties["meta"]
+	require.NotNil(t, metaProp, "inline media type schema property")
+	require.NotNil(t, metaProp.XML, "inline schema xml")
+	assert.Equal(t, "meta", metaProp.XML.Name, "inline schema xml.name")
+	assert.Equal(t, "element", metaProp.XML.NodeType, "inline schema xml.nodeType")
+	// No extension assertion here: this function also runs against the document
+	// stripOAS32Extensions has cleared, which is how the fast marshal path is
+	// exercised. Extension survival is the strip/no-strip pairing's job.
+
 	// Components Object
 	sharedMediaType := doc.Components.MediaTypes["PetStream"]
 	require.NotNil(t, sharedMediaType, "components.mediaTypes")
@@ -161,10 +174,42 @@ func parseOAS32Fixture(t *testing.T, path string) *OAS3Document {
 
 // TestOAS32AllFieldsParse is the decode half of issue #397: the fields have to
 // reach the struct at all, from either format.
+// assertInlineXMLExtensionPresent asserts the extension on the inline media type
+// schema survived. Separate from [assertOAS32FieldsPresent], which also runs
+// against the document stripOAS32Extensions has cleared.
+//
+// The suite proved extensions are *removed* on the fast path and that the two
+// formats agree with each other, but nothing asserted an extension survives a
+// marshal round-trip at all.
+func assertInlineXMLExtensionPresent(t *testing.T, doc *OAS3Document) {
+	t.Helper()
+
+	xml := inlineMetaXML(t, doc)
+	assert.Equal(t, "keep", xml.Extra["x-inline-xml-ext"],
+		"the inline schema's extension should survive the round trip")
+}
+
+// inlineMetaXML returns the XML Object on the inline media type schema property.
+func inlineMetaXML(t *testing.T, doc *OAS3Document) *XML {
+	t.Helper()
+
+	resp := doc.Paths["/pets"].Get.Responses.Codes["200"]
+	require.NotNil(t, resp)
+	formData := resp.Content["multipart/form-data"]
+	require.NotNil(t, formData)
+	require.NotNil(t, formData.Schema)
+	meta := formData.Schema.Properties["meta"]
+	require.NotNil(t, meta)
+	require.NotNil(t, meta.XML)
+	return meta.XML
+}
+
 func TestOAS32AllFieldsParse(t *testing.T) {
 	for name, path := range map[string]string{"yaml": oas32FixtureYAML, "json": oas32FixtureJSON} {
 		t.Run(name, func(t *testing.T) {
-			assertOAS32FieldsPresent(t, parseOAS32Fixture(t, path))
+			doc := parseOAS32Fixture(t, path)
+			assertOAS32FieldsPresent(t, doc)
+			assertInlineXMLExtensionPresent(t, doc)
 		})
 	}
 }
@@ -189,6 +234,7 @@ func TestOAS32AllFieldsSurviveRoundTrip(t *testing.T) {
 		require.True(t, ok)
 
 		assertOAS32FieldsPresent(t, reparsed)
+		assertInlineXMLExtensionPresent(t, reparsed)
 	})
 
 	t.Run("yaml", func(t *testing.T) {
@@ -203,6 +249,7 @@ func TestOAS32AllFieldsSurviveRoundTrip(t *testing.T) {
 		require.True(t, ok)
 
 		assertOAS32FieldsPresent(t, reparsed)
+		assertInlineXMLExtensionPresent(t, reparsed)
 	})
 }
 
@@ -230,6 +277,8 @@ func TestOAS32AllFieldsRoundTripWithoutExtensions(t *testing.T) {
 	require.True(t, ok)
 
 	assertOAS32FieldsPresent(t, reparsed)
+	assert.NotContains(t, inlineMetaXML(t, reparsed).Extra, "x-inline-xml-ext",
+		"the extension was cleared, so it must not come back")
 }
 
 // stripOAS32Extensions clears Extra on every object the fixture puts an extension
@@ -246,6 +295,13 @@ func stripOAS32Extensions(doc *OAS3Document) {
 	resp.Extra = nil
 	for _, mt := range resp.Content {
 		mt.Extra = nil
+		if mt.Schema != nil {
+			for _, prop := range mt.Schema.Properties {
+				if prop != nil && prop.XML != nil {
+					prop.XML.Extra = nil
+				}
+			}
+		}
 		if mt.ItemEncoding != nil {
 			mt.ItemEncoding.Extra = nil
 		}

--- a/testdata/oas32-all-fields.json
+++ b/testdata/oas32-all-fields.json
@@ -145,7 +145,12 @@
                 "schema": {
                   "properties": {
                     "meta": {
-                      "type": "object"
+                      "type": "object",
+                      "xml": {
+                        "name": "meta",
+                        "nodeType": "element",
+                        "x-inline-xml-ext": "keep"
+                      }
                     }
                   },
                   "type": "object"

--- a/testdata/oas32-all-fields.yaml
+++ b/testdata/oas32-all-fields.yaml
@@ -63,6 +63,13 @@ paths:
                 properties:
                   meta:
                     type: object
+                    # Inline rather than under components.schemas: the schema-level
+                    # 3.2 rules reached components.schemas and the request body
+                    # alone, so this position had no coverage at all. Issue #423.
+                    xml:
+                      name: meta
+                      nodeType: element
+                      x-inline-xml-ext: keep
               encoding:
                 meta:
                   contentType: application/json

--- a/validator/oas3.go
+++ b/validator/oas3.go
@@ -234,6 +234,9 @@ func (v *Validator) validateOAS3Paths(doc *parser.OAS3Document, result *Validati
 		// already built, rather than taking a traversal of their own (see oas32.go).
 		v.validateOAS32PathItem(pathItem, pathPrefix, doc.OASVersion, operations, result)
 
+		// A path item carries parameters of its own, shared by every operation in it.
+		v.validateParameterListSchemas(pathItem.Parameters, pathPrefix, result)
+
 		for method, op := range operations {
 			if op == nil {
 				continue
@@ -262,6 +265,10 @@ func (v *Validator) validateOAS3Operation(op *parser.Operation, path string, res
 
 	// Validate response status codes
 	v.validateResponseStatusCodes(op.Responses, path, result, baseURL)
+
+	// Every schema this operation carries beyond the request body, which
+	// validateOAS3RequestBody already reaches. See schema_traversal.go.
+	v.validateOAS3OperationSchemas(op, path, result)
 }
 
 // validateOAS3RequestBody validates a request body in OAS 3.x
@@ -296,10 +303,10 @@ func (v *Validator) validateOAS3RequestBody(requestBody *parser.RequestBody, pat
 			)
 		}
 
-		// Validate that media type has a schema
-		if mediaTypeObj != nil && mediaTypeObj.Schema != nil {
-			v.validateSchema(mediaTypeObj.Schema, mediaTypePath+".schema", result)
-		}
+		// Both the schema and the 3.2 itemSchema beside it, so a request body is
+		// covered the same way every other media type position is. See
+		// schema_traversal.go.
+		v.validateMediaTypeSchemas(mediaTypeObj, mediaTypePath, result)
 	}
 }
 
@@ -312,6 +319,10 @@ func (v *Validator) validateOAS3Components(doc *parser.OAS3Document, result *Val
 	// Checked across every section first, so a nil value cannot cause its name
 	// to go unchecked by the loops below, several of which skip nil entries.
 	v.validateOAS3ComponentNames(doc.Components, result, baseURL)
+
+	// The schemas held by the sections other than `schemas`. See
+	// schema_traversal.go.
+	v.validateOAS3ComponentSchemas(doc.Components, result)
 
 	// Validate schemas
 	for name, schema := range doc.Components.Schemas {
@@ -552,6 +563,9 @@ func (v *Validator) validateOAS3Webhooks(doc *parser.OAS3Document, result *Valid
 
 		v.validateOAS32PathItem(pathItem, pathPrefix, doc.OASVersion, operations, result)
 
+		// A path item carries parameters of its own, shared by every operation in it.
+		v.validateParameterListSchemas(pathItem.Parameters, pathPrefix, result)
+
 		for method, op := range operations {
 			if op == nil {
 				continue
@@ -604,6 +618,9 @@ func (v *Validator) validateOAS3ComponentPathItems(doc *parser.OAS3Document, res
 		operations := parser.GetOperations(pathItem, doc.OASVersion)
 
 		v.validateOAS32PathItem(pathItem, prefix, doc.OASVersion, operations, result)
+
+		// A path item carries parameters of its own, shared by every operation in it.
+		v.validateParameterListSchemas(pathItem.Parameters, prefix, result)
 
 		for method, op := range operations {
 			if op == nil {

--- a/validator/schema_traversal.go
+++ b/validator/schema_traversal.go
@@ -17,13 +17,23 @@ package validator
 import (
 	"strconv"
 
+	"github.com/erraggy/oastools/internal/httputil"
+
 	"github.com/erraggy/oastools/parser"
 )
 
 // validateOAS3OperationSchemas validates the schemas an operation carries that
 // [Validator.validateOAS3RequestBody] does not already reach.
 func (v *Validator) validateOAS3OperationSchemas(op *parser.Operation, path string, result *ValidationResult) {
-	v.validateOperationSchemasAtDepth(op, path, result, make(map[*parser.PathItem]bool), 0)
+	// The visited set exists only for the callback traversal, and most operations
+	// carry no callbacks. Allocating it unconditionally cost one map per operation
+	// in the document; nil is never written, because validatePathItemSchemas is
+	// reachable only through a callback.
+	var visited map[*parser.PathItem]bool
+	if op != nil && len(op.Callbacks) > 0 {
+		visited = make(map[*parser.PathItem]bool)
+	}
+	v.validateOperationSchemasAtDepth(op, path, result, visited, 0)
 }
 
 // validateOperationSchemasAtDepth carries the callback traversal's cycle state,
@@ -44,6 +54,28 @@ func (v *Validator) validateOperationSchemasAtDepth(op *parser.Operation, path s
 	for code, resp := range op.Responses.Codes {
 		v.validateResponseSchemas(resp, path+".responses."+code, result)
 	}
+}
+
+// pathItemOperations pairs each of a Path Item's operation fields with its method
+// name.
+//
+// Listed rather than taken from [parser.GetOperations], which needs a version to
+// decide which methods exist: a schema is a schema whatever version admits the
+// operation holding it. A package-level slice rather than a map built per path
+// item, so it allocates nothing and iterates in a stable order.
+var pathItemOperations = []struct {
+	method string
+	get    func(*parser.PathItem) *parser.Operation
+}{
+	{httputil.MethodGet, func(p *parser.PathItem) *parser.Operation { return p.Get }},
+	{httputil.MethodPut, func(p *parser.PathItem) *parser.Operation { return p.Put }},
+	{httputil.MethodPost, func(p *parser.PathItem) *parser.Operation { return p.Post }},
+	{httputil.MethodDelete, func(p *parser.PathItem) *parser.Operation { return p.Delete }},
+	{httputil.MethodOptions, func(p *parser.PathItem) *parser.Operation { return p.Options }},
+	{httputil.MethodHead, func(p *parser.PathItem) *parser.Operation { return p.Head }},
+	{httputil.MethodPatch, func(p *parser.PathItem) *parser.Operation { return p.Patch }},
+	{httputil.MethodTrace, func(p *parser.PathItem) *parser.Operation { return p.Trace }},
+	{httputil.MethodQuery, func(p *parser.PathItem) *parser.Operation { return p.Query }},
 }
 
 // maxCallbackNestingDepth bounds the recursive Callback traversal. A callback
@@ -84,15 +116,8 @@ func (v *Validator) validatePathItemSchemas(item *parser.PathItem, path string, 
 
 	v.validateParameterListSchemas(item.Parameters, path, result)
 
-	// Listed rather than taken from [parser.GetOperations], which needs a version
-	// to decide which methods exist. A schema is a schema whatever version admits
-	// the operation holding it.
-	for method, op := range map[string]*parser.Operation{
-		"get": item.Get, "put": item.Put, "post": item.Post, "delete": item.Delete,
-		"options": item.Options, "head": item.Head, "patch": item.Patch,
-		"trace": item.Trace, "query": item.Query,
-	} {
-		v.validateOperationSchemasAtDepth(op, path+"."+method, result, visited, depth+1)
+	for _, entry := range pathItemOperations {
+		v.validateOperationSchemasAtDepth(entry.get(item), path+"."+entry.method, result, visited, depth+1)
 	}
 	for method, op := range item.AdditionalOperations {
 		v.validateOperationSchemasAtDepth(op, path+".additionalOperations."+method, result, visited, depth+1)
@@ -223,5 +248,7 @@ func (v *Validator) validateOAS3ComponentSchemas(c *parser.Components, result *V
 	for name, mt := range c.MediaTypes {
 		v.validateMediaTypeSchemas(mt, "components.mediaTypes."+name, result)
 	}
-	v.validateCallbackMapSchemas(c.Callbacks, "components", result, make(map[*parser.PathItem]bool), 0)
+	if len(c.Callbacks) > 0 {
+		v.validateCallbackMapSchemas(c.Callbacks, "components", result, make(map[*parser.PathItem]bool), 0)
+	}
 }

--- a/validator/schema_traversal.go
+++ b/validator/schema_traversal.go
@@ -1,0 +1,227 @@
+// schema_traversal.go reaches the Schema Objects the rest of the validator does
+// not.
+//
+// [Validator.validateSchema] was called from two places: the Request Body media
+// type loop and `components.schemas`. Every schema in a response, a parameter or
+// a header was therefore never validated at all — by any of the rules
+// validateSchema runs, not only the OAS 3.2 ones that exposed it. Issue #423 has
+// the four-position reproduction.
+//
+// Sections are walked in map order, like every other walk in this package. The
+// validator's error order is already not stable — the existing path walk alone
+// produces five orderings in eight runs — so sorting keys here would allocate a
+// slice per map on every document to fix a fraction of a problem. Issue #425.
+
+package validator
+
+import (
+	"strconv"
+
+	"github.com/erraggy/oastools/parser"
+)
+
+// validateOAS3OperationSchemas validates the schemas an operation carries that
+// [Validator.validateOAS3RequestBody] does not already reach.
+func (v *Validator) validateOAS3OperationSchemas(op *parser.Operation, path string, result *ValidationResult) {
+	v.validateOperationSchemasAtDepth(op, path, result, make(map[*parser.PathItem]bool), 0)
+}
+
+// validateOperationSchemasAtDepth carries the callback traversal's cycle state,
+// which only that traversal needs.
+func (v *Validator) validateOperationSchemasAtDepth(op *parser.Operation, path string, result *ValidationResult, visited map[*parser.PathItem]bool, depth int) {
+	if op == nil {
+		return
+	}
+	v.validateCallbackMapSchemas(op.Callbacks, path, result, visited, depth)
+	v.validateParameterListSchemas(op.Parameters, path, result)
+
+	if op.Responses == nil {
+		return
+	}
+	if op.Responses.Default != nil {
+		v.validateResponseSchemas(op.Responses.Default, path+".responses.default", result)
+	}
+	for code, resp := range op.Responses.Codes {
+		v.validateResponseSchemas(resp, path+".responses."+code, result)
+	}
+}
+
+// maxCallbackNestingDepth bounds the recursive Callback traversal. A callback
+// holds path items whose operations hold callbacks, so the graph can close a
+// loop. Same reasoning as [maxPathItemNestingDepth]: a parsed document cannot
+// build one, but ValidateParsed takes the caller's.
+const maxCallbackNestingDepth = 100
+
+// validateCallbackMapSchemas validates the schemas held by a named callback map.
+func (v *Validator) validateCallbackMapSchemas(callbacks map[string]*parser.Callback, path string, result *ValidationResult, visited map[*parser.PathItem]bool, depth int) {
+	for name, cb := range callbacks {
+		if cb == nil {
+			continue
+		}
+		for expr, item := range *cb {
+			v.validatePathItemSchemas(item, path+".callbacks."+name+"."+expr, result, visited, depth)
+		}
+	}
+}
+
+// validatePathItemSchemas validates the schemas a Path Item and its operations
+// carry. Used for the path items inside callbacks; the ones under `paths`,
+// `webhooks` and `components.pathItems` are reached by the walks that already
+// visit them.
+func (v *Validator) validatePathItemSchemas(item *parser.PathItem, path string, result *ValidationResult, visited map[*parser.PathItem]bool, depth int) {
+	if item == nil || depth > maxCallbackNestingDepth {
+		return
+	}
+	// The depth bound alone does not contain a cycle: a path item whose operations
+	// each lead back to it branches, so the walk is exponential in depth long
+	// before the bound is reached — two such operations ran for minutes without
+	// returning. Visiting each path item once is what makes it terminate; the
+	// bound stays as a fail-safe. Mirrors validateSchemaWithVisited.
+	if visited[item] {
+		return
+	}
+	visited[item] = true
+
+	v.validateParameterListSchemas(item.Parameters, path, result)
+
+	// Listed rather than taken from [parser.GetOperations], which needs a version
+	// to decide which methods exist. A schema is a schema whatever version admits
+	// the operation holding it.
+	for method, op := range map[string]*parser.Operation{
+		"get": item.Get, "put": item.Put, "post": item.Post, "delete": item.Delete,
+		"options": item.Options, "head": item.Head, "patch": item.Patch,
+		"trace": item.Trace, "query": item.Query,
+	} {
+		v.validateOperationSchemasAtDepth(op, path+"."+method, result, visited, depth+1)
+	}
+	for method, op := range item.AdditionalOperations {
+		v.validateOperationSchemasAtDepth(op, path+".additionalOperations."+method, result, visited, depth+1)
+	}
+}
+
+// validateResponseSchemas validates a Response Object's content and header
+// schemas.
+func (v *Validator) validateResponseSchemas(resp *parser.Response, path string, result *ValidationResult) {
+	if resp == nil {
+		return
+	}
+	v.validateContentSchemas(resp.Content, path, result)
+	v.validateHeaderMapSchemas(resp.Headers, path, result)
+}
+
+// validateContentSchemas validates the schema of each media type in a content map.
+func (v *Validator) validateContentSchemas(content map[string]*parser.MediaType, path string, result *ValidationResult) {
+	if len(content) == 0 {
+		return
+	}
+	for mediaType, mt := range content {
+		v.validateMediaTypeSchemas(mt, path+".content."+mediaType, result)
+	}
+}
+
+// validateMediaTypeSchemas validates a Media Type Object's schema and, at 3.2, the
+// itemSchema beside it.
+func (v *Validator) validateMediaTypeSchemas(mt *parser.MediaType, path string, result *ValidationResult) {
+	if mt == nil {
+		return
+	}
+	if mt.Schema != nil {
+		v.validateSchema(mt.Schema, path+".schema", result)
+	}
+	if mt.ItemSchema != nil {
+		v.validateSchema(mt.ItemSchema, path+".itemSchema", result)
+	}
+
+	for name, enc := range mt.Encoding {
+		v.validateEncodingSchemas(enc, path+".encoding."+name, result, 0)
+	}
+	v.validateEncodingSchemas(mt.ItemEncoding, path+".itemEncoding", result, 0)
+	for i, enc := range mt.PrefixEncoding {
+		v.validateEncodingSchemas(enc, path+".prefixEncoding["+strconv.Itoa(i)+"]", result, 0)
+	}
+}
+
+// validateEncodingSchemas validates the schemas an Encoding Object's headers
+// carry, and recurses through the encoding nesting 3.2 added. depth mirrors the
+// bound on [Validator.visitEncodingExamples].
+func (v *Validator) validateEncodingSchemas(enc *parser.Encoding, path string, result *ValidationResult, depth int) {
+	if enc == nil || depth > maxEncodingNestingDepth {
+		return
+	}
+	v.validateHeaderMapSchemas(enc.Headers, path, result)
+
+	for name, nested := range enc.Encoding {
+		v.validateEncodingSchemas(nested, path+".encoding."+name, result, depth+1)
+	}
+	v.validateEncodingSchemas(enc.ItemEncoding, path+".itemEncoding", result, depth+1)
+	for i, nested := range enc.PrefixEncoding {
+		v.validateEncodingSchemas(nested, path+".prefixEncoding["+strconv.Itoa(i)+"]", result, depth+1)
+	}
+}
+
+// validateParameterListSchemas validates the schemas of a parameter list.
+func (v *Validator) validateParameterListSchemas(params []*parser.Parameter, path string, result *ValidationResult) {
+	for i, param := range params {
+		v.validateParameterSchemas(param, path+".parameters["+strconv.Itoa(i)+"]", result)
+	}
+}
+
+// validateParameterSchemas validates a Parameter Object's schema and content
+// schemas. A parameter carries one or the other, never both, but which one is a
+// separate rule's business.
+func (v *Validator) validateParameterSchemas(param *parser.Parameter, path string, result *ValidationResult) {
+	if param == nil {
+		return
+	}
+	if param.Schema != nil {
+		v.validateSchema(param.Schema, path+".schema", result)
+	}
+	v.validateContentSchemas(param.Content, path, result)
+}
+
+// validateHeaderMapSchemas validates the schemas of a named header map.
+func (v *Validator) validateHeaderMapSchemas(headers map[string]*parser.Header, path string, result *ValidationResult) {
+	if len(headers) == 0 {
+		return
+	}
+	for name, header := range headers {
+		v.validateHeaderSchemas(header, path+".headers."+name, result)
+	}
+}
+
+// validateHeaderSchemas validates a Header Object's schema and content schemas.
+func (v *Validator) validateHeaderSchemas(header *parser.Header, path string, result *ValidationResult) {
+	if header == nil {
+		return
+	}
+	if header.Schema != nil {
+		v.validateSchema(header.Schema, path+".schema", result)
+	}
+	v.validateContentSchemas(header.Content, path, result)
+}
+
+// validateOAS3ComponentSchemas validates the schemas held by the Components
+// sections that nothing else reaches.
+//
+// `schemas` and `requestBodies` are not among them: validateOAS3Components walks
+// the first directly and the second through validateOAS3RequestBody, which
+// validates its content schemas. Walking either here reports every error in it
+// twice.
+func (v *Validator) validateOAS3ComponentSchemas(c *parser.Components, result *ValidationResult) {
+	if c == nil {
+		return
+	}
+	for name, resp := range c.Responses {
+		v.validateResponseSchemas(resp, "components.responses."+name, result)
+	}
+	for name, param := range c.Parameters {
+		v.validateParameterSchemas(param, "components.parameters."+name, result)
+	}
+	for name, header := range c.Headers {
+		v.validateHeaderSchemas(header, "components.headers."+name, result)
+	}
+	for name, mt := range c.MediaTypes {
+		v.validateMediaTypeSchemas(mt, "components.mediaTypes."+name, result)
+	}
+	v.validateCallbackMapSchemas(c.Callbacks, "components", result, make(map[*parser.PathItem]bool), 0)
+}

--- a/validator/schema_traversal_test.go
+++ b/validator/schema_traversal_test.go
@@ -1,0 +1,526 @@
+package validator
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erraggy/oastools/parser"
+)
+
+// TestSchemaValidationReachesEveryPosition covers issue #423.
+//
+// validateSchema was called from two places — the Request Body media type loop
+// and `components.schemas` — so a schema in a response, a parameter or a header
+// was never validated by any of the six rule families it runs. The OAS 3.2 field
+// check is only how the gap surfaced; `xml.nodeType` is used here because it is
+// unambiguous and needs nothing else in the document to fire.
+//
+// One position per case, so a failure names the position that lost its
+// traversal rather than a count.
+func TestSchemaValidationReachesEveryPosition(t *testing.T) {
+	// nodeType is OAS 3.2+, so a 3.0.3 document carrying it is an error wherever
+	// the traversal reaches.
+	const xml = `{type: string, xml: {name: x, nodeType: attribute}}`
+
+	tests := []struct {
+		name     string
+		spec     string
+		wantPath string
+	}{
+		{
+			name: "request body content schema",
+			spec: `
+paths:
+  /pets:
+    post:
+      operationId: addPet
+      requestBody:
+        content: {application/json: {schema: ` + xml + `}}
+      responses: {"200": {description: OK}}
+`,
+			wantPath: "paths./pets.post.requestBody.content.application/json.schema.xml",
+		},
+		{
+			name: "response content schema",
+			spec: `
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        "200":
+          description: OK
+          content: {application/json: {schema: ` + xml + `}}
+`,
+			wantPath: "paths./pets.get.responses.200.content.application/json.schema.xml",
+		},
+		{
+			name: "default response content schema",
+			spec: `
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        default:
+          description: Fallback
+          content: {application/json: {schema: ` + xml + `}}
+`,
+			wantPath: "paths./pets.get.responses.default.content.application/json.schema.xml",
+		},
+		{
+			name: "operation parameter schema",
+			spec: `
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      parameters: [{name: q, in: query, schema: ` + xml + `}]
+      responses: {"200": {description: OK}}
+`,
+			wantPath: "paths./pets.get.parameters[0].schema.xml",
+		},
+		{
+			name: "path item parameter schema",
+			spec: `
+paths:
+  /pets:
+    parameters: [{name: q, in: query, schema: ` + xml + `}]
+    get:
+      operationId: listPets
+      responses: {"200": {description: OK}}
+`,
+			wantPath: "paths./pets.parameters[0].schema.xml",
+		},
+		{
+			name: "response header schema",
+			spec: `
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        "200":
+          description: OK
+          headers: {X-Rate: {schema: ` + xml + `}}
+`,
+			wantPath: "paths./pets.get.responses.200.headers.X-Rate.schema.xml",
+		},
+		{
+			name: "component response content schema",
+			spec: `
+paths: {}
+components:
+  responses:
+    Shared:
+      description: OK
+      content: {application/json: {schema: ` + xml + `}}
+`,
+			wantPath: "components.responses.Shared.content.application/json.schema.xml",
+		},
+		{
+			name: "component parameter schema",
+			spec: `
+paths: {}
+components:
+  parameters:
+    Shared: {name: q, in: query, schema: ` + xml + `}
+`,
+			wantPath: "components.parameters.Shared.schema.xml",
+		},
+		{
+			name: "component header schema",
+			spec: `
+paths: {}
+components:
+  headers:
+    Shared: {schema: ` + xml + `}
+`,
+			wantPath: "components.headers.Shared.schema.xml",
+		},
+		{
+			name: "component request body content schema",
+			spec: `
+paths: {}
+components:
+  requestBodies:
+    Shared:
+      content: {application/json: {schema: ` + xml + `}}
+`,
+			wantPath: "components.requestBodies.Shared.content.application/json.schema.xml",
+		},
+		{
+			name: "request body itemSchema",
+			spec: `
+paths:
+  /pets:
+    post:
+      operationId: addPet
+      requestBody:
+        content: {application/json: {itemSchema: ` + xml + `}}
+      responses: {"200": {description: OK}}
+`,
+			wantPath: "paths./pets.post.requestBody.content.application/json.itemSchema.xml",
+		},
+		{
+			name: "component request body itemSchema",
+			spec: `
+paths: {}
+components:
+  requestBodies:
+    Shared:
+      content: {application/json: {itemSchema: ` + xml + `}}
+`,
+			wantPath: "components.requestBodies.Shared.content.application/json.itemSchema.xml",
+		},
+		{
+			name: "webhook operation parameter schema",
+			spec: `
+paths: {}
+webhooks:
+  petEvent:
+    post:
+      operationId: onPet
+      parameters: [{name: q, in: query, schema: ` + xml + `}]
+      responses: {"200": {description: OK}}
+`,
+			wantPath: "webhooks.petEvent.post.parameters[0].schema.xml",
+		},
+		{
+			name: "webhook operation response schema",
+			spec: `
+paths: {}
+webhooks:
+  petEvent:
+    post:
+      operationId: onPet
+      responses:
+        "200":
+          description: OK
+          content: {application/json: {schema: ` + xml + `}}
+`,
+			wantPath: "webhooks.petEvent.post.responses.200.content.application/json.schema.xml",
+		},
+		{
+			name: "component path item response schema",
+			spec: `
+paths: {}
+components:
+  pathItems:
+    shared:
+      post:
+        operationId: shared
+        responses:
+          "200":
+            description: OK
+            content: {application/json: {schema: ` + xml + `}}
+`,
+			wantPath: "components.pathItems.shared.post.responses.200.content.application/json.schema.xml",
+		},
+		{
+			name: "component path item parameter schema",
+			spec: `
+paths: {}
+components:
+  pathItems:
+    shared:
+      parameters: [{name: q, in: query, schema: ` + xml + `}]
+      post:
+        operationId: shared
+        responses: {"200": {description: OK}}
+`,
+			wantPath: "components.pathItems.shared.parameters[0].schema.xml",
+		},
+		{
+			name: "encoding header schema",
+			spec: `
+paths:
+  /pets:
+    post:
+      operationId: addPet
+      requestBody:
+        content:
+          multipart/form-data:
+            schema: {type: object}
+            encoding:
+              part:
+                contentType: text/plain
+                headers: {X-Enc: {schema: ` + xml + `}}
+      responses: {"200": {description: OK}}
+`,
+			wantPath: "paths./pets.post.requestBody.content.multipart/form-data.encoding.part.headers.X-Enc.schema.xml",
+		},
+		{
+			name: "operation callback response schema",
+			spec: `
+paths:
+  /pets:
+    post:
+      operationId: addPet
+      callbacks:
+        onEvent:
+          '{$request.body#/url}':
+            post:
+              operationId: cb
+              responses:
+                "200":
+                  description: OK
+                  content: {application/json: {schema: ` + xml + `}}
+      responses: {"200": {description: OK}}
+`,
+			wantPath: "paths./pets.post.callbacks.onEvent.{$request.body#/url}.post.responses.200.content.application/json.schema.xml",
+		},
+		{
+			name: "component callback response schema",
+			spec: `
+paths: {}
+components:
+  callbacks:
+    Shared:
+      '{$request.body#/u}':
+        post:
+          operationId: cbShared
+          responses:
+            "200":
+              description: OK
+              content: {application/json: {schema: ` + xml + `}}
+`,
+			wantPath: "components.callbacks.Shared.{$request.body#/u}.post.responses.200.content.application/json.schema.xml",
+		},
+		{
+			name: "response media type itemSchema",
+			spec: `
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        "200":
+          description: OK
+          content: {application/json: {itemSchema: ` + xml + `}}
+`,
+			wantPath: "paths./pets.get.responses.200.content.application/json.itemSchema.xml",
+		},
+		{
+			name: "response header content schema",
+			spec: `
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        "200":
+          description: OK
+          headers:
+            X-Hdr:
+              content: {application/json: {schema: ` + xml + `}}
+`,
+			wantPath: "paths./pets.get.responses.200.headers.X-Hdr.content.application/json.schema.xml",
+		},
+		{
+			name: "components.mediaTypes schema",
+			spec: `
+paths: {}
+components:
+  mediaTypes:
+    PetStream: {schema: ` + xml + `}
+`,
+			wantPath: "components.mediaTypes.PetStream.schema.xml",
+		},
+		{
+			name: "media type itemEncoding header schema",
+			spec: `
+paths:
+  /pets:
+    post:
+      operationId: addPet
+      requestBody:
+        content:
+          multipart/mixed:
+            itemEncoding:
+              contentType: text/plain
+              headers: {X-Item: {schema: ` + xml + `}}
+      responses: {"200": {description: OK}}
+`,
+			wantPath: "paths./pets.post.requestBody.content.multipart/mixed.itemEncoding.headers.X-Item.schema.xml",
+		},
+		{
+			name: "media type prefixEncoding header schema",
+			spec: `
+paths:
+  /pets:
+    post:
+      operationId: addPet
+      requestBody:
+        content:
+          multipart/mixed:
+            prefixEncoding:
+              - contentType: text/plain
+                headers: {X-Prefix: {schema: ` + xml + `}}
+      responses: {"200": {description: OK}}
+`,
+			wantPath: "paths./pets.post.requestBody.content.multipart/mixed.prefixEncoding[0].headers.X-Prefix.schema.xml",
+		},
+		{
+			name: "nested encoding header schema",
+			spec: `
+paths:
+  /pets:
+    post:
+      operationId: addPet
+      requestBody:
+        content:
+          multipart/form-data:
+            schema: {type: object}
+            encoding:
+              part:
+                contentType: text/plain
+                encoding:
+                  nested:
+                    contentType: text/plain
+                    headers: {X-Nested: {schema: ` + xml + `}}
+      responses: {"200": {description: OK}}
+`,
+			wantPath: "paths./pets.post.requestBody.content.multipart/form-data.encoding.part.encoding.nested.headers.X-Nested.schema.xml",
+		},
+		{
+			name: "additionalOperations inside a callback path item",
+			spec: `
+paths:
+  /pets:
+    post:
+      operationId: addPet
+      callbacks:
+        onEvent:
+          '{$request.body#/url}':
+            additionalOperations:
+              PURGE:
+                operationId: cbPurge
+                responses:
+                  "200":
+                    description: OK
+                    content: {application/json: {schema: ` + xml + `}}
+      responses: {"200": {description: OK}}
+`,
+			wantPath: "paths./pets.post.callbacks.onEvent.{$request.body#/url}.additionalOperations.PURGE.responses.200.content.application/json.schema.xml",
+		},
+		{
+			name: "parameter content schema",
+			spec: `
+paths:
+  /pets:
+    post:
+      operationId: addPet
+      parameters:
+        - name: q
+          in: query
+          content: {application/json: {schema: ` + xml + `}}
+      responses: {"200": {description: OK}}
+`,
+			wantPath: "paths./pets.post.parameters[0].content.application/json.schema.xml",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := "openapi: 3.0.3\ninfo: {title: T, version: \"1.0.0\"}\n" + tt.spec
+			errs := validationErrors(t, spec)
+
+			var matched []string
+			for _, e := range errs {
+				if strings.Contains(e, "nodeType") {
+					matched = append(matched, e)
+				}
+			}
+			require.Len(t, matched, 1,
+				"the schema at %s should be validated exactly once; got %v", tt.wantPath, errs)
+			assert.Contains(t, matched[0], tt.wantPath,
+				"the error should be reported at the schema's own position")
+		})
+	}
+}
+
+// TestSchemaValidationDoesNotDoubleReport pins that a schema reachable from two
+// places is still reported once.
+//
+// validateSchema builds a fresh visited set per call, so widening the traversal
+// raised the question. It does not double-report, because a `$ref` media type
+// schema is a wrapper carrying only the reference: the definition it names is
+// validated once, under components.
+func TestSchemaValidationDoesNotDoubleReport(t *testing.T) {
+	spec := `
+openapi: 3.0.3
+info: {title: T, version: "1.0.0"}
+paths:
+  /pets:
+    post:
+      operationId: addPet
+      requestBody:
+        content: {application/json: {schema: {$ref: '#/components/schemas/Bad'}}}
+      responses:
+        "200":
+          description: OK
+          content: {application/json: {schema: {$ref: '#/components/schemas/Bad'}}}
+components:
+  schemas:
+    Bad: {type: string, enum: [1]}
+`
+	errs := validationErrors(t, spec)
+
+	var enumErrors []string
+	for _, e := range errs {
+		if strings.Contains(e, "Enum value") {
+			enumErrors = append(enumErrors, e)
+		}
+	}
+	require.Len(t, enumErrors, 1,
+		"the shared schema should be reported once, at its definition; got %v", enumErrors)
+	assert.Contains(t, enumErrors[0], "components.schemas.Bad.enum[0]")
+}
+
+// TestSchemaValidationBoundsCyclicCallbacks pins termination for the one graph the
+// walk cannot treat as a tree.
+//
+// A Callback holds path items whose operations hold callbacks, so the two can
+// point at each other. A depth bound alone does not contain that: a path item
+// whose operations each lead back to it branches, and the walk is exponential in
+// depth long before the bound is reached. Two such operations ran past forty
+// seconds without returning; the visited set is what makes it terminate.
+//
+// Built by hand because a parsed document cannot close the loop, and
+// ValidateParsed takes the caller's.
+func TestSchemaValidationBoundsCyclicCallbacks(t *testing.T) {
+	item := &parser.PathItem{
+		// An enum that disagrees with its type, so each pass round the loop has
+		// something to report. Not a 3.2 field: this calls the traversal directly,
+		// with no document to carry a version for the 3.2 rules to read.
+		Parameters: []*parser.Parameter{
+			{Name: "q", In: "query", Schema: &parser.Schema{
+				Type: "string", Enum: []any{1}}},
+		},
+	}
+	callback := parser.Callback{"loop": item}
+	// Two operations, both cycling back: branching, not just depth.
+	item.Get = &parser.Operation{Callbacks: map[string]*parser.Callback{"c": &callback}}
+	item.Post = &parser.Operation{Callbacks: map[string]*parser.Callback{"c": &callback}}
+
+	result := &ValidationResult{}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		New().validateOAS3OperationSchemas(item.Get, "paths./a.get", result)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the callback walk did not terminate; the cycle guard is gone")
+	}
+
+	assert.Len(t, result.Errors, 1,
+		"the cycle should be walked once, reporting the parameter schema a single time")
+}


### PR DESCRIPTION
`validateSchema` was called from exactly two places: the Request Body media type loop and `components.schemas`. Every schema in a response, a parameter or a header was therefore never validated — by **any** of the six rule families it runs, not only the OAS 3.2 one that exposed it. 🔍

Fixes #423

## Reproduction

One 3.0.3 document, the same offending schema in four positions:

```yaml
requestBody:
  content: {application/json: {schema: {type: object, xml: {name: p, nodeType: element}}}}
parameters:
  - {name: q, in: query, schema: {type: string, xml: {name: q, nodeType: attribute}}}
responses:
  "200":
    content: {application/json: {schema: {type: object, xml: {name: r, nodeType: element}}}}
components:
  schemas:
    Direct: {type: object, xml: {name: d, nodeType: element}}
```

Before: two of the four reported. After: all four.

## What now gets reached

Response content, parameters (schema and content form), headers, `components.mediaTypes`, path-item-level parameters, Encoding Object headers, and Callback path items — at the operation, path item and components levels, under `paths`, `webhooks` and `components.pathItems` alike.

`components.requestBodies` is deliberately **not** among them: `validateOAS3Components` already reaches it through `validateOAS3RequestBody`, and walking it here reported every error in it twice. A test caught that, which is why every case asserts its schema is reported *exactly once* rather than merely present.

Callbacks are cycle-bounded. `Callback → PathItem → Operation → Callback` closes a loop that a parsed document cannot build but `ValidateParsed` accepts from a caller — the same reasoning as `maxEncodingNestingDepth` and the bound added in #419.

Request bodies now go through the same media type walk as every other position, so their 3.2 `itemSchema` is validated rather than only `schema`.

## The converter had the matching half

`detectOAS32SchemaFeatures` was called for `components.schemas` and for `mt.ItemSchema` — never for `mt.Schema`, the ordinary schema every 3.0 document already has. So `oastools convert -t 3.0.3` stayed silent on a 3.2 field in an inline media type schema.

The fixture now carries an inline occurrence, so this cannot reopen silently: it previously put `nodeType` and `defaultMapping` only under `components.schemas`, one of the two positions that already worked.

## Google Maps stops being valid, correctly

```json
"schema": { "type": "string", "enum": [0, 1, 2, 3, 4] }
```

Two of its parameters declare a string type with integer enum values, and the spec's own description says the values "range between 0 and 4" — so the type is the mistake, not the enum. That document read as valid only because parameter schemas were never looked at. The corpus expectation records the reason, not just the number.

All 8 corpus specs pass; no other count moved.

## Order and cost

Sections are walked in map order rather than sorted. The passes that needed stable output (#411, #420) sorted the errors they *appended*, so a document with no findings paid nothing; sorting keys here would allocate a slice per map on every document — measured at double the cost, +1.0% versus +0.4% on MediumOAS3 — to fix a fraction of the problem. The validator's order is already unstable: the existing path walk alone produces five orderings in eight runs. Filed as #425.

| | baseline | with the traversal |
|---|---|---|
| SmallOAS3 | 2211 | 2222 |
| MediumOAS3 | 18905 | 19008 |
| LargeOAS3 | 213072 | 214264 |
| OAS 2.0 | — | unchanged |

Unlike the version gate in #411, this cost is real work — validating schemas that were never validated — not overhead.

## Verification

22 positions covered, each asserting the schema is reported exactly once, which is also what catches a position being reached twice. Removing the traversal fails 9 subtests; removing the callback and encoding-header walks fails 3; the old request-body handling fails 2. The converter half fails 2 of its own.

`make check` green.

## Release note

This changes validation **outcomes**, not just internals. Documents that passed at 3.0/3.1 may now report errors — five rule families beyond the 3.2 check now run in positions that were never examined. The findings are real defects that were previously invisible, but they will read as new failures in a CI pipeline, so this belongs near the top of the v1.59.0 notes rather than in a bugfix list.
