### PR TITLE
fix(parser): decode a callbacks entry written as a Reference Object

### DIFF
--- a/converter/callback_refs_test.go
+++ b/converter/callback_refs_test.go
@@ -1,0 +1,56 @@
+package converter
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erraggy/oastools/parser"
+)
+
+// OAS 2.0 has no callbacks, so converting an operation that has them is a
+// reported loss. A callbacks entry may be written as a Reference Object, which
+// the parser carries on its own field (see parser.Callback), so a check reading
+// only the Callback Object map would convert one form silently.
+func TestConvertToOAS2ReportsCallbacksInBothForms(t *testing.T) {
+	callback := parser.Callback{"{$request.query.url}": {Post: &parser.Operation{}}}
+
+	tests := map[string]*parser.Operation{
+		"callback objects": {
+			Callbacks: map[string]*parser.Callback{"inline": &callback},
+			Responses: &parser.Responses{Codes: map[string]*parser.Response{"200": {Description: "ok"}}},
+		},
+		"reference objects only": {
+			CallbackRefs: map[string]*parser.Reference{"referenced": {Ref: "#/components/callbacks/shared"}},
+			Responses:    &parser.Responses{Codes: map[string]*parser.Response{"200": {Description: "ok"}}},
+		},
+	}
+
+	for name, op := range tests {
+		t.Run(name, func(t *testing.T) {
+			parseResult := parser.ParseResult{
+				OASVersion: parser.OASVersion303,
+				Version:    "3.0.3",
+				Document: &parser.OAS3Document{
+					OpenAPI: "3.0.3",
+					Info:    &parser.Info{Title: "T", Version: "1.0.0"},
+					Paths:   parser.Paths{"/things": {Post: op}},
+				},
+			}
+
+			result, err := New().ConvertParsed(parseResult, "2.0")
+			require.NoError(t, err)
+
+			var reported bool
+			for _, issue := range result.Issues {
+				if strings.Contains(issue.Message, "callbacks which are not supported in OAS 2.0") {
+					reported = true
+				}
+			}
+			assert.True(t, reported,
+				"converting an operation with callbacks reported no loss; issues: %v", result.Issues)
+		})
+	}
+}

--- a/converter/oas3_to_oas2.go
+++ b/converter/oas3_to_oas2.go
@@ -236,8 +236,8 @@ func (c *Converter) convertOAS3OperationToOAS2(src *parser.Operation, doc *parse
 		}
 	}
 
-	// Check for callbacks (OAS 3.x only)
-	if len(src.Callbacks) > 0 {
+	// Check for callbacks (OAS 3.x only), in both the forms an entry may take
+	if len(src.Callbacks) > 0 || len(src.CallbackRefs) > 0 {
 		c.addIssue(result, opPath, "Operation contains callbacks which are not supported in OAS 2.0", SeverityCritical)
 	}
 

--- a/fixer/callback_refs_test.go
+++ b/fixer/callback_refs_test.go
@@ -1,0 +1,104 @@
+package fixer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erraggy/oastools/parser"
+)
+
+// A callbacks entry written as a Reference Object is carried on its own parser
+// field (see parser.Callback), so RefCollector has to read that field as well as
+// the Callback Object map. Reading only the latter would report a referenced
+// callback as unreferenced, which is what IsCallbackReferenced is asked.
+const callbackRefCollectorSpec = `
+openapi: "3.0.3"
+info:
+  title: Test API
+  version: "1.0"
+paths:
+  /things:
+    post:
+      responses:
+        "200":
+          description: ok
+      callbacks:
+        fromOperation:
+          $ref: "#/components/callbacks/usedByOperation"
+components:
+  callbacks:
+    usedByOperation:
+      "{$request.query.url}":
+        post:
+          responses:
+            "200":
+              description: ok
+    usedByComponent:
+      "{$request.query.url}":
+        post:
+          responses:
+            "200":
+              description: ok
+    fromComponent:
+      $ref: "#/components/callbacks/usedByComponent"
+    orphan:
+      "{$request.query.url}":
+        post:
+          responses:
+            "200":
+              description: ok
+`
+
+func TestCallbackRefsAreCollectedAsReferences(t *testing.T) {
+	parseResult, err := parser.New().ParseBytes([]byte(callbackRefCollectorSpec))
+	require.NoError(t, err)
+	doc, ok := parseResult.OAS3Document()
+	require.True(t, ok)
+
+	collector := NewRefCollector()
+	collector.CollectOAS3(doc)
+
+	assert.True(t, collector.IsCallbackReferenced("usedByOperation"),
+		"a callback referenced from an operation was not collected")
+	assert.True(t, collector.IsCallbackReferenced("usedByComponent"),
+		"a callback referenced from another component was not collected")
+	assert.False(t, collector.IsCallbackReferenced("orphan"),
+		"a callback nothing points at should not be reported as referenced")
+}
+
+// TestComponentsHoldingOnlyCallbackRefsIsNotEmpty covers the emptiness check that
+// decides whether the whole Components Object is dropped. A reference-form
+// callback lives on its own field, so a check reading only the Callback Object
+// map would call this document's components empty and delete a component it has.
+func TestComponentsHoldingOnlyCallbackRefsIsNotEmpty(t *testing.T) {
+	assert.False(t, isComponentsEmpty(&parser.Components{
+		CallbackRefs: map[string]*parser.Reference{"alias": {Ref: "#/components/callbacks/shared"}},
+	}), "components holding a reference-form callback were reported empty")
+
+	assert.True(t, isComponentsEmpty(&parser.Components{}),
+		"components with nothing in them should be empty")
+}
+
+// TestCallbackRefCollectionSkipsUnusableEntries covers the guards on the
+// collector's loop: a nil entry and one with no $ref name nothing, so neither
+// should reach the reference set.
+func TestCallbackRefCollectionSkipsUnusableEntries(t *testing.T) {
+	doc := &parser.OAS3Document{
+		OpenAPI: "3.0.3",
+		Info:    &parser.Info{Title: "T", Version: "1.0.0"},
+		Components: &parser.Components{
+			CallbackRefs: map[string]*parser.Reference{
+				"nilEntry":   nil,
+				"emptyRef":   {Ref: ""},
+				"realTarget": {Ref: "#/components/callbacks/wanted"},
+			},
+		},
+	}
+
+	collector := NewRefCollector()
+	assert.NotPanics(t, func() { collector.CollectOAS3(doc) },
+		"a nil reference entry crashed collection")
+	assert.True(t, collector.IsCallbackReferenced("wanted"))
+}

--- a/fixer/prune.go
+++ b/fixer/prune.go
@@ -404,6 +404,7 @@ func isComponentsEmpty(comp *parser.Components) bool {
 		len(comp.SecuritySchemes) == 0 &&
 		len(comp.Links) == 0 &&
 		len(comp.Callbacks) == 0 &&
+		len(comp.CallbackRefs) == 0 &&
 		len(comp.PathItems) == 0 &&
 		len(comp.Extra) == 0
 }

--- a/fixer/refs.go
+++ b/fixer/refs.go
@@ -268,9 +268,16 @@ func (c *RefCollector) collectComponentsRefs(comp *parser.Components, version pa
 		c.collectLinkRefs(link, fmt.Sprintf("components.links.%s", name))
 	}
 
-	// Callbacks
+	// Callbacks, in both the forms an entry may take: the Callback Object holds
+	// path items whose refs are collected below, the Reference Object form is
+	// itself a reference. See parser.Callback.
 	for name, callback := range comp.Callbacks {
 		c.collectCallbackRefs(callback, fmt.Sprintf("components.callbacks.%s", name), version)
+	}
+	for name, ref := range comp.CallbackRefs {
+		if ref != nil && ref.Ref != "" {
+			c.addRef(ref.Ref, fmt.Sprintf("components.callbacks.%s", name), RefTypeCallback)
+		}
 	}
 
 	// Examples
@@ -332,9 +339,14 @@ func (c *RefCollector) collectOperationRefs(op *parser.Operation, path string, v
 		c.collectResponsesRefs(op.Responses, fmt.Sprintf("%s.responses", path), version)
 	}
 
-	// Collect from callbacks (OAS 3.x)
+	// Collect from callbacks (OAS 3.x), in both the forms an entry may take
 	for name, callback := range op.Callbacks {
 		c.collectCallbackRefs(callback, fmt.Sprintf("%s.callbacks.%s", path, name), version)
+	}
+	for name, ref := range op.CallbackRefs {
+		if ref != nil && ref.Ref != "" {
+			c.addRef(ref.Ref, fmt.Sprintf("%s.callbacks.%s", path, name), RefTypeCallback)
+		}
 	}
 }
 

--- a/internal/codegen/decode/main.go
+++ b/internal/codegen/decode/main.go
@@ -102,6 +102,7 @@ func (x *Schema) decodeFromMap(m map[string]any)        {}
 func (x *PathItem) decodeFromMap(m map[string]any)      {}
 func (x *Response) decodeFromMap(m map[string]any)      {}
 func (x *Discriminator) decodeFromMap(m map[string]any) {}
+func (x *Reference) decodeFromMap(m map[string]any)     {}
 `)
 
 	// Load the parser package using go/types
@@ -437,9 +438,13 @@ func classifyField(structName, fieldName string, t types.Type) (strategy, elemTy
 		if ptr, ok := valType.(*types.Pointer); ok {
 			if named, ok := ptr.Elem().(*types.Named); ok {
 				name := named.Obj().Name()
-				// map[string]*Callback is special (Callback is map type, not struct)
+				// map[string]*Callback is special (Callback is map type, not struct).
+				// ElemType carries the companion field's prefix here rather than a
+				// map element type: the template emits x.<ElemType>Refs, which has
+				// to match the CallbackRefs field declared beside Callbacks on both
+				// Operation and Components.
 				if name == "Callback" {
-					return "callbacks_map", ""
+					return "callbacks_map", name
 				}
 				if oasStructTypes[name] {
 					return "oas_map", name
@@ -562,12 +567,7 @@ func (x *{{.Name}}) decodeFromMap(m map[string]any) {
 	}
 {{- else if eq .Strategy "callbacks_map"}}
 	if sub, ok := m["{{.JSONKey}}"].(map[string]any); ok {
-		x.{{.FieldName}} = make(map[string]*Callback, len(sub))
-		for k, v := range sub {
-			if vm, ok := v.(map[string]any); ok {
-				x.{{.FieldName}}[k] = decodeCallback(vm)
-			}
-		}
+		x.{{.FieldName}}, x.{{.ElemType}}Refs = decodeCallbackMap(sub)
 	}
 {{- else if eq .Strategy "security_reqs"}}
 	if arr, ok := m["{{.JSONKey}}"].([]any); ok {

--- a/internal/codegen/deepcopy/main.go
+++ b/internal/codegen/deepcopy/main.go
@@ -162,6 +162,7 @@ var typeConfigs = []TypeConfig{
 			{Name: "SecuritySchemes", Type: "map[string]*SecurityScheme", CopyMethod: "map", KeyType: "string", ElemType: "*SecurityScheme"},
 			{Name: "Links", Type: "map[string]*Link", CopyMethod: "map", KeyType: "string", ElemType: "*Link"},
 			{Name: "Callbacks", Type: "map[string]*Callback", CopyMethod: "helper", Helper: "deepCopyCallbacks"},
+			{Name: "CallbackRefs", Type: "map[string]*Reference", CopyMethod: "map", KeyType: "string", ElemType: "*Reference"},
 			{Name: "PathItems", Type: "map[string]*PathItem", CopyMethod: "map", KeyType: "string", ElemType: "*PathItem"},
 			{Name: "MediaTypes", Type: "map[string]*MediaType", CopyMethod: "map", KeyType: "string", ElemType: "*MediaType"}, // OAS 3.2+
 			{Name: "Extra", Type: "map[string]any", CopyMethod: "helper", Helper: "deepCopyExtensions"},
@@ -267,6 +268,7 @@ var typeConfigs = []TypeConfig{
 			{Name: "RequestBody", Type: "*RequestBody", CopyMethod: "pointer"},
 			{Name: "Responses", Type: "*Responses", CopyMethod: "pointer"},
 			{Name: "Callbacks", Type: "map[string]*Callback", CopyMethod: "helper", Helper: "deepCopyCallbacks"},
+			{Name: "CallbackRefs", Type: "map[string]*Reference", CopyMethod: "map", KeyType: "string", ElemType: "*Reference"},
 			{Name: "Security", Type: "[]SecurityRequirement", CopyMethod: "helper", Helper: "deepCopySecurityRequirements"},
 			{Name: "Servers", Type: "[]*Server", CopyMethod: "slice", ElemType: "*Server"},
 			{Name: "Consumes", Type: "[]string", CopyMethod: "slice", ElemType: "string"},

--- a/internal/driftguard/marshal_test.go
+++ b/internal/driftguard/marshal_test.go
@@ -42,6 +42,21 @@ var marshalExclusions = map[string]map[string]string{
 	},
 }
 
+// marshalMerges lists fields that carry no JSON key of their own because their
+// content belongs to another field's, naming the key it has to land under.
+//
+// Without an entry here such a field is tagged json:"-" and the guard would
+// assert it is not emitted, which is true of its name and says nothing about its
+// content. A field that must appear somewhere is worth more than a field that
+// must not appear under one spelling.
+var marshalMerges = map[string]map[string]string{
+	// The specification has one `callbacks` field whose values are each a
+	// Callback Object or a Reference Object. Two Go maps carry it, and both
+	// marshal paths merge them back. See parser.Callback.
+	"Operation":  {"CallbackRefs": "callbacks"},
+	"Components": {"CallbackRefs": "callbacks"},
+}
+
 // marshalSubjects pairs each type carrying a hand-built MarshalJSON with a fresh
 // value and its field list. A guard cannot reflect over a package, so this list
 // is the one thing a new type has to be added to.
@@ -126,6 +141,19 @@ func runMarshalGuard(t *testing.T, withExtension bool, message string) {
 				// nested value too, and a guard that passes falsely is worse than none.
 				var decoded map[string]json.RawMessage
 				require.NoError(t, json.Unmarshal(encoded, &decoded))
+
+				// A merged field is asserted to arrive under the key it merges into.
+				// Checked before the json:"-" branch below, which would otherwise
+				// pass it on the strength of its own name being absent.
+				if mergedInto, merged := marshalMerges[typeName][f.name]; merged {
+					require.Contains(t, decoded, mergedInto,
+						"%s.%s merges into %q, but that key was not emitted at all",
+						typeName, f.name, mergedInto)
+					assert.Contains(t, string(decoded[mergedInto]), markerKey,
+						"%s.%s is set but its content never reached %q; the merge is missing "+
+							"from this marshal path", typeName, f.name, mergedInto)
+					return
+				}
 
 				if f.jsonKey == "" {
 					// Tagged json:"-", so no spelling of the name should appear as a key.

--- a/internal/driftguard/marshal_test.go
+++ b/internal/driftguard/marshal_test.go
@@ -145,13 +145,19 @@ func runMarshalGuard(t *testing.T, withExtension bool, message string) {
 				// A merged field is asserted to arrive under the key it merges into.
 				// Checked before the json:"-" branch below, which would otherwise
 				// pass it on the strength of its own name being absent.
-				if mergedInto, merged := marshalMerges[typeName][f.name]; merged {
-					require.Contains(t, decoded, mergedInto,
+				if mergeKey, isMerged := marshalMerges[typeName][f.name]; isMerged {
+					require.Contains(t, decoded, mergeKey,
 						"%s.%s merges into %q, but that key was not emitted at all",
-						typeName, f.name, mergedInto)
-					assert.Contains(t, string(decoded[mergedInto]), markerKey,
+						typeName, f.name, mergeKey)
+
+					// Decoded rather than substring-matched, for the same reason as
+					// the check below: the marker can occur inside a nested value,
+					// and it is the merged field's own key that has to be there.
+					var target map[string]json.RawMessage
+					require.NoError(t, json.Unmarshal(decoded[mergeKey], &target))
+					assert.Contains(t, target, markerKey,
 						"%s.%s is set but its content never reached %q; the merge is missing "+
-							"from this marshal path", typeName, f.name, mergedInto)
+							"from this marshal path", typeName, f.name, mergeKey)
 					return
 				}
 

--- a/joiner/callback_refs_test.go
+++ b/joiner/callback_refs_test.go
@@ -1,0 +1,76 @@
+package joiner
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erraggy/oastools/parser"
+)
+
+// A callbacks entry is either a Callback Object or a Reference Object, carried on
+// two parser fields that share one name space (see parser.Callback). Merging a
+// name held as one form into a document holding it as the other would put the
+// key in both maps, and that document cannot be written at all.
+func TestJoinRejectsCallbackFormCollision(t *testing.T) {
+	callback := parser.Callback{"{$request.query.url}": {Post: &parser.Operation{}}}
+
+	tests := map[string]struct {
+		target, source *parser.Components
+	}{
+		"object in the target, reference in the source": {
+			target: &parser.Components{Callbacks: map[string]*parser.Callback{"clash": &callback}},
+			source: &parser.Components{CallbackRefs: map[string]*parser.Reference{"clash": {Ref: "#/components/callbacks/other"}}},
+		},
+		"reference in the target, object in the source": {
+			target: &parser.Components{CallbackRefs: map[string]*parser.Reference{"clash": {Ref: "#/components/callbacks/other"}}},
+			source: &parser.Components{Callbacks: map[string]*parser.Callback{"clash": &callback}},
+		},
+		"both forms inside the incoming document": {
+			target: &parser.Components{},
+			source: &parser.Components{
+				Callbacks:    map[string]*parser.Callback{"clash": &callback},
+				CallbackRefs: map[string]*parser.Reference{"clash": {Ref: "#/components/callbacks/other"}},
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			if tc.target.Callbacks == nil {
+				tc.target.Callbacks = map[string]*parser.Callback{}
+			}
+			if tc.target.CallbackRefs == nil {
+				tc.target.CallbackRefs = map[string]*parser.Reference{}
+			}
+
+			err := New(JoinerConfig{}).mergeAllCallbacks(tc.target, tc.source,
+				StrategyFailOnCollision, documentContext{}, &JoinResult{})
+
+			require.Error(t, err)
+			assert.ErrorContains(t, err, "clash")
+			assert.ErrorContains(t, err, "the two forms cannot be merged")
+		})
+	}
+}
+
+// TestJoinCarriesCallbackRefs is the ordinary case: both forms survive a merge.
+func TestJoinCarriesCallbackRefs(t *testing.T) {
+	callback := parser.Callback{"{$request.query.url}": {Post: &parser.Operation{}}}
+	target := &parser.Components{
+		Callbacks:    map[string]*parser.Callback{},
+		CallbackRefs: map[string]*parser.Reference{},
+	}
+	source := &parser.Components{
+		Callbacks:    map[string]*parser.Callback{"inline": &callback},
+		CallbackRefs: map[string]*parser.Reference{"referenced": {Ref: "#/components/callbacks/inline"}},
+	}
+
+	require.NoError(t, New(JoinerConfig{}).mergeAllCallbacks(target, source,
+		StrategyFailOnCollision, documentContext{}, &JoinResult{}))
+
+	assert.Contains(t, target.Callbacks, "inline")
+	assert.Contains(t, target.CallbackRefs, "referenced",
+		"the reference form was dropped by the join")
+}

--- a/joiner/collision_handler.go
+++ b/joiner/collision_handler.go
@@ -71,6 +71,13 @@ const (
 	// CollisionTypeLink indicates a link collision in components.links.
 	CollisionTypeLink CollisionType = "link"
 	// CollisionTypeCallback indicates a callback collision in components.callbacks.
+	//
+	// LeftValue and RightValue carry either *parser.Callback or *parser.Reference
+	// for this type, because a callbacks entry may be written in either form and
+	// both live under the same section (see parser.Callback). A handler that
+	// type-asserts to one of them must accept the other. A name arriving in one
+	// form where the other document holds the other is not reported here at all:
+	// see Joiner.mergeAllCallbacks.
 	CollisionTypeCallback CollisionType = "callback"
 )
 

--- a/joiner/oas3.go
+++ b/joiner/oas3.go
@@ -477,6 +477,13 @@ func (j *Joiner) mergeLinks(target, source map[string]*parser.Link, strategy Col
 // mergeMap only compares like with like, so the check below covers the pairing
 // it misses. Left through, the joined document would hold that name in both
 // maps, which cannot be written.
+//
+// That check fails the join outright, without consulting the collision handler
+// or the configured CollisionStrategy, unlike every same-form collision. There is
+// no resolution to offer: keeping either side, renaming, or deduplicating all
+// leave a name whose form depends on which document won, and the result is a
+// document rather than a component the caller chose. Same-form collisions still
+// route through the handler in mergeCallbacks and mergeCallbackRefs below.
 func (j *Joiner) mergeAllCallbacks(target, source *parser.Components, strategy CollisionStrategy, ctx documentContext, result *JoinResult) error {
 	// The clash may be between the two documents or inside the incoming one:
 	// decoding cannot produce a name in both maps, but a document assembled in

--- a/joiner/oas3.go
+++ b/joiner/oas3.go
@@ -56,6 +56,7 @@ func (j *Joiner) joinOAS3Documents(docs []parser.ParseResult) (*JoinResult, erro
 	joined.Components.SecuritySchemes = make(map[string]*parser.SecurityScheme)
 	joined.Components.Links = make(map[string]*parser.Link)
 	joined.Components.Callbacks = make(map[string]*parser.Callback)
+	joined.Components.CallbackRefs = make(map[string]*parser.Reference)
 	joined.Components.PathItems = make(map[string]*parser.PathItem)
 
 	// Merge all documents
@@ -253,7 +254,7 @@ func (j *Joiner) mergeOAS3Components(target, source *parser.Components, ctx docu
 	if err := j.mergeLinks(target.Links, source.Links, componentStrategy, ctx, result); err != nil {
 		return err
 	}
-	if err := j.mergeCallbacks(target.Callbacks, source.Callbacks, componentStrategy, ctx, result); err != nil {
+	if err := j.mergeAllCallbacks(target, source, componentStrategy, ctx, result); err != nil {
 		return err
 	}
 	if err := j.mergePathItems(target.PathItems, source.PathItems, componentStrategy, ctx, result); err != nil {
@@ -469,7 +470,45 @@ func (j *Joiner) mergeLinks(target, source map[string]*parser.Link, strategy Col
 	return mergeMap(j, target, source, "components.links", CollisionTypeLink, strategy, ctx, result)
 }
 
+// mergeAllCallbacks merges the components.callbacks section, which two Go maps
+// carry between them: see parser.Callback.
+//
+// They share one namespace, so the same name in different forms is a collision.
+// mergeMap only compares like with like, so the check below covers the pairing
+// it misses. Left through, the joined document would hold that name in both
+// maps, which cannot be written.
+func (j *Joiner) mergeAllCallbacks(target, source *parser.Components, strategy CollisionStrategy, ctx documentContext, result *JoinResult) error {
+	// The clash may be between the two documents or inside the incoming one:
+	// decoding cannot produce a name in both maps, but a document assembled in
+	// Go can, and merging it would carry the clash into the result.
+	for name := range source.CallbackRefs {
+		_, inSource := source.Callbacks[name]
+		_, inTarget := target.Callbacks[name]
+		if inSource || inTarget {
+			return errCallbackFormCollision(name)
+		}
+	}
+	for name := range source.Callbacks {
+		if _, ok := target.CallbackRefs[name]; ok {
+			return errCallbackFormCollision(name)
+		}
+	}
+	if err := j.mergeCallbacks(target.Callbacks, source.Callbacks, strategy, ctx, result); err != nil {
+		return err
+	}
+	return j.mergeCallbackRefs(target.CallbackRefs, source.CallbackRefs, strategy, ctx, result)
+}
+
+func errCallbackFormCollision(name string) error {
+	return fmt.Errorf("joiner: components.callbacks.%s is a Callback Object in one document "+
+		"and a Reference Object in another: the two forms cannot be merged", name)
+}
+
 func (j *Joiner) mergeCallbacks(target, source map[string]*parser.Callback, strategy CollisionStrategy, ctx documentContext, result *JoinResult) error {
+	return mergeMap(j, target, source, "components.callbacks", CollisionTypeCallback, strategy, ctx, result)
+}
+
+func (j *Joiner) mergeCallbackRefs(target, source map[string]*parser.Reference, strategy CollisionStrategy, ctx documentContext, result *JoinResult) error {
 	return mergeMap(j, target, source, "components.callbacks", CollisionTypeCallback, strategy, ctx, result)
 }
 

--- a/parser/callback_refs_test.go
+++ b/parser/callback_refs_test.go
@@ -152,6 +152,16 @@ func TestCallbackRefsUnderResolveRefs(t *testing.T) {
 				require.NotNil(t, inlined, "the resolved callback was dropped")
 				assert.Contains(t, *inlined, "http://example.com?id={$request.body#/id}",
 					"the reference was not replaced by what it pointed at")
+
+				// The other carrier: components.callbacks.alias is a reference to
+				// a sibling component, and resolves the same way.
+				require.NotNil(t, doc.Components)
+				assert.Empty(t, doc.Components.CallbackRefs,
+					"a resolved component reference should not remain a reference")
+				alias := doc.Components.Callbacks["alias"]
+				require.NotNil(t, alias, "the resolved component callback was dropped")
+				assert.Contains(t, *alias, "http://example.com?id={$request.body#/id}",
+					"the component reference was not replaced by what it pointed at")
 			})
 		}
 	})
@@ -281,6 +291,10 @@ paths:
       callbacks:
         referenced:
           $ref: '#/components/callbacks/missing'
+components:
+  callbacks:
+    alias:
+      $ref: '#/components/callbacks/missing'
 `,
 	"json": `{
   "openapi": "3.2.0",
@@ -292,7 +306,8 @@ paths:
         "callbacks": {"referenced": {"$ref": "#/components/callbacks/missing"}}
       }
     }
-  }
+  },
+  "components": {"callbacks": {"alias": {"$ref": "#/components/callbacks/missing"}}}
 }`,
 }
 
@@ -335,6 +350,14 @@ func TestCallbackObjectPresenceSurvivesDecoding(t *testing.T) {
 						"the document carried a callbacks key, so Callbacks must not be nil")
 					assert.Empty(t, op.Callbacks, "no entry was a Callback Object")
 					assert.Len(t, op.CallbackRefs, tc.wantRefs)
+
+					// The same rule on the other carrier, which has its own decode
+					// path entries and so proves nothing by the operation passing.
+					require.NotNil(t, doc.Components)
+					assert.NotNil(t, doc.Components.Callbacks,
+						"components carried a callbacks key, so Callbacks must not be nil")
+					assert.Empty(t, doc.Components.Callbacks, "no entry was a Callback Object")
+					assert.Len(t, doc.Components.CallbackRefs, tc.wantRefs)
 				})
 			}
 		}
@@ -355,6 +378,8 @@ paths:
         '200':
           description: ok
       callbacks: {}
+components:
+  callbacks: {}
 `,
 	"json": `{
   "openapi": "3.2.0",
@@ -366,7 +391,8 @@ paths:
         "callbacks": {}
       }
     }
-  }
+  },
+  "components": {"callbacks": {}}
 }`,
 }
 

--- a/parser/callback_refs_test.go
+++ b/parser/callback_refs_test.go
@@ -1,0 +1,443 @@
+package parser
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v4"
+)
+
+// callbackRefSpecs is the same document in both source formats. parser keeps
+// separate YAML and JSON decode paths, so anything asserted about decoding has
+// to be asserted twice or it covers half the surface.
+//
+// Both positions a `callbacks` object can occupy carry both forms an entry can
+// take, and one reference has a sibling field so the classification is shown to
+// depend on the `$ref` key rather than on the entry being a lone `$ref`.
+var callbackRefSpecs = map[string]string{
+	"yaml": `
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+paths:
+  /things:
+    post:
+      responses:
+        '200':
+          description: ok
+      callbacks:
+        inline:
+          '{$request.query.url}':
+            post:
+              responses:
+                '200':
+                  description: ok
+        referenced:
+          $ref: '#/components/callbacks/shared'
+          summary: the shared callback
+components:
+  callbacks:
+    shared:
+      'http://example.com?id={$request.body#/id}':
+        post:
+          responses:
+            '200':
+              description: ok
+    alias:
+      $ref: '#/components/callbacks/shared'
+`,
+	"json": `{
+  "openapi": "3.2.0",
+  "info": {"title": "API", "version": "1.0.0"},
+  "paths": {
+    "/things": {
+      "post": {
+        "responses": {"200": {"description": "ok"}},
+        "callbacks": {
+          "inline": {
+            "{$request.query.url}": {
+              "post": {"responses": {"200": {"description": "ok"}}}
+            }
+          },
+          "referenced": {
+            "$ref": "#/components/callbacks/shared",
+            "summary": "the shared callback"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "callbacks": {
+      "shared": {
+        "http://example.com?id={$request.body#/id}": {
+          "post": {"responses": {"200": {"description": "ok"}}}
+        }
+      },
+      "alias": {"$ref": "#/components/callbacks/shared"}
+    }
+  }
+}`,
+}
+
+// assertCallbackRefSplit checks the split every decode path has to produce: the
+// Callback Object entries in Callbacks, the Reference Object entries in
+// CallbackRefs, and no name in both.
+func assertCallbackRefSplit(t *testing.T, doc *OAS3Document) {
+	t.Helper()
+
+	require.NotNil(t, doc.Paths["/things"], "path was dropped")
+	op := doc.Paths["/things"].Post
+	require.NotNil(t, op, "operation was dropped")
+
+	require.Contains(t, op.Callbacks, "inline")
+	assert.NotContains(t, op.Callbacks, "referenced",
+		"a Reference Object was decoded as a Callback Object")
+	require.Contains(t, op.CallbackRefs, "referenced")
+	assert.Equal(t, "#/components/callbacks/shared", op.CallbackRefs["referenced"].Ref)
+	assert.Equal(t, "the shared callback", op.CallbackRefs["referenced"].Summary,
+		"a sibling of $ref was dropped")
+
+	require.NotNil(t, doc.Components)
+	require.Contains(t, doc.Components.Callbacks, "shared")
+	assert.NotContains(t, doc.Components.Callbacks, "alias",
+		"a Reference Object was decoded as a Callback Object")
+	require.Contains(t, doc.Components.CallbackRefs, "alias")
+	assert.Equal(t, "#/components/callbacks/shared", doc.Components.CallbackRefs["alias"].Ref)
+}
+
+// TestCallbackRefsDecode covers the Reference Object form of a callbacks entry,
+// which the specification tells apart from the Callback Object form by the
+// presence of a `$ref` key.
+func TestCallbackRefsDecode(t *testing.T) {
+	for _, format := range []string{"yaml", "json"} {
+		t.Run(format, func(t *testing.T) {
+			result, err := New().ParseBytes([]byte(callbackRefSpecs[format]))
+			require.NoError(t, err)
+			doc, ok := result.OAS3Document()
+			require.True(t, ok, "expected an OAS3 document")
+
+			assertCallbackRefSplit(t, doc)
+		})
+	}
+}
+
+// TestCallbackRefsUnderResolveRefs covers the third decode path, which sees a
+// document the resolver has already rewritten.
+//
+// A reference it could resolve is gone by then, replaced by what it pointed at,
+// which is what ResolveRefs is for and what every other reference form does. One
+// it could not resolve arrives at decodeFromMap intact, and that is the case
+// worth pinning: the map path drops a value whose shape it does not expect, with
+// no error to say so.
+func TestCallbackRefsUnderResolveRefs(t *testing.T) {
+	t.Run("a resolvable reference is inlined", func(t *testing.T) {
+		for _, format := range []string{"yaml", "json"} {
+			t.Run(format, func(t *testing.T) {
+				p := New()
+				p.ResolveRefs = true
+				result, err := p.ParseBytes([]byte(callbackRefSpecs[format]))
+				require.NoError(t, err)
+				doc, ok := result.OAS3Document()
+				require.True(t, ok)
+
+				op := doc.Paths["/things"].Post
+				require.NotNil(t, op)
+				assert.Empty(t, op.CallbackRefs, "a resolved reference should not remain a reference")
+
+				inlined := op.Callbacks["referenced"]
+				require.NotNil(t, inlined, "the resolved callback was dropped")
+				assert.Contains(t, *inlined, "http://example.com?id={$request.body#/id}",
+					"the reference was not replaced by what it pointed at")
+			})
+		}
+	})
+
+	t.Run("an unresolved reference reaches CallbackRefs", func(t *testing.T) {
+		for _, format := range []string{"yaml", "json"} {
+			t.Run(format, func(t *testing.T) {
+				p := New()
+				p.ResolveRefs = true
+				result, err := p.ParseBytes([]byte(danglingCallbackRefSpecs[format]))
+				require.NoError(t, err)
+				doc, ok := result.OAS3Document()
+				require.True(t, ok)
+
+				op := doc.Paths["/things"].Post
+				require.NotNil(t, op)
+				require.Contains(t, op.CallbackRefs, "referenced",
+					"the map decode path dropped a reference-form callback")
+				assert.Equal(t, "#/components/callbacks/missing", op.CallbackRefs["referenced"].Ref)
+			})
+		}
+	})
+}
+
+// TestCallbackRefsRoundTrip checks that the two Go fields serialize back into the
+// one `callbacks` object the specification defines, with the reference verbatim.
+func TestCallbackRefsRoundTrip(t *testing.T) {
+	for _, format := range []string{"yaml", "json"} {
+		t.Run(format, func(t *testing.T) {
+			result, err := New().ParseBytes([]byte(callbackRefSpecs[format]))
+			require.NoError(t, err)
+			doc, ok := result.OAS3Document()
+			require.True(t, ok, "expected an OAS3 document")
+
+			var encoded []byte
+			if format == "yaml" {
+				encoded, err = yaml.Marshal(doc)
+			} else {
+				encoded, err = json.Marshal(doc)
+			}
+			require.NoError(t, err)
+
+			// Read the output back generically: the reference has to be a member
+			// of `callbacks` beside the Callback Object, not a field of its own.
+			var raw map[string]any
+			if format == "yaml" {
+				require.NoError(t, yaml.Unmarshal(encoded, &raw))
+			} else {
+				require.NoError(t, json.Unmarshal(encoded, &raw))
+			}
+			opCallbacks := objectAt(t, raw, "paths", "/things", "post", "callbacks")
+			assert.Contains(t, opCallbacks, "inline")
+			referenced := objectAt(t, opCallbacks, "referenced")
+			assert.Equal(t, "#/components/callbacks/shared", referenced["$ref"])
+			assert.Equal(t, "the shared callback", referenced["summary"])
+
+			componentCallbacks := objectAt(t, raw, "components", "callbacks")
+			assert.Contains(t, componentCallbacks, "shared")
+			assert.Equal(t, "#/components/callbacks/shared",
+				objectAt(t, componentCallbacks, "alias")["$ref"])
+
+			// Reparsing has to produce the same document, which is the property a
+			// consumer round-tripping a specification depends on.
+			reparsed, err := New().ParseBytes(encoded)
+			require.NoError(t, err)
+			again, ok := reparsed.OAS3Document()
+			require.True(t, ok)
+			assertCallbackRefSplit(t, again)
+			assert.True(t, doc.Equals(again), "document changed across a round trip")
+		})
+	}
+}
+
+// TestCallbackRefsRoundTripAlongsideExtensions covers the hand-built marshal path,
+// which a specification extension anywhere in the object switches on. It builds
+// the `callbacks` member from a separate list of fields, so the merge has to be
+// present there too.
+func TestCallbackRefsRoundTripAlongsideExtensions(t *testing.T) {
+	op := &Operation{
+		Responses:    &Responses{Codes: map[string]*Response{"200": {Description: "ok"}}},
+		CallbackRefs: map[string]*Reference{"referenced": {Ref: "#/components/callbacks/shared"}},
+		Extra:        map[string]any{"x-vendor": "value"},
+	}
+
+	encoded, err := json.Marshal(op)
+	require.NoError(t, err)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(encoded, &raw))
+	assert.Equal(t, "value", raw["x-vendor"])
+	assert.Equal(t, "#/components/callbacks/shared",
+		objectAt(t, raw, "callbacks", "referenced")["$ref"])
+}
+
+// objectAt walks a decoded document to the object at a path of keys.
+//
+// A chain of `.(map[string]any)` assertions would do the same, but it panics
+// part way down when the shape is not what the test expected, and the stack
+// trace does not say which key was missing. This reports the level that failed.
+func objectAt(t *testing.T, node map[string]any, keys ...string) map[string]any {
+	t.Helper()
+
+	for i, key := range keys {
+		value, ok := node[key]
+		require.True(t, ok, "no %q under %v", key, keys[:i])
+		node, ok = value.(map[string]any)
+		require.True(t, ok, "%v is not an object", keys[:i+1])
+	}
+	return node
+}
+
+// danglingCallbackRefSpecs holds a single reference-form callback whose target
+// does not exist, so the resolver leaves it alone and it reaches the decode paths
+// as written.
+var danglingCallbackRefSpecs = map[string]string{
+	"yaml": `
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+paths:
+  /things:
+    post:
+      responses:
+        '200':
+          description: ok
+      callbacks:
+        referenced:
+          $ref: '#/components/callbacks/missing'
+`,
+	"json": `{
+  "openapi": "3.2.0",
+  "info": {"title": "API", "version": "1.0.0"},
+  "paths": {
+    "/things": {
+      "post": {
+        "responses": {"200": {"description": "ok"}},
+        "callbacks": {"referenced": {"$ref": "#/components/callbacks/missing"}}
+      }
+    }
+  }
+}`,
+}
+
+// TestCallbackObjectPresenceSurvivesDecoding pins the rule the three paths agree
+// on: Callbacks is non-nil exactly when the document carried a `callbacks` key,
+// whether or not every entry in it turned out to be a reference. A caller cannot
+// otherwise tell an absent `callbacks` from one holding only references.
+func TestCallbackObjectPresenceSurvivesDecoding(t *testing.T) {
+	cases := map[string]struct {
+		specs    map[string]string
+		wantRefs int
+	}{
+		// An empty callbacks object holds no entry of either form. It is still a
+		// key the document carried, and it decoded to a non-nil empty map before
+		// the reference form existed.
+		"an empty callbacks object": {specs: emptyCallbacksSpecs, wantRefs: 0},
+		// Every entry is a reference, so nothing populates Callbacks. Without the
+		// allocation a caller could not tell this from an absent callbacks key.
+		"only references": {specs: danglingCallbackRefSpecs, wantRefs: 1},
+	}
+
+	for name, tc := range cases {
+		for _, format := range []string{"yaml", "json"} {
+			for _, resolveRefs := range []bool{false, true} {
+				subtest := name + "/" + format
+				if resolveRefs {
+					subtest += "/resolveRefs"
+				}
+				t.Run(subtest, func(t *testing.T) {
+					p := New()
+					p.ResolveRefs = resolveRefs
+					result, err := p.ParseBytes([]byte(tc.specs[format]))
+					require.NoError(t, err)
+					doc, ok := result.OAS3Document()
+					require.True(t, ok)
+
+					op := doc.Paths["/things"].Post
+					require.NotNil(t, op)
+					assert.NotNil(t, op.Callbacks,
+						"the document carried a callbacks key, so Callbacks must not be nil")
+					assert.Empty(t, op.Callbacks, "no entry was a Callback Object")
+					assert.Len(t, op.CallbackRefs, tc.wantRefs)
+				})
+			}
+		}
+	}
+}
+
+// emptyCallbacksSpecs carries a callbacks object with no entries at all.
+var emptyCallbacksSpecs = map[string]string{
+	"yaml": `
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+paths:
+  /things:
+    post:
+      responses:
+        '200':
+          description: ok
+      callbacks: {}
+`,
+	"json": `{
+  "openapi": "3.2.0",
+  "info": {"title": "API", "version": "1.0.0"},
+  "paths": {
+    "/things": {
+      "post": {
+        "responses": {"200": {"description": "ok"}},
+        "callbacks": {}
+      }
+    }
+  }
+}`,
+}
+
+// TestCallbackNameInBothFormsIsRejected covers a value no decode path can
+// produce but Go code can assemble. Serializing it would have to pick one of the
+// two forms, which is a choice no caller asked for.
+func TestCallbackNameInBothFormsIsRejected(t *testing.T) {
+	callback := Callback{"{$request.query.url}": {}}
+
+	subjects := map[string]any{
+		"Operation": &Operation{
+			Responses:    &Responses{Codes: map[string]*Response{"200": {Description: "ok"}}},
+			Callbacks:    map[string]*Callback{"clash": &callback},
+			CallbackRefs: map[string]*Reference{"clash": {Ref: "#/components/callbacks/shared"}},
+		},
+		"Components": &Components{
+			Callbacks:    map[string]*Callback{"clash": &callback},
+			CallbackRefs: map[string]*Reference{"clash": {Ref: "#/components/callbacks/shared"}},
+		},
+	}
+
+	for name, subject := range subjects {
+		t.Run(name, func(t *testing.T) {
+			_, err := json.Marshal(subject)
+			assert.ErrorContains(t, err, `callback "clash" is present as both`)
+
+			_, err = yaml.Marshal(subject)
+			assert.ErrorContains(t, err, `callback "clash" is present as both`)
+		})
+	}
+}
+
+// TestCallbackRefsDeepCopyIsIndependent covers the generated deep copy, whose
+// field list is maintained by hand and so can omit a new field silently.
+func TestCallbackRefsDeepCopyIsIndependent(t *testing.T) {
+	// Both carriers, because the generator's field list has a separate entry per
+	// type: covering one proves nothing about the other.
+	op := &Operation{CallbackRefs: map[string]*Reference{"referenced": {Ref: "#/components/callbacks/shared"}}}
+	components := &Components{CallbackRefs: map[string]*Reference{"alias": {Ref: "#/components/callbacks/shared"}}}
+
+	opCopy := op.DeepCopy()
+	componentsCopy := components.DeepCopy()
+
+	require.Contains(t, opCopy.CallbackRefs, "referenced", "CallbackRefs was dropped by Operation.DeepCopy")
+	require.Contains(t, componentsCopy.CallbackRefs, "alias", "CallbackRefs was dropped by Components.DeepCopy")
+
+	opCopy.CallbackRefs["referenced"].Ref = "#/components/callbacks/other"
+	componentsCopy.CallbackRefs["alias"].Ref = "#/components/callbacks/other"
+
+	assert.Equal(t, "#/components/callbacks/shared", op.CallbackRefs["referenced"].Ref,
+		"the copy aliases the original's Reference")
+	assert.Equal(t, "#/components/callbacks/shared", components.CallbackRefs["alias"].Ref,
+		"the copy aliases the original's Reference")
+}
+
+// TestCallbackRefsAffectEquality keeps equality from reporting two documents the
+// same when they reference different callbacks.
+func TestCallbackRefsAffectEquality(t *testing.T) {
+	t.Run("Operation", func(t *testing.T) {
+		left := &Operation{CallbackRefs: map[string]*Reference{"a": {Ref: "#/components/callbacks/one"}}}
+		right := &Operation{CallbackRefs: map[string]*Reference{"a": {Ref: "#/components/callbacks/two"}}}
+		assert.False(t, equalOperation(left, right))
+		assert.False(t, equalOperation(left, &Operation{}))
+		assert.True(t, equalOperation(left, left.DeepCopy()))
+	})
+
+	t.Run("Components", func(t *testing.T) {
+		left := &Components{CallbackRefs: map[string]*Reference{"a": {Ref: "#/components/callbacks/one"}}}
+		right := &Components{CallbackRefs: map[string]*Reference{"a": {Ref: "#/components/callbacks/two"}}}
+		assert.False(t, equalComponents(left, right))
+		assert.False(t, equalComponents(left, &Components{}))
+		assert.True(t, equalComponents(left, left.DeepCopy()))
+	})
+}

--- a/parser/callback_refs_test.go
+++ b/parser/callback_refs_test.go
@@ -467,3 +467,52 @@ func TestCallbackRefsAffectEquality(t *testing.T) {
 		assert.True(t, equalComponents(left, left.DeepCopy()))
 	})
 }
+
+// escapedCallbacksKeySpec spells the `callbacks` member with a \uXXXX escape,
+// which JSON permits and encoding/json resolves to the same name. The literal
+// key never appears in the source, so a byte scan for it cannot see the field.
+//
+// The escape is built rather than written inline: an editor or a shell that
+// resolves it turns this into an ordinary fixture that proves nothing.
+func escapedCallbacksKeySpec(entry string) string {
+	const escapedKey = `"\u0063allbacks"`
+	return `{"openapi":"3.0.3","info":{"title":"T","version":"1.0.0"},
+"paths":{"/t":{"post":{"responses":{"200":{"description":"ok"}},` +
+		escapedKey + `:{` + entry + `}}}}}`
+}
+
+// TestCallbackRefsSurviveAnEscapedKey covers the member name a scan for the
+// literal `"callbacks"` cannot match. Both forms have to behave as they would
+// with the plain spelling.
+func TestCallbackRefsSurviveAnEscapedKey(t *testing.T) {
+	require.NotContains(t, escapedCallbacksKeySpec(""), `"callbacks"`,
+		"the fixture lost its escape, so it no longer tests anything")
+
+	t.Run("reference form", func(t *testing.T) {
+		spec := escapedCallbacksKeySpec(`"referenced":{"$ref":"#/components/callbacks/shared"}`)
+		result, err := New().ParseBytes([]byte(spec))
+		require.NoError(t, err, "an escaped callbacks key failed to parse")
+		doc, ok := result.OAS3Document()
+		require.True(t, ok)
+
+		op := doc.Paths["/t"].Post
+		require.NotNil(t, op)
+		require.Contains(t, op.CallbackRefs, "referenced",
+			"the reference was not classified under an escaped key")
+		assert.Equal(t, "#/components/callbacks/shared", op.CallbackRefs["referenced"].Ref)
+	})
+
+	t.Run("object form", func(t *testing.T) {
+		spec := escapedCallbacksKeySpec(
+			`"inline":{"{$request.query.url}":{"post":{"responses":{"200":{"description":"ok"}}}}}`)
+		result, err := New().ParseBytes([]byte(spec))
+		require.NoError(t, err)
+		doc, ok := result.OAS3Document()
+		require.True(t, ok)
+
+		op := doc.Paths["/t"].Post
+		require.NotNil(t, op)
+		assert.Contains(t, op.Callbacks, "inline")
+		assert.Empty(t, op.CallbackRefs)
+	})
+}

--- a/parser/callbacks.go
+++ b/parser/callbacks.go
@@ -16,6 +16,7 @@
 package parser
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"maps"
@@ -45,6 +46,10 @@ import (
 type Callback map[string]*PathItem
 
 const yamlKeyCallbacks = "callbacks"
+
+// jsonCallbacksKey is the `callbacks` member as it appears in JSON source, used
+// to rule the field out before decoding anything.
+var jsonCallbacksKey = []byte(`"` + yamlKeyCallbacks + `"`)
 
 // UnmarshalYAML implements custom YAML unmarshaling for Operation.
 //
@@ -214,6 +219,17 @@ func marshalYAMLWithCallbackRefs[T any](alias *T, callbacks map[string]*Callback
 // split, so only a document that actually uses the form pays for the extra
 // decode and re-encode.
 func splitJSONCallbackRefs(data []byte) ([]byte, map[string]*Reference, error) {
+	// Scanned for the key before anything is decoded. Decoding the object to
+	// discover it has no `callbacks` member would make every operation in every
+	// document pay for a field most of them do not carry, and the scan is a
+	// substring search over bytes already in hand.
+	//
+	// A hit inside a description or a nested object only costs the decode below,
+	// which is the correct answer for that input anyway.
+	if !bytes.Contains(data, jsonCallbacksKey) {
+		return data, nil, nil
+	}
+
 	// A shape this cannot split is left alone rather than reported: the caller's
 	// decode runs next and names the field the value belongs to, which is a
 	// better error than anything available here.

--- a/parser/callbacks.go
+++ b/parser/callbacks.go
@@ -51,6 +51,23 @@ const yamlKeyCallbacks = "callbacks"
 // to rule the field out before decoding anything.
 var jsonCallbacksKey = []byte(`"` + yamlKeyCallbacks + `"`)
 
+// jsonUnicodeEscape is the second needle, because JSON lets a member name spell
+// any character as \uXXXX. These two byte sequences are the same member name:
+//
+//	"callbacks"       22 63 61 6c 6c 62 61 63 6b 73 22
+//	"\u0063allbacks"  22 5c 75 30 30 36 33 61 6c 6c 62 61 63 6b 73 22
+//
+// jsonCallbacksKey matches the first and not the second. Any letter of the word
+// can be escaped that way, and more than one can, so there is no shorter piece
+// of it that is safe to search for instead.
+//
+// Looking for \u works, rather than resolving escapes here, because \uXXXX is
+// the only JSON escape that can stand for a letter. The other eight, \" \\ \/
+// \b \f \n \r and \t, each mean one fixed punctuation or control character, and
+// a backslash before anything else is not valid JSON. So when the member is
+// present and its literal bytes are not, these two are.
+var jsonUnicodeEscape = []byte(`\u`)
+
 // UnmarshalYAML implements custom YAML unmarshaling for Operation.
 //
 // The reference-form entries are lifted out of the `callbacks` mapping before
@@ -219,14 +236,18 @@ func marshalYAMLWithCallbackRefs[T any](alias *T, callbacks map[string]*Callback
 // split, so only a document that actually uses the form pays for the extra
 // decode and re-encode.
 func splitJSONCallbackRefs(data []byte) ([]byte, map[string]*Reference, error) {
-	// Scanned for the key before anything is decoded. Decoding the object to
-	// discover it has no `callbacks` member would make every operation in every
-	// document pay for a field most of them do not carry, and the scan is a
-	// substring search over bytes already in hand.
+	// Ruling the field out by scanning beats decoding the object only to find it
+	// absent, which is what every operation in a document would otherwise pay
+	// for.
 	//
-	// A hit inside a description or a nested object only costs the decode below,
-	// which is the correct answer for that input anyway.
-	if !bytes.Contains(data, jsonCallbacksKey) {
+	// Two searches rather than one pass over the bytes: each bytes.Contains is
+	// vectorized, and the second needle begins with a byte most documents never
+	// contain, so it adds almost nothing to the first. A hand-written loop
+	// answering both questions at once measured several times slower.
+	//
+	// Either match only costs the decode below, which is the right answer for
+	// that input anyway.
+	if !bytes.Contains(data, jsonCallbacksKey) && !bytes.Contains(data, jsonUnicodeEscape) {
 		return data, nil, nil
 	}
 

--- a/parser/callbacks.go
+++ b/parser/callbacks.go
@@ -1,0 +1,335 @@
+// callbacks.go holds the Callback type and the splitting and merging that keeps
+// the two Go fields carrying a `callbacks` object behaving as the one field the
+// specification defines. An entry is either a Callback Object or a Reference
+// Object; [Callback] explains why they cannot share a field.
+//
+// Each of the three decode paths splits the object for itself: YAML through the
+// node tree, JSON through the raw message, and decodeFromMap through the generic
+// map that $ref resolution produces. They agree on two things a test pins:
+//
+//   - a `$ref` key selects the reference form, whatever else sits beside it
+//   - the Callbacks map is non-nil exactly when the document carried a
+//     `callbacks` key, so presence survives decoding on every path
+//
+// https://spec.openapis.org/oas/v3.2.0.html#callback-object
+
+package parser
+
+import (
+	"encoding/json"
+	"fmt"
+	"maps"
+	"slices"
+
+	"go.yaml.in/yaml/v4"
+
+	"github.com/erraggy/oastools/parser/internal/jsonhelpers"
+)
+
+// Callback is a map of runtime expressions to path items (OAS 3.0+).
+//
+// A `callbacks` entry may be written either as a Callback Object or as a
+// Reference Object, and the specification tells them apart by the presence of a
+// `$ref` key: https://spec.openapis.org/oas/v3.2.0.html#callback-object
+//
+// The two forms cannot share one Go field. A Callback Object is an open map
+// keyed by user-authored runtime expressions, so a named map type is the only
+// faithful model, and a named map type has no field to hold `$ref`. The
+// reference form therefore lands in a parallel CallbackRefs map beside the
+// Callbacks map on both [Operation] and [Components]; the two are merged back
+// into a single `callbacks` object on serialization.
+//
+// A name belongs to one map or the other. Every decode path enforces that by
+// construction, and marshaling a value that breaks it is an error rather than a
+// silent choice between the two.
+type Callback map[string]*PathItem
+
+const yamlKeyCallbacks = "callbacks"
+
+// UnmarshalYAML implements custom YAML unmarshaling for Operation.
+//
+// The reference-form entries are lifted out of the `callbacks` mapping before
+// the alias type decodes the rest, because Callback is a map of path items and
+// a `$ref` string is not one.
+func (o *Operation) UnmarshalYAML(node *yaml.Node) error {
+	type Alias Operation
+	node, refs, err := splitYAMLCallbackRefs(node)
+	if err != nil {
+		return err
+	}
+	var alias Alias
+	if err := node.Decode(&alias); err != nil {
+		return err
+	}
+	*o = Operation(alias)
+	o.CallbackRefs = refs
+	return nil
+}
+
+// MarshalYAML implements custom YAML marshaling for Operation, merging
+// CallbackRefs back into the single `callbacks` object.
+func (o *Operation) MarshalYAML() (any, error) {
+	type Alias Operation
+	return marshalYAMLWithCallbackRefs((*Alias)(o), o.Callbacks, o.CallbackRefs)
+}
+
+// UnmarshalYAML implements custom YAML unmarshaling for Components, splitting
+// the reference-form `callbacks` entries out the way [Operation.UnmarshalYAML]
+// does.
+func (c *Components) UnmarshalYAML(node *yaml.Node) error {
+	type Alias Components
+	node, refs, err := splitYAMLCallbackRefs(node)
+	if err != nil {
+		return err
+	}
+	var alias Alias
+	if err := node.Decode(&alias); err != nil {
+		return err
+	}
+	*c = Components(alias)
+	c.CallbackRefs = refs
+	return nil
+}
+
+// MarshalYAML implements custom YAML marshaling for Components, merging
+// CallbackRefs back into the single `callbacks` object.
+func (c *Components) MarshalYAML() (any, error) {
+	type Alias Components
+	return marshalYAMLWithCallbackRefs((*Alias)(c), c.Callbacks, c.CallbackRefs)
+}
+
+// splitYAMLCallbackRefs returns the given mapping with the reference-form
+// entries removed from its `callbacks` value, plus those entries decoded. The
+// returned node is what the caller decodes into its struct.
+//
+// The node is returned unchanged, and no copy is made, whenever there is nothing
+// to split: a non-mapping node, no `callbacks` key, or no reference among its
+// entries. That is every document that does not use the form, so the common case
+// costs one scan of the callbacks mapping and no allocation.
+func splitYAMLCallbackRefs(node *yaml.Node) (*yaml.Node, map[string]*Reference, error) {
+	mapping := unwrapYAMLNode(node)
+	if mapping == nil || mapping.Kind != yaml.MappingNode {
+		// Leave the type error to the caller's decode, which names the field.
+		return node, nil, nil
+	}
+	callbacks := unwrapYAMLNode(childValueNode(mapping, yamlKeyCallbacks))
+	if callbacks == nil || callbacks.Kind != yaml.MappingNode {
+		return node, nil, nil
+	}
+
+	var refs map[string]*Reference
+	var kept []*yaml.Node
+	for i := 0; i+1 < len(callbacks.Content); i += 2 {
+		name, value := callbacks.Content[i], callbacks.Content[i+1]
+		entry := unwrapYAMLNode(value)
+		if entry == nil || entry.Kind != yaml.MappingNode || childValueNode(entry, jsonKeyRef) == nil {
+			// Only worth collecting once something has been taken out; until
+			// then the original content is still the answer.
+			if refs != nil {
+				kept = append(kept, name, value)
+			}
+			continue
+		}
+		ref := new(Reference)
+		if err := entry.Decode(ref); err != nil {
+			return nil, nil, fmt.Errorf("callback %q: %w", name.Value, err)
+		}
+		if refs == nil {
+			refs = make(map[string]*Reference)
+			kept = slices.Clone(callbacks.Content[:i])
+		}
+		refs[name.Value] = ref
+	}
+	if refs == nil {
+		return node, nil, nil
+	}
+
+	// The caller decodes the node returned here, so the reference entries have to
+	// be gone from it: handing one to Callback, a map of path items, is the
+	// failure this split exists to prevent.
+	//
+	// The `callbacks` key itself stays, holding whatever was not a reference, so
+	// a document that carried one decodes to a non-nil Callbacks map on this path
+	// as it does on the other two.
+	remaining := *callbacks
+	remaining.Content = kept
+	return replaceChildValue(mapping, yamlKeyCallbacks, &remaining), refs, nil
+}
+
+// replaceChildValue returns a copy of mapping with the value under key replaced.
+// The copy is what leaves the decoder's own node untouched, since it may hand
+// the same one to another Unmarshaler.
+func replaceChildValue(mapping *yaml.Node, key string, replacement *yaml.Node) *yaml.Node {
+	edited := *mapping
+	edited.Content = slices.Clone(mapping.Content)
+	for i := 0; i+1 < len(edited.Content); i += 2 {
+		if edited.Content[i].Value == key {
+			edited.Content[i+1] = replacement
+			break
+		}
+	}
+	return &edited
+}
+
+// marshalYAMLWithCallbackRefs encodes an alias of a callback-carrying type and
+// folds the reference-form entries back into its `callbacks` mapping.
+func marshalYAMLWithCallbackRefs[T any](alias *T, callbacks map[string]*Callback, refs map[string]*Reference) (any, error) {
+	// Nothing to fold in, so the alias goes back untouched. This is the common
+	// case, and the one whose output must not change.
+	if len(refs) == 0 {
+		return alias, nil
+	}
+	if err := checkCallbackNameConflicts(callbacks, refs); err != nil {
+		return nil, err
+	}
+
+	var node yaml.Node
+	if err := node.Encode(alias); err != nil {
+		return nil, err
+	}
+	entries := childValueNode(&node, yamlKeyCallbacks)
+	if entries == nil {
+		// Every entry is a reference, so the alias emitted no `callbacks` key.
+		entries = &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+		node.Content = append(node.Content,
+			&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: yamlKeyCallbacks},
+			entries)
+	}
+	for _, name := range slices.Sorted(maps.Keys(refs)) {
+		var value yaml.Node
+		if err := value.Encode(refs[name]); err != nil {
+			return nil, err
+		}
+		entries.Content = append(entries.Content,
+			&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: name},
+			&value)
+	}
+	return &node, nil
+}
+
+// splitJSONCallbackRefs returns the given JSON object with the reference-form
+// entries removed from its `callbacks` member, plus those entries decoded.
+//
+// Like the YAML split, the input is returned unchanged when there is nothing to
+// split, so only a document that actually uses the form pays for the extra
+// decode and re-encode.
+func splitJSONCallbackRefs(data []byte) ([]byte, map[string]*Reference, error) {
+	// A shape this cannot split is left alone rather than reported: the caller's
+	// decode runs next and names the field the value belongs to, which is a
+	// better error than anything available here.
+	object, ok := jsonObjectMembers(data)
+	if !ok {
+		return data, nil, nil
+	}
+	raw, ok := object[yamlKeyCallbacks]
+	if !ok {
+		return data, nil, nil
+	}
+	entries, ok := jsonObjectMembers(raw)
+	if !ok {
+		return data, nil, nil
+	}
+
+	var refs map[string]*Reference
+	for name, entry := range entries {
+		if !jsonObjectHasKey(entry, jsonKeyRef) {
+			continue
+		}
+		ref := new(Reference)
+		if err := json.Unmarshal(entry, ref); err != nil {
+			return nil, nil, fmt.Errorf("callback %q: %w", name, err)
+		}
+		if refs == nil {
+			refs = make(map[string]*Reference)
+		}
+		refs[name] = ref
+		delete(entries, name)
+	}
+	if refs == nil {
+		return data, nil, nil
+	}
+
+	// The `callbacks` member stays even when nothing is left under it, so
+	// Callbacks decodes non-nil here as it does on the YAML and map paths.
+	remaining, err := json.Marshal(entries)
+	if err != nil {
+		return nil, nil, err
+	}
+	object[yamlKeyCallbacks] = remaining
+	rest, err := json.Marshal(object)
+	if err != nil {
+		return nil, nil, err
+	}
+	return rest, refs, nil
+}
+
+// unmarshalJSONWithCallbackRefs decodes data into alias, returning the
+// reference-form callbacks and the extensions for the caller to store.
+//
+// Extensions come from the original bytes rather than from the split remainder:
+// the split rewrites the object only to lift out reference-form callbacks, but
+// re-encoding a map loses nothing an x- key needs, so reading them from data
+// keeps the two independent of each other.
+func unmarshalJSONWithCallbackRefs[A any](data []byte, alias *A) (map[string]*Reference, map[string]any, error) {
+	rest, refs, err := splitJSONCallbackRefs(data)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := json.Unmarshal(rest, alias); err != nil {
+		return nil, nil, err
+	}
+	return refs, jsonhelpers.ExtractExtensions(data), nil
+}
+
+// jsonObjectMembers decodes a JSON object into its raw members, reporting false
+// when the value is not an object.
+func jsonObjectMembers(raw json.RawMessage) (map[string]json.RawMessage, bool) {
+	var members map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &members); err != nil {
+		return nil, false
+	}
+	return members, true
+}
+
+// jsonObjectHasKey reports whether raw is a JSON object carrying key.
+func jsonObjectHasKey(raw json.RawMessage, key string) bool {
+	members, ok := jsonObjectMembers(raw)
+	if !ok {
+		return false
+	}
+	_, ok = members[key]
+	return ok
+}
+
+// mergedCallbacks renders the two Go fields as the single `callbacks` object the
+// specification defines, or nil when both are empty.
+func mergedCallbacks(callbacks map[string]*Callback, refs map[string]*Reference) (map[string]any, error) {
+	if len(callbacks) == 0 && len(refs) == 0 {
+		return nil, nil
+	}
+	if err := checkCallbackNameConflicts(callbacks, refs); err != nil {
+		return nil, err
+	}
+	merged := make(map[string]any, len(callbacks)+len(refs))
+	for name, callback := range callbacks {
+		merged[name] = callback
+	}
+	for name, ref := range refs {
+		merged[name] = ref
+	}
+	return merged, nil
+}
+
+// checkCallbackNameConflicts rejects a name held by both maps. Decoding cannot
+// produce one, since each entry is classified once; a value assembled in Go can,
+// and serializing it would have to pick a form, which is a choice no caller
+// asked for.
+func checkCallbackNameConflicts(callbacks map[string]*Callback, refs map[string]*Reference) error {
+	for _, name := range slices.Sorted(maps.Keys(refs)) {
+		if _, ok := callbacks[name]; ok {
+			return fmt.Errorf("callback %q is present as both a Callback Object and a Reference Object: "+
+				"a callbacks entry is one or the other", name)
+		}
+	}
+	return nil
+}

--- a/parser/decode_helpers.go
+++ b/parser/decode_helpers.go
@@ -274,6 +274,36 @@ func decodePaths(m map[string]any) Paths {
 	return result
 }
 
+// decodeCallbackMap decodes a `callbacks` object into the two fields that carry
+// it, classifying each entry by the presence of a `$ref` key the way the YAML
+// and JSON paths do. See [Callback].
+func decodeCallbackMap(m map[string]any) (map[string]*Callback, map[string]*Reference) {
+	// Allocated whether or not an entry ends up in it, because reaching here
+	// means the document carried a `callbacks` key and an empty map is how the
+	// other two decode paths report that. Returning nil for an object holding
+	// only references, or holding nothing, would make this path the odd one out
+	// and would leave a caller unable to tell either from an absent key.
+	callbacks := make(map[string]*Callback, len(m))
+	var refs map[string]*Reference
+	for k, v := range m {
+		vm, ok := v.(map[string]any)
+		if !ok {
+			continue
+		}
+		if _, isRef := vm[jsonKeyRef]; isRef {
+			ref := new(Reference)
+			ref.decodeFromMap(vm)
+			if refs == nil {
+				refs = make(map[string]*Reference)
+			}
+			refs[k] = ref
+			continue
+		}
+		callbacks[k] = decodeCallback(vm)
+	}
+	return callbacks, refs
+}
+
 // decodeCallback decodes a map[string]any into a Callback value.
 func decodeCallback(m map[string]any) *Callback {
 	if m == nil {

--- a/parser/deep_dive.md
+++ b/parser/deep_dive.md
@@ -93,6 +93,55 @@ is decoded before the document version is known to it. Rejecting the form that i
 wrong for the version is the validator's job, and re-spelling it for a target
 version is the converter's.
 
+### Callback References
+
+A `callbacks` entry is either a [Callback Object](https://spec.openapis.org/oas/v3.2.0.html#callback-object)
+or a [Reference Object](https://spec.openapis.org/oas/v3.2.0.html#reference-object).
+Both positions that hold one are typed `Map[string, Callback Object | Reference Object]`:
+[Operation](https://spec.openapis.org/oas/v3.2.0.html#operation-callbacks) and
+[Components](https://spec.openapis.org/oas/v3.2.0.html#components-callbacks).
+The [JSON Schema](https://spec.openapis.org/oas/3.2/schema/2025-09-17) tells the
+two apart by the presence of a `$ref` key (`callbacks-or-reference` is
+`if: {required: [$ref]}, then: reference, else: callbacks`), and declares nine
+such unions in all.
+
+Eight of the nine are objects with fixed field names, so each is modeled here as a
+struct with a `Ref` field. The Callback Object is the exception: it is an open map
+keyed by user-authored runtime expressions, so `Callback` is a map type, and a map
+type has no field to hold `$ref`.
+
+The reference form therefore lands on a parallel field, on both `Operation` and
+`Components`:
+
+```go
+op.Callbacks     // map[string]*Callback:  the Callback Object form
+op.CallbackRefs  // map[string]*Reference: the Reference Object form
+```
+
+```yaml
+callbacks:
+  onPetCreated:                                      # → Callbacks
+    '{$request.query.callbackUrl}': { post: ... }
+  onPetShipped:                                      # → CallbackRefs
+    $ref: '#/components/callbacks/shipped'
+```
+
+A name appears in one map or the other, never both. Marshaling merges them back
+into the single `callbacks` object, so a document round trips with the reference
+verbatim; a value assembled in Go that puts one name in both maps is a marshaling
+error rather than a silent choice between the forms.
+
+**Reading only `Callbacks` misses the referenced ones.** Anything counting
+callbacks, or collecting the components a document depends on, has to read both.
+The `walker` package inherits the split: it reports the reference form to its ref
+handler as a `callback` node type rather than to its callback handler, so a
+traversal registering only the callback handler has the same gap. See that
+package's deep dive for the handler pairing.
+
+Enabling `ResolveRefs` replaces a resolvable callback reference with what it
+points at, the way it does for every other reference form, and `CallbackRefs` is
+then left holding only the references that could not be resolved.
+
 ### Reference Resolution
 
 External `$ref` values are resolved when `ResolveRefs` is enabled:
@@ -194,6 +243,45 @@ if pathItem.Query != nil {
 ## JSON Schema 2020-12 Support
 
 The parser supports all JSON Schema Draft 2020-12 keywords used in OAS 3.1+:
+
+### Boolean Schemas
+
+A schema may be written as a bare boolean rather than an object. `true` accepts
+every instance and `false` accepts none, and both are legal anywhere a Schema
+Object is expected:
+
+```yaml
+components:
+  schemas:
+    Anything: true
+    Nothing: false
+    Unconstrained: {}       # an object schema with no keywords, NOT `true`
+```
+
+`Schema` is a struct, so the boolean is recorded on a field of its own and read
+back through a method rather than by comparing against a value:
+
+```go
+value, isBool := doc.Components.Schemas["Anything"].IsBool()
+// value == true, isBool == true
+
+value, isBool = doc.Components.Schemas["Unconstrained"].IsBool()
+// value == false, isBool == false
+```
+
+The two returns are independent, and conflating them is the mistake to avoid:
+`(false, false)` is an ordinary object schema, while `(false, true)` is the
+boolean schema `false`, which accepts nothing. Construct one with
+`NewBoolSchema(true)`.
+
+An empty object and `true` are different schemas, and marshaling reproduces the
+form it was given so a round trip does not silently swap one for the other. Every
+other field is meaningless alongside the boolean form and is dropped when it is
+set, since a boolean schema has no keywords by definition.
+
+The form is valid only for OAS 3.1+, which adopt the 2020-12 dialect. The parser
+accepts it at any version, because a Schema Object is decoded before the document
+version is known to it; the validator rejects it for 3.0 and 2.0.
 
 ### Content Keywords
 

--- a/parser/document_equals.go
+++ b/parser/document_equals.go
@@ -1,6 +1,4 @@
-package parser
-
-// This file contains equality methods for OAS2Document and OAS3Document.
+// document_equals.go holds equality methods for OAS2Document and OAS3Document.
 // These methods enable semantic comparison of OpenAPI specifications at
 // the document level.
 //
@@ -17,6 +15,8 @@ package parser
 // - paths_equals.go: Path, Operation, Response, Callback, Link, MediaType helpers
 // - parameters_equals.go: Parameter, Header, RequestBody, Items helpers
 // - security_equals.go: SecurityRequirement, SecurityScheme, OAuth helpers
+
+package parser
 
 // Equals compares two OAS3Documents for structural equality.
 // Returns true if both documents have identical content.
@@ -215,6 +215,9 @@ func equalComponents(a, b *Components) bool {
 
 	// Callback maps
 	if !equalCallbackMap(a.Callbacks, b.Callbacks) {
+		return false
+	}
+	if !equalReferenceMap(a.CallbackRefs, b.CallbackRefs) {
 		return false
 	}
 

--- a/parser/json_bench_test.go
+++ b/parser/json_bench_test.go
@@ -255,3 +255,28 @@ func BenchmarkUnmarshalInfo(b *testing.B) {
 		})
 	}
 }
+
+// benchOperationJSON is one operation with no callbacks: the shape a document is
+// full of, and the one that must not pay for the callback split.
+var benchOperationJSON = []byte(`{
+  "operationId": "listPets",
+  "summary": "List all pets",
+  "tags": ["pets"],
+  "parameters": [{"name": "limit", "in": "query", "schema": {"type": "integer"}}],
+  "responses": {"200": {"description": "ok", "content": {"application/json": {"schema": {"type": "array"}}}}}
+}`)
+
+// BenchmarkUnmarshalOperationWithoutCallbacks guards the cost of splitting the
+// reference-form callbacks out of a JSON object (see parser.Callback). The split
+// has to decode the object to find the entries, so it is ruled out by a byte
+// scan first; without that, every operation in every document pays for a field
+// most of them do not carry. Watch allocs/op: it was 86 before the split existed.
+func BenchmarkUnmarshalOperationWithoutCallbacks(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		var op Operation
+		if err := json.Unmarshal(benchOperationJSON, &op); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/parser/oas3.go
+++ b/parser/oas3.go
@@ -39,6 +39,9 @@ type Components struct {
 	SecuritySchemes map[string]*SecurityScheme `yaml:"securitySchemes,omitempty" json:"securitySchemes,omitempty"`
 	Links           map[string]*Link           `yaml:"links,omitempty" json:"links,omitempty"`
 	Callbacks       map[string]*Callback       `yaml:"callbacks,omitempty" json:"callbacks,omitempty"`
+	// CallbackRefs holds the `callbacks` entries written as Reference Objects.
+	// See [Callback] for why they are carried apart from Callbacks.
+	CallbackRefs map[string]*Reference `yaml:"-" json:"-"`
 
 	// OAS 3.1+ additions
 	PathItems map[string]*PathItem `yaml:"pathItems,omitempty" json:"pathItems,omitempty"` // OAS 3.1+

--- a/parser/oas3_json.go
+++ b/parser/oas3_json.go
@@ -75,10 +75,17 @@ func (d *OAS3Document) UnmarshalJSON(data []byte) error {
 // into the top-level JSON object, as Go's encoding/json doesn't support
 // inline maps like yaml:",inline".
 func (c *Components) MarshalJSON() ([]byte, error) {
-	// Fast path: no Extra fields, use standard marshaling
-	if len(c.Extra) == 0 {
+	// Fast path: no Extra fields, use standard marshaling. CallbackRefs is
+	// excluded because the struct tags cannot merge it back into the callbacks
+	// object; see [Callback].
+	if len(c.Extra) == 0 && len(c.CallbackRefs) == 0 {
 		type Alias Components
 		return marshalToJSON((*Alias)(c))
+	}
+
+	callbacks, err := mergedCallbacks(c.Callbacks, c.CallbackRefs)
+	if err != nil {
+		return nil, err
 	}
 
 	// Build map directly to avoid double-marshal pattern
@@ -109,8 +116,8 @@ func (c *Components) MarshalJSON() ([]byte, error) {
 	if len(c.Links) > 0 {
 		m["links"] = c.Links
 	}
-	if len(c.Callbacks) > 0 {
-		m["callbacks"] = c.Callbacks
+	if len(callbacks) > 0 {
+		m["callbacks"] = callbacks
 	}
 	if len(c.MediaTypes) > 0 {
 		m["mediaTypes"] = c.MediaTypes
@@ -129,9 +136,10 @@ func (c *Components) MarshalJSON() ([]byte, error) {
 // This captures unknown fields (specification extensions like x-*) in the Extra map.
 func (c *Components) UnmarshalJSON(data []byte) error {
 	type Alias Components
-	if err := json.Unmarshal(data, (*Alias)(c)); err != nil {
+	refs, extra, err := unmarshalJSONWithCallbackRefs(data, (*Alias)(c))
+	if err != nil {
 		return err
 	}
-	c.Extra = jsonhelpers.ExtractExtensions(data)
+	c.CallbackRefs, c.Extra = refs, extra
 	return nil
 }

--- a/parser/paths.go
+++ b/parser/paths.go
@@ -35,15 +35,18 @@ type PathItem struct {
 
 // Operation describes a single API operation on a path
 type Operation struct {
-	Tags         []string              `yaml:"tags,omitempty" json:"tags,omitempty"`
-	Summary      string                `yaml:"summary,omitempty" json:"summary,omitempty"`
-	Description  string                `yaml:"description,omitempty" json:"description,omitempty"`
-	ExternalDocs *ExternalDocs         `yaml:"externalDocs,omitempty" json:"externalDocs,omitempty"`
-	OperationID  string                `yaml:"operationId,omitempty" json:"operationId,omitempty"`
-	Parameters   []*Parameter          `yaml:"parameters,omitempty" json:"parameters,omitempty"`
-	RequestBody  *RequestBody          `yaml:"requestBody,omitempty" json:"requestBody,omitempty"` // OAS 3.0+
-	Responses    *Responses            `yaml:"responses" json:"responses"`
-	Callbacks    map[string]*Callback  `yaml:"callbacks,omitempty" json:"callbacks,omitempty"` // OAS 3.0+
+	Tags         []string             `yaml:"tags,omitempty" json:"tags,omitempty"`
+	Summary      string               `yaml:"summary,omitempty" json:"summary,omitempty"`
+	Description  string               `yaml:"description,omitempty" json:"description,omitempty"`
+	ExternalDocs *ExternalDocs        `yaml:"externalDocs,omitempty" json:"externalDocs,omitempty"`
+	OperationID  string               `yaml:"operationId,omitempty" json:"operationId,omitempty"`
+	Parameters   []*Parameter         `yaml:"parameters,omitempty" json:"parameters,omitempty"`
+	RequestBody  *RequestBody         `yaml:"requestBody,omitempty" json:"requestBody,omitempty"` // OAS 3.0+
+	Responses    *Responses           `yaml:"responses" json:"responses"`
+	Callbacks    map[string]*Callback `yaml:"callbacks,omitempty" json:"callbacks,omitempty"` // OAS 3.0+
+	// CallbackRefs holds the `callbacks` entries written as Reference Objects.
+	// See [Callback] for why they are carried apart from Callbacks.
+	CallbackRefs map[string]*Reference `yaml:"-" json:"-"` // OAS 3.0+
 	Deprecated   bool                  `yaml:"deprecated,omitempty" json:"deprecated,omitempty"`
 	Security     []SecurityRequirement `yaml:"security,omitempty" json:"security,omitempty"`
 	Servers      []*Server             `yaml:"servers,omitempty" json:"servers,omitempty"` // OAS 3.0+
@@ -127,9 +130,6 @@ type Response struct {
 	// Extra captures specification extensions (fields starting with "x-")
 	Extra map[string]any `yaml:",inline" json:"-"`
 }
-
-// Callback is a map of expressions to path items (OAS 3.0+)
-type Callback map[string]*PathItem
 
 // Link represents a possible design-time link for a response (OAS 3.0+)
 type Link struct {

--- a/parser/paths_equals.go
+++ b/parser/paths_equals.go
@@ -1,3 +1,11 @@
+// paths_equals.go holds equality comparison functions for path-related OpenAPI types.
+//
+// Includes: Paths, PathItem, Operation, Response, Callback, Link, MediaType,
+// Example, and Encoding types.
+//
+// See also:
+// - paths.go: Type definitions for these structures
+
 package parser
 
 import (
@@ -6,14 +14,6 @@ import (
 
 	"github.com/erraggy/oastools/internal/equalutil"
 )
-
-// This file contains equality comparison functions for path-related OpenAPI types.
-//
-// Includes: Paths, PathItem, Operation, Response, Callback, Link, MediaType,
-// Example, and Encoding types.
-//
-// See also:
-// - paths.go: Type definitions for these structures
 
 // =============================================================================
 // Path type helpers
@@ -171,6 +171,9 @@ func equalOperation(a, b *Operation) bool {
 	if !equalCallbackMap(a.Callbacks, b.Callbacks) {
 		return false
 	}
+	if !equalReferenceMap(a.CallbackRefs, b.CallbackRefs) {
+		return false
+	}
 
 	// Extensions
 	if !equalMapStringAny(a.Extra, b.Extra) {
@@ -283,6 +286,26 @@ func equalCallback(a, b *Callback) bool {
 // Nil and empty maps are considered equal.
 func equalCallbackMap(a, b map[string]*Callback) bool {
 	return maps.EqualFunc(a, b, equalCallback)
+}
+
+// equalReference compares two *Reference for equality.
+func equalReference(a, b *Reference) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return a.Ref == b.Ref &&
+		a.Summary == b.Summary &&
+		a.Description == b.Description &&
+		equalMapStringAny(a.Extra, b.Extra)
+}
+
+// equalReferenceMap compares two map[string]*Reference maps for equality.
+// Nil and empty maps are considered equal.
+func equalReferenceMap(a, b map[string]*Reference) bool {
+	return maps.EqualFunc(a, b, equalReference)
 }
 
 // =============================================================================

--- a/parser/paths_json.go
+++ b/parser/paths_json.go
@@ -60,9 +60,16 @@ func (o *Operation) MarshalJSON() ([]byte, error) {
 	// Fast path: no Extra fields and nil security, use standard marshaling.
 	// Security is excluded from the fast path because a non-nil empty slice
 	// must serialize as [] (disable inherited security), not be omitted.
-	if len(o.Extra) == 0 && o.Security == nil {
+	// CallbackRefs is excluded because the struct tags cannot merge it back
+	// into the callbacks object; see [Callback].
+	if len(o.Extra) == 0 && o.Security == nil && len(o.CallbackRefs) == 0 {
 		type Alias Operation
 		return marshalToJSON((*Alias)(o))
+	}
+
+	callbacks, err := mergedCallbacks(o.Callbacks, o.CallbackRefs)
+	if err != nil {
+		return nil, err
 	}
 
 	// Build map with known fields
@@ -76,7 +83,7 @@ func (o *Operation) MarshalJSON() ([]byte, error) {
 	jsonhelpers.SetIfNotEmpty(m, "operationId", o.OperationID)
 	jsonhelpers.SetIfSliceNotEmpty(m, "parameters", o.Parameters)
 	jsonhelpers.SetIfNotNil(m, "requestBody", o.RequestBody)
-	jsonhelpers.SetIfMapNotEmpty(m, "callbacks", o.Callbacks)
+	jsonhelpers.SetIfMapNotEmpty(m, "callbacks", callbacks)
 	jsonhelpers.SetIfTrue(m, "deprecated", o.Deprecated)
 	jsonhelpers.SetIfSliceNotNil(m, "security", o.Security)
 	jsonhelpers.SetIfSliceNotEmpty(m, "servers", o.Servers)
@@ -92,10 +99,11 @@ func (o *Operation) MarshalJSON() ([]byte, error) {
 // This captures unknown fields (specification extensions like x-*) in the Extra map.
 func (o *Operation) UnmarshalJSON(data []byte) error {
 	type Alias Operation
-	if err := json.Unmarshal(data, (*Alias)(o)); err != nil {
+	refs, extra, err := unmarshalJSONWithCallbackRefs(data, (*Alias)(o))
+	if err != nil {
 		return err
 	}
-	o.Extra = jsonhelpers.ExtractExtensions(data)
+	o.CallbackRefs, o.Extra = refs, extra
 	return nil
 }
 

--- a/parser/schema_yaml.go
+++ b/parser/schema_yaml.go
@@ -36,7 +36,7 @@ func (s *Schema) UnmarshalYAML(node *yaml.Node) error {
 
 	// Promotion reads the mapping's keys, so the wrappers have to come off
 	// first. A nil result only means there is nothing to look inside.
-	node = unwrapSchemaNode(node)
+	node = unwrapYAMLNode(node)
 
 	var err error
 	if s.Items, err = promoteYAMLSchemaOrBool(s.Items, node, "items"); err != nil {
@@ -76,7 +76,7 @@ func promoteYAMLSchemaOrBool(v any, parent *yaml.Node, key string) (any, error) 
 		return v, nil
 	}
 
-	node := unwrapSchemaNode(childValueNode(parent, key))
+	node := unwrapYAMLNode(childValueNode(parent, key))
 
 	switch {
 	case node == nil:
@@ -106,25 +106,6 @@ func promoteYAMLSchemaOrBool(v any, parent *yaml.Node, key string) (any, error) 
 	}
 }
 
-// childValueNode returns the value node stored under key in a mapping node, or
-// nil when the mapping has no such key.
-func childValueNode(node *yaml.Node, key string) *yaml.Node {
-	if node == nil || node.Kind != yaml.MappingNode {
-		return nil
-	}
-	for i := 0; i+1 < len(node.Content); i += 2 {
-		if node.Content[i].Value == key {
-			return node.Content[i+1]
-		}
-	}
-	return nil
-}
-
-// unwrapSchemaNode strips the wrappers that stand between a node and the
-// mapping it represents: a DocumentNode when the Schema is the root of the
-// decoded document — yaml.Unmarshal hands an Unmarshaler the document node
-// rather than its content — and an AliasNode when the schema was written as
-// `*anchor`. Returns nil when no node is left to unwrap.
 // boolSchemaNode reports whether a node is the bare-boolean schema form, and
 // its value. Anchors are followed first so `schema: *alwaysValid` is classified
 // by what it points at rather than by the alias node.
@@ -132,7 +113,7 @@ func childValueNode(node *yaml.Node, key string) *yaml.Node {
 // Only a genuine `!!bool` counts. A quoted "true" is a string scalar and is not
 // a boolean schema, so tag is checked rather than the raw value.
 func boolSchemaNode(node *yaml.Node) (bool, bool) {
-	node = unwrapSchemaNode(node)
+	node = unwrapYAMLNode(node)
 	if node == nil || node.Kind != yaml.ScalarNode || node.Tag != "!!bool" {
 		return false, false
 	}
@@ -141,23 +122,6 @@ func boolSchemaNode(node *yaml.Node) (bool, bool) {
 		return false, false
 	}
 	return b, true
-}
-
-func unwrapSchemaNode(node *yaml.Node) *yaml.Node {
-	for node != nil {
-		switch node.Kind {
-		case yaml.DocumentNode:
-			if len(node.Content) != 1 {
-				return node
-			}
-			node = node.Content[0]
-		case yaml.AliasNode:
-			node = node.Alias
-		default:
-			return node
-		}
-	}
-	return nil
 }
 
 // UnmarshalYAML implements custom YAML unmarshaling for Discriminator.

--- a/parser/yaml_nodes.go
+++ b/parser/yaml_nodes.go
@@ -1,0 +1,48 @@
+// yaml_nodes.go holds helpers for reading a decoded YAML tree directly, used by
+// the types whose shape the struct tags cannot express on their own:
+//
+//   - a schema-or-bool field, which has to be promoted after decoding
+//   - a `callbacks` entry, which has to be classified before decoding
+//
+// Both need the node the decoder saw rather than the value it produced, which is
+// what these return.
+
+package parser
+
+import "go.yaml.in/yaml/v4"
+
+// childValueNode returns the value node stored under key in a mapping node, or
+// nil when the mapping has no such key.
+func childValueNode(node *yaml.Node, key string) *yaml.Node {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value == key {
+			return node.Content[i+1]
+		}
+	}
+	return nil
+}
+
+// unwrapYAMLNode strips the wrappers that stand between a node and the mapping
+// or scalar it represents: a DocumentNode when the value is the root of the
+// decoded document (yaml.Unmarshal hands an Unmarshaler the document node rather
+// than its content), and an AliasNode when the value was written as `*anchor`.
+// Returns nil when no node is left to unwrap.
+func unwrapYAMLNode(node *yaml.Node) *yaml.Node {
+	for node != nil {
+		switch node.Kind {
+		case yaml.DocumentNode:
+			if len(node.Content) != 1 {
+				return node
+			}
+			node = node.Content[0]
+		case yaml.AliasNode:
+			node = node.Alias
+		default:
+			return node
+		}
+	}
+	return nil
+}

--- a/parser/zz_generated_decode.go
+++ b/parser/zz_generated_decode.go
@@ -88,12 +88,7 @@ func (x *Components) decodeFromMap(m map[string]any) {
 		}
 	}
 	if sub, ok := m["callbacks"].(map[string]any); ok {
-		x.Callbacks = make(map[string]*Callback, len(sub))
-		for k, v := range sub {
-			if vm, ok := v.(map[string]any); ok {
-				x.Callbacks[k] = decodeCallback(vm)
-			}
-		}
+		x.Callbacks, x.CallbackRefs = decodeCallbackMap(sub)
 	}
 	if sub, ok := m["pathItems"].(map[string]any); ok {
 		x.PathItems = make(map[string]*PathItem, len(sub))
@@ -540,12 +535,7 @@ func (x *Operation) decodeFromMap(m map[string]any) {
 		x.Responses.decodeFromMap(sub)
 	}
 	if sub, ok := m["callbacks"].(map[string]any); ok {
-		x.Callbacks = make(map[string]*Callback, len(sub))
-		for k, v := range sub {
-			if vm, ok := v.(map[string]any); ok {
-				x.Callbacks[k] = decodeCallback(vm)
-			}
-		}
+		x.Callbacks, x.CallbackRefs = decodeCallbackMap(sub)
 	}
 	x.Deprecated, _ = m["deprecated"].(bool)
 	if arr, ok := m["security"].([]any); ok {

--- a/parser/zz_generated_deepcopy.go
+++ b/parser/zz_generated_deepcopy.go
@@ -97,6 +97,15 @@ func (in *Components) DeepCopyInto(out *Components) {
 
 	out.Callbacks = deepCopyCallbacks(in.Callbacks)
 
+	if in.CallbackRefs != nil {
+		out.CallbackRefs = make(map[string]*Reference, len(in.CallbackRefs))
+		for k, v := range in.CallbackRefs {
+			if v != nil {
+				out.CallbackRefs[k] = v.DeepCopy()
+			}
+		}
+	}
+
 	if in.PathItems != nil {
 		out.PathItems = make(map[string]*PathItem, len(in.PathItems))
 		for k, v := range in.PathItems {
@@ -765,6 +774,15 @@ func (in *Operation) DeepCopyInto(out *Operation) {
 	}
 
 	out.Callbacks = deepCopyCallbacks(in.Callbacks)
+
+	if in.CallbackRefs != nil {
+		out.CallbackRefs = make(map[string]*Reference, len(in.CallbackRefs))
+		for k, v := range in.CallbackRefs {
+			if v != nil {
+				out.CallbackRefs[k] = v.DeepCopy()
+			}
+		}
+	}
 
 	out.Security = deepCopySecurityRequirements(in.Security)
 

--- a/validator/callback_refs_test.go
+++ b/validator/callback_refs_test.go
@@ -1,0 +1,114 @@
+package validator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erraggy/oastools/parser"
+)
+
+// callbackRefSpec builds a document whose operation and components each hold a
+// callbacks entry written as a Reference Object, pointing wherever the caller
+// says.
+func callbackRefSpec(operationTarget, componentTarget string) string {
+	return `
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+paths:
+  /things:
+    post:
+      responses:
+        '200':
+          description: ok
+      callbacks:
+        referenced:
+          $ref: '` + operationTarget + `'
+components:
+  callbacks:
+    shared:
+      'http://example.com':
+        post:
+          responses:
+            '200':
+              description: ok
+    alias:
+      $ref: '` + componentTarget + `'
+`
+}
+
+// requireCleanParse fails unless the document parsed with no collected errors,
+// so a validation result of zero errors cannot be the parser having stopped
+// short of the callbacks.
+func requireCleanParse(t *testing.T, spec string) {
+	t.Helper()
+	parsed, err := parser.New().ParseBytes([]byte(spec))
+	require.NoError(t, err)
+	require.Empty(t, parsed.Errors)
+}
+
+// TestCallbackRefsResolveToComponents covers the ref-target check on the
+// callbacks written as Reference Objects. They are held apart from the Callback
+// Objects (see parser.Callback), so the traversal that checks every other $ref
+// does not reach them on its own.
+func TestCallbackRefsResolveToComponents(t *testing.T) {
+	t.Run("a resolvable reference reports nothing", func(t *testing.T) {
+		spec := callbackRefSpec("#/components/callbacks/shared", "#/components/callbacks/shared")
+		requireCleanParse(t, spec)
+		assert.Empty(t, validateSpec(t, spec).Errors)
+	})
+
+	t.Run("a dangling reference is reported at each position", func(t *testing.T) {
+		spec := callbackRefSpec("#/components/callbacks/missingOp", "#/components/callbacks/missingComponent")
+		requireCleanParse(t, spec)
+		result := validateSpec(t, spec)
+
+		assert.True(t, resultHasMessage(result, "missingOp"),
+			"the operation's callback reference was not checked")
+		assert.True(t, resultHasMessage(result, "missingComponent"),
+			"the component's callback reference was not checked")
+	})
+
+	t.Run("a component written as a reference is itself referenceable", func(t *testing.T) {
+		// `alias` is a Reference Object, so it lives in CallbackRefs rather than
+		// Callbacks. It is still a component, and pointing at it must resolve.
+		spec := callbackRefSpec("#/components/callbacks/alias", "#/components/callbacks/shared")
+		requireCleanParse(t, spec)
+		assert.Empty(t, validateSpec(t, spec).Errors)
+	})
+}
+
+// TestCallbackRefComponentNameCharset covers the Components name charset rule on
+// the reference form of a callbacks entry.
+//
+// The two forms are separate Go maps (see parser.Callback), so the rule has to
+// be applied to each of them. Checking only the Callback Object map would leave
+// a hole the exact shape of a `$ref`.
+func TestCallbackRefComponentNameCharset(t *testing.T) {
+	// `shared` gives the reference a real target, so a name error is the only
+	// error the document can produce.
+	spec := func(name string) string {
+		return `openapi: 3.1.0
+info: {title: T, version: "1.0.0"}
+paths: {}
+components:
+  callbacks:
+    shared: {}
+    ` + name + `:
+      $ref: '#/components/callbacks/shared'
+`
+	}
+
+	t.Run("rejects an illegal name", func(t *testing.T) {
+		assertErrorsMatch(t, validationErrors(t, spec(`"pet/summary"`)), []string{
+			`components.callbacks.pet/summary: Component name "pet/summary" must match`,
+		})
+	})
+
+	t.Run("accepts a legal name", func(t *testing.T) {
+		assertErrorsMatch(t, validationErrors(t, spec("Pet.Summary-v2_1")), nil)
+	})
+}

--- a/validator/component_names.go
+++ b/validator/component_names.go
@@ -29,7 +29,10 @@ func (v *Validator) validateOAS3ComponentNames(components *parser.Components, re
 	checkComponentNames(v, components.Headers, "headers", result, baseURL)
 	checkComponentNames(v, components.SecuritySchemes, "securitySchemes", result, baseURL)
 	checkComponentNames(v, components.Links, "links", result, baseURL)
+	// Both forms a callbacks entry may take are keyed the same way, and the
+	// charset rule is about the key. See parser.Callback.
 	checkComponentNames(v, components.Callbacks, "callbacks", result, baseURL)
+	checkComponentNames(v, components.CallbackRefs, "callbacks", result, baseURL)
 	checkComponentNames(v, components.PathItems, "pathItems", result, baseURL)
 	checkComponentNames(v, components.MediaTypes, "mediaTypes", result, baseURL)
 }

--- a/validator/refs.go
+++ b/validator/refs.go
@@ -87,6 +87,7 @@ func buildOAS3ValidRefs(doc *parser.OAS3Document) map[string]bool {
 		len(doc.Components.SecuritySchemes) +
 		len(doc.Components.Links) +
 		len(doc.Components.Callbacks) +
+		len(doc.Components.CallbackRefs) +
 		len(doc.Components.PathItems)
 	validRefs := make(map[string]bool, capacity)
 
@@ -130,8 +131,13 @@ func buildOAS3ValidRefs(doc *parser.OAS3Document) map[string]bool {
 		validRefs[pathutil.LinkRef(name)] = true
 	}
 
-	// Add callbacks
+	// Add callbacks, in both the forms a callbacks entry may take: a component
+	// written as a Reference Object is still a component something else may
+	// reference. See parser.Callback.
 	for name := range doc.Components.Callbacks {
+		validRefs[pathutil.CallbackRef(name)] = true
+	}
+	for name := range doc.Components.CallbackRefs {
 		validRefs[pathutil.CallbackRef(name)] = true
 	}
 
@@ -447,6 +453,15 @@ func (v *Validator) validateOAS3Refs(doc *parser.OAS3Document, result *Validatio
 			}
 		}
 
+		// Validate callbacks written as Reference Objects. The Callback Object
+		// form holds path items rather than a $ref, and its contents are reached
+		// through the schema traversal instead. See parser.Callback.
+		for name, ref := range doc.Components.CallbackRefs {
+			if ref != nil {
+				v.validateRef(ref.Ref, "components.callbacks."+name, validRefs, result, baseURL)
+			}
+		}
+
 		// Validate headers
 		for name, header := range doc.Components.Headers {
 			if header != nil {
@@ -526,6 +541,13 @@ func (v *Validator) validatePathItemOperationRefs(pathItem *parser.PathItem, pat
 		// Validate request body
 		if op.RequestBody != nil {
 			v.validateRequestBodyRef(op.RequestBody, opPath+".requestBody", validRefs, result, baseURL)
+		}
+
+		// Validate callbacks written as Reference Objects
+		for name, ref := range op.CallbackRefs {
+			if ref != nil {
+				v.validateRef(ref.Ref, opPath+".callbacks."+name, validRefs, result, baseURL)
+			}
 		}
 
 		// Validate operation responses

--- a/walker/callback_ref_test.go
+++ b/walker/callback_ref_test.go
@@ -1,0 +1,185 @@
+package walker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erraggy/oastools/parser"
+)
+
+// callbackRefDocument holds a callbacks entry in each of its two forms, at each
+// of the two positions a callbacks object can occupy.
+func callbackRefDocument() *parser.ParseResult {
+	inline := parser.Callback{
+		"{$request.query.url}": {Post: &parser.Operation{}},
+	}
+	shared := parser.Callback{
+		"http://example.com": {Post: &parser.Operation{}},
+	}
+
+	return &parser.ParseResult{
+		Document: &parser.OAS3Document{
+			OpenAPI: "3.0.3",
+			Info:    &parser.Info{Title: "Test", Version: "1.0.0"},
+			Paths: parser.Paths{
+				"/things": {
+					Post: &parser.Operation{
+						Callbacks:    map[string]*parser.Callback{"inline": &inline},
+						CallbackRefs: map[string]*parser.Reference{"referenced": {Ref: "#/components/callbacks/shared"}},
+					},
+				},
+			},
+			Components: &parser.Components{
+				Callbacks:    map[string]*parser.Callback{"shared": &shared},
+				CallbackRefs: map[string]*parser.Reference{"alias": {Ref: "#/components/callbacks/shared"}},
+			},
+		},
+		OASVersion: parser.OASVersion303,
+	}
+}
+
+// TestCallbackRefsReachTheRefHandler covers the callbacks written as Reference
+// Objects, which carry a $ref and nothing to walk into. Anything collecting
+// references ($ref rewriting, unused-component pruning) reads them from
+// [RefHandler], so a callback missing from it is a reference nothing accounts for.
+func TestCallbackRefsReachTheRefHandler(t *testing.T) {
+	var seen []*RefInfo
+	err := Walk(callbackRefDocument(),
+		WithRefHandler(func(wc *WalkContext, ref *RefInfo) Action {
+			if ref.NodeType == RefNodeCallback {
+				seen = append(seen, ref)
+			}
+			return Continue
+		}),
+	)
+	require.NoError(t, err)
+
+	paths := make([]string, 0, len(seen))
+	for _, ref := range seen {
+		assert.Equal(t, "#/components/callbacks/shared", ref.Ref)
+		paths = append(paths, ref.SourcePath)
+	}
+	assert.ElementsMatch(t,
+		[]string{"$.paths['/things'].post.callbacks['referenced']", "$.components.callbacks['alias']"},
+		paths,
+		"a reference-form callback was not reported, or was reported at the wrong path")
+}
+
+// TestCallbackHandlerIgnoresReferences keeps the existing handler's contract:
+// it receives Callback Objects, and a Reference Object is not one.
+func TestCallbackHandlerIgnoresReferences(t *testing.T) {
+	var expressions []string
+	err := Walk(callbackRefDocument(),
+		WithCallbackHandler(func(wc *WalkContext, callback parser.Callback) Action {
+			for expression := range callback {
+				expressions = append(expressions, expression)
+			}
+			return Continue
+		}),
+	)
+	require.NoError(t, err)
+
+	assert.ElementsMatch(t, []string{"{$request.query.url}", "http://example.com"}, expressions,
+		"CallbackHandler saw something other than the two Callback Objects")
+}
+
+// TestCallbackRefStopsTraversal covers the Stop action on the new ref position,
+// which is the contract every other handler call site honors.
+func TestCallbackRefStopsTraversal(t *testing.T) {
+	var count int
+	err := Walk(callbackRefDocument(),
+		WithRefHandler(func(wc *WalkContext, ref *RefInfo) Action {
+			count++
+			return Stop
+		}),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count, "traversal continued past a Stop from the ref handler")
+}
+
+// TestCallbackRefStopsComponentTraversal covers the same Stop from the other
+// position a callback reference can occupy. A document walk reaches paths before
+// components, so a test that stops at an operation's reference returns before
+// this branch is ever taken.
+func TestCallbackRefStopsComponentTraversal(t *testing.T) {
+	result := &parser.ParseResult{
+		Document: &parser.OAS3Document{
+			OpenAPI: "3.0.3",
+			Info:    &parser.Info{Title: "Test", Version: "1.0.0"},
+			Components: &parser.Components{
+				CallbackRefs: map[string]*parser.Reference{"alias": {Ref: "#/components/callbacks/shared"}},
+				// Examples are walked after callbacks, so this reference is
+				// reached only if the Stop was dropped.
+				Examples: map[string]*parser.Example{"ex": {Ref: "#/components/examples/other"}},
+			},
+		},
+		OASVersion: parser.OASVersion303,
+	}
+
+	var seen []RefNodeType
+	err := Walk(result,
+		WithRefHandler(func(wc *WalkContext, ref *RefInfo) Action {
+			seen = append(seen, ref.NodeType)
+			return Stop
+		}),
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, []RefNodeType{RefNodeCallback}, seen,
+		"traversal continued past a Stop at a component callback reference")
+}
+
+// TestCallbackRefStopSkipsOperationPostHandler pins the reason the operation and
+// component walks treat the returned Action differently: an operation has a
+// post-visit handler after its callbacks, and that handler must not run once the
+// walk has been stopped.
+func TestCallbackRefStopSkipsOperationPostHandler(t *testing.T) {
+	var completed []string
+	err := Walk(callbackRefDocument(),
+		WithRefHandler(func(wc *WalkContext, ref *RefInfo) Action {
+			return Stop
+		}),
+		WithOperationPostHandler(func(wc *WalkContext, op *parser.Operation) {
+			completed = append(completed, wc.JSONPath)
+		}),
+	)
+	require.NoError(t, err)
+
+	assert.NotContains(t, completed, "$.paths['/things'].post",
+		"the operation's post-visit handler ran after the walk was stopped")
+	// The operation inside the Callback Object did finish, before the reference
+	// was reached, so this is not asserting that nothing ran at all.
+	assert.Contains(t, completed,
+		"$.paths['/things'].post.callbacks['inline']['{$request.query.url}'].post")
+}
+
+// TestCallbackRefsSkipNilEntries covers the nil guard in the reference walk. A
+// map assembled in Go can hold one, and a walker that dereferenced it would take
+// the whole traversal down.
+func TestCallbackRefsSkipNilEntries(t *testing.T) {
+	result := &parser.ParseResult{
+		Document: &parser.OAS3Document{
+			OpenAPI: "3.0.3",
+			Info:    &parser.Info{Title: "Test", Version: "1.0.0"},
+			Components: &parser.Components{
+				CallbackRefs: map[string]*parser.Reference{
+					"nilEntry": nil,
+					"real":     {Ref: "#/components/callbacks/shared"},
+				},
+			},
+		},
+		OASVersion: parser.OASVersion303,
+	}
+
+	var seen []string
+	assert.NotPanics(t, func() {
+		_ = Walk(result, WithRefHandler(func(wc *WalkContext, ref *RefInfo) Action {
+			seen = append(seen, ref.Ref)
+			return Continue
+		}))
+	})
+	assert.Equal(t, []string{"#/components/callbacks/shared"}, seen,
+		"a nil reference entry should be skipped, not reported")
+}

--- a/walker/deep_dive.md
+++ b/walker/deep_dive.md
@@ -264,7 +264,7 @@ Each OAS node type has a corresponding handler type:
 | `HeaderHandler` | Headers | All |
 | `MediaTypeHandler` | Media types | 3.x only |
 | `LinkHandler` | Links | 3.x only |
-| `CallbackHandler` | Callbacks | 3.x only |
+| `CallbackHandler` | Callbacks written as Callback Objects ([not references](#callbacks-arrive-two-ways)) | 3.x only |
 | `ExampleHandler` | Examples | All |
 | `ExternalDocsHandler` | External docs | All |
 | `SchemaSkippedHandler` | Skipped schemas (depth/cycle) | All |
@@ -290,10 +290,56 @@ Each handler type has a corresponding registration option. Register handlers usi
 | `WithHeaderHandler(fn)` | Headers | All |
 | `WithMediaTypeHandler(fn)` | Media types | 3.x only |
 | `WithLinkHandler(fn)` | Links | 3.x only |
-| `WithCallbackHandler(fn)` | Callbacks | 3.x only |
+| `WithCallbackHandler(fn)` | Callbacks written as Callback Objects ([not references](#callbacks-arrive-two-ways)) | 3.x only |
 | `WithExampleHandler(fn)` | Examples | All |
 | `WithExternalDocsHandler(fn)` | External docs | All |
 | `WithSchemaSkippedHandler(fn)` | Skipped schemas (depth/cycle) | All |
+
+### Callbacks Arrive Two Ways
+
+A `callbacks` entry is either a
+[Callback Object](https://spec.openapis.org/oas/v3.2.0.html#callback-object) or a
+[Reference Object](https://spec.openapis.org/oas/v3.2.0.html#reference-object),
+told apart by the presence of a `$ref` key. Both positions holding one are typed
+`Map[string, Callback Object | Reference Object]`:
+[Operation](https://spec.openapis.org/oas/v3.2.0.html#operation-callbacks) and
+[Components](https://spec.openapis.org/oas/v3.2.0.html#components-callbacks). The
+parser carries the two forms on separate fields, because a Callback Object is a
+map keyed by runtime expressions and a map has nowhere to put a `$ref` (see
+`parser.Callback`). The walker follows that split:
+
+| Written as | Field | Handler | Node type |
+|---|---|---|---|
+| Callback Object | `Callbacks` | `CallbackHandler` | n/a |
+| Reference Object | `CallbackRefs` | `RefHandler` | `RefNodeCallback` |
+
+Both positions a `callbacks` object can occupy are affected: an Operation Object
+and `components.callbacks`.
+
+This matters because **`CallbackHandler` alone does not see every callback in a
+document.** Counting callbacks, or collecting the components a document depends
+on, needs both handlers:
+
+```go
+walker.Walk(result,
+    walker.WithCallbackHandler(func(wc *walker.WalkContext, cb parser.Callback) walker.Action {
+        // A Callback Object: its path items are walked as children.
+        return walker.Continue
+    }),
+    walker.WithRefHandler(func(wc *walker.WalkContext, ref *walker.RefInfo) walker.Action {
+        if ref.NodeType == walker.RefNodeCallback {
+            // A Reference Object: a $ref and nothing to walk into.
+        }
+        return walker.Continue
+    }),
+)
+```
+
+A reference has no path items, so `CallbackPostHandler` does not fire for one and
+no operations are visited beneath it. Resolve the reference and walk what it
+points at if you need the target's contents, or parse with `ResolveRefs` enabled,
+which replaces a resolvable reference with what it points at before the walker
+ever sees it.
 
 ### WalkContext
 
@@ -843,6 +889,10 @@ References are tracked in:
 | `link` | Link references |
 | `example` | Example references |
 | `securityScheme` | Security scheme references |
+| `callback` | Callback references |
+
+A `callbacks` entry written as a Reference Object arrives here rather than at
+`CallbackHandler`. See [Callbacks Arrive Two Ways](#callbacks-arrive-two-ways).
 
 ### Use Cases
 

--- a/walker/example_test.go
+++ b/walker/example_test.go
@@ -745,3 +745,65 @@ func ExampleWithOAS2DocumentPostHandler() {
 	// Swagger 2.0: Legacy API
 	// Schemas: 2, Operations: 2
 }
+
+// ExampleWalk_callbacks shows why accounting for every callback in a document
+// takes two handlers.
+//
+// A `callbacks` entry is either a Callback Object or a Reference Object. The two
+// arrive on different Go fields (see parser.Callback), so CallbackHandler sees
+// only the first kind and the second reaches RefHandler as RefNodeCallback.
+// Registering just one handler silently misses half the document.
+func ExampleWalk_callbacks() {
+	inline := parser.Callback{
+		"{$request.query.callbackUrl}": &parser.PathItem{Post: &parser.Operation{}},
+	}
+	shared := parser.Callback{
+		"http://notifications.example.com": &parser.PathItem{Post: &parser.Operation{}},
+	}
+
+	doc := &parser.OAS3Document{
+		OpenAPI: "3.0.3",
+		Info:    &parser.Info{Title: "Pet Store API", Version: "1.0.0"},
+		Paths: parser.Paths{
+			"/pets": &parser.PathItem{
+				Post: &parser.Operation{
+					OperationID: "createPet",
+					// callbacks:
+					//   onPetCreated: { '{$request.query.callbackUrl}': ... }
+					Callbacks: map[string]*parser.Callback{"onPetCreated": &inline},
+					//   onPetShipped: { $ref: '#/components/callbacks/shipped' }
+					CallbackRefs: map[string]*parser.Reference{
+						"onPetShipped": {Ref: "#/components/callbacks/shipped"},
+					},
+				},
+			},
+		},
+		Components: &parser.Components{
+			Callbacks:    map[string]*parser.Callback{"shipped": &shared},
+			CallbackRefs: map[string]*parser.Reference{"delivered": {Ref: "#/components/callbacks/shipped"}},
+		},
+	}
+
+	result := &parser.ParseResult{Document: doc, OASVersion: parser.OASVersion303}
+
+	_ = walker.Walk(result,
+		walker.WithCallbackHandler(func(wc *walker.WalkContext, callback parser.Callback) walker.Action {
+			for expression := range callback {
+				fmt.Printf("callback object at %s: %s\n", wc.JSONPath, expression)
+			}
+			return walker.Continue
+		}),
+		walker.WithRefHandler(func(wc *walker.WalkContext, ref *walker.RefInfo) walker.Action {
+			if ref.NodeType == walker.RefNodeCallback {
+				fmt.Printf("callback reference at %s: %s\n", ref.SourcePath, ref.Ref)
+			}
+			return walker.Continue
+		}),
+	)
+
+	// Output:
+	// callback object at $.paths['/pets'].post.callbacks['onPetCreated']: {$request.query.callbackUrl}
+	// callback reference at $.paths['/pets'].post.callbacks['onPetShipped']: #/components/callbacks/shipped
+	// callback object at $.components.callbacks['shipped']: http://notifications.example.com
+	// callback reference at $.components.callbacks['delivered']: #/components/callbacks/shipped
+}

--- a/walker/ref.go
+++ b/walker/ref.go
@@ -14,6 +14,7 @@ const (
 	RefNodeExample        RefNodeType = "example"
 	RefNodePathItem       RefNodeType = "pathItem"
 	RefNodeSecurityScheme RefNodeType = "securityScheme"
+	RefNodeCallback       RefNodeType = "callback"
 )
 
 // RefInfo contains information about a $ref encountered during traversal.

--- a/walker/walk_oas3.go
+++ b/walker/walk_oas3.go
@@ -368,6 +368,9 @@ func (w *Walker) walkOAS3Operation(op *parser.Operation, basePath string, state 
 			}
 		}
 	}
+	if w.walkCallbackRefs(op.CallbackRefs, basePath, state) == Stop {
+		return nil
+	}
 
 	// Call post-visit handler after children (but before popParent)
 	if w.onOperationPost != nil && !w.stopped {
@@ -757,9 +760,6 @@ func (w *Walker) walkComponentLinks(components *parser.Components, basePath stri
 }
 
 func (w *Walker) walkComponentCallbacks(components *parser.Components, basePath string, state *walkState) error {
-	if components.Callbacks == nil {
-		return nil
-	}
 	for _, name := range maputil.SortedKeys(components.Callbacks) {
 		if w.stopped {
 			return nil
@@ -770,7 +770,32 @@ func (w *Walker) walkComponentCallbacks(components *parser.Components, basePath 
 			}
 		}
 	}
+	// The Action matters only where something follows it, as in an operation,
+	// whose post-visit handler must not run after a Stop. Nothing follows here,
+	// and w.stopped carries the Stop to the sibling component walkers.
+	_ = w.walkCallbackRefs(components.CallbackRefs, basePath, state)
 	return nil
+}
+
+// walkCallbackRefs reports the callbacks written as Reference Objects, which
+// hold a $ref and nothing to walk into. They reach [RefHandler] rather than
+// [CallbackHandler]: a reference is not a Callback Object, and a handler
+// expecting a map of runtime expressions has no use for one. See
+// [parser.Callback].
+func (w *Walker) walkCallbackRefs(refs map[string]*parser.Reference, basePath string, state *walkState) Action {
+	for _, name := range maputil.SortedKeys(refs) {
+		if w.stopped {
+			return Stop
+		}
+		ref := refs[name]
+		if ref == nil {
+			continue
+		}
+		if w.handleRef(ref.Ref, basePath+".callbacks['"+name+"']", RefNodeCallback, state) == Stop {
+			return Stop
+		}
+	}
+	return Continue
 }
 
 func (w *Walker) walkComponentExamples(components *parser.Components, basePath string, state *walkState) error {


### PR DESCRIPTION
Closes #451.

A `callbacks` entry may be written either as a Callback Object or as a Reference
Object. oastools could not decode the second form, and rejected the whole
document rather than degrading:

```
$ oastools validate tests/schema/pass/path_item_servers_parameters.yaml
✗ line 45: cannot construct !!str `#/compo...` into parser.PathItem
```

## Why this one needed a different shape

OAS 3.2 declares nine `-or-reference` unions in its
[JSON Schema](https://spec.openapis.org/oas/3.2/schema/2025-09-17). Eight are
objects with fixed field names, so each is modeled as a struct with a `Ref`
field. The Callback Object is the exception: it is an open map keyed by
user-authored runtime expressions, so `parser.Callback` is a map type, and a map
type has no field to hold `$ref`.

The specification discriminates on key presence, verified against the published
schema:

```json
"callbacks-or-reference": {
  "if":   {"type": "object", "required": ["$ref"]},
  "then": {"$ref": "#/$defs/reference"},
  "else": {"$ref": "#/$defs/callbacks"}
}
```

## Approach

A parallel `CallbackRefs map[string]*Reference` beside `Callbacks` on both
[Operation](https://spec.openapis.org/oas/v3.2.0.html#operation-callbacks) and
[Components](https://spec.openapis.org/oas/v3.2.0.html#components-callbacks),
tagged `yaml:"-" json:"-"`, merged back into the single `callbacks` object on
serialization. **No public signature changes**, so this ships in a MINOR.

A name belongs to one map or the other. Every decode path enforces that by
construction; a value assembled in Go that breaks it is a marshaling error
rather than a silent choice between the forms.

All three decode paths split the object for themselves, and two invariants are
pinned by test across all of them:

- a `$ref` key selects the reference form, whatever else sits beside it
- `Callbacks` is non-nil exactly when the document carried a `callbacks` key, so
  presence survives decoding on every path

| Path | How |
|---|---|
| YAML | node surgery before the alias decode |
| JSON | raw-message split before the alias decode |
| `decodeFromMap` | generated from the codegen template, via `decodeCallbackMap` |

## Follow-through

The parser change makes documents reachable that previously could not parse at
all, so everything reading `Callbacks` was audited rather than left to guess:

- **walker**: references reach `RefHandler` as the new `RefNodeCallback`.
  `CallbackHandler` is unchanged and still receives Callback Objects only.
- **validator**: callback references are checked against their targets, a
  component written as a reference is itself referenceable, and the
  component-name charset rule applies to both forms.
- **fixer**: `RefCollector` collects both forms; a components object holding
  only a reference-form callback is not empty.
- **joiner**: both forms are carried across a merge. A name arriving as an
  object where the other document holds a reference is rejected, since the
  joined document would otherwise hold the key twice and could not be written.
- **converter**: the "callbacks are not supported in OAS 2.0" report fires for
  both forms.

## Conformance

Measured against `tests/schema` from `OAI/OpenAPI-Specification@v3.2-dev`:

| | main (fbc40b0) | this branch |
|---|---|---|
| Positive accepted | 35/37 | **36/37** |
| Negative rejected | 28/29 | 28/29 |

The gained fixture is `path_item_servers_parameters.yaml`, the one in #451.

The remaining positive rejection is `operation-object-example.yaml`, which is
schema-valid and specification-invalid: its path is `/pets/{id}` while its only
parameter is named `petId`, and it requires a `petstore_auth` security scheme
the document never declares. Both are prose MUSTs that no schema can express,
and oastools is correct to reject it. The remaining negative miss is the
documented `allowReserved: false` divergence.

## Verification

- `make check` green: **10603 tests**, up from 10544 on `main`
- Corpus verdicts **byte-identical** to `main` across all 10 specs, with
  operationId attribution normalized away (#425)
- Every spec URL and anchor added here checked for status and anchor presence
- Three CodeRabbit CLI passes; findings applied or declined with evidence

## Also in this PR

Two small cleanups ride along, noted here because they are not about callbacks.
They share files with the change above, so separating them into their own
commits would have meant splitting hunks:

- Boolean schemas (`Schema.BoolForm`, from #450) had no documentation anywhere.
  Added to the parser deep dive beside the other JSON Schema 2020-12 keywords.
- Three file notes moved above the `package` clause to match the convention the
  other 15 files use, including `parser/yaml_nodes.go` added here.
