### PR TITLE
fix(validator,converter): contain branching cycles in five recursive walks

### DIFF
--- a/converter/oas32_features.go
+++ b/converter/oas32_features.go
@@ -304,25 +304,32 @@ func (c *Converter) detectOAS32MediaTypeFeatures(mt *parser.MediaType, prefix st
 		c.detectOAS32SchemaFeatures(mt.ItemSchema, prefix+".itemSchema", report, make(map[*parser.Schema]bool))
 	}
 	for name, enc := range mt.Encoding {
-		detectOAS32EncodingFeatures(enc, prefix+".encoding."+name, report, 0)
+		detectOAS32EncodingFeatures(enc, prefix+".encoding."+name, report, nil, 0)
 	}
-	detectOAS32EncodingFeatures(mt.ItemEncoding, prefix+".itemEncoding", report, 0)
+	detectOAS32EncodingFeatures(mt.ItemEncoding, prefix+".itemEncoding", report, nil, 0)
 	for i, enc := range mt.PrefixEncoding {
-		detectOAS32EncodingFeatures(enc, prefix+".prefixEncoding["+strconv.Itoa(i)+"]", report, 0)
+		detectOAS32EncodingFeatures(enc, prefix+".prefixEncoding["+strconv.Itoa(i)+"]", report, nil, 0)
 	}
 }
 
-// maxEncodingNestingDepth bounds the recursive Encoding walk 3.2 introduced.
+// maxEncodingNestingDepth bounds the recursive Encoding walk 3.2 introduced, as a
+// fail-safe behind the visited set.
 // https://spec.openapis.org/oas/v3.2.0.html#encoding-object
 //
-// A parsed document cannot build a cyclic Encoding graph, but the bound keeps a
-// hand-assembled one from recursing without end.
+// A parsed document can build neither a cyclic Encoding graph nor a chain this
+// long, but Convert takes the caller's document.
 const maxEncodingNestingDepth = 100
 
 // detectOAS32EncodingFeatures reports the nesting fields 3.2 added to Encoding.
 // https://spec.openapis.org/oas/v3.2.0.html#encoding-object
-func detectOAS32EncodingFeatures(enc *parser.Encoding, prefix string, report oas32Reporter, depth int) {
-	if enc == nil || depth > maxEncodingNestingDepth {
+//
+// visited is what makes a cyclic graph terminate. The depth bound alone does not
+// contain one: nested encodings that lead back to their parent branch, so the
+// walk goes exponential in depth long before the bound is reached. It stays nil
+// until an encoding actually nests, so a document without nesting allocates
+// nothing.
+func detectOAS32EncodingFeatures(enc *parser.Encoding, prefix string, report oas32Reporter, visited map[*parser.Encoding]bool, depth int) {
+	if enc == nil || depth > maxEncodingNestingDepth || visited[enc] {
 		return
 	}
 	if len(enc.Encoding) > 0 {
@@ -335,12 +342,23 @@ func detectOAS32EncodingFeatures(enc *parser.Encoding, prefix string, report oas
 		report(prefix, "prefixEncoding")
 	}
 
-	for name, nested := range enc.Encoding {
-		detectOAS32EncodingFeatures(nested, prefix+".encoding."+name, report, depth+1)
+	// Nothing below to reach, so nothing can repeat: an encoding that does not
+	// nest allocates no visited set. The validator's three Encoding walks make
+	// the same test before allocating theirs.
+	if len(enc.Encoding) == 0 && enc.ItemEncoding == nil && len(enc.PrefixEncoding) == 0 {
+		return
 	}
-	detectOAS32EncodingFeatures(enc.ItemEncoding, prefix+".itemEncoding", report, depth+1)
+	if visited == nil {
+		visited = make(map[*parser.Encoding]bool)
+	}
+	visited[enc] = true
+
+	for name, nested := range enc.Encoding {
+		detectOAS32EncodingFeatures(nested, prefix+".encoding."+name, report, visited, depth+1)
+	}
+	detectOAS32EncodingFeatures(enc.ItemEncoding, prefix+".itemEncoding", report, visited, depth+1)
 	for i, nested := range enc.PrefixEncoding {
-		detectOAS32EncodingFeatures(nested, prefix+".prefixEncoding["+strconv.Itoa(i)+"]", report, depth+1)
+		detectOAS32EncodingFeatures(nested, prefix+".prefixEncoding["+strconv.Itoa(i)+"]", report, visited, depth+1)
 	}
 }
 

--- a/converter/oas32_features_test.go
+++ b/converter/oas32_features_test.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -263,4 +264,76 @@ paths:
 			}
 		})
 	}
+}
+
+// cyclicEncoding returns an Encoding Object whose nested encodings all lead back
+// to it, so the graph is a cycle that branches `cycling` ways at every step.
+//
+// Hand-built because no parsed document can reach the same Encoding Object twice.
+// Encoding is not a referenceable component, and the two routes that could share
+// a pointer do not: `$ref` resolution and YAML aliases each produce a copy.
+// Convert takes the caller's document.
+func cyclicEncoding(cycling int) *parser.Encoding {
+	enc := &parser.Encoding{}
+	nested := make(map[string]*parser.Encoding, cycling)
+	for i := range cycling {
+		nested[string(rune('a'+i))] = enc
+	}
+	enc.Encoding = nested
+	return enc
+}
+
+// TestDetectOAS32EncodingFeaturesTerminatesOnACycle pins the visited set. The
+// depth bound alone does not contain a cycle whose encoding nests more than once,
+// because the walk branches and goes exponential in depth long before the bound
+// is reached; removing the set hangs this rather than failing it.
+//
+// The validator carries three more Encoding walks with the same shape, pinned by
+// TestEncodingWalksTerminateOnACycle. Nothing in the type system connects the
+// four.
+func TestDetectOAS32EncodingFeaturesTerminatesOnACycle(t *testing.T) {
+	for _, cycling := range []int{1, 2, 3} {
+		var reported []string
+		report := func(path, field string) {
+			reported = append(reported, path+": "+field)
+		}
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			detectOAS32EncodingFeatures(cyclicEncoding(cycling), "content.x", report, nil, 0)
+		}()
+		select {
+		case <-done:
+		case <-time.After(15 * time.Second):
+			t.Fatalf("fan-out %d: the walk did not terminate; the visited set is gone", cycling)
+		}
+
+		assert.Equal(t, []string{"content.x: encoding"}, reported,
+			"fan-out %d: the encoding should be reported once however many nested keys lead back to it", cycling)
+	}
+}
+
+// TestDetectOAS32EncodingFeaturesStopsAtTheDepthBound pins the bound, which the
+// visited set does not subsume: a chain of distinct encodings repeats nothing, so
+// only the counter stops it.
+func TestDetectOAS32EncodingFeaturesStopsAtTheDepthBound(t *testing.T) {
+	const links = maxEncodingNestingDepth + 150
+
+	head := &parser.Encoding{}
+	current := head
+	for range links - 1 {
+		next := &parser.Encoding{}
+		current.Encoding = map[string]*parser.Encoding{"next": next}
+		current = next
+	}
+
+	var reported int
+	report := func(string, string) { reported++ }
+	detectOAS32EncodingFeatures(head, "content.x", report, nil, 0)
+
+	// Every link but the last holds a nested encoding to report, and the head
+	// sits at depth 0, so the bound admits one more link than it names.
+	assert.Equal(t, maxEncodingNestingDepth+1, reported,
+		"the walk should stop at the nesting bound rather than following all %d links", links)
 }

--- a/validator/callback_traversal_test.go
+++ b/validator/callback_traversal_test.go
@@ -1,6 +1,7 @@
 package validator
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
@@ -91,16 +92,8 @@ func TestCallbackWalksTerminateOnACycle(t *testing.T) {
 			for _, cycling := range []int{1, 2, 3} {
 				item := cyclicCallbackItem(cycling)
 				var got int
-				done := make(chan struct{})
-				go func() {
-					defer close(done)
-					got = walk(item)
-				}()
-				select {
-				case <-done:
-				case <-time.After(15 * time.Second):
-					t.Fatalf("fan-out %d: the walk did not terminate; the visited set is gone", cycling)
-				}
+				runsWithin(t, 15*time.Second, "fan-out "+strconv.Itoa(cycling),
+					func() { got = walk(item) })
 				assert.Equal(t, 1, got,
 					"fan-out %d: the path item should be walked once however many operations lead back to it", cycling)
 			}

--- a/validator/callback_traversal_test.go
+++ b/validator/callback_traversal_test.go
@@ -1,0 +1,125 @@
+package validator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/erraggy/oastools/parser"
+)
+
+// callbackCarrier is a parameter holding one violation for each walk below:
+// `example` beside `examples` for the Example rules, and an enum disagreeing with
+// its type for the schema rules.
+func callbackCarrier() []*parser.Parameter {
+	return []*parser.Parameter{{
+		Name:     "q",
+		In:       "query",
+		Example:  "one",
+		Examples: map[string]*parser.Example{"other": {Value: "two"}},
+		Schema:   &parser.Schema{Type: "string", Enum: []any{1}},
+	}}
+}
+
+// callbackChain returns the head of a chain of `links` distinct path items, each
+// reaching the next through a callback on its `get`. Nothing repeats, so the
+// visited set never fires and only the depth bound stops the walk.
+func callbackChain(links int) *parser.PathItem {
+	head := &parser.PathItem{Parameters: callbackCarrier()}
+	current := head
+	for range links - 1 {
+		next := &parser.PathItem{Parameters: callbackCarrier()}
+		callback := parser.Callback{"next": next}
+		current.Get = &parser.Operation{
+			Callbacks: map[string]*parser.Callback{"chain": &callback},
+		}
+		current = next
+	}
+	return head
+}
+
+// cyclicCallbackItem returns a path item whose `cycling` operations each lead
+// back to it through a callback, so the graph branches at every step.
+//
+// Hand-built because a parsed document cannot close that loop: `$ref` resolution
+// and YAML aliases both copy rather than share, so no two positions hold the same
+// Path Item. ValidateParsed takes the caller's.
+func cyclicCallbackItem(cycling int) *parser.PathItem {
+	item := &parser.PathItem{Parameters: callbackCarrier()}
+	callback := parser.Callback{"loop": item}
+	cycle := map[string]*parser.Callback{"c": &callback}
+
+	setters := []func(*parser.Operation){
+		func(op *parser.Operation) { item.Get = op },
+		func(op *parser.Operation) { item.Post = op },
+		func(op *parser.Operation) { item.Put = op },
+	}
+	for _, set := range setters[:cycling] {
+		set(&parser.Operation{Callbacks: cycle})
+	}
+	return item
+}
+
+// walkFromPathItem runs one of the two callback walks over a path item and
+// returns how many errors it reported.
+var walkFromPathItem = map[string]func(*parser.PathItem) int{
+	// The Example and `querystring` traversal.
+	"traversePathItem": func(item *parser.PathItem) int {
+		result := &ValidationResult{}
+		New().validateOAS3TraversalPathItem(item, "paths./a", parser.OASVersion310,
+			parser.GetOperations(item, parser.OASVersion310), result)
+		return len(result.Errors)
+	},
+	// The schema traversal, entered at an operation rather than a path item.
+	"validatePathItemSchemas": func(item *parser.PathItem) int {
+		result := &ValidationResult{}
+		New().validateOAS3OperationSchemas(item.Get, "paths./a.get", result)
+		return len(result.Errors)
+	},
+}
+
+// TestCallbackWalksTerminateOnACycle pins the visited set both callback walks
+// carry. A Callback Object holds path items whose operations hold callbacks, so
+// the two can point at each other, and a depth bound alone does not contain that:
+// a path item with more than one operation leading back to it branches, so the
+// walk goes exponential in depth long before the bound is reached. Removing
+// either set hangs the corresponding case rather than failing it.
+func TestCallbackWalksTerminateOnACycle(t *testing.T) {
+	for name, walk := range walkFromPathItem {
+		t.Run(name, func(t *testing.T) {
+			for _, cycling := range []int{1, 2, 3} {
+				item := cyclicCallbackItem(cycling)
+				var got int
+				done := make(chan struct{})
+				go func() {
+					defer close(done)
+					got = walk(item)
+				}()
+				select {
+				case <-done:
+				case <-time.After(15 * time.Second):
+					t.Fatalf("fan-out %d: the walk did not terminate; the visited set is gone", cycling)
+				}
+				assert.Equal(t, 1, got,
+					"fan-out %d: the path item should be walked once however many operations lead back to it", cycling)
+			}
+		})
+	}
+}
+
+// TestCallbackWalksStopAtTheDepthBound pins maxCallbackNestingDepth, which the
+// visited set does not subsume: a chain of distinct path items repeats nothing,
+// so only the counter stops it.
+func TestCallbackWalksStopAtTheDepthBound(t *testing.T) {
+	const links = maxCallbackNestingDepth + 150
+
+	for name, walk := range walkFromPathItem {
+		t.Run(name, func(t *testing.T) {
+			// The head sits at depth 0, so the bound admits one more link than it
+			// names, and each link carries one violation.
+			assert.Equal(t, maxCallbackNestingDepth+1, walk(callbackChain(links)),
+				"the walk should stop at the nesting bound rather than following all %d links", links)
+		})
+	}
+}

--- a/validator/encoding_traversal_test.go
+++ b/validator/encoding_traversal_test.go
@@ -1,6 +1,7 @@
 package validator
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
@@ -60,8 +61,9 @@ func encodingChain(links int) *parser.Encoding {
 }
 
 // runsWithin fails the test if walk has not returned by limit. A walk that lost
-// its visited set does not fail an assertion, it stops returning.
-func runsWithin(t *testing.T, limit time.Duration, walk func()) {
+// its visited set does not fail an assertion, it stops returning, so the only
+// report is this one: what names the case that hung.
+func runsWithin(t *testing.T, limit time.Duration, what string, walk func()) {
 	t.Helper()
 	done := make(chan struct{})
 	go func() {
@@ -71,7 +73,7 @@ func runsWithin(t *testing.T, limit time.Duration, walk func()) {
 	select {
 	case <-done:
 	case <-time.After(limit):
-		t.Fatal("the walk did not terminate; the visited set is gone")
+		t.Fatalf("%s: the walk did not terminate; the visited set is gone", what)
 	}
 }
 
@@ -157,7 +159,8 @@ func TestEncodingWalksTerminateOnACycle(t *testing.T) {
 					Encoding: map[string]*parser.Encoding{"field": cyclicEncoding(cycling)},
 				}
 				var got int
-				runsWithin(t, 15*time.Second, func() { got = walk.run(mt) })
+				runsWithin(t, 15*time.Second, "fan-out "+strconv.Itoa(cycling),
+					func() { got = walk.run(mt) })
 				assert.Equal(t, walk.wantCycle, got,
 					"fan-out %d: the encoding should be walked once however many nested keys lead back to it", cycling)
 			}

--- a/validator/encoding_traversal_test.go
+++ b/validator/encoding_traversal_test.go
@@ -1,0 +1,186 @@
+package validator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/erraggy/oastools/parser"
+)
+
+// cyclicEncoding returns an Encoding Object whose nested encodings all lead back
+// to it, so the graph is a cycle that branches `cycling` ways at every step. Its
+// header carries one violation for each walk below: `example` beside `examples`
+// for the Example rules, and an enum disagreeing with its type for the schema
+// rules.
+//
+// Hand-built because no parsed document can reach the same Encoding Object twice.
+// Encoding is not a referenceable component, and the two routes that could share
+// a pointer do not: `$ref` resolution and YAML aliases each produce a copy.
+// ValidateParsed takes the caller's document.
+func cyclicEncoding(cycling int) *parser.Encoding {
+	enc := &parser.Encoding{
+		Headers: map[string]*parser.Header{
+			"X-Trace": {
+				Example:  "one",
+				Examples: map[string]*parser.Example{"other": {Value: "two"}},
+				Schema:   &parser.Schema{Type: "string", Enum: []any{1}},
+			},
+		},
+	}
+	nested := make(map[string]*parser.Encoding, cycling)
+	for i := range cycling {
+		nested[string(rune('a'+i))] = enc
+	}
+	enc.Encoding = nested
+	return enc
+}
+
+// encodingChain returns the head of a chain of `links` distinct Encoding Objects,
+// each nesting the next. Nothing repeats, so the visited set never fires and only
+// the depth bound stops the walk.
+func encodingChain(links int) *parser.Encoding {
+	head := &parser.Encoding{}
+	current := head
+	for range links - 1 {
+		next := &parser.Encoding{
+			Headers: map[string]*parser.Header{
+				"X-Trace": {
+					Example:  "one",
+					Examples: map[string]*parser.Example{"other": {Value: "two"}},
+					Schema:   &parser.Schema{Type: "string", Enum: []any{1}},
+				},
+			},
+		}
+		current.Encoding = map[string]*parser.Encoding{"next": next}
+		current = next
+	}
+	return head
+}
+
+// runsWithin fails the test if walk has not returned by limit. A walk that lost
+// its visited set does not fail an assertion, it stops returning.
+func runsWithin(t *testing.T, limit time.Duration, walk func()) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		walk()
+	}()
+	select {
+	case <-done:
+	case <-time.After(limit):
+		t.Fatal("the walk did not terminate; the visited set is gone")
+	}
+}
+
+// gateEncodingDoc wraps a media type in a pre-3.2 document, so the version gate
+// applies and its own Encoding walk runs.
+func gateEncodingDoc(mt *parser.MediaType) *parser.OAS3Document {
+	return &parser.OAS3Document{
+		OpenAPI: "3.0.3",
+		Info:    &parser.Info{Title: "T", Version: "1.0.0"},
+		Paths: parser.Paths{"/a": {Get: &parser.Operation{
+			RequestBody: &parser.RequestBody{
+				Content: map[string]*parser.MediaType{"multipart/form-data": mt},
+			},
+		}}},
+		OASVersion: parser.OASVersion303,
+	}
+}
+
+// encodingWalks is every Encoding walk the validator carries. Nothing in the type
+// system connects them, so they are listed here and each test runs all three.
+var encodingWalks = []struct {
+	name string
+	// run walks one media type and returns how many errors it reported.
+	run func(*parser.MediaType) int
+	// wantCycle is the error count for a cycle, which every fan-out shares: the
+	// encoding is visited once however many nested keys lead back to it.
+	wantCycle int
+	// wantChain is the error count for a chain longer than the bound. The two
+	// example walks report on a nested encoding's own header, so the deepest
+	// admitted encoding contributes nothing and the count is the bound. The gate
+	// reports the nesting field on the parent instead, so it counts one more.
+	wantChain int
+}{
+	{
+		name: "visitEncodingExamples",
+		run: func(mt *parser.MediaType) int {
+			result := &ValidationResult{}
+			New().visitMediaTypeExamples(mt, "paths./a.get.requestBody.content.x", result)
+			return len(result.Errors)
+		},
+		// The header's `example` beside its `examples`.
+		wantCycle: 1,
+		wantChain: maxEncodingNestingDepth,
+	},
+	{
+		name: "validateEncodingSchemas",
+		run: func(mt *parser.MediaType) int {
+			result := &ValidationResult{}
+			New().validateMediaTypeSchemas(mt, "paths./a.get.requestBody.content.x", result)
+			return len(result.Errors)
+		},
+		// The header schema's enum disagreeing with its type.
+		wantCycle: 1,
+		wantChain: maxEncodingNestingDepth,
+	},
+	{
+		name: "oas32Gate.encoding",
+		run: func(mt *parser.MediaType) int {
+			result := &ValidationResult{}
+			New().validateOAS32FieldsNotYetIntroduced(gateEncodingDoc(mt), result)
+			return len(result.Errors)
+		},
+		// The nested `encoding` field, which 3.0.3 predates.
+		wantCycle: 1,
+		wantChain: maxEncodingNestingDepth + 1,
+	},
+}
+
+// TestEncodingWalksTerminateOnACycle covers the three Encoding walks the
+// validator carries. Each recurses through the nesting 3.2 added, and each needs
+// its own visited set: a depth bound alone does not contain a cycle whose
+// encoding nests more than once, because the walk branches and goes exponential
+// in depth long before the bound is reached.
+//
+// One test over all three because nothing in the type system connects them, so a
+// guard added to one is not inherited by the others. Issue #431 has the
+// measurements.
+func TestEncodingWalksTerminateOnACycle(t *testing.T) {
+	for _, walk := range encodingWalks {
+		t.Run(walk.name, func(t *testing.T) {
+			for _, cycling := range []int{1, 2, 3} {
+				mt := &parser.MediaType{
+					Encoding: map[string]*parser.Encoding{"field": cyclicEncoding(cycling)},
+				}
+				var got int
+				runsWithin(t, 15*time.Second, func() { got = walk.run(mt) })
+				assert.Equal(t, walk.wantCycle, got,
+					"fan-out %d: the encoding should be walked once however many nested keys lead back to it", cycling)
+			}
+		})
+	}
+}
+
+// TestEncodingWalksStopAtTheDepthBound pins the bound, which the visited set does
+// not subsume: a chain of distinct encodings repeats nothing, so only the counter
+// stops it.
+//
+// The head sits at depth 0 and carries no header, so the bound admits one more
+// encoding than it names.
+func TestEncodingWalksStopAtTheDepthBound(t *testing.T) {
+	const links = maxEncodingNestingDepth + 150
+
+	for _, walk := range encodingWalks {
+		t.Run(walk.name, func(t *testing.T) {
+			mt := &parser.MediaType{
+				Encoding: map[string]*parser.Encoding{"field": encodingChain(links)},
+			}
+			assert.Equal(t, walk.wantChain, walk.run(mt),
+				"the walk should stop at the nesting bound rather than following all %d links", links)
+		})
+	}
+}

--- a/validator/oas32_gate.go
+++ b/validator/oas32_gate.go
@@ -86,9 +86,10 @@ func (p *gatePath) String() string {
 	return b.String()
 }
 
-// maxPathItemNestingDepth bounds the recursive Path Item traversal, which a
-// callback can close into a loop. Same reasoning as [maxEncodingNestingDepth]: a
-// parsed document cannot build one, but ValidateParsed takes the caller's.
+// maxPathItemNestingDepth bounds the recursive Path Item traversal, as a
+// fail-safe behind [oas32Gate.visited]. Same reasoning as
+// [maxEncodingNestingDepth]: a parsed document cannot build a chain this long,
+// but ValidateParsed takes the caller's.
 const maxPathItemNestingDepth = 100
 
 // oas32Gate carries the walk state, so it stays off every method signature.
@@ -97,6 +98,18 @@ type oas32Gate struct {
 	version parser.OASVersion
 	result  *ValidationResult
 	path    gatePath
+	// visited records the path items already walked, and is what makes a cyclic
+	// graph terminate: the depth bound alone does not contain one, because a path
+	// item whose operations lead back to it branches, so the walk goes
+	// exponential in depth long before the bound is reached. Same reasoning as
+	// [Validator.validatePathItemSchemas].
+	//
+	// Every path item is recorded, not only the ones a callback leads to.
+	// Recording lazily would leave the entry point of a cycle unrecorded until
+	// the cycle returned to it, so how often it reported would depend on which
+	// path the map order reached first. Measured at 2 allocations on the small
+	// benchmark fixture and 9 on the large one.
+	visited map[*parser.PathItem]bool
 	// depth counts nested path items, not path segments.
 	depth int
 }
@@ -243,9 +256,13 @@ func walkNamedIn[T any](g *oas32Gate, section string, items map[string]*T, visit
 }
 
 func (g *oas32Gate) pathItem(item *parser.PathItem) {
-	if item == nil || g.depth >= maxPathItemNestingDepth {
+	if item == nil || g.depth > maxPathItemNestingDepth || g.visited[item] {
 		return
 	}
+	if g.visited == nil {
+		g.visited = make(map[*parser.PathItem]bool)
+	}
+	g.visited[item] = true
 	g.depth++
 	defer func() { g.depth-- }()
 
@@ -384,40 +401,40 @@ func (g *oas32Gate) mediaType(mt *parser.MediaType) {
 	}
 
 	g.examples(mt.Examples)
-	g.encodings(mt.Encoding, 0)
+	g.encodings(mt.Encoding, nil, 0)
 
 	if mt.ItemEncoding != nil {
 		g.path.push("itemEncoding")
-		g.encoding(mt.ItemEncoding, 0)
+		g.encoding(mt.ItemEncoding, nil, 0)
 		g.path.pop()
 	}
 	for i, nested := range mt.PrefixEncoding {
 		g.path.pushIndex("prefixEncoding", i)
-		g.encoding(nested, 0)
+		g.encoding(nested, nil, 0)
 		g.path.pop()
 	}
 }
 
 // encodings walks a named encoding map, which Media Type and Encoding both hold.
-func (g *oas32Gate) encodings(encodings map[string]*parser.Encoding, depth int) {
+func (g *oas32Gate) encodings(encodings map[string]*parser.Encoding, visited map[*parser.Encoding]bool, depth int) {
 	if len(encodings) == 0 {
 		return
 	}
 	g.path.push("encoding")
 	for name, enc := range encodings {
 		g.path.push(name)
-		g.encoding(enc, depth)
+		g.encoding(enc, visited, depth)
 		g.path.pop()
 	}
 	g.path.pop()
 }
 
-// encoding recurses through the [Encoding Object] graph 3.2 introduced. depth
-// mirrors the bound on [Validator.visitEncodingExamples].
+// encoding recurses through the [Encoding Object] graph 3.2 introduced. visited
+// and depth mirror the guards on [Validator.visitEncodingExamples].
 //
 // [Encoding Object]: https://spec.openapis.org/oas/v3.2.0.html#encoding-object
-func (g *oas32Gate) encoding(enc *parser.Encoding, depth int) {
-	if enc == nil || depth > maxEncodingNestingDepth {
+func (g *oas32Gate) encoding(enc *parser.Encoding, visited map[*parser.Encoding]bool, depth int) {
+	if enc == nil || depth > maxEncodingNestingDepth || visited[enc] {
 		return
 	}
 	if len(enc.Encoding) > 0 {
@@ -432,16 +449,24 @@ func (g *oas32Gate) encoding(enc *parser.Encoding, depth int) {
 
 	g.walkHeaders(enc.Headers)
 
-	g.encodings(enc.Encoding, depth+1)
+	if !encodingNests(enc) {
+		return
+	}
+	if visited == nil {
+		visited = make(map[*parser.Encoding]bool)
+	}
+	visited[enc] = true
+
+	g.encodings(enc.Encoding, visited, depth+1)
 
 	if enc.ItemEncoding != nil {
 		g.path.push("itemEncoding")
-		g.encoding(enc.ItemEncoding, depth+1)
+		g.encoding(enc.ItemEncoding, visited, depth+1)
 		g.path.pop()
 	}
 	for i, nested := range enc.PrefixEncoding {
 		g.path.pushIndex("prefixEncoding", i)
-		g.encoding(nested, depth+1)
+		g.encoding(nested, visited, depth+1)
 		g.path.pop()
 	}
 }

--- a/validator/oas32_gate_test.go
+++ b/validator/oas32_gate_test.go
@@ -3,6 +3,7 @@ package validator
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -733,33 +734,106 @@ func TestOAS32FieldGate_ErrorOrderIsDeterministic(t *testing.T) {
 	assert.IsIncreasing(t, first, "sorted by path, so the order is predictable and not merely stable")
 }
 
-// TestOAS32FieldGate_BoundsCyclicPathItems covers the one graph the walk cannot
-// treat as a tree — a [Callback Object] holds path items whose operations hold
-// callbacks. Hand-built because a parsed document cannot close that loop, and
-// ValidateParsed takes the caller's; before the bound this exhausted the stack.
+// cyclicGateDoc returns a pre-3.2 document whose single path item cycles back to
+// itself through a callback on each of the named operations, carrying one 3.2
+// field so every visit has something to report.
 //
-// [Callback Object]: https://spec.openapis.org/oas/v3.2.0.html#callback-object
-func TestOAS32FieldGate_BoundsCyclicPathItems(t *testing.T) {
+// Hand-built because a parsed document cannot close that loop: both routes to a
+// shared pointer produce copies instead, so `$ref` resolution and YAML anchors
+// each yield a distinct Path Item. ValidateParsed takes the caller's document.
+func cyclicGateDoc(cycling int) *parser.OAS3Document {
 	item := &parser.PathItem{}
 	callback := parser.Callback{"loop": item}
-	item.Get = &parser.Operation{
-		Callbacks: map[string]*parser.Callback{"cycle": &callback},
+	cycle := map[string]*parser.Callback{"cycle": &callback}
+
+	setters := []func(*parser.Operation){
+		func(op *parser.Operation) { item.Get = op },
+		func(op *parser.Operation) { item.Post = op },
+		func(op *parser.Operation) { item.Put = op },
 	}
-	// A 3.2 field, so each pass round the loop has something to report and the
-	// bound is observable rather than merely survived.
+	for _, set := range setters[:cycling] {
+		set(&parser.Operation{Callbacks: cycle})
+	}
+	// A 3.2 field, so a visit is observable rather than merely survived.
 	item.Query = &parser.Operation{}
 
-	doc := &parser.OAS3Document{
+	return &parser.OAS3Document{
 		OpenAPI:    "3.0.3",
 		Info:       &parser.Info{Title: "T", Version: "1.0.0"},
 		Paths:      parser.Paths{"/a": item},
 		OASVersion: parser.OASVersion303,
 	}
+}
+
+// TestOAS32FieldGate_BoundsCyclicPathItems covers the one graph the walk cannot
+// treat as a tree: a [Callback Object] holds path items whose operations hold
+// callbacks.
+//
+// The visited set is what makes this terminate, and removing it hangs the second
+// case rather than slowing it. A depth bound alone does not contain a cycle whose
+// path item has more than one operation leading back to it, because the walk
+// branches and goes exponential in depth long before the bound is reached: two
+// such operations ran past 15 seconds without returning.
+//
+// [Callback Object]: https://spec.openapis.org/oas/v3.2.0.html#callback-object
+func TestOAS32FieldGate_BoundsCyclicPathItems(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		cycling int
+	}{
+		{"one operation cycles back, so the walk is a chain", 1},
+		{"two cycle back, so it branches", 2},
+		{"three cycle back", 3},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			doc := cyclicGateDoc(tc.cycling)
+			result := &ValidationResult{}
+
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				New().validateOAS32FieldsNotYetIntroduced(doc, result)
+			}()
+			select {
+			case <-done:
+			case <-time.After(15 * time.Second):
+				t.Fatal("the gate walk did not terminate; the visited set is gone")
+			}
+
+			assert.Len(t, result.Errors, 1,
+				"the path item should be walked once however many operations lead back to it")
+		})
+	}
+}
+
+// TestOAS32FieldGate_BoundsAcyclicPathItemChain pins the depth bound, which the
+// visited set does not subsume: a chain of distinct path items repeats nothing,
+// so only the counter stops it. Removing the bound walks all 250 links.
+func TestOAS32FieldGate_BoundsAcyclicPathItemChain(t *testing.T) {
+	const links = maxPathItemNestingDepth + 150
+
+	head := &parser.PathItem{Query: &parser.Operation{}}
+	current := head
+	for range links - 1 {
+		next := &parser.PathItem{Query: &parser.Operation{}}
+		callback := parser.Callback{"next": next}
+		current.Get = &parser.Operation{
+			Callbacks: map[string]*parser.Callback{"chain": &callback},
+		}
+		current = next
+	}
+
+	doc := &parser.OAS3Document{
+		OpenAPI:    "3.0.3",
+		Info:       &parser.Info{Title: "T", Version: "1.0.0"},
+		Paths:      parser.Paths{"/a": head},
+		OASVersion: parser.OASVersion303,
+	}
 
 	result := &ValidationResult{}
-	require.NotPanics(t, func() {
-		New().validateOAS32FieldsNotYetIntroduced(doc, result)
-	})
-	assert.Len(t, result.Errors, maxPathItemNestingDepth,
-		"the walk should stop at the nesting bound, having reported once per level")
+	New().validateOAS32FieldsNotYetIntroduced(doc, result)
+
+	// The head sits at depth 0, so the bound admits one more link than it names.
+	assert.Len(t, result.Errors, maxPathItemNestingDepth+1,
+		"the walk should stop at the nesting bound, having reported once per link")
 }

--- a/validator/oas3_examples.go
+++ b/validator/oas3_examples.go
@@ -98,7 +98,7 @@ func (v *Validator) traversePathItem(
 	visited map[*parser.PathItem]bool,
 	depth int,
 ) {
-	if item == nil || !oas3TraversalApplies(version) {
+	if item == nil || !oas3TraversalApplies(version) || depth > maxCallbackNestingDepth {
 		return
 	}
 
@@ -154,6 +154,16 @@ func (v *Validator) traversePathItem(
 			}
 		}
 
+		if len(op.Callbacks) > 0 {
+			// Recording this path item before descending is what keeps a callback
+			// leading back to it from walking it a second time. visited is a local,
+			// so assigning it here also shares one map across the operations below:
+			// each would otherwise build its own and none would see the others.
+			if visited == nil {
+				visited = make(map[*parser.PathItem]bool)
+			}
+			visited[item] = true
+		}
 		v.visitCallbacks(op.Callbacks, opPath, version, result, visited, depth)
 	}
 }
@@ -176,7 +186,7 @@ func (v *Validator) visitCallbacks(
 	visited map[*parser.PathItem]bool,
 	depth int,
 ) {
-	if len(callbacks) == 0 || depth >= maxCallbackNestingDepth {
+	if len(callbacks) == 0 {
 		return
 	}
 	for name, cb := range callbacks {
@@ -308,6 +318,20 @@ func encodingNeedsVisit(enc *parser.Encoding) bool {
 		enc.PrefixEncoding != nil)
 }
 
+// encodingNests reports whether an Encoding Object holds another, which is the
+// only way any Encoding walk can reach the same object twice. Narrower than
+// [encodingNeedsVisit], which also counts headers: those are leaves.
+//
+// Every Encoding walk consults this before allocating its visited set, so a
+// document whose encodings do not nest allocates nothing. The three fields it
+// tests are 3.2 additions, which is why a document carrying them at an earlier
+// version is what [oas32Gate.encoding] exists to report.
+func encodingNests(enc *parser.Encoding) bool {
+	return enc != nil && (len(enc.Encoding) > 0 ||
+		enc.ItemEncoding != nil ||
+		len(enc.PrefixEncoding) > 0)
+}
+
 func (v *Validator) visitResponseExamples(resp *parser.Response, prefix string, result *ValidationResult) {
 	if !responseNeedsVisit(resp) {
 		return
@@ -348,21 +372,35 @@ func (v *Validator) visitMediaTypeExamples(mt *parser.MediaType, prefix string, 
 	// Encoding Objects carry Headers, which carry Examples, including through the
 	// nested encodings 3.2 added.
 	for name, enc := range mt.Encoding {
-		v.visitEncodingExamples(enc, prefix+".encoding."+name, result, 0)
+		v.visitEncodingExamples(enc, prefix+".encoding."+name, result, nil, 0)
 	}
-	v.visitEncodingExamples(mt.ItemEncoding, prefix+".itemEncoding", result, 0)
+	v.visitEncodingExamples(mt.ItemEncoding, prefix+".itemEncoding", result, nil, 0)
 	for i, enc := range mt.PrefixEncoding {
-		v.visitEncodingExamples(enc, prefix+".prefixEncoding["+strconv.Itoa(i)+"]", result, 0)
+		v.visitEncodingExamples(enc, prefix+".prefixEncoding["+strconv.Itoa(i)+"]", result, nil, 0)
 	}
 }
 
-// maxEncodingNestingDepth bounds the recursive Encoding traversal 3.2 introduced.
-// A parsed document cannot build a cyclic Encoding graph, but the bound keeps a
-// hand-assembled one from recursing without end.
+// maxEncodingNestingDepth bounds the recursive Encoding traversal 3.2 introduced,
+// as a fail-safe behind the visited set each walk carries. A parsed document can
+// build neither a cycle nor a chain this long, but ValidateParsed takes the
+// caller's.
 const maxEncodingNestingDepth = 100
 
-func (v *Validator) visitEncodingExamples(enc *parser.Encoding, prefix string, result *ValidationResult, depth int) {
-	if !encodingNeedsVisit(enc) || depth > maxEncodingNestingDepth {
+// visitEncodingExamples reaches the Examples an Encoding Object's headers carry,
+// through the nesting 3.2 added.
+//
+// visited is what makes this terminate, for the reason [Validator.visitCallbacks]
+// gives: nested encodings that lead back to their parent branch, so the walk goes
+// exponential in depth long before the bound is reached. It stays nil until an
+// encoding actually nests.
+func (v *Validator) visitEncodingExamples(
+	enc *parser.Encoding,
+	prefix string,
+	result *ValidationResult,
+	visited map[*parser.Encoding]bool,
+	depth int,
+) {
+	if !encodingNeedsVisit(enc) || depth > maxEncodingNestingDepth || visited[enc] {
 		return
 	}
 	v.reportExclusions(encodingExclusions, []fieldPresence{
@@ -374,11 +412,23 @@ func (v *Validator) visitEncodingExamples(enc *parser.Encoding, prefix string, r
 	for name, header := range enc.Headers {
 		v.visitHeaderExamples(header, prefix+".headers."+name, result)
 	}
-	for name, nested := range enc.Encoding {
-		v.visitEncodingExamples(nested, prefix+".encoding."+name, result, depth+1)
+
+	// Nothing below to reach, so nothing can repeat. Reading a nil map is legal,
+	// so the guard above needs no map and only the write here does: an encoding
+	// holding nothing but headers allocates nothing.
+	if !encodingNests(enc) {
+		return
 	}
-	v.visitEncodingExamples(enc.ItemEncoding, prefix+".itemEncoding", result, depth+1)
+	if visited == nil {
+		visited = make(map[*parser.Encoding]bool)
+	}
+	visited[enc] = true
+
+	for name, nested := range enc.Encoding {
+		v.visitEncodingExamples(nested, prefix+".encoding."+name, result, visited, depth+1)
+	}
+	v.visitEncodingExamples(enc.ItemEncoding, prefix+".itemEncoding", result, visited, depth+1)
 	for i, nested := range enc.PrefixEncoding {
-		v.visitEncodingExamples(nested, prefix+".prefixEncoding["+strconv.Itoa(i)+"]", result, depth+1)
+		v.visitEncodingExamples(nested, prefix+".prefixEncoding["+strconv.Itoa(i)+"]", result, visited, depth+1)
 	}
 }

--- a/validator/schema_traversal.go
+++ b/validator/schema_traversal.go
@@ -158,29 +158,37 @@ func (v *Validator) validateMediaTypeSchemas(mt *parser.MediaType, path string, 
 	}
 
 	for name, enc := range mt.Encoding {
-		v.validateEncodingSchemas(enc, path+".encoding."+name, result, 0)
+		v.validateEncodingSchemas(enc, path+".encoding."+name, result, nil, 0)
 	}
-	v.validateEncodingSchemas(mt.ItemEncoding, path+".itemEncoding", result, 0)
+	v.validateEncodingSchemas(mt.ItemEncoding, path+".itemEncoding", result, nil, 0)
 	for i, enc := range mt.PrefixEncoding {
-		v.validateEncodingSchemas(enc, path+".prefixEncoding["+strconv.Itoa(i)+"]", result, 0)
+		v.validateEncodingSchemas(enc, path+".prefixEncoding["+strconv.Itoa(i)+"]", result, nil, 0)
 	}
 }
 
 // validateEncodingSchemas validates the schemas an Encoding Object's headers
-// carry, and recurses through the encoding nesting 3.2 added. depth mirrors the
-// bound on [Validator.visitEncodingExamples].
-func (v *Validator) validateEncodingSchemas(enc *parser.Encoding, path string, result *ValidationResult, depth int) {
-	if enc == nil || depth > maxEncodingNestingDepth {
+// carry, and recurses through the encoding nesting 3.2 added. visited and depth
+// mirror the guards on [Validator.visitEncodingExamples].
+func (v *Validator) validateEncodingSchemas(enc *parser.Encoding, path string, result *ValidationResult, visited map[*parser.Encoding]bool, depth int) {
+	if enc == nil || depth > maxEncodingNestingDepth || visited[enc] {
 		return
 	}
 	v.validateHeaderMapSchemas(enc.Headers, path, result)
 
-	for name, nested := range enc.Encoding {
-		v.validateEncodingSchemas(nested, path+".encoding."+name, result, depth+1)
+	if !encodingNests(enc) {
+		return
 	}
-	v.validateEncodingSchemas(enc.ItemEncoding, path+".itemEncoding", result, depth+1)
+	if visited == nil {
+		visited = make(map[*parser.Encoding]bool)
+	}
+	visited[enc] = true
+
+	for name, nested := range enc.Encoding {
+		v.validateEncodingSchemas(nested, path+".encoding."+name, result, visited, depth+1)
+	}
+	v.validateEncodingSchemas(enc.ItemEncoding, path+".itemEncoding", result, visited, depth+1)
 	for i, nested := range enc.PrefixEncoding {
-		v.validateEncodingSchemas(nested, path+".prefixEncoding["+strconv.Itoa(i)+"]", result, depth+1)
+		v.validateEncodingSchemas(nested, path+".prefixEncoding["+strconv.Itoa(i)+"]", result, visited, depth+1)
 	}
 }
 


### PR DESCRIPTION
Closes #431.

## The defect

A depth bound does not contain a cycle. A path item whose operations each lead back to it branches, so the walk is exponential in depth long before the bound is reached. The issue measured a 21-node graph producing 1.05M errors in 1.4s and a 23-node one producing 4.19M in 6.4s, scaling cleanly as 2^d, which means a depth-100 bound permits roughly 2^100 calls.

Reproduced before changing anything: two of the five walks below did not return within 15 seconds on a two-way cycle.

`validator/schema_traversal.go` learned this in #453 and grew a visited set. Five siblings had only the counter:

| Walk | File |
|---|---|
| `oas32Gate.pathItem` | `validator/oas32_gate.go` |
| `visitEncodingExamples` | `validator/oas3_examples.go` |
| `validateEncodingSchemas` | `validator/schema_traversal.go` |
| `oas32Gate.encoding` | `validator/oas32_gate.go` |
| `detectOAS32EncodingFeatures` | `converter/oas32_features.go` |

## The fix

Each walk now carries a visited set, with the depth bound kept as a fail-safe rather than replaced. The two guards catch different graphs: a chain of distinct nodes repeats nothing, so only the counter stops it, and a cycle never reaches the counter, so only the set stops it.

**Why an all-visited set rather than a recursion stack.** The measured blowups are DAGs, not cycles. A set that unmarks on exit would still walk 2^d paths through a diamond, so only an all-visited set collapses the work to the node count. That set reports a shared node once instead of once per path, which is safe here because it was checked rather than assumed: neither `$ref` resolution nor a YAML anchor produces two positions holding the same Path Item, both routes copy instead. So no parsed document can reach one twice, and the set can only ever suppress a revisit in a caller-assembled document, which is what the bound already existed for.

**Allocation.** The Encoding walks allocate their set only when an encoding actually nests, so a document without nesting allocates nothing. The gate records every path item instead: recording lazily leaves the entry point of a cycle unrecorded until the cycle returns to it, so how often it reported would depend on which route map order reached first, which is the #425 class of instability. That is the only cost in the change.

| `BenchmarkValidateParsed` | main | this branch |
|---|---|---|
| Small | 64 allocs/op | 66 (+2) |
| Medium | 624 allocs/op | 626 (+2) |
| Large | 6,875 allocs/op | 6,884 (+9) |

Measured against a scratch clone of `main`, 5 runs each. Everything else is allocation-neutral.

## Two guards were inconsistent with their siblings

The issue's "Also" section calls this out, and both are now aligned on the majority form, "refuse a node deeper than the bound":

- `oas32Gate.pathItem` compared `>=` where every other walk compares `>`.
- `visitCallbacks` held its bound on the caller's depth rather than on the item being entered, so the bound moved into `traversePathItem`, where the object is entered.

## One walk beyond the five

`traversePathItem` already had a visited set, so it terminated and was correctly outside the issue's scope, but a new test showed it reporting a cycle `1 + fan-out` times. Its `visited` is a local, so each operation built its own map and none saw the others. Recording the path item before the first descent fixes both, and costs nothing on a document without callbacks.

## Verification

- **Each guard is pinned by a test that fails when it is removed**, which the issue asks for explicitly. Verified mechanically: a script removes each of the 14 guards in turn and confirms the corresponding test fails. It found one gap, the gate's encoding bound, which was unpinned until the test was widened.
- **`maxCallbackNestingDepth` had no test at all**, which the issue also names. `validator/callback_traversal_test.go` now pins it for both walks that use it.
- `make check` green, **10,626 tests** (10,606 on `main`).
- `make test-corpus` green.
- **Corpus verdicts identical across all 10 specs.** Worth noting for anyone re-running this: a raw diff shows differences, because 4 of the 10 differ between two runs of the *same* `main` binary. The comparison needs the operationId attribution stripped (#425) and the lines sorted; done that way, every spec matches.
- CodeRabbit CLI review against `main`: 0 findings.

Background on the walk inventory and how it was measured is in the [gap analysis plan](https://github.com/erraggy/oastools/blob/docs/spec-gap-analysis/docs/plans/2026-08-01-spec-conformance-gap-plan.md).
