### PR TITLE
fix(parser,validator): stop enforcing three constraints no spec version states

### DIFF
--- a/parser/conformance_relaxed_test.go
+++ b/parser/conformance_relaxed_test.go
@@ -245,9 +245,16 @@ paths:
 	}
 }
 
-// TestOperationResponsesStatusCodesStillChecked guards the else-branch of the
-// relaxation: dropping the requirement must not stop status codes from being
-// validated when `responses` *is* present.
+// TestOperationResponsesStatusCodesStillChecked guards the relaxation from the
+// obvious way it could go wrong: dropping the `responses` requirement for 3.1+
+// must not stop an invalid status code being reported when `responses` *is*
+// present.
+//
+// Note that the check which fires here is the decoder's, not the structure
+// validator's. Every decode path — paths.go (YAML), paths_json.go (JSON) and
+// the generated decodeFromMap — filters status codes before a Responses object
+// is built, so validateOAS3Operation's own loop over Responses.Codes can never
+// see an invalid one. That loop is unreachable, and predates this change.
 func TestOperationResponsesStatusCodesStillChecked(t *testing.T) {
 	spec := `
 openapi: 3.2.0
@@ -261,20 +268,23 @@ paths:
         "999":
           description: not a status code
 `
-	result, err := New().ParseBytes([]byte(spec))
-
-	// The status-code check reaches this document through the decoder, which
-	// reports it as a hard parse failure rather than a collected error, so
-	// accept either channel — the point is that relaxing the `responses`
-	// requirement did not stop the code being checked.
 	const want = "invalid status code '999'"
-	if err != nil {
-		if !strings.Contains(err.Error(), want) {
-			t.Fatalf("want error containing %q, got: %v", want, err)
-		}
-		return
+
+	// Pinned to the channel that actually carries this today: the decoder
+	// rejects an invalid status code, so ParseBytes returns a hard error and
+	// never reaches structure validation. Both the YAML and JSON decode paths
+	// behave this way.
+	//
+	// Asserting the channel and not just the message is deliberate. If a change
+	// moves this diagnostic into the collected result.Errors instead, that is a
+	// change to ParseBytes's external contract — callers today can rely on a
+	// non-nil error for this input — and the test should fail so the move is a
+	// decision rather than a side effect.
+	_, err := New().ParseBytes([]byte(spec))
+	if err == nil {
+		t.Fatalf("want a hard ParseBytes error containing %q, got nil", want)
 	}
-	if !hasErrorContaining(result.Errors, want) {
-		t.Errorf("want error containing %q, got: %v", want, result.Errors)
+	if !strings.Contains(err.Error(), want) {
+		t.Errorf("want error containing %q, got: %v", want, err)
 	}
 }

--- a/parser/conformance_relaxed_test.go
+++ b/parser/conformance_relaxed_test.go
@@ -255,8 +255,24 @@ paths:
 // the generated decodeFromMap — filters status codes before a Responses object
 // is built, so validateOAS3Operation's own loop over Responses.Codes can never
 // see an invalid one. That loop is unreachable, and predates this change.
+//
+// The two paths ParseBytes can reach are both covered below. The third,
+// decodeFromMap, is not reachable from here and does not agree with them — it
+// drops the offending key silently rather than erroring. That inconsistency and
+// the dead loop are tracked in issue #449, not fixed here.
 func TestOperationResponsesStatusCodesStillChecked(t *testing.T) {
-	spec := `
+	const want = "invalid status code '999'"
+
+	// paths.go and paths_json.go implement this check separately, so both are
+	// exercised — the same document in each source format. Covering only YAML
+	// would leave the JSON decoder's copy free to drift.
+	tests := []struct {
+		name string
+		spec string
+	}{
+		{
+			name: "yaml",
+			spec: `
 openapi: 3.2.0
 info:
   title: API
@@ -267,24 +283,45 @@ paths:
       responses:
         "999":
           description: not a status code
-`
-	const want = "invalid status code '999'"
-
-	// Pinned to the channel that actually carries this today: the decoder
-	// rejects an invalid status code, so ParseBytes returns a hard error and
-	// never reaches structure validation. Both the YAML and JSON decode paths
-	// behave this way.
-	//
-	// Asserting the channel and not just the message is deliberate. If a change
-	// moves this diagnostic into the collected result.Errors instead, that is a
-	// change to ParseBytes's external contract — callers today can rely on a
-	// non-nil error for this input — and the test should fail so the move is a
-	// decision rather than a side effect.
-	_, err := New().ParseBytes([]byte(spec))
-	if err == nil {
-		t.Fatalf("want a hard ParseBytes error containing %q, got nil", want)
+`,
+		},
+		{
+			name: "json",
+			spec: `{
+  "openapi": "3.2.0",
+  "info": {"title": "API", "version": "1.0.0"},
+  "paths": {
+    "/pets": {
+      "get": {
+        "responses": {
+          "999": {"description": "not a status code"}
+        }
+      }
+    }
+  }
+}`,
+		},
 	}
-	if !strings.Contains(err.Error(), want) {
-		t.Errorf("want error containing %q, got: %v", want, err)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Pinned to the channel that actually carries this today: the
+			// decoder rejects an invalid status code, so ParseBytes returns a
+			// hard error and never reaches structure validation.
+			//
+			// Asserting the channel and not just the message is deliberate. If
+			// a change moves this diagnostic into the collected result.Errors
+			// instead, that is a change to ParseBytes's external contract —
+			// callers today can rely on a non-nil error for this input — and
+			// the test should fail so the move is a decision rather than a
+			// side effect.
+			_, err := New().ParseBytes([]byte(tt.spec))
+			if err == nil {
+				t.Fatalf("want a hard ParseBytes error containing %q, got nil", want)
+			}
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("want error containing %q, got: %v", want, err)
+			}
+		})
 	}
 }

--- a/parser/conformance_relaxed_test.go
+++ b/parser/conformance_relaxed_test.go
@@ -1,0 +1,280 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+)
+
+// hasErrorContaining reports whether any parse error mentions substr.
+func hasErrorContaining(errs []error, substr string) bool {
+	for _, err := range errs {
+		if strings.Contains(err.Error(), substr) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestRootRequirementRelaxedIn31 covers the OAS 3.1 relaxation of the root
+// requirement. OAS 3.0 requires `paths`; 3.1+ replaced that with a three-way
+// `anyOf` over `paths`, `components` and `webhooks`.
+func TestRootRequirementRelaxedIn31(t *testing.T) {
+	const wantMsg = "at least one of 'paths', 'components' or 'webhooks'"
+	const want30Msg = "missing required root field 'paths'"
+
+	tests := []struct {
+		name     string
+		spec     string
+		wantErr  bool
+		errSubst string
+	}{
+		{
+			name: "3.0 with paths is valid",
+			spec: `
+openapi: 3.0.3
+info:
+  title: API
+  version: 1.0.0
+paths: {}
+`,
+		},
+		{
+			name: "3.0 with only components is invalid: paths is required in 3.0",
+			spec: `
+openapi: 3.0.3
+info:
+  title: API
+  version: 1.0.0
+components: {}
+`,
+			wantErr:  true,
+			errSubst: want30Msg,
+		},
+		{
+			name: "3.1 with only components is valid",
+			spec: `
+openapi: 3.1.0
+info:
+  title: API
+  version: 1.0.0
+components: {}
+`,
+		},
+		{
+			name: "3.2 with only components is valid",
+			spec: `
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+components: {}
+`,
+		},
+		{
+			name: "3.1 with only paths is valid",
+			spec: `
+openapi: 3.1.0
+info:
+  title: API
+  version: 1.0.0
+paths: {}
+`,
+		},
+		{
+			// `anyOf: [required: webhooks]` asks only that the key be present,
+			// so an empty map satisfies it. This is why the check compares
+			// against nil rather than using len().
+			name: "3.1 with an empty but present webhooks map is valid",
+			spec: `
+openapi: 3.1.0
+info:
+  title: API
+  version: 1.0.0
+webhooks: {}
+`,
+		},
+		{
+			name: "3.2 with an empty but present components map is valid",
+			spec: `
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+components: {}
+`,
+		},
+		{
+			name: "3.1 with none of the three is invalid",
+			spec: `
+openapi: 3.1.0
+info:
+  title: API
+  version: 1.0.0
+`,
+			wantErr:  true,
+			errSubst: wantMsg,
+		},
+		{
+			name: "3.2 with none of the three is invalid",
+			spec: `
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+`,
+			wantErr:  true,
+			errSubst: wantMsg,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := New().ParseBytes([]byte(tt.spec))
+			if err != nil {
+				t.Fatalf("ParseBytes: %v", err)
+			}
+			got := hasErrorContaining(result.Errors, tt.errSubst)
+			if tt.wantErr && !got {
+				t.Errorf("want error containing %q, got errors: %v", tt.errSubst, result.Errors)
+			}
+			if !tt.wantErr {
+				// Neither form of the root requirement may fire.
+				if hasErrorContaining(result.Errors, wantMsg) || hasErrorContaining(result.Errors, want30Msg) {
+					t.Errorf("want no root-requirement error, got: %v", result.Errors)
+				}
+			}
+		})
+	}
+}
+
+// TestOperationResponsesRelaxedIn31 covers the OAS 3.1 relaxation of the
+// Operation Object's `responses` field. It is REQUIRED in 2.0 and 3.0 and
+// optional from 3.1 onward: 3.1+ `$defs.operation` carries no `required:`
+// clause, and the prose drops the **REQUIRED** marker, which per its own
+// preamble means OPTIONAL.
+func TestOperationResponsesRelaxedIn31(t *testing.T) {
+	const wantMsg = "Operation must have a responses object"
+
+	tests := []struct {
+		name    string
+		spec    string
+		wantErr bool
+	}{
+		{
+			name: "2.0 operation without responses is invalid",
+			spec: `
+swagger: "2.0"
+info:
+  title: API
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      summary: list pets
+`,
+			wantErr: true,
+		},
+		{
+			name: "3.0 operation without responses is invalid",
+			spec: `
+openapi: 3.0.3
+info:
+  title: API
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      summary: list pets
+`,
+			wantErr: true,
+		},
+		{
+			name: "3.1 operation without responses is valid",
+			spec: `
+openapi: 3.1.0
+info:
+  title: API
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      summary: list pets
+`,
+		},
+		{
+			name: "3.2 operation without responses is valid",
+			spec: `
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      summary: list pets
+`,
+		},
+		{
+			name: "3.1 operation with responses is valid",
+			spec: `
+openapi: 3.1.0
+info:
+  title: API
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      responses:
+        "200":
+          description: ok
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := New().ParseBytes([]byte(tt.spec))
+			if err != nil {
+				t.Fatalf("ParseBytes: %v", err)
+			}
+			got := hasErrorContaining(result.Errors, wantMsg)
+			if got != tt.wantErr {
+				t.Errorf("responses-required error = %v, want %v; errors: %v", got, tt.wantErr, result.Errors)
+			}
+		})
+	}
+}
+
+// TestOperationResponsesStatusCodesStillChecked guards the else-branch of the
+// relaxation: dropping the requirement must not stop status codes from being
+// validated when `responses` *is* present.
+func TestOperationResponsesStatusCodesStillChecked(t *testing.T) {
+	spec := `
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      responses:
+        "999":
+          description: not a status code
+`
+	result, err := New().ParseBytes([]byte(spec))
+
+	// The status-code check reaches this document through the decoder, which
+	// reports it as a hard parse failure rather than a collected error, so
+	// accept either channel — the point is that relaxing the `responses`
+	// requirement did not stop the code being checked.
+	const want = "invalid status code '999'"
+	if err != nil {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("want error containing %q, got: %v", want, err)
+		}
+		return
+	}
+	if !hasErrorContaining(result.Errors, want) {
+		t.Errorf("want error containing %q, got: %v", want, result.Errors)
+	}
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -990,9 +990,18 @@ func (p *Parser) validateOAS3PathsRequirement(doc *OAS3Document, version string)
 			errors = append(errors, fmt.Errorf("oas %s: missing required root field 'paths': Paths object is required in OAS 3.0.x (https://spec.openapis.org/oas/v3.0.0.html#paths-object)", version))
 		}
 	} else if versionInRangeExclusive(doc.OpenAPI, oas310, "") {
-		// In OAS 3.1+, either paths or webhooks must be present
-		if doc.Paths == nil && len(doc.Webhooks) == 0 {
-			errors = append(errors, fmt.Errorf("oas %s: document must have either 'paths' or 'webhooks': at least one is required in OAS 3.1+", version))
+		// OAS 3.1+ relaxed the 3.0 requirement into a three-way choice. The
+		// root `anyOf` lists `paths`, `components` and `webhooks` — identical
+		// in 3.1, 3.2 and 3.3 — so a document carrying only reusable
+		// components and no operations at all is valid.
+		//
+		// The test is presence, not content: `anyOf: [required: webhooks]` is
+		// satisfied by `webhooks: {}`, so an empty-but-present map counts.
+		// The parser preserves that distinction — an absent field decodes to a
+		// nil map, a `{}` one to a non-nil empty map — so compare against nil,
+		// never len().
+		if doc.Paths == nil && doc.Webhooks == nil && doc.Components == nil {
+			errors = append(errors, fmt.Errorf("oas %s: document must have at least one of 'paths', 'components' or 'webhooks' (https://spec.openapis.org/oas/v3.1.0.html#openapi-object)", version))
 		}
 	}
 	return errors
@@ -1049,9 +1058,14 @@ func (p *Parser) validateOAS3Operation(op *Operation, opPath string, operationID
 		}
 	}
 
-	// Validate responses object exists
+	// `responses` is REQUIRED on an Operation in OAS 2.0 and 3.0, and was
+	// relaxed to optional in 3.1. The 3.1+ `$defs.operation` carries no
+	// `required:` clause, and the prose drops the **REQUIRED** marker from the
+	// field's row — which, per its own preamble, means OPTIONAL.
 	if op.Responses == nil {
-		errors = append(errors, fmt.Errorf("oas %s: missing required field '%s.responses': Operation must have a responses object", version, opPath))
+		if versionInRangeExclusive(version, oas300, oas310) {
+			errors = append(errors, fmt.Errorf("oas %s: missing required field '%s.responses': Operation must have a responses object (https://spec.openapis.org/oas/v3.0.0.html#operation-object)", version, opPath))
+		}
 	} else {
 		// Validate status codes in responses
 		for code := range op.Responses.Codes {

--- a/validator/conformance_items_test.go
+++ b/validator/conformance_items_test.go
@@ -1,0 +1,353 @@
+package validator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/erraggy/oastools/parser"
+)
+
+// validateSpec parses and validates a spec, returning the result.
+func validateSpec(t *testing.T, spec string) *ValidationResult {
+	t.Helper()
+	parseResult, err := parser.New().ParseBytes([]byte(spec))
+	if err != nil {
+		t.Fatalf("ParseBytes: %v", err)
+	}
+	result, err := New().ValidateParsed(*parseResult)
+	if err != nil {
+		t.Fatalf("ValidateParsed: %v", err)
+	}
+	return result
+}
+
+// resultHasMessage reports whether any issue's message contains substr.
+func resultHasMessage(result *ValidationResult, substr string) bool {
+	for _, e := range result.Errors {
+		if strings.Contains(e.Message, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestArraySchemaWithoutItemsIsValid covers the removal of the
+// "Array schema must have 'items' defined" rule from the Schema Object path.
+//
+// No OAS version states that constraint for a Schema Object: it is absent from
+// schema.yaml, meta.yaml and dialect.yaml, and no version's prose asserts it.
+// OAS 2.0 requires `items` when `type` is "array", but only on the Items,
+// Parameter and Header Objects — see TestOAS2PrimitiveItemsRequired.
+func TestArraySchemaWithoutItemsIsValid(t *testing.T) {
+	const wantAbsent = "Array schema must have 'items' defined"
+
+	tests := []struct {
+		name string
+		spec string
+	}{
+		{
+			name: "2.0 array definition without items",
+			spec: `
+swagger: "2.0"
+info:
+  title: API
+  version: 1.0.0
+paths: {}
+definitions:
+  Tags:
+    type: array
+`,
+		},
+		{
+			name: "3.0 array schema without items",
+			spec: `
+openapi: 3.0.3
+info:
+  title: API
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Tags:
+      type: array
+`,
+		},
+		{
+			name: "3.1 array schema without items",
+			spec: `
+openapi: 3.1.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  schemas:
+    Tags:
+      type: array
+`,
+		},
+		{
+			name: "3.2 array schema without items",
+			spec: `
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  schemas:
+    Tags:
+      type: array
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := validateSpec(t, tt.spec)
+			if resultHasMessage(result, wantAbsent) {
+				t.Errorf("no OAS version requires 'items' on an array Schema Object, got: %v", result.Errors)
+			}
+		})
+	}
+}
+
+// TestOAS2PrimitiveItemsRequired covers the narrowing half: Swagger 2.0 does
+// require `items` when `type` is "array", on the Parameter, Header and Items
+// Objects — the "primitives" form, which is an Items Object rather than a
+// Schema Object.
+func TestOAS2PrimitiveItemsRequired(t *testing.T) {
+	tests := []struct {
+		name    string
+		spec    string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "non-body parameter of type array without items",
+			spec: `
+swagger: "2.0"
+info:
+  title: API
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      parameters:
+        - name: tags
+          in: query
+          type: array
+      responses:
+        "200":
+          description: ok
+`,
+			want:    `Non-body parameter with type "array" must have 'items' defined`,
+			wantErr: true,
+		},
+		{
+			name: "non-body parameter of type array with items is valid",
+			spec: `
+swagger: "2.0"
+info:
+  title: API
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      parameters:
+        - name: tags
+          in: query
+          type: array
+          items:
+            type: string
+      responses:
+        "200":
+          description: ok
+`,
+			want: `must have 'items' defined`,
+		},
+		{
+			name: "body parameter of type array is a Schema Object and is exempt",
+			spec: `
+swagger: "2.0"
+info:
+  title: API
+  version: 1.0.0
+paths:
+  /pets:
+    post:
+      parameters:
+        - name: body
+          in: body
+          schema:
+            type: array
+      responses:
+        "200":
+          description: ok
+`,
+			want: `must have 'items' defined`,
+		},
+		{
+			name: "path-item-level parameter is covered",
+			spec: `
+swagger: "2.0"
+info:
+  title: API
+  version: 1.0.0
+paths:
+  /pets:
+    parameters:
+      - name: tags
+        in: query
+        type: array
+    get:
+      responses:
+        "200":
+          description: ok
+`,
+			want:    `Non-body parameter with type "array" must have 'items' defined`,
+			wantErr: true,
+		},
+		{
+			name: "root-level parameter definition is covered",
+			spec: `
+swagger: "2.0"
+info:
+  title: API
+  version: 1.0.0
+paths: {}
+parameters:
+  tagsParam:
+    name: tags
+    in: query
+    type: array
+`,
+			want:    `Non-body parameter with type "array" must have 'items' defined`,
+			wantErr: true,
+		},
+		{
+			name: "nested Items Object of type array without items",
+			spec: `
+swagger: "2.0"
+info:
+  title: API
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      parameters:
+        - name: matrix
+          in: query
+          type: array
+          items:
+            type: array
+      responses:
+        "200":
+          description: ok
+`,
+			want:    `Items with type "array" must have 'items' defined`,
+			wantErr: true,
+		},
+		{
+			name: "operation response header of type array without items",
+			spec: `
+swagger: "2.0"
+info:
+  title: API
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      responses:
+        "200":
+          description: ok
+          headers:
+            X-Rate-Limits:
+              type: array
+`,
+			want:    `Header with type "array" must have 'items' defined`,
+			wantErr: true,
+		},
+		{
+			name: "root-level response header of type array without items",
+			spec: `
+swagger: "2.0"
+info:
+  title: API
+  version: 1.0.0
+paths: {}
+responses:
+  Standard:
+    description: ok
+    headers:
+      X-Rate-Limits:
+        type: array
+`,
+			want:    `Header with type "array" must have 'items' defined`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := validateSpec(t, tt.spec)
+			if got := resultHasMessage(result, tt.want); got != tt.wantErr {
+				t.Errorf("message %q present = %v, want %v; errors: %v", tt.want, got, tt.wantErr, result.Errors)
+			}
+		})
+	}
+}
+
+// TestOAS3ArrayParameterIsNotSubjectToOAS2ItemsRule guards the version gate on
+// the narrowed rule: OAS 3.x parameters carry a Schema Object, not an Items
+// Object, and no 3.x version requires `items`.
+func TestOAS3ArrayParameterIsNotSubjectToOAS2ItemsRule(t *testing.T) {
+	spec := `
+openapi: 3.0.3
+info:
+  title: API
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      parameters:
+        - name: tags
+          in: query
+          schema:
+            type: array
+      responses:
+        "200":
+          description: ok
+`
+	result := validateSpec(t, spec)
+	if resultHasMessage(result, "must have 'items' defined") {
+		t.Errorf("OAS 3.x has no items-required rule, got: %v", result.Errors)
+	}
+}
+
+// TestOAS2ItemsNestingDepthBounded guards the depth bound on the Items chain.
+func TestOAS2ItemsNestingDepthBounded(t *testing.T) {
+	var sb strings.Builder
+	sb.WriteString(`swagger: "2.0"
+info:
+  title: API
+  version: 1.0.0
+paths: {}
+parameters:
+  deep:
+    name: deep
+    in: query
+    type: array
+`)
+	// Build an items chain deeper than maxSchemaNestingDepth. Each level is
+	// indented one step further than the last.
+	indent := "    "
+	for i := 0; i < maxSchemaNestingDepth+5; i++ {
+		sb.WriteString(indent + "items:\n")
+		indent += "  "
+		sb.WriteString(indent + "type: array\n")
+	}
+
+	result := validateSpec(t, sb.String())
+	if !resultHasMessage(result, "Items nesting depth") {
+		t.Errorf("want a depth-bound error, got: %v", result.Errors)
+	}
+}

--- a/validator/oas2.go
+++ b/validator/oas2.go
@@ -98,6 +98,11 @@ func (v *Validator) validateOAS2Paths(doc *parser.OAS2Document, result *Validati
 
 		pathPrefix := "paths." + pathPattern
 
+		// Path-item-level parameters are inherited by every operation, so the
+		// primitives constraints apply to them just as they do to an
+		// operation's own parameters.
+		v.validateOAS2PrimitiveParameters(pathItem.Parameters, pathPrefix, result, baseURL)
+
 		// Validate QUERY method is not used in OAS 2.0
 		if pathItem.Query != nil {
 			v.addError(result, pathPrefix+".query",
@@ -143,6 +148,21 @@ func (v *Validator) validateOAS2Paths(doc *parser.OAS2Document, result *Validati
 func (v *Validator) validateOAS2Operation(op *parser.Operation, path string, result *ValidationResult, baseURL string) {
 	// Validate response status codes
 	v.validateResponseStatusCodes(op.Responses, path, result, baseURL)
+
+	// Validate the primitives constraints on this operation's own parameters
+	// and on the headers of its responses.
+	v.validateOAS2PrimitiveParameters(op.Parameters, path, result, baseURL)
+	if op.Responses != nil {
+		if op.Responses.Default != nil {
+			v.validateOAS2ResponseHeaders(op.Responses.Default, path+".responses.default", result, baseURL)
+		}
+		for code, resp := range op.Responses.Codes {
+			if resp == nil {
+				continue
+			}
+			v.validateOAS2ResponseHeaders(resp, path+".responses."+code, result, baseURL)
+		}
+	}
 
 	// Validate consumes/produces media types
 	for i, mediaType := range op.Consumes {
@@ -223,6 +243,8 @@ func (v *Validator) validateOAS2Parameters(doc *parser.OAS2Document, result *Val
 				withField("type"),
 			)
 		}
+
+		v.validateOAS2PrimitiveParameter(param, path, result, baseURL)
 	}
 }
 
@@ -240,6 +262,86 @@ func (v *Validator) validateOAS2Responses(doc *parser.OAS2Document, result *Vali
 				withField("description"),
 			)
 		}
+
+		v.validateOAS2ResponseHeaders(response, "responses."+name, result, baseURL)
+	}
+}
+
+// validateOAS2ResponseHeaders checks the primitives constraints on every header
+// of an OAS 2.0 Response Object.
+func (v *Validator) validateOAS2ResponseHeaders(response *parser.Response, path string, result *ValidationResult, baseURL string) {
+	for name, header := range response.Headers {
+		if header == nil || header.Ref != "" {
+			continue
+		}
+		headerPath := path + ".headers." + name
+		// Swagger 2.0 Header Object: `items` is "Required if type is 'array'".
+		if header.Type == "array" && header.Items == nil {
+			v.addError(result, headerPath,
+				`Header with type "array" must have 'items' defined`,
+				withSpecRef(fmt.Sprintf("%s#header-object", baseURL)),
+				withField("items"),
+			)
+		}
+		v.validateOAS2Items(header.Items, headerPath+".items", result, baseURL)
+	}
+}
+
+// validateOAS2PrimitiveParameters applies validateOAS2PrimitiveParameter to
+// each entry of an inline parameter list.
+func (v *Validator) validateOAS2PrimitiveParameters(params []*parser.Parameter, path string, result *ValidationResult, baseURL string) {
+	for i, param := range params {
+		if param == nil || param.Ref != "" {
+			continue
+		}
+		v.validateOAS2PrimitiveParameter(param, path+".parameters["+strconv.Itoa(i)+"]", result, baseURL)
+	}
+}
+
+// validateOAS2PrimitiveParameter checks the constraints Swagger 2.0 places on a
+// non-body parameter — the "primitives" form, which is an Items Object rather
+// than a Schema Object.
+//
+// This is deliberately *not* a Schema Object rule. Swagger 2.0 requires `items`
+// when `type` is "array" on the Parameter, Header and Items Objects only; no OAS
+// version requires it on a Schema Object. See validateSchemaTypeConstraints.
+func (v *Validator) validateOAS2PrimitiveParameter(param *parser.Parameter, path string, result *ValidationResult, baseURL string) {
+	if param.In == "body" {
+		return
+	}
+	if param.Type == "array" && param.Items == nil {
+		v.addError(result, path,
+			`Non-body parameter with type "array" must have 'items' defined`,
+			withSpecRef(fmt.Sprintf("%s#parameter-object", baseURL)),
+			withField("items"),
+		)
+	}
+	v.validateOAS2Items(param.Items, path+".items", result, baseURL)
+}
+
+// validateOAS2Items walks a chain of Swagger 2.0 Items Objects, which nest
+// through their own `items` field when describing an array of arrays.
+func (v *Validator) validateOAS2Items(items *parser.Items, path string, result *ValidationResult, baseURL string) {
+	for depth := 0; items != nil; depth++ {
+		// The Items Object nests only through `items`, so the chain is linear
+		// and cannot cycle — but a hand-written document can still make it
+		// arbitrarily deep, so bound it the way schema traversal is bounded.
+		if depth > maxSchemaNestingDepth {
+			v.addError(result, path,
+				fmt.Sprintf("Items nesting depth (%d) exceeds maximum allowed (%d)", depth, maxSchemaNestingDepth),
+				withSpecRef(fmt.Sprintf("%s#items-object", baseURL)),
+			)
+			return
+		}
+		if items.Type == "array" && items.Items == nil {
+			v.addError(result, path,
+				`Items with type "array" must have 'items' defined`,
+				withSpecRef(fmt.Sprintf("%s#items-object", baseURL)),
+				withField("items"),
+			)
+		}
+		items = items.Items
+		path += ".items"
 	}
 }
 

--- a/validator/schema.go
+++ b/validator/schema.go
@@ -158,7 +158,8 @@ func (v *Validator) validateSchemaTypeConstraints(schema *parser.Schema, path st
 		// version's prose states it. OAS 2.0 does require it when `type` is
 		// "array" — but only on the Items Object and on non-body Parameters
 		// and Headers, which are `parser.Items`, not `parser.Schema`. That
-		// rule lives in validateOAS2PrimitiveItems.
+		// rule lives in validateOAS2PrimitiveParameter,
+		// validateOAS2ResponseHeaders and validateOAS2Items.
 	case "string":
 		// Validate min/max length
 		if schema.MinLength != nil && schema.MaxLength != nil && *schema.MinLength > *schema.MaxLength {

--- a/validator/schema.go
+++ b/validator/schema.go
@@ -153,13 +153,12 @@ func (v *Validator) validateSchemaTypeConstraints(schema *parser.Schema, path st
 
 	switch schema.Type {
 	case "array":
-		if schema.Items == nil {
-			v.addError(result, path,
-				"Array schema must have 'items' defined",
-				withSpecRef(getJSONSchemaRef()),
-				withField("items"),
-			)
-		}
+		// No OAS version requires `items` on an array-typed *Schema Object*.
+		// It is absent from schema.yaml, meta.yaml and dialect.yaml, and no
+		// version's prose states it. OAS 2.0 does require it when `type` is
+		// "array" — but only on the Items Object and on non-body Parameters
+		// and Headers, which are `parser.Items`, not `parser.Schema`. That
+		// rule lives in validateOAS2PrimitiveItems.
 	case "string":
 		// Validate min/max length
 		if schema.MinLength != nil && schema.MaxLength != nil && *schema.MinLength > *schema.MaxLength {


### PR DESCRIPTION
Closes #433 🎯

First implementation PR of the **spec-conformance project** _(epic A)_. Three validator rules rejected documents that every OAS version considers valid.

## The measurement

Run against OAI's own conformance suite for OAS 3.2 (`tests/schema/` on `v3.2-dev`, 37 positive fixtures), v1.59.0 accepted **11**. All 26 failures were these three rules.

| Rule | Fixtures | What the spec says |
|---|---|---|
| Root `anyOf` treated as `paths` **or** `webhooks` | 16 | `schema.yaml` root lists `paths ǀ components ǀ webhooks` — identical in 3.1, 3.2, 3.3 |
| `responses` required on every Operation | 5 | 3.1+ `$defs.operation` has no `required:`; the prose drops the **REQUIRED** marker |
| `Array schema must have 'items' defined` | 6 | Absent from `schema.yaml`, `meta.yaml`, `dialect.yaml`; no version's prose states it |

**Result: 11/37 → 33/37.** The remaining four are #434 and #447.

Every claim was verified against **both** the published schema and the prose, per OAI's own note that the schema is not the source of truth:

| Rule | 2.0 | 3.0 | 3.1 | 3.2 |
|---|---|---|---|---|
| Root requires `paths` | Required | REQUIRED | `paths ǀ components ǀ webhooks` | same |
| Operation `responses` | Required | REQUIRED | **optional** | **optional** |
| `items` when `type: array` | Parameter/Header/Items Object only | never | never | never |

## One failure mode, three instances

All three are **a constraint a later version relaxed, never re-gated**. `validator/oas32_gate.go` catches fields that are *too new* for a document's version; nothing caught a rule that *stopped applying*. #440 makes that class representable so instance four cannot ship — this PR fixes the three known ones.

These are false *positives*, which is why no corpus test caught them: the corpus is real-world specs that happen to satisfy the stricter rule.

## The `items` rule was exactly inverted

`validateSchemaTypeConstraints` only ever receives a `*parser.Schema`, so the rule fired **only** on Schema Objects — where no version requires it — while the place OAS 2.0 *does* require it (`parser.Items`, reached from non-body Parameters and Headers) was enforced **nowhere**.

So this is a move, not a deletion: removed from the Schema Object path, added as `validateOAS2PrimitiveItems` covering root-level parameter definitions, path-item parameters, operation parameters, and response headers at both root and operation level — including the nested Items chain, with the same depth bound schema traversal uses.

That half is a *tightening* in a PR otherwise framed as loosening. It is spec-mandated (2.0 prose: "**Required if `type` is 'array'**" on the Parameter, Header and Items Objects) and causes **zero corpus verdict changes**.

## Two more defects surfaced, filed separately

Fixing the root requirement unmasked two parse-level failures that the false positive had been hiding — a boolean `components.schemas` entry and a `$ref`-form Callback. Both filed as #447.

## Correction to the project's baseline

Worth flagging because it changes how the project is measured: the design doc recorded **28/29 negative** and called the rejection side strong. Measured locally, the true figure is **18/29**. Ten of those 28 were the root-requirement false positive firing on a components-only fixture — rejecting for the wrong reason and detecting nothing. This PR does not regress the negative side; it removes an accidental rejection. Detail in erraggy/oastools#434.

## Testing

Not one existing test asserted any of the three rules, in either direction — `grep` for all three messages across `*_test.go` returns nothing. Two new files close that gap:

- `parser/conformance_relaxed_test.go` — root requirement and Operation `responses` across 2.0, 3.0, 3.1 and 3.2, asserting both that 3.1+ accepts and that 2.0/3.0 still reject; plus the empty-but-present `webhooks: {}` case and a guard that status codes are still checked when `responses` is present
- `validator/conformance_items_test.go` — array schemas without `items` valid at every version; the 2.0 primitives rule at all six positions; nested Items chains; the depth bound; and that OAS 3.x parameters are not subject to it

Verified:
- `make check` green — 10,360 tests
- OAS 3.2 positive fixtures 11/37 → 33/37, negative unchanged at 18/29
- Corpus error counts identical before and after across all 10 specs

## Release note framing

v1.59.0's notes opened with "Documents that passed in v1.58.0 may now fail". **v1.60.0 needs the inverse**: these documents were always *valid*, and oastools was wrong to reject them.
