### PR TITLE
docs: do not amend a PR commit once review has begun

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@
 
 - `make check` before committing
 - Conventional commits: `feat(parser): add feature`
+- **Never amend a pushed PR commit once review has begun** — add a new commit. PRs squash on merge, so amending only breaks review diffs and comment anchors
 - See [WORKFLOW.md](WORKFLOW.md) for PR/release process
 - See [AGENTS.md](AGENTS.md) for agent workflow
 

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -296,9 +296,24 @@ gh pr view <PR_NUMBER> --comments
 
 1. Make requested changes in your local branch
 2. Run `make check` to ensure quality
-3. Commit changes with descriptive message
+3. Commit changes as a **new commit** — see below
 4. Push to update the PR
 5. Respond to review comments
+
+**Do not amend or rebase a commit once review has begun.**
+
+PRs merge with squash, so every commit on the branch collapses into one at merge
+time. Amending buys nothing and costs plenty:
+
+- Reviewers lose the diff between what they reviewed and what you changed, and
+  GitHub cannot show "changes since your last review".
+- Review comments anchored to the old commit come unstuck.
+- The push needs `--force-with-lease`; a plain `git push` is rejected as a
+  non-fast-forward, and a scheduled or chained push can fail while later steps —
+  posting replies that reference the commit — carry on regardless.
+
+Add a new commit describing what the feedback changed. Amend freely *before* the
+first push, and never after.
 
 **Never submit a PR with:**
 


### PR DESCRIPTION
Add a new commit instead. 📌

PRs here merge with **squash**, so every commit on a branch collapses into one at merge time — amending buys nothing, and costs three things:

- Reviewers lose the diff between what they reviewed and what changed; GitHub cannot show "changes since your last review".
- Review comments anchored to the old commit come unstuck.
- The push needs `--force-with-lease`. A plain `git push` is rejected as a non-fast-forward.

## Why now

That last point bit during #426. Amending diverged local from remote, so a scheduled `git push` was rejected — but the steps after it were newline-separated rather than chained with `&&`, so two threaded replies posted anyway, each citing a commit that was not on the PR for about four minutes.

So the guidance covers both halves: don't amend after review starts, and gate any outward-facing step on the push actually succeeding.

The fix was proven on the same PR — the follow-up commit went on top as 0f6ed22 and pushed as a plain fast-forward, with the replies chained behind it.

## Changes

- **WORKFLOW.md** → "PR Review Process": the rule with its rationale, beside the "Addressing review feedback" steps it corrects
- **CLAUDE.md** → Quick Reference: one line, since that file loads every session

Amend freely *before* the first push, never after.

## Testing

- [x] `make check` passes

Docs only — no code paths touched.