### PR TITLE
feat(testdata): vendor the OAI conformance suite at a pinned revision

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -515,6 +515,23 @@ bench-corpus:
 	@go test -tags=corpus -bench='BenchmarkCorpus' -benchmem -benchtime=$(BENCH_TIME) ./parser ./validator ./fixer ./differ
 
 # =============================================================================
+# Conformance Suite Targets
+# =============================================================================
+# Unlike the corpus, these fixtures are committed. They are vendored from the
+# OpenAPI Specification repository at an exact commit, so measuring conformance
+# needs no network and cannot drift under a branch that moved.
+
+## conformance-vendor: Re-materialize the vendored OAI suite at its pinned commits
+.PHONY: conformance-vendor
+conformance-vendor:
+	@./scripts/conformance-vendor.sh
+
+## conformance-update: Move the pins to each ref's current head, then re-vendor
+.PHONY: conformance-update
+conformance-update:
+	@./scripts/conformance-vendor.sh --update
+
+# =============================================================================
 # Documentation Targets
 # =============================================================================
 

--- a/internal/conformance/conformance.go
+++ b/internal/conformance/conformance.go
@@ -1,0 +1,115 @@
+package conformance
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+// Source is one vendored version: where its fixtures came from and how many of
+// each kind sources.txt says should be present.
+type Source struct {
+	// Version is the OAS version the fixtures target, as "3.0" or "3.2".
+	Version string
+	// Ref is the upstream branch the fixtures were taken from. Recorded so a
+	// refresh knows what to resolve; the commit is what it actually fetches.
+	Ref string
+	// Commit is the exact upstream revision vendored, which is what makes the
+	// suite reproducible.
+	Commit string
+	// Subpath is the directory holding pass/ and fail/ upstream. It differs
+	// between the version branches and main, which keeps 3.0 under _archive_.
+	Subpath string
+	// Pass and Fail are the fixture counts recorded at vendor time. A tree that
+	// disagrees has lost or gained files since.
+	Pass int
+	Fail int
+}
+
+// Dir returns the absolute path to the vendored suite, resolved from this
+// file's own location so a test's working directory does not matter.
+func Dir() string {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		return ""
+	}
+	return filepath.Join(filepath.Dir(thisFile), "..", "..", "testdata", "conformance")
+}
+
+// FixtureDir returns the directory holding one version's fixtures of one kind,
+// where kind is "pass" or "fail".
+func FixtureDir(version, kind string) string {
+	return filepath.Join(Dir(), version, kind)
+}
+
+// LoadSources parses testdata/conformance/sources.txt.
+//
+// The format is deliberately plain: comment lines, then one whitespace-separated
+// record per version. The refresh script is shell and has to read the same file,
+// and macOS ships bash 3.2, so anything needing a JSON parser would have meant
+// depending on jq being installed.
+func LoadSources() ([]Source, error) {
+	data, err := os.ReadFile(filepath.Join(Dir(), "sources.txt"))
+	if err != nil {
+		return nil, err
+	}
+
+	var sources []Source
+	for raw := range strings.Lines(string(data)) {
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) != 6 {
+			return nil, &parseError{line: line, reason: "want 6 fields: version ref commit subpath pass fail"}
+		}
+		pass, err := strconv.Atoi(fields[4])
+		if err != nil {
+			return nil, &parseError{line: line, reason: "pass count is not a number"}
+		}
+		fail, err := strconv.Atoi(fields[5])
+		if err != nil {
+			return nil, &parseError{line: line, reason: "fail count is not a number"}
+		}
+		sources = append(sources, Source{
+			Version: fields[0],
+			Ref:     fields[1],
+			Commit:  fields[2],
+			Subpath: fields[3],
+			Pass:    pass,
+			Fail:    fail,
+		})
+	}
+	return sources, nil
+}
+
+// Fixtures lists the fixture file names for one version and kind, sorted, so a
+// caller iterating them reports in a stable order.
+func Fixtures(version, kind string) ([]string, error) {
+	entries, err := os.ReadDir(FixtureDir(version, kind))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".yaml") {
+			names = append(names, entry.Name())
+		}
+	}
+	return names, nil
+}
+
+type parseError struct {
+	line   string
+	reason string
+}
+
+func (e *parseError) Error() string {
+	return "conformance: cannot parse sources.txt line " + strconv.Quote(e.line) + ": " + e.reason
+}

--- a/internal/conformance/conformance.go
+++ b/internal/conformance/conformance.go
@@ -1,95 +1,78 @@
 package conformance
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 )
 
-// Source is one vendored version: where its fixtures came from and how many of
-// each kind sources.txt says should be present.
+// Kind distinguishes the two halves of the suite. A bare string would sit next
+// to the version at every call site, where the two are indistinguishable to the
+// compiler and a swap reports no fixtures rather than an error.
+type Kind string
+
+const (
+	// KindPass holds documents the published JSON Schema accepts.
+	KindPass Kind = "pass"
+	// KindFail holds documents it rejects.
+	KindFail Kind = "fail"
+)
+
+// Kinds is every kind, for callers walking the whole suite.
+var Kinds = []Kind{KindPass, KindFail}
+
+// Source is one vendored version: where its fixtures came from, how many of
+// each kind sources.txt records, and a digest over their names and contents.
 type Source struct {
 	// Version is the OAS version the fixtures target, as "3.0" or "3.2".
 	Version string
 	// Ref is the upstream branch the fixtures were taken from. Recorded so a
 	// refresh knows what to resolve; the commit is what it actually fetches.
 	Ref string
-	// Commit is the exact upstream revision vendored, which is what makes the
-	// suite reproducible.
+	// Commit is the exact upstream revision vendored, always unabbreviated: an
+	// abbreviation can become ambiguous as the upstream repository grows.
 	Commit string
 	// Subpath is the directory holding pass/ and fail/ upstream. It differs
 	// between the version branches and main, which keeps 3.0 under _archive_.
 	Subpath string
-	// Pass and Fail are the fixture counts recorded at vendor time. A tree that
-	// disagrees has lost or gained files since.
-	Pass int
-	Fail int
+	// pass and fail are the fixture counts recorded at vendor time. Unexported
+	// so the count and its kind cannot drift apart at a call site; read them
+	// through Count.
+	pass int
+	fail int
+	// Digest fingerprints every fixture's name and content for this version.
+	// Counts alone cannot see a fixture edited in place, nor one version's
+	// fixtures vendored into another's directory: 3.2 and 3.3 publish the same
+	// 37 pass fixture names and all 37 differ in content.
+	Digest string
 }
 
-// Dir returns the absolute path to the vendored suite, resolved from this
-// file's own location so a test's working directory does not matter.
-func Dir() string {
-	_, thisFile, _, ok := runtime.Caller(0)
-	if !ok {
-		return ""
+// Count returns the number of fixtures of one kind that sources.txt records.
+func (s Source) Count(kind Kind) int {
+	if kind == KindFail {
+		return s.fail
 	}
-	return filepath.Join(filepath.Dir(thisFile), "..", "..", "testdata", "conformance")
+	return s.pass
 }
 
-// FixtureDir returns the directory holding one version's fixtures of one kind,
-// where kind is "pass" or "fail".
-func FixtureDir(version, kind string) string {
-	return filepath.Join(Dir(), version, kind)
+// FixtureDir returns the directory holding this version's fixtures of one kind.
+func (s Source) FixtureDir(kind Kind) string {
+	return filepath.Join(Dir(), s.Version, string(kind))
 }
 
-// LoadSources parses testdata/conformance/sources.txt.
+// Fixtures lists this version's fixture file names of one kind, sorted.
 //
-// The format is deliberately plain: comment lines, then one whitespace-separated
-// record per version. The refresh script is shell and has to read the same file,
-// and macOS ships bash 3.2, so anything needing a JSON parser would have meant
-// depending on jq being installed.
-func LoadSources() ([]Source, error) {
-	data, err := os.ReadFile(filepath.Join(Dir(), "sources.txt"))
-	if err != nil {
-		return nil, err
-	}
-
-	var sources []Source
-	for raw := range strings.Lines(string(data)) {
-		line := strings.TrimSpace(raw)
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
-		fields := strings.Fields(line)
-		if len(fields) != 6 {
-			return nil, &parseError{line: line, reason: "want 6 fields: version ref commit subpath pass fail"}
-		}
-		pass, err := strconv.Atoi(fields[4])
-		if err != nil {
-			return nil, &parseError{line: line, reason: "pass count is not a number"}
-		}
-		fail, err := strconv.Atoi(fields[5])
-		if err != nil {
-			return nil, &parseError{line: line, reason: "fail count is not a number"}
-		}
-		sources = append(sources, Source{
-			Version: fields[0],
-			Ref:     fields[1],
-			Commit:  fields[2],
-			Subpath: fields[3],
-			Pass:    pass,
-			Fail:    fail,
-		})
-	}
-	return sources, nil
-}
-
-// Fixtures lists the fixture file names for one version and kind, sorted, so a
-// caller iterating them reports in a stable order.
-func Fixtures(version, kind string) ([]string, error) {
-	entries, err := os.ReadDir(FixtureDir(version, kind))
+// A version that publishes none of a kind has no directory, which yields no
+// names and no error: 3.0 has no fail fixtures. Callers must therefore treat a
+// count of zero as meaningful rather than as an empty success, which is what
+// Count is for.
+func (s Source) Fixtures(kind Kind) ([]string, error) {
+	entries, err := os.ReadDir(s.FixtureDir(kind))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
@@ -98,12 +81,144 @@ func Fixtures(version, kind string) ([]string, error) {
 	}
 	names := make([]string, 0, len(entries))
 	for _, entry := range entries {
-		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".yaml") {
+		if entry.Type().IsRegular() && strings.HasSuffix(entry.Name(), ".yaml") {
 			names = append(names, entry.Name())
 		}
 	}
 	return names, nil
 }
+
+// ComputeDigest fingerprints this version's vendored fixtures, by the same
+// construction scripts/conformance-vendor.sh uses: one line per fixture holding
+// its kind, name and content hash, sorted bytewise, hashed.
+func (s Source) ComputeDigest() (string, error) {
+	var lines []string
+	for _, kind := range Kinds {
+		names, err := s.Fixtures(kind)
+		if err != nil {
+			return "", err
+		}
+		for _, name := range names {
+			content, err := os.ReadFile(filepath.Join(s.FixtureDir(kind), name))
+			if err != nil {
+				return "", err
+			}
+			sum := sha256.Sum256(content)
+			lines = append(lines, string(kind)+"/"+name+" "+hex.EncodeToString(sum[:]))
+		}
+	}
+	slices.Sort(lines)
+
+	h := sha256.New()
+	for _, line := range lines {
+		h.Write([]byte(line + "\n"))
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// Dir returns the absolute path to the vendored suite, resolved from this
+// file's own location so a caller's working directory does not matter.
+//
+// It panics rather than returning a path it could not resolve. runtime.Caller
+// does not fail for depth 0 in any ordinary build, and an empty root would be
+// joined away silently, leaving every lookup relative and every version looking
+// like a version that publishes nothing.
+func Dir() string {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("conformance: cannot resolve this file's location")
+	}
+	return filepath.Join(filepath.Dir(thisFile), "..", "..", "testdata", "conformance")
+}
+
+// LoadSources parses testdata/conformance/sources.txt.
+func LoadSources() ([]Source, error) {
+	data, err := os.ReadFile(filepath.Join(Dir(), "sources.txt"))
+	if err != nil {
+		return nil, err
+	}
+	return parseSources(data)
+}
+
+// parseSources is LoadSources without the file, so the error paths below are
+// reachable from a test.
+//
+// The format is deliberately plain: comment lines, then one whitespace-separated
+// record per version. The refresh script is shell and has to read the same file,
+// and macOS ships bash 3.2, so anything needing a JSON parser would have meant
+// depending on jq being installed.
+func parseSources(data []byte) ([]Source, error) {
+	var sources []Source
+	for raw := range strings.Lines(string(data)) {
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) != 7 {
+			return nil, &parseError{line: line, reason: "want 7 fields: version ref commit subpath pass fail digest"}
+		}
+		pass, err := parseCount(fields[4])
+		if err != nil {
+			return nil, &parseError{line: line, reason: "pass count: " + err.Error()}
+		}
+		fail, err := parseCount(fields[5])
+		if err != nil {
+			return nil, &parseError{line: line, reason: "fail count: " + err.Error()}
+		}
+		if !isHex(fields[2], 40) {
+			return nil, &parseError{line: line, reason: "commit is not a full 40-character revision"}
+		}
+		if !isHex(fields[6], 64) {
+			return nil, &parseError{line: line, reason: "digest is not a 64-character sha256"}
+		}
+		sources = append(sources, Source{
+			Version: fields[0],
+			Ref:     fields[1],
+			Commit:  fields[2],
+			Subpath: fields[3],
+			pass:    pass,
+			fail:    fail,
+			Digest:  fields[6],
+		})
+	}
+	if len(sources) == 0 {
+		return nil, &parseError{line: "", reason: "no records"}
+	}
+	return sources, nil
+}
+
+func parseCount(field string) (int, error) {
+	n, err := strconv.Atoi(field)
+	if err != nil {
+		return 0, errNotANumber
+	}
+	if n < 0 {
+		return 0, errNegative
+	}
+	return n, nil
+}
+
+func isHex(s string, want int) bool {
+	if len(s) != want {
+		return false
+	}
+	for _, r := range s {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+type constError string
+
+func (e constError) Error() string { return string(e) }
+
+const (
+	errNotANumber constError = "not a number"
+	errNegative   constError = "negative"
+)
 
 type parseError struct {
 	line   string
@@ -111,5 +226,8 @@ type parseError struct {
 }
 
 func (e *parseError) Error() string {
+	if e.line == "" {
+		return "conformance: cannot parse sources.txt: " + e.reason
+	}
 	return "conformance: cannot parse sources.txt line " + strconv.Quote(e.line) + ": " + e.reason
 }

--- a/internal/conformance/conformance_test.go
+++ b/internal/conformance/conformance_test.go
@@ -3,85 +3,151 @@ package conformance
 import (
 	"os"
 	"path/filepath"
-	"regexp"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// fullSHA matches an unabbreviated commit. A pin has to be exact: an
-// abbreviation can become ambiguous as the upstream repository grows, and a
-// branch name would not be a pin at all.
-var fullSHA = regexp.MustCompile(`^[0-9a-f]{40}$`)
-
-func TestSourcesParse(t *testing.T) {
+// loadSources fails the test rather than returning, and asserts the suite is
+// non-empty: every guard below iterates the records, so an empty slice would
+// turn them all into assertions that never run.
+func loadSources(t *testing.T) []Source {
+	t.Helper()
 	sources, err := LoadSources()
 	require.NoError(t, err)
+	require.Len(t, sources, 4, "3.0 through 3.3 are vendored")
+	return sources
+}
+
+func TestSourcesParse(t *testing.T) {
+	sources := loadSources(t)
 
 	versions := make([]string, 0, len(sources))
 	for _, s := range sources {
 		versions = append(versions, s.Version)
 	}
 	assert.Equal(t, []string{"3.0", "3.1", "3.2", "3.3"}, versions,
-		"the vendored versions are 3.0 through 3.3; 2.0 publishes no fixtures upstream and none are authored here")
-
-	for _, s := range sources {
-		t.Run(s.Version, func(t *testing.T) {
-			assert.Regexp(t, fullSHA, s.Commit, "the pin must be a full commit")
-			assert.NotEmpty(t, s.Ref)
-			assert.NotEmpty(t, s.Subpath)
-			assert.Positive(t, s.Pass, "every vendored version has pass fixtures")
-			assert.GreaterOrEqual(t, s.Fail, 0)
-		})
-	}
+		"2.0 publishes no fixtures upstream and none are authored here")
 }
 
-// TestVendoredTreeMatchesSources is the drift guard. The counts in sources.txt
-// were what upstream published at the pinned commit, so a tree that disagrees
-// has lost or gained files since it was vendored, which no other test would
-// notice: a deleted fixture makes a suite smaller, not redder.
-func TestVendoredTreeMatchesSources(t *testing.T) {
-	sources, err := LoadSources()
-	require.NoError(t, err)
+// TestParseSourcesRejects covers the malformed records parseSources refuses.
+// sources.txt is rewritten by a shell script doing string concatenation, so a
+// malformed rewrite is a plausible failure and this message is the only thing a
+// maintainer would see.
+func TestParseSourcesRejects(t *testing.T) {
+	const (
+		commit = "5423da4b0c16a563a7226663018fcd9294be279d"
+		digest = "d1fe82bdd6909d31a6c5f501559ab5a88b9dc9b590adf63fe4054e55bc028fa8"
+	)
+	good := "3.0 main " + commit + " _archive_/schemas/v3.0 6 0 " + digest
 
-	for _, s := range sources {
+	for _, tc := range []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"too few fields", "3.0 main " + commit + " sub 6 0", "want 7 fields"},
+		{"too many fields", good + " extra", "want 7 fields"},
+		{"pass is not a number", "3.0 main " + commit + " sub x 0 " + digest, "pass count: not a number"},
+		{"fail is not a number", "3.0 main " + commit + " sub 6 3.5 " + digest, "fail count: not a number"},
+		{"pass is negative", "3.0 main " + commit + " sub -1 0 " + digest, "pass count: negative"},
+		{"commit is abbreviated", "3.0 main 5423da4 sub 6 0 " + digest, "not a full 40-character revision"},
+		{"commit is not hex", "3.0 main " + commit[:39] + "z sub 6 0 " + digest, "not a full 40-character revision"},
+		{"digest is truncated", "3.0 main " + commit + " sub 6 0 " + digest[:63], "not a 64-character sha256"},
+		{"no records at all", "# only a comment\n\n", "no records"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseSources([]byte(tc.input + "\n"))
+			assert.Nil(t, got)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.want)
+			assert.Contains(t, err.Error(), "conformance: cannot parse sources.txt")
+		})
+	}
+
+	t.Run("the good record round-trips", func(t *testing.T) {
+		got, err := parseSources([]byte("# header\n\n" + good + "\n"))
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, "3.0", got[0].Version)
+		assert.Equal(t, 6, got[0].Count(KindPass))
+		assert.Equal(t, 0, got[0].Count(KindFail))
+		assert.Equal(t, digest, got[0].Digest)
+	})
+}
+
+// TestVendoredTreeMatchesSources is the count half of the drift guard. A
+// deleted fixture makes a suite smaller rather than redder, so nothing else
+// would notice it.
+func TestVendoredTreeMatchesSources(t *testing.T) {
+	for _, s := range loadSources(t) {
 		t.Run(s.Version, func(t *testing.T) {
-			for kind, want := range map[string]int{"pass": s.Pass, "fail": s.Fail} {
-				got, err := Fixtures(s.Version, kind)
+			for _, kind := range Kinds {
+				got, err := s.Fixtures(kind)
 				require.NoError(t, err)
-				assert.Len(t, got, want,
+
+				if s.Count(kind) == 0 {
+					// Absence is asserted rather than inferred. Fixtures reports
+					// no names for a directory that is missing and for one that
+					// is empty, so without this the subtest would pass either way.
+					assert.Empty(t, got)
+					assert.NoDirExists(t, s.FixtureDir(kind),
+						"%s/%s: sources.txt records none, so upstream publishes no such directory",
+						s.Version, kind)
+					continue
+				}
+				assert.Len(t, got, s.Count(kind),
 					"%s/%s: sources.txt records %d fixtures; run 'make conformance-vendor' to restore the tree",
-					s.Version, kind, want)
+					s.Version, kind, s.Count(kind))
 			}
 		})
 	}
 }
 
-// TestVendoredTreeHoldsOnlyFixtures keeps the vendor to documents. Upstream
-// keeps a JavaScript harness beside its fixtures, and 3.3 keeps
-// minimal-objects.yaml, a table of object stubs rather than an OpenAPI
-// document, so a walk that took everything in the directory would feed all
-// three to a validator.
-func TestVendoredTreeHoldsOnlyFixtures(t *testing.T) {
-	sources, err := LoadSources()
-	require.NoError(t, err)
+// TestVendoredTreeMatchesDigests is the content half, and it is what makes the
+// guard exact. Names and counts cannot distinguish 3.2 from 3.3: both publish
+// the same 37 pass fixture names, and all 37 differ in content, so vendoring
+// one into the other's directory changes nothing a count can see. It also
+// catches a fixture edited in place, which is how a failing fixture would stop
+// failing.
+func TestVendoredTreeMatchesDigests(t *testing.T) {
+	seen := make(map[string]string, 4)
+	for _, s := range loadSources(t) {
+		t.Run(s.Version, func(t *testing.T) {
+			got, err := s.ComputeDigest()
+			require.NoError(t, err)
+			assert.Equal(t, s.Digest, got,
+				"%s: the vendored fixtures are not the ones sources.txt records", s.Version)
+		})
+		if other, dup := seen[s.Digest]; dup {
+			t.Errorf("%s and %s have the same digest, so one was vendored into the other", other, s.Version)
+		}
+		seen[s.Digest] = s.Version
+	}
+}
 
-	for _, s := range sources {
-		for _, kind := range []string{"pass", "fail"} {
-			dir := FixtureDir(s.Version, kind)
+// TestVendoredTreeHoldsOnlyFixtures keeps the tree to documents, so a stray
+// file cannot be counted as a fixture or fed to a validator by #436's harness.
+func TestVendoredTreeHoldsOnlyFixtures(t *testing.T) {
+	for _, s := range loadSources(t) {
+		for _, kind := range Kinds {
+			dir := s.FixtureDir(kind)
 			entries, err := os.ReadDir(dir)
-			if os.IsNotExist(err) {
+			if s.Count(kind) == 0 {
+				// Covered by TestVendoredTreeMatchesSources, which asserts the
+				// directory is absent rather than skipping it.
 				continue
 			}
-			require.NoError(t, err)
+			require.NoError(t, err, "%s/%s: sources.txt records fixtures here", s.Version, kind)
 
 			for _, entry := range entries {
-				name := filepath.Join(s.Version, kind, entry.Name())
-				assert.False(t, entry.IsDir(), "%s: the suite is flat, so a directory here is unexpected", name)
-				assert.True(t, strings.HasSuffix(entry.Name(), ".yaml"),
-					"%s: only .yaml documents are vendored", name)
+				name := filepath.Join(s.Version, string(kind), entry.Name())
+				// Regular rather than "not a directory": DirEntry reports the
+				// link itself, so a symlink is neither, and its size is the
+				// length of the target path rather than of any document.
+				assert.True(t, entry.Type().IsRegular(), "%s: only regular files are vendored", name)
+				assert.Equal(t, ".yaml", filepath.Ext(entry.Name()), "%s: only .yaml documents are vendored", name)
 
 				info, err := entry.Info()
 				require.NoError(t, err)
@@ -91,38 +157,75 @@ func TestVendoredTreeHoldsOnlyFixtures(t *testing.T) {
 	}
 }
 
-// TestKnownFixturesArePresent names one fixture per version that the project
-// already reasons about, so a refresh that silently dropped the interesting
-// cases is caught by more than a count.
+// TestVendoredTreeHasNothingElse checks the complement. Every other guard walks
+// the versions sources.txt names, so a stale directory from a renamed version,
+// or a stray file at the root, is invisible to all of them.
+func TestVendoredTreeHasNothingElse(t *testing.T) {
+	want := map[string]bool{"README.md": true, "sources.txt": true}
+	for _, s := range loadSources(t) {
+		want[s.Version] = true
+	}
+
+	entries, err := os.ReadDir(Dir())
+	require.NoError(t, err)
+	for _, entry := range entries {
+		assert.True(t, want[entry.Name()],
+			"%s is not recorded in sources.txt, so nothing else here checks it", entry.Name())
+	}
+
+	for _, s := range loadSources(t) {
+		sub, err := os.ReadDir(filepath.Join(Dir(), s.Version))
+		require.NoError(t, err)
+		for _, entry := range sub {
+			assert.Contains(t, []string{"pass", "fail"}, entry.Name(),
+				"%s/%s: a version holds only pass and fail", s.Version, entry.Name())
+		}
+	}
+}
+
+// TestKnownFixturesArePresent names fixtures this project already reasons
+// about, so a refresh that kept the counts while dropping the interesting cases
+// is caught by more than an arithmetic check.
 func TestKnownFixturesArePresent(t *testing.T) {
+	byVersion := make(map[string]Source, 4)
+	for _, s := range loadSources(t) {
+		byVersion[s.Version] = s
+	}
+
 	for _, tc := range []struct {
 		version string
-		kind    string
+		kind    Kind
 		name    string
 		why     string
 	}{
-		{"3.0", "pass", "petstore.yaml", "the archived 3.0 documents are the only fixtures that version publishes"},
-		{"3.1", "fail", "parameter-object-header-allowReserved.yaml", "the documented v1 divergence, which a bool cannot express"},
-		{"3.2", "pass", "operation-object-example.yaml", "schema-valid and specification-invalid, so it stays rejected"},
-		{"3.2", "fail", "server_enum_empty.yaml", "a server variable enum that must not be empty"},
-		{"3.3", "fail", "server_enum_empty.yaml", "3.3 restates the constraints 3.2 states, so the suite carries them forward"},
+		{"3.0", KindPass, "petstore.yaml", "the archived documents are the only fixtures 3.0 publishes"},
+		{"3.1", KindFail, "parameter-object-header-allowReserved.yaml", "the documented v1 divergence, which a bool cannot express"},
+		{"3.2", KindPass, "operation-object-example.yaml", "schema-valid and specification-invalid, so it stays rejected"},
+		{"3.2", KindFail, "server_enum_empty.yaml", "a server variable enum that must not be empty"},
+		{"3.3", KindFail, "server_enum_empty.yaml", "3.3 restates the constraints 3.2 states, so the suite carries them forward"},
 	} {
-		t.Run(tc.version+"/"+tc.kind+"/"+tc.name, func(t *testing.T) {
-			names, err := Fixtures(tc.version, tc.kind)
+		t.Run(tc.version+"/"+string(tc.kind)+"/"+tc.name, func(t *testing.T) {
+			names, err := byVersion[tc.version].Fixtures(tc.kind)
 			require.NoError(t, err)
 			assert.Contains(t, names, tc.name, tc.why)
 		})
 	}
 }
 
-// TestVersionsAreNotCopiesOfEachOther pins fixtures that change sides between
-// versions, which no count can detect.
+// TestVersionsDifferWhereTheSpecificationDid pins fixtures that change sides
+// between versions, which pins a boundary no digest can explain.
 //
-// 3.2 widened where `allowReserved` may appear, so two documents that are
-// negative fixtures at 3.1 are positive ones at 3.2 and 3.3. A refresh that
-// vendored one branch into all three version directories would produce the
-// recorded counts and still be wrong; this is what would catch it.
-func TestVersionsAreNotCopiesOfEachOther(t *testing.T) {
+// A digest proves the versions hold different bytes; it cannot say the
+// difference is the right one. 3.2 widened where `allowReserved` may appear, so
+// two documents that are negative fixtures at 3.1 are positive ones at 3.2 and
+// 3.3, and a refresh that pointed 3.1 at a later branch would satisfy every
+// other guard here.
+func TestVersionsDifferWhereTheSpecificationDid(t *testing.T) {
+	byVersion := make(map[string]Source, 4)
+	for _, s := range loadSources(t) {
+		byVersion[s.Version] = s
+	}
+
 	for _, name := range []string{
 		"parameter-object-path-allowReserved.yaml",
 		"parameter-object-cookie-form-allowReserved.yaml",
@@ -130,18 +233,35 @@ func TestVersionsAreNotCopiesOfEachOther(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			for _, tc := range []struct {
 				version string
-				kind    string
+				kind    Kind
 			}{
-				{"3.1", "fail"},
-				{"3.2", "pass"},
-				{"3.3", "pass"},
+				{"3.1", KindFail},
+				{"3.2", KindPass},
+				{"3.3", KindPass},
 			} {
-				names, err := Fixtures(tc.version, tc.kind)
+				names, err := byVersion[tc.version].Fixtures(tc.kind)
 				require.NoError(t, err)
 				assert.Contains(t, names, name,
 					"%s should be a %s fixture at %s, since 3.2 widened where allowReserved may appear",
 					name, tc.kind, tc.version)
 			}
+		})
+	}
+
+	// 3.2 and 3.3 are the pair a name-level check cannot separate, so the one
+	// asymmetry between them is worth pinning by name as well as by digest.
+	for _, name := range []string{
+		"discriminator-object-unexpected-property.yaml",
+		"xml-object-unexpected-property.yaml",
+	} {
+		t.Run("3.3 only: "+name, func(t *testing.T) {
+			at33, err := byVersion["3.3"].Fixtures(KindFail)
+			require.NoError(t, err)
+			at32, err := byVersion["3.2"].Fixtures(KindFail)
+			require.NoError(t, err)
+
+			assert.Contains(t, at33, name, "3.3 adds this negative fixture")
+			assert.NotContains(t, at32, name, "3.2 does not have it, which is what separates the two")
 		})
 	}
 }

--- a/internal/conformance/conformance_test.go
+++ b/internal/conformance/conformance_test.go
@@ -1,0 +1,147 @@
+package conformance
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fullSHA matches an unabbreviated commit. A pin has to be exact: an
+// abbreviation can become ambiguous as the upstream repository grows, and a
+// branch name would not be a pin at all.
+var fullSHA = regexp.MustCompile(`^[0-9a-f]{40}$`)
+
+func TestSourcesParse(t *testing.T) {
+	sources, err := LoadSources()
+	require.NoError(t, err)
+
+	versions := make([]string, 0, len(sources))
+	for _, s := range sources {
+		versions = append(versions, s.Version)
+	}
+	assert.Equal(t, []string{"3.0", "3.1", "3.2", "3.3"}, versions,
+		"the vendored versions are 3.0 through 3.3; 2.0 publishes no fixtures upstream and none are authored here")
+
+	for _, s := range sources {
+		t.Run(s.Version, func(t *testing.T) {
+			assert.Regexp(t, fullSHA, s.Commit, "the pin must be a full commit")
+			assert.NotEmpty(t, s.Ref)
+			assert.NotEmpty(t, s.Subpath)
+			assert.Positive(t, s.Pass, "every vendored version has pass fixtures")
+			assert.GreaterOrEqual(t, s.Fail, 0)
+		})
+	}
+}
+
+// TestVendoredTreeMatchesSources is the drift guard. The counts in sources.txt
+// were what upstream published at the pinned commit, so a tree that disagrees
+// has lost or gained files since it was vendored, which no other test would
+// notice: a deleted fixture makes a suite smaller, not redder.
+func TestVendoredTreeMatchesSources(t *testing.T) {
+	sources, err := LoadSources()
+	require.NoError(t, err)
+
+	for _, s := range sources {
+		t.Run(s.Version, func(t *testing.T) {
+			for kind, want := range map[string]int{"pass": s.Pass, "fail": s.Fail} {
+				got, err := Fixtures(s.Version, kind)
+				require.NoError(t, err)
+				assert.Len(t, got, want,
+					"%s/%s: sources.txt records %d fixtures; run 'make conformance-vendor' to restore the tree",
+					s.Version, kind, want)
+			}
+		})
+	}
+}
+
+// TestVendoredTreeHoldsOnlyFixtures keeps the vendor to documents. Upstream
+// keeps a JavaScript harness beside its fixtures, and 3.3 keeps
+// minimal-objects.yaml, a table of object stubs rather than an OpenAPI
+// document, so a walk that took everything in the directory would feed all
+// three to a validator.
+func TestVendoredTreeHoldsOnlyFixtures(t *testing.T) {
+	sources, err := LoadSources()
+	require.NoError(t, err)
+
+	for _, s := range sources {
+		for _, kind := range []string{"pass", "fail"} {
+			dir := FixtureDir(s.Version, kind)
+			entries, err := os.ReadDir(dir)
+			if os.IsNotExist(err) {
+				continue
+			}
+			require.NoError(t, err)
+
+			for _, entry := range entries {
+				name := filepath.Join(s.Version, kind, entry.Name())
+				assert.False(t, entry.IsDir(), "%s: the suite is flat, so a directory here is unexpected", name)
+				assert.True(t, strings.HasSuffix(entry.Name(), ".yaml"),
+					"%s: only .yaml documents are vendored", name)
+
+				info, err := entry.Info()
+				require.NoError(t, err)
+				assert.Positive(t, info.Size(), "%s: an empty fixture asserts nothing", name)
+			}
+		}
+	}
+}
+
+// TestKnownFixturesArePresent names one fixture per version that the project
+// already reasons about, so a refresh that silently dropped the interesting
+// cases is caught by more than a count.
+func TestKnownFixturesArePresent(t *testing.T) {
+	for _, tc := range []struct {
+		version string
+		kind    string
+		name    string
+		why     string
+	}{
+		{"3.0", "pass", "petstore.yaml", "the archived 3.0 documents are the only fixtures that version publishes"},
+		{"3.1", "fail", "parameter-object-header-allowReserved.yaml", "the documented v1 divergence, which a bool cannot express"},
+		{"3.2", "pass", "operation-object-example.yaml", "schema-valid and specification-invalid, so it stays rejected"},
+		{"3.2", "fail", "server_enum_empty.yaml", "a server variable enum that must not be empty"},
+		{"3.3", "fail", "server_enum_empty.yaml", "3.3 restates the constraints 3.2 states, so the suite carries them forward"},
+	} {
+		t.Run(tc.version+"/"+tc.kind+"/"+tc.name, func(t *testing.T) {
+			names, err := Fixtures(tc.version, tc.kind)
+			require.NoError(t, err)
+			assert.Contains(t, names, tc.name, tc.why)
+		})
+	}
+}
+
+// TestVersionsAreNotCopiesOfEachOther pins fixtures that change sides between
+// versions, which no count can detect.
+//
+// 3.2 widened where `allowReserved` may appear, so two documents that are
+// negative fixtures at 3.1 are positive ones at 3.2 and 3.3. A refresh that
+// vendored one branch into all three version directories would produce the
+// recorded counts and still be wrong; this is what would catch it.
+func TestVersionsAreNotCopiesOfEachOther(t *testing.T) {
+	for _, name := range []string{
+		"parameter-object-path-allowReserved.yaml",
+		"parameter-object-cookie-form-allowReserved.yaml",
+	} {
+		t.Run(name, func(t *testing.T) {
+			for _, tc := range []struct {
+				version string
+				kind    string
+			}{
+				{"3.1", "fail"},
+				{"3.2", "pass"},
+				{"3.3", "pass"},
+			} {
+				names, err := Fixtures(tc.version, tc.kind)
+				require.NoError(t, err)
+				assert.Contains(t, names, name,
+					"%s should be a %s fixture at %s, since 3.2 widened where allowReserved may appear",
+					name, tc.kind, tc.version)
+			}
+		})
+	}
+}

--- a/internal/conformance/doc.go
+++ b/internal/conformance/doc.go
@@ -1,0 +1,19 @@
+// Package conformance reads the OpenAPI Specification conformance suite
+// vendored under testdata/conformance.
+//
+// The suite is OAI's own, published per version at tests/schema/{pass,fail} on
+// the version branches, plus the six archived 3.0 documents on main. It is
+// vendored at an exact commit rather than fetched, because the schemas version
+// independently of the specification and OAI publishes no endpoint naming the
+// current one. testdata/conformance/sources.txt records what is pinned, and
+// scripts/conformance-vendor.sh is what materializes it.
+//
+// What the suite is an oracle for matters when reading a result. The fixtures
+// assert validity against the published JSON Schema, not against the prose, and
+// the schema's own README says it covers only the mandatory aspects of the OAS.
+// So the suite is sound in the rejection direction and incomplete in the
+// acceptance one: a fail fixture that oastools accepts is a gap, while a pass
+// fixture that oastools rejects is a triage item that may turn out to be
+// correct. tests/schema/pass/operation-object-example.yaml on 3.2 is the known
+// case, being schema-valid and specification-invalid.
+package conformance

--- a/internal/conformance/doc.go
+++ b/internal/conformance/doc.go
@@ -5,8 +5,13 @@
 // the version branches, plus the six archived 3.0 documents on main. It is
 // vendored at an exact commit rather than fetched, because the schemas version
 // independently of the specification and OAI publishes no endpoint naming the
-// current one. testdata/conformance/sources.txt records what is pinned, and
-// scripts/conformance-vendor.sh is what materializes it.
+// current one. testdata/conformance/sources.txt records what is pinned, along
+// with each version's fixture counts and a digest over their names and
+// contents, and scripts/conformance-vendor.sh is what materializes it.
+//
+// The digest is what makes the guard exact. 3.2 and 3.3 publish the same 37
+// pass fixture names and all 37 differ in content, so counts and names alone
+// cannot tell one version's fixtures from the other's.
 //
 // What the suite is an oracle for matters when reading a result. The fixtures
 // assert validity against the published JSON Schema, not against the prose, and

--- a/internal/corpusutil/corpus.go
+++ b/internal/corpusutil/corpus.go
@@ -160,16 +160,20 @@ var Corpus = []SpecInfo{
 }
 
 // CorpusDir returns the absolute path to the corpus directory.
+//
+// It panics rather than falling back to a relative path. runtime.Caller does not
+// fail for depth 0 in any ordinary build, and "testdata/corpus" resolves against
+// the working directory, which for `go test` is the package directory rather
+// than the repository root: the fallback would find nothing and every corpus
+// test would skip itself as though the corpus had not been downloaded.
 func CorpusDir() string {
-	// Get the directory of this source file
 	_, thisFile, _, ok := runtime.Caller(0)
-	if ok {
-		// Go up from internal/corpusutil to project root
-		projectRoot := filepath.Dir(filepath.Dir(filepath.Dir(thisFile)))
-		return filepath.Join(projectRoot, "testdata", "corpus")
+	if !ok {
+		panic("corpusutil: cannot resolve this file's location")
 	}
-	// Fallback to relative path
-	return filepath.Join("testdata", "corpus")
+	// Go up from internal/corpusutil to project root
+	projectRoot := filepath.Dir(filepath.Dir(filepath.Dir(thisFile)))
+	return filepath.Join(projectRoot, "testdata", "corpus")
 }
 
 // GetSpecs returns specs filtered by the includeLarge flag.

--- a/scripts/conformance-vendor.sh
+++ b/scripts/conformance-vendor.sh
@@ -4,13 +4,14 @@
 # conformance suite under testdata/conformance, at the commits pinned in
 # testdata/conformance/sources.txt.
 #
-# With --update it first resolves each pinned ref to its current upstream head,
+# With --update it resolves each pinned ref to its current upstream head,
 # vendors from there, and rewrites sources.txt with what it found. That is how a
 # pin moves, and it is always a reviewed diff rather than a live fetch.
 #
-# Every failure is fatal. A partial vendor that looks like a successful run is
-# the trap #391 and #401 were, so the fixture counts recorded in sources.txt are
-# checked against what actually landed and a short tree exits non-zero.
+# Every failure is fatal, and every check fails closed. A vendor that lands the
+# wrong bytes must not exit zero: the counts and the per-version digest recorded
+# in sources.txt are both compared against what is on disk, and anything the
+# script cannot compare it refuses to guess at.
 
 set -euo pipefail
 
@@ -33,13 +34,50 @@ if [ ! -f "$SOURCES" ]; then
 fi
 
 WORK="$(mktemp -d)"
-trap 'rm -rf "$WORK"' EXIT
+trap 'rm -rf "$WORK"' EXIT INT TERM
+
+# sha256 of stdin, as bare hex. macOS ships shasum, most Linux images ship
+# sha256sum, and CI may be either.
+sha256() {
+	if command -v shasum >/dev/null 2>&1; then
+		shasum -a 256 | cut -d' ' -f1
+	else
+		sha256sum | cut -d' ' -f1
+	fi
+}
+
+# digest_version fingerprints one vendored version: every fixture's name and
+# content, in a byte-stable order. Counts alone cannot see a fixture edited in
+# place, nor one version's fixtures vendored into another's directory when both
+# publish the same names, which 3.2 and 3.3 do for all 37 of their pass
+# fixtures. internal/conformance recomputes this identically.
+digest_version() {
+	local vdir="$1" kind f
+	{
+		for kind in pass fail; do
+			[ -d "$vdir/$kind" ] || continue
+			for f in "$vdir/$kind"/*.yaml; do
+				[ -e "$f" ] || continue
+				printf '%s/%s %s\n' "$kind" "$(basename "$f")" "$(sha256 <"$f")"
+			done
+		done
+	} | LC_ALL=C sort | sha256
+}
 
 # macOS ships bash 3.2, which has no associative arrays, so each phase re-reads
 # the records from a file rather than holding them in a map.
 records() {
-	grep -vE '^[[:space:]]*(#|$)' "$1"
+	grep -vE '^[[:space:]]*(#|$)' "$1" || true
 }
+
+# A sources.txt that survives the existence check but carries no records would
+# otherwise walk every loop zero times and report success, since the exit status
+# of a process substitution is not observable to the shell.
+record_count="$(records "$SOURCES" | wc -l | tr -d ' ')"
+if [ "$record_count" -eq 0 ]; then
+	echo "error: $SOURCES has no records" >&2
+	exit 1
+fi
 
 git init -q "$WORK/oai"
 git -C "$WORK/oai" remote add origin "$REPO_URL"
@@ -50,9 +88,18 @@ git -C "$WORK/oai" remote add origin "$REPO_URL"
 PLAN="$WORK/plan"
 : >"$PLAN"
 
-while read -r version ref commit subpath want_pass want_fail; do
+while read -r version ref commit subpath want_pass want_fail want_digest; do
+	# version names a directory that is about to be removed and rewritten, so it
+	# is checked rather than trusted.
+	case "$version" in
+	*[!0-9.]* | *..* | "")
+		echo "error: $version is not a usable version directory name" >&2
+		exit 1
+		;;
+	esac
+
 	if [ "$UPDATE" -eq 1 ]; then
-		head="$(git -C "$WORK/oai" ls-remote origin "refs/heads/$ref" | cut -f1)"
+		head="$(git -C "$WORK/oai" ls-remote origin "refs/heads/$ref" </dev/null | cut -f1)"
 		if [ -z "$head" ]; then
 			echo "error: $ref does not exist in $REPO_URL" >&2
 			exit 1
@@ -62,52 +109,81 @@ while read -r version ref commit subpath want_pass want_fail; do
 		fi
 		commit="$head"
 	fi
-	printf '%s %s %s %s %s %s\n' "$version" "$ref" "$commit" "$subpath" "$want_pass" "$want_fail" >>"$PLAN"
+	printf '%s %s %s %s %s %s %s\n' \
+		"$version" "$ref" "$commit" "$subpath" "$want_pass" "$want_fail" "$want_digest" >>"$PLAN"
 done < <(records "$SOURCES")
 
+if [ "$(wc -l <"$PLAN" | tr -d ' ')" -ne "$record_count" ]; then
+	echo "error: planned $(wc -l <"$PLAN") versions from $record_count records" >&2
+	exit 1
+fi
+
 # -----------------------------------------------------------------------------
-# Phase 2: materialize each version and count what landed.
+# Phase 2: materialize each version and measure what landed.
 # -----------------------------------------------------------------------------
 echo "Vendoring the OAI conformance suite into testdata/conformance..."
 FOUND="$WORK/found"
 : >"$FOUND"
 
-while read -r version ref commit subpath want_pass want_fail; do
+while read -r version ref commit subpath want_pass want_fail want_digest; do
 	echo "  ${version} (${ref} @ ${commit:0:7})"
 
 	# Fetching the commit rather than the branch is what makes this a pinned
-	# vendor: the result does not change when the branch moves.
-	if ! git -C "$WORK/oai" fetch -q --depth 1 --filter=blob:none origin "$commit"; then
+	# vendor: the result does not change when the branch moves. Ordered before
+	# the removal below so a network failure cannot destroy the existing tree.
+	if ! git -C "$WORK/oai" fetch -q --depth 1 --filter=blob:none origin "$commit" </dev/null; then
 		echo "error: cannot fetch $commit from $REPO_URL" >&2
 		exit 1
 	fi
 
-	rm -rf "${DEST:?}/$version"
+	rm -rf "${DEST:?}/${version:?}"
 	got_pass=0
 	got_fail=0
 
 	for kind in pass fail; do
-		# A version that publishes no fixtures of this kind has no directory
-		# upstream, so asking for one would fail the checkout.
-		case "$kind" in
-		pass) [ "$want_pass" -eq 0 ] && continue ;;
-		fail) [ "$want_fail" -eq 0 ] && continue ;;
-		esac
+		# The checkout is what establishes whether upstream publishes this kind,
+		# rather than the recorded count, which would make a count of 0
+		# self-perpetuating: a kind upstream later added would never be looked
+		# for again.
+		# Cleared first: every version branch checks out into the same working
+		# path, so a stale tree would leave one version holding the union of
+		# itself and the one vendored before it.
+		rm -rf "${WORK:?}/oai/${subpath:?}/$kind"
 
-		rm -rf "${WORK:?}/oai/$subpath/$kind"
-		if ! git -C "$WORK/oai" checkout -q FETCH_HEAD -- "$subpath/$kind"; then
-			echo "error: $version: $subpath/$kind is absent at $commit" >&2
+		if ! git -C "$WORK/oai" checkout -q FETCH_HEAD -- "$subpath/$kind" </dev/null 2>/dev/null; then
+			# Absent upstream. Legitimate when the pins record none of this kind,
+			# and always legitimate under --update, which is re-deriving the
+			# counts rather than trusting them. Compared as a string so a
+			# malformed count cannot make the test error out and read as false.
+			case "$kind" in
+			pass) recorded="$want_pass" ;;
+			fail) recorded="$want_fail" ;;
+			esac
+			if [ "$UPDATE" -eq 1 ] || [ "$recorded" = "0" ]; then
+				continue
+			fi
+			echo "error: $version: cannot check out $subpath/$kind at $commit" >&2
+			echo "  the path may not exist at that commit, or the blob fetch may have failed" >&2
 			exit 1
 		fi
 
 		mkdir -p "$DEST/$version/$kind"
-		# Only the document fixtures are vendored. Upstream keeps its own
-		# JavaScript harness beside them, and 3.3 keeps minimal-objects.yaml,
-		# which is a table of object stubs rather than an OpenAPI document.
-		find "$WORK/oai/$subpath/$kind" -maxdepth 1 -type f -name '*.yaml' \
-			-exec cp {} "$DEST/$version/$kind/" \;
+		# The copy is checked one file at a time: find does not report a failing
+		# -exec in its own exit status, so an unwritable or full destination
+		# would otherwise produce a short tree and a successful run.
+		#
+		# The .yaml filter narrows what a future upstream reshuffle could bring
+		# in. It excludes nothing today: the checkout above materializes only
+		# this directory, and upstream keeps its non-fixture files a level above.
+		find "$WORK/oai/$subpath/$kind" -maxdepth 1 -type f -name '*.yaml' -print0 |
+			while IFS= read -r -d '' f; do
+				cp "$f" "$DEST/$version/$kind/" || {
+					echo "error: $version/$kind: cannot copy $f" >&2
+					exit 1
+				}
+			done || exit 1
 
-		n="$(find "$DEST/$version/$kind" -maxdepth 1 -type f -name '*.yaml' | wc -l | tr -d ' ')"
+		n="$(find "$DEST/$version/$kind" -maxdepth 1 -type f -name '*.yaml' -print0 | tr -dc '\0' | wc -c | tr -d ' ')"
 		echo "    $kind: $n"
 		case "$kind" in
 		pass) got_pass="$n" ;;
@@ -115,17 +191,31 @@ while read -r version ref commit subpath want_pass want_fail; do
 		esac
 	done
 
-	printf '%s %s %s %s %s %s\n' "$version" "$ref" "$commit" "$subpath" "$got_pass" "$got_fail" >>"$FOUND"
+	# A version with no positive fixtures is a broken vendor rather than a
+	# legitimate state: every version upstream publishes has some.
+	if [ "$got_pass" -eq 0 ]; then
+		echo "error: $version: no pass fixtures landed" >&2
+		exit 1
+	fi
+
+	printf '%s %s %s %s %s %s %s\n' \
+		"$version" "$ref" "$commit" "$subpath" "$got_pass" "$got_fail" "$(digest_version "$DEST/$version")" >>"$FOUND"
 done < <(records "$PLAN")
+
+if [ "$(wc -l <"$FOUND" | tr -d ' ')" -ne "$record_count" ]; then
+	echo "error: vendored $(wc -l <"$FOUND") versions from $record_count records" >&2
+	exit 1
+fi
 
 # -----------------------------------------------------------------------------
 # Phase 3: verify against the pins, or rewrite them.
 # -----------------------------------------------------------------------------
 if [ "$UPDATE" -eq 1 ]; then
-	# The comment header is this file's documentation, so it is carried across
-	# rather than regenerated.
-	rewritten="$WORK/sources.txt"
-	grep -E '^[[:space:]]*(#|$)' "$SOURCES" >"$rewritten"
+	# Staged inside the destination so the move is same-filesystem, and so an
+	# interrupt cannot leave sources.txt truncated. A missing comment header is
+	# not fatal: the records are what matter.
+	rewritten="$(mktemp "$DEST/.sources.XXXXXX")"
+	grep -E '^[[:space:]]*(#|$)' "$SOURCES" >"$rewritten" || true
 	cat "$FOUND" >>"$rewritten"
 	mv "$rewritten" "$SOURCES"
 	echo "Updated sources.txt. Review 'git diff testdata/conformance' before committing."
@@ -133,20 +223,45 @@ if [ "$UPDATE" -eq 1 ]; then
 fi
 
 status=0
-while read -r version ref commit subpath want_pass want_fail; do
-	got="$(grep "^$version " "$FOUND")"
-	got_pass="$(echo "$got" | cut -d' ' -f5)"
-	got_fail="$(echo "$got" | cut -d' ' -f6)"
+while read -r version ref commit subpath want_pass want_fail want_digest; do
+	# Exact field match rather than a regex, and exactly one record, so a
+	# duplicated or near-miss version cannot produce a multi-line value that
+	# turns the comparisons below into a silent no-op.
+	matches="$(awk -v v="$version" '$1 == v' "$FOUND" | wc -l | tr -d ' ')"
+	if [ "$matches" -ne 1 ]; then
+		echo "error: $version: $matches records in the vendored output, want exactly 1" >&2
+		status=1
+		continue
+	fi
+	got_pass="$(awk -v v="$version" '$1 == v {print $5}' "$FOUND")"
+	got_fail="$(awk -v v="$version" '$1 == v {print $6}' "$FOUND")"
+	got_digest="$(awk -v v="$version" '$1 == v {print $7}' "$FOUND")"
+
+	# [ -ne ] returns 2 on a non-integer and, inside an if, that reads as "no
+	# mismatch". Checked first so the comparison cannot fail open.
+	case "$want_pass$want_fail$got_pass$got_fail" in
+	*[!0-9]* | "")
+		echo "error: $version: non-numeric fixture count" >&2
+		status=1
+		continue
+		;;
+	esac
+
 	if [ "$got_pass" -ne "$want_pass" ] || [ "$got_fail" -ne "$want_fail" ]; then
 		echo "error: $version: sources.txt records ${want_pass}/${want_fail} pass/fail, upstream gave ${got_pass}/${got_fail}" >&2
+		status=1
+	fi
+	if [ -z "$want_digest" ] || [ "$got_digest" != "$want_digest" ]; then
+		echo "error: $version: digest ${want_digest:-<missing>} recorded, ${got_digest} vendored" >&2
+		echo "  the fixture names and counts may match while their contents do not" >&2
 		status=1
 	fi
 done < <(records "$SOURCES")
 
 if [ "$status" -ne 0 ]; then
-	echo "Vendoring failed: the fixture counts do not match sources.txt." >&2
+	echo "Vendoring failed: the tree does not match sources.txt." >&2
 	echo "Run 'make conformance-update' if upstream legitimately changed." >&2
 	exit "$status"
 fi
 
-echo "Done. Pins unchanged, so 'git diff testdata/conformance' should be empty."
+echo "Done. Pins unchanged, so the tree matches what sources.txt records."

--- a/scripts/conformance-vendor.sh
+++ b/scripts/conformance-vendor.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+#
+# conformance-vendor.sh materializes the vendored OpenAPI Specification
+# conformance suite under testdata/conformance, at the commits pinned in
+# testdata/conformance/sources.txt.
+#
+# With --update it first resolves each pinned ref to its current upstream head,
+# vendors from there, and rewrites sources.txt with what it found. That is how a
+# pin moves, and it is always a reviewed diff rather than a live fetch.
+#
+# Every failure is fatal. A partial vendor that looks like a successful run is
+# the trap #391 and #401 were, so the fixture counts recorded in sources.txt are
+# checked against what actually landed and a short tree exits non-zero.
+
+set -euo pipefail
+
+REPO_URL="https://github.com/OAI/OpenAPI-Specification.git"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEST="$ROOT/testdata/conformance"
+SOURCES="$DEST/sources.txt"
+
+UPDATE=0
+if [ "${1:-}" = "--update" ]; then
+	UPDATE=1
+elif [ $# -gt 0 ]; then
+	echo "usage: $(basename "$0") [--update]" >&2
+	exit 2
+fi
+
+if [ ! -f "$SOURCES" ]; then
+	echo "error: $SOURCES not found" >&2
+	exit 1
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# macOS ships bash 3.2, which has no associative arrays, so each phase re-reads
+# the records from a file rather than holding them in a map.
+records() {
+	grep -vE '^[[:space:]]*(#|$)' "$1"
+}
+
+git init -q "$WORK/oai"
+git -C "$WORK/oai" remote add origin "$REPO_URL"
+
+# -----------------------------------------------------------------------------
+# Phase 1: decide which commit each version is vendored from.
+# -----------------------------------------------------------------------------
+PLAN="$WORK/plan"
+: >"$PLAN"
+
+while read -r version ref commit subpath want_pass want_fail; do
+	if [ "$UPDATE" -eq 1 ]; then
+		head="$(git -C "$WORK/oai" ls-remote origin "refs/heads/$ref" | cut -f1)"
+		if [ -z "$head" ]; then
+			echo "error: $ref does not exist in $REPO_URL" >&2
+			exit 1
+		fi
+		if [ "$head" != "$commit" ]; then
+			echo "  $version: $ref moved ${commit:0:7} -> ${head:0:7}"
+		fi
+		commit="$head"
+	fi
+	printf '%s %s %s %s %s %s\n' "$version" "$ref" "$commit" "$subpath" "$want_pass" "$want_fail" >>"$PLAN"
+done < <(records "$SOURCES")
+
+# -----------------------------------------------------------------------------
+# Phase 2: materialize each version and count what landed.
+# -----------------------------------------------------------------------------
+echo "Vendoring the OAI conformance suite into testdata/conformance..."
+FOUND="$WORK/found"
+: >"$FOUND"
+
+while read -r version ref commit subpath want_pass want_fail; do
+	echo "  ${version} (${ref} @ ${commit:0:7})"
+
+	# Fetching the commit rather than the branch is what makes this a pinned
+	# vendor: the result does not change when the branch moves.
+	if ! git -C "$WORK/oai" fetch -q --depth 1 --filter=blob:none origin "$commit"; then
+		echo "error: cannot fetch $commit from $REPO_URL" >&2
+		exit 1
+	fi
+
+	rm -rf "${DEST:?}/$version"
+	got_pass=0
+	got_fail=0
+
+	for kind in pass fail; do
+		# A version that publishes no fixtures of this kind has no directory
+		# upstream, so asking for one would fail the checkout.
+		case "$kind" in
+		pass) [ "$want_pass" -eq 0 ] && continue ;;
+		fail) [ "$want_fail" -eq 0 ] && continue ;;
+		esac
+
+		rm -rf "${WORK:?}/oai/$subpath/$kind"
+		if ! git -C "$WORK/oai" checkout -q FETCH_HEAD -- "$subpath/$kind"; then
+			echo "error: $version: $subpath/$kind is absent at $commit" >&2
+			exit 1
+		fi
+
+		mkdir -p "$DEST/$version/$kind"
+		# Only the document fixtures are vendored. Upstream keeps its own
+		# JavaScript harness beside them, and 3.3 keeps minimal-objects.yaml,
+		# which is a table of object stubs rather than an OpenAPI document.
+		find "$WORK/oai/$subpath/$kind" -maxdepth 1 -type f -name '*.yaml' \
+			-exec cp {} "$DEST/$version/$kind/" \;
+
+		n="$(find "$DEST/$version/$kind" -maxdepth 1 -type f -name '*.yaml' | wc -l | tr -d ' ')"
+		echo "    $kind: $n"
+		case "$kind" in
+		pass) got_pass="$n" ;;
+		fail) got_fail="$n" ;;
+		esac
+	done
+
+	printf '%s %s %s %s %s %s\n' "$version" "$ref" "$commit" "$subpath" "$got_pass" "$got_fail" >>"$FOUND"
+done < <(records "$PLAN")
+
+# -----------------------------------------------------------------------------
+# Phase 3: verify against the pins, or rewrite them.
+# -----------------------------------------------------------------------------
+if [ "$UPDATE" -eq 1 ]; then
+	# The comment header is this file's documentation, so it is carried across
+	# rather than regenerated.
+	rewritten="$WORK/sources.txt"
+	grep -E '^[[:space:]]*(#|$)' "$SOURCES" >"$rewritten"
+	cat "$FOUND" >>"$rewritten"
+	mv "$rewritten" "$SOURCES"
+	echo "Updated sources.txt. Review 'git diff testdata/conformance' before committing."
+	exit 0
+fi
+
+status=0
+while read -r version ref commit subpath want_pass want_fail; do
+	got="$(grep "^$version " "$FOUND")"
+	got_pass="$(echo "$got" | cut -d' ' -f5)"
+	got_fail="$(echo "$got" | cut -d' ' -f6)"
+	if [ "$got_pass" -ne "$want_pass" ] || [ "$got_fail" -ne "$want_fail" ]; then
+		echo "error: $version: sources.txt records ${want_pass}/${want_fail} pass/fail, upstream gave ${got_pass}/${got_fail}" >&2
+		status=1
+	fi
+done < <(records "$SOURCES")
+
+if [ "$status" -ne 0 ]; then
+	echo "Vendoring failed: the fixture counts do not match sources.txt." >&2
+	echo "Run 'make conformance-update' if upstream legitimately changed." >&2
+	exit "$status"
+fi
+
+echo "Done. Pins unchanged, so 'git diff testdata/conformance' should be empty."

--- a/testdata/conformance/3.0/pass/api-with-examples.yaml
+++ b/testdata/conformance/3.0/pass/api-with-examples.yaml
@@ -1,0 +1,170 @@
+openapi: "3.0.0"
+info:
+  title: Simple API overview
+  version: 2.0.0
+paths:
+  /:
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        '200':
+          description: |-
+            200 response
+          content:
+            application/json:
+              examples: 
+                foo:
+                  value:
+                    {
+                      "versions": [
+                        {
+                            "status": "CURRENT",
+                            "updated": "2011-01-21T11:33:21Z",
+                            "id": "v2.0",
+                            "links": [
+                                {
+                                    "href": "http://127.0.0.1:8774/v2/",
+                                    "rel": "self"
+                                }
+                            ]
+                        },
+                        {
+                            "status": "EXPERIMENTAL",
+                            "updated": "2013-07-23T11:33:21Z",
+                            "id": "v3.0",
+                            "links": [
+                                {
+                                    "href": "http://127.0.0.1:8774/v3/",
+                                    "rel": "self"
+                                }
+                            ]
+                        }
+                      ]
+                    }
+        '300':
+          description: |-
+            300 response
+          content:
+            application/json: 
+              examples: 
+                foo:
+                  value: |
+                   {
+                    "versions": [
+                          {
+                            "status": "CURRENT",
+                            "updated": "2011-01-21T11:33:21Z",
+                            "id": "v2.0",
+                            "links": [
+                                {
+                                    "href": "http://127.0.0.1:8774/v2/",
+                                    "rel": "self"
+                                }
+                            ]
+                        },
+                        {
+                            "status": "EXPERIMENTAL",
+                            "updated": "2013-07-23T11:33:21Z",
+                            "id": "v3.0",
+                            "links": [
+                                {
+                                    "href": "http://127.0.0.1:8774/v3/",
+                                    "rel": "self"
+                                }
+                            ]
+                        }
+                    ]
+                   }
+  /v2:
+    get:
+      operationId: getVersionDetailsv2
+      summary: Show API version details
+      responses:
+        '200':
+          description: |-
+            200 response
+          content:
+            application/json: 
+              examples:
+                foo:
+                  value:
+                    {
+                      "version": {
+                        "status": "CURRENT",
+                        "updated": "2011-01-21T11:33:21Z",
+                        "media-types": [
+                          {
+                              "base": "application/xml",
+                              "type": "application/vnd.openstack.compute+xml;version=2"
+                          },
+                          {
+                              "base": "application/json",
+                              "type": "application/vnd.openstack.compute+json;version=2"
+                          }
+                        ],
+                        "id": "v2.0",
+                        "links": [
+                          {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                          },
+                          {
+                              "href": "http://docs.openstack.org/api/openstack-compute/2/os-compute-devguide-2.pdf",
+                              "type": "application/pdf",
+                              "rel": "describedby"
+                          },
+                          {
+                              "href": "http://docs.openstack.org/api/openstack-compute/2/wadl/os-compute-2.wadl",
+                              "type": "application/vnd.sun.wadl+xml",
+                              "rel": "describedby"
+                          },
+                          {
+                            "href": "http://docs.openstack.org/api/openstack-compute/2/wadl/os-compute-2.wadl",
+                            "type": "application/vnd.sun.wadl+xml",
+                            "rel": "describedby"
+                          }
+                        ]
+                      }
+                    }
+        '203':
+          description: |-
+            203 response
+          content:
+            application/json: 
+              examples:
+                foo:
+                  value:
+                    {
+                      "version": {
+                        "status": "CURRENT",
+                        "updated": "2011-01-21T11:33:21Z",
+                        "media-types": [
+                          {
+                              "base": "application/xml",
+                              "type": "application/vnd.openstack.compute+xml;version=2"
+                          },
+                          {
+                              "base": "application/json",
+                              "type": "application/vnd.openstack.compute+json;version=2"
+                          }
+                        ],
+                        "id": "v2.0",
+                        "links": [
+                          {
+                              "href": "http://23.253.228.211:8774/v2/",
+                              "rel": "self"
+                          },
+                          {
+                              "href": "http://docs.openstack.org/api/openstack-compute/2/os-compute-devguide-2.pdf",
+                              "type": "application/pdf",
+                              "rel": "describedby"
+                          },
+                          {
+                              "href": "http://docs.openstack.org/api/openstack-compute/2/wadl/os-compute-2.wadl",
+                              "type": "application/vnd.sun.wadl+xml",
+                              "rel": "describedby"
+                          }
+                        ]
+                      }
+                    }

--- a/testdata/conformance/3.0/pass/callback-example.yaml
+++ b/testdata/conformance/3.0/pass/callback-example.yaml
@@ -1,0 +1,61 @@
+openapi: 3.0.0
+info:
+  title: Callback Example
+  version: 1.0.0
+paths:
+  /streams:
+    post:
+      description: subscribes a client to receive out-of-band data
+      parameters:
+        - name: callbackUrl
+          in: query
+          required: true
+          description: |
+            the location where data will be sent.  Must be network accessible
+            by the source server
+          schema:
+            type: string
+            format: uri
+            example: https://tonys-server.com
+      responses:
+        '201':
+          description: subscription successfully created
+          content:
+            application/json:
+              schema:
+                description: subscription information
+                required:
+                  - subscriptionId
+                properties:
+                  subscriptionId:
+                    description: this unique identifier allows management of the subscription
+                    type: string
+                    example: 2531329f-fb09-4ef7-887e-84e648214436
+      callbacks:
+        # the name `onData` is a convenience locator
+        onData:
+          # when data is sent, it will be sent to the `callbackUrl` provided
+          # when making the subscription PLUS the suffix `/data`
+          '{$request.query.callbackUrl}/data':
+            post:
+              requestBody:
+                description: subscription payload
+                content:
+                  application/json:
+                    schema:
+                      type: object
+                      properties:
+                        timestamp:
+                          type: string
+                          format: date-time
+                        userData:
+                          type: string
+              responses:
+                '202':
+                  description: |
+                    Your server implementation should return this HTTP status code
+                    if the data was received successfully
+                '204':
+                  description: |
+                    Your server should return this HTTP status code if no longer interested
+                    in further updates

--- a/testdata/conformance/3.0/pass/link-example.yaml
+++ b/testdata/conformance/3.0/pass/link-example.yaml
@@ -1,0 +1,203 @@
+openapi: 3.0.0
+info: 
+  title: Link Example
+  version: 1.0.0
+paths: 
+  /2.0/users/{username}: 
+    get: 
+      operationId: getUserByName
+      parameters: 
+      - name: username
+        in: path
+        required: true
+        schema:
+          type: string
+      responses: 
+        '200':
+          description: The User
+          content:
+            application/json:
+              schema: 
+                $ref: '#/components/schemas/user'
+          links:
+            userRepositories:
+              $ref: '#/components/links/UserRepositories'
+  /2.0/repositories/{username}:
+    get:
+      operationId: getRepositoriesByOwner
+      parameters:
+        - name: username
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: repositories owned by the supplied user
+          content: 
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/repository'
+          links:
+            userRepository:
+              $ref: '#/components/links/UserRepository'
+  /2.0/repositories/{username}/{slug}: 
+    get: 
+      operationId: getRepository
+      parameters: 
+        - name: username
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: slug
+          in: path
+          required: true
+          schema:
+            type: string
+      responses: 
+        '200':
+          description: The repository
+          content:
+              application/json: 
+                schema: 
+                  $ref: '#/components/schemas/repository'
+          links:
+            repositoryPullRequests:
+              $ref: '#/components/links/RepositoryPullRequests'
+  /2.0/repositories/{username}/{slug}/pullrequests: 
+    get: 
+      operationId: getPullRequestsByRepository
+      parameters: 
+      - name: username
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: slug
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: state
+        in: query
+        schema:
+          type: string
+          enum: 
+            - open
+            - merged
+            - declined
+      responses: 
+        '200':
+          description: an array of pull request objects
+          content:
+            application/json: 
+              schema: 
+                type: array
+                items: 
+                  $ref: '#/components/schemas/pullrequest'
+  /2.0/repositories/{username}/{slug}/pullrequests/{pid}: 
+    get: 
+      operationId: getPullRequestsById
+      parameters: 
+      - name: username
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: slug
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: pid
+        in: path
+        required: true
+        schema:
+          type: string
+      responses: 
+        '200':
+          description: a pull request object
+          content:
+            application/json: 
+              schema: 
+                $ref: '#/components/schemas/pullrequest'
+          links:
+            pullRequestMerge:
+              $ref: '#/components/links/PullRequestMerge'
+  /2.0/repositories/{username}/{slug}/pullrequests/{pid}/merge: 
+    post: 
+      operationId: mergePullRequest
+      parameters: 
+      - name: username
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: slug
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: pid
+        in: path
+        required: true
+        schema:
+          type: string
+      responses: 
+        '204':
+          description: the PR was successfully merged
+components:
+  links:
+    UserRepositories:
+      # returns array of '#/components/schemas/repository'
+      operationId: getRepositoriesByOwner
+      parameters:
+        username: $response.body#/username
+    UserRepository:
+      # returns '#/components/schemas/repository'
+      operationId: getRepository
+      parameters:
+        username: $response.body#/owner/username
+        slug: $response.body#/slug
+    RepositoryPullRequests:
+      # returns '#/components/schemas/pullrequest'
+      operationId: getPullRequestsByRepository
+      parameters: 
+          username: $response.body#/owner/username
+          slug: $response.body#/slug
+    PullRequestMerge:
+      # executes /2.0/repositories/{username}/{slug}/pullrequests/{pid}/merge
+      operationId: mergePullRequest
+      parameters:
+        username: $response.body#/author/username
+        slug: $response.body#/repository/slug
+        pid: $response.body#/id
+  schemas: 
+    user: 
+      type: object
+      properties: 
+        username: 
+          type: string
+        uuid: 
+          type: string
+    repository: 
+      type: object
+      properties: 
+        slug: 
+          type: string
+        owner: 
+          $ref: '#/components/schemas/user'
+    pullrequest: 
+      type: object
+      properties: 
+        id: 
+          type: integer
+        title: 
+          type: string
+        repository: 
+          $ref: '#/components/schemas/repository'
+        author: 
+          $ref: '#/components/schemas/user'

--- a/testdata/conformance/3.0/pass/petstore-expanded.yaml
+++ b/testdata/conformance/3.0/pass/petstore-expanded.yaml
@@ -1,0 +1,158 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  description: A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.0 specification
+  termsOfService: http://swagger.io/terms/
+  contact:
+    name: Swagger API Team
+    email: apiteam@swagger.io
+    url: http://swagger.io
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+servers:
+  - url: https://petstore.swagger.io/v2
+paths:
+  /pets:
+    get:
+      description: |
+        Returns all pets from the system that the user has access to
+        Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.
+
+        Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.
+      operationId: findPets
+      parameters:
+        - name: tags
+          in: query
+          description: tags to filter by
+          required: false
+          style: form
+          schema:
+            type: array
+            items:
+              type: string
+        - name: limit
+          in: query
+          description: maximum number of results to return
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    post:
+      description: Creates a new pet in the store. Duplicates are allowed
+      operationId: addPet
+      requestBody:
+        description: Pet to add to the store
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewPet'
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /pets/{id}:
+    get:
+      description: Returns a user based on a single ID, if the user does not have access to the pet
+      operationId: find pet by id
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to fetch
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    delete:
+      description: deletes a single pet based on the ID supplied
+      operationId: deletePet
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to delete
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '204':
+          description: pet deleted
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+components:
+  schemas:
+    Pet:
+      allOf:
+        - $ref: '#/components/schemas/NewPet'
+        - type: object
+          required:
+          - id
+          properties:
+            id:
+              type: integer
+              format: int64
+
+    NewPet:
+      type: object
+      required:
+        - name  
+      properties:
+        name:
+          type: string
+        tag:
+          type: string    
+
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/testdata/conformance/3.0/pass/petstore.yaml
+++ b/testdata/conformance/3.0/pass/petstore.yaml
@@ -1,0 +1,119 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            maximum: 100
+            format: int32
+      responses:
+        '200':
+          description: A paged array of pets
+          headers:
+            x-next:
+              description: A link to the next page of responses
+              schema:
+                type: string
+          content:
+            application/json:    
+              schema:
+                $ref: "#/components/schemas/Pets"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+        required: true
+      responses:
+        '201':
+          description: Null response
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /pets/{petId}:
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+    Pets:
+      type: array
+      maxItems: 100
+      items:
+        $ref: "#/components/schemas/Pet"
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/testdata/conformance/3.0/pass/uspto.yaml
+++ b/testdata/conformance/3.0/pass/uspto.yaml
@@ -1,0 +1,210 @@
+openapi: 3.0.1
+servers:
+  - url: '{scheme}://developer.uspto.gov/ds-api'
+    variables:
+      scheme:
+        description: 'The Data Set API is accessible via https and http'
+        enum:
+          - 'https'
+          - 'http'
+        default: 'https'
+info:
+  description: >-
+    The Data Set API (DSAPI) allows the public users to discover and search
+    USPTO exported data sets. This is a generic API that allows USPTO users to
+    make any CSV based data files searchable through API. With the help of GET
+    call, it returns the list of data fields that are searchable. With the help
+    of POST call, data can be fetched based on the filters on the field names.
+    Please note that POST call is used to search the actual data. The reason for
+    the POST call is that it allows users to specify any complex search criteria
+    without worry about the GET size limitations as well as encoding of the
+    input parameters.
+  version: 1.0.0
+  title: USPTO Data Set API
+  contact:
+    name: Open Data Portal
+    url: 'https://developer.uspto.gov'
+    email: developer@uspto.gov
+tags:
+  - name: metadata
+    description: Find out about the data sets
+  - name: search
+    description: Search a data set
+paths:
+  /:
+    get:
+      tags:
+        - metadata
+      operationId: list-data-sets
+      summary: List available data sets
+      responses:
+        '200':
+          description: Returns a list of data sets
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/dataSetList'
+              example:
+                {
+                  "total": 2,
+                  "apis": [
+                    {
+                      "apiKey": "oa_citations",
+                      "apiVersionNumber": "v1",
+                      "apiUrl": "https://developer.uspto.gov/ds-api/oa_citations/v1/fields",
+                      "apiDocumentationUrl": "https://developer.uspto.gov/ds-api-docs/index.html?url=https://developer.uspto.gov/ds-api/swagger/docs/oa_citations.json"
+                    },
+                    {
+                      "apiKey": "cancer_moonshot",
+                      "apiVersionNumber": "v1",
+                      "apiUrl": "https://developer.uspto.gov/ds-api/cancer_moonshot/v1/fields",
+                      "apiDocumentationUrl": "https://developer.uspto.gov/ds-api-docs/index.html?url=https://developer.uspto.gov/ds-api/swagger/docs/cancer_moonshot.json"
+                    }
+                  ]
+                }
+  /{dataset}/{version}/fields:
+    get:
+      tags:
+        - metadata
+      summary: >-
+        Provides the general information about the API and the list of fields
+        that can be used to query the dataset.
+      description: >-
+        This GET API returns the list of all the searchable field names that are
+        in the oa_citations. Please see the 'fields' attribute which returns an
+        array of field names. Each field or a combination of fields can be
+        searched using the syntax options shown below.
+      operationId: list-searchable-fields
+      parameters:
+        - name: dataset
+          in: path
+          description: 'Name of the dataset.'
+          required: true
+          example: "oa_citations"
+          schema:
+            type: string
+        - name: version
+          in: path
+          description: Version of the dataset.
+          required: true
+          example: "v1"
+          schema:
+            type: string
+      responses:
+        '200':
+          description: >-
+            The dataset API for the given version is found and it is accessible
+            to consume.
+          content:
+            application/json:
+              schema:
+                type: string
+        '404':
+          description: >-
+            The combination of dataset name and version is not found in the
+            system or it is not published yet to be consumed by public.
+          content:
+            application/json:
+              schema:
+                type: string
+  /{dataset}/{version}/records:
+    post:
+      tags:
+        - search
+      summary: >-
+        Provides search capability for the data set with the given search
+        criteria.
+      description: >-
+        This API is based on Solr/Lucene Search. The data is indexed using
+        SOLR. This GET API returns the list of all the searchable field names
+        that are in the Solr Index. Please see the 'fields' attribute which
+        returns an array of field names. Each field or a combination of fields
+        can be searched using the Solr/Lucene Syntax. Please refer
+        https://lucene.apache.org/core/3_6_2/queryparsersyntax.html#Overview for
+        the query syntax. List of field names that are searchable can be
+        determined using above GET api.
+      operationId: perform-search
+      parameters:
+        - name: version
+          in: path
+          description: Version of the dataset.
+          required: true
+          schema:
+            type: string
+            default: v1
+        - name: dataset
+          in: path
+          description: 'Name of the dataset. In this case, the default value is oa_citations'
+          required: true
+          schema:
+            type: string
+            default: oa_citations
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  additionalProperties:
+                    type: object
+        '404':
+          description: No matching record found for the given criteria.
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                criteria:
+                  description: >-
+                    Uses Lucene Query Syntax in the format of
+                    propertyName:value, propertyName:[num1 TO num2] and date
+                    range format: propertyName:[yyyyMMdd TO yyyyMMdd]. In the
+                    response please see the 'docs' element which has the list of
+                    record objects. Each record structure would consist of all
+                    the fields and their corresponding values.
+                  type: string
+                  default: '*:*'
+                start:
+                  description: Starting record number. Default value is 0.
+                  type: integer
+                  default: 0
+                rows:
+                  description: >-
+                    Specify number of rows to be returned. If you run the search
+                    with default values, in the response you will see 'numFound'
+                    attribute which will tell the number of records available in
+                    the dataset.
+                  type: integer
+                  default: 100
+              required:
+                - criteria
+components:
+  schemas:
+    dataSetList:
+      type: object
+      properties:
+        total:
+          type: integer
+        apis:
+          type: array
+          items:
+            type: object
+            properties:
+              apiKey:
+                type: string
+                description: To be used as a dataset parameter value
+              apiVersionNumber:
+                type: string
+                description: To be used as a version parameter value
+              apiUrl:
+                type: string
+                format: uriref
+                description: "The URL describing the dataset's fields"
+              apiDocumentationUrl:
+                type: string
+                format: uriref
+                description: A URL to the API console for each API

--- a/testdata/conformance/3.1/fail/example-examples.yaml
+++ b/testdata/conformance/3.1/fail/example-examples.yaml
@@ -1,0 +1,17 @@
+openapi: 3.1.1
+
+# this example should fail, as example cannot be used together with examples.
+
+info:
+  title: API
+  version: 1.0.0
+components:
+  parameters:
+    animal:
+      name: animal
+      in: header
+      schema: {}
+      example: bear
+      examples:
+        a mammalian example:
+          value: bear

--- a/testdata/conformance/3.1/fail/header-object-allowReserved.yaml
+++ b/testdata/conformance/3.1/fail/header-object-allowReserved.yaml
@@ -1,0 +1,12 @@
+openapi: 3.1.0
+info:
+  title: "allowReserved only permitted with in: query"
+  version: 1.0.0
+components:
+  headers:
+    Style:
+      schema:
+        type: array
+      style: simple
+      explode: true
+      allowReserved: true

--- a/testdata/conformance/3.1/fail/invalid_schema_types.yaml
+++ b/testdata/conformance/3.1/fail/invalid_schema_types.yaml
@@ -1,0 +1,12 @@
+openapi: 3.1.1
+
+# this example shows invalid types for the schemaObject
+
+info:
+  title: API
+  version: 1.0.0
+components:
+  schemas:
+    invalid_null: null
+    invalid_number: 0
+    invalid_array: []

--- a/testdata/conformance/3.1/fail/link-object-no-body.yaml
+++ b/testdata/conformance/3.1/fail/link-object-no-body.yaml
@@ -1,0 +1,11 @@
+openapi: 3.1.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  links:
+    Link-Object-with-body-property:
+      operationId: getThing
+      description: The "server" property was misspelled as "body" in a previous schema iteration, now fixed
+      body:
+        url: https://things.example.com

--- a/testdata/conformance/3.1/fail/no_containers.yaml
+++ b/testdata/conformance/3.1/fail/no_containers.yaml
@@ -1,0 +1,7 @@
+openapi: 3.1.0
+
+# this example should fail as there are no paths, components or webhooks containers (at least one of which must be present)
+
+info:
+  title: API
+  version: 1.0.0

--- a/testdata/conformance/3.1/fail/parameter-object-cookie-form-allowReserved.yaml
+++ b/testdata/conformance/3.1/fail/parameter-object-cookie-form-allowReserved.yaml
@@ -1,0 +1,18 @@
+openapi: 3.1.0
+info:
+  title: allowReserved only permitted with in and style values that percent-encode
+  version: 1.0.0
+components:
+  parameters:
+    style_form:
+      name: my_form_cookie
+      in: cookie
+      # default style is form, therefore allowReserved is allowed
+      allowReserved: true
+      schema: {}
+    style_cookie:
+      name: my_cookie_cookie
+      in: cookie
+      style: cookie
+      # no percent decoding for style=cookie, therefore allowReserved is not allowed
+      schema: {}

--- a/testdata/conformance/3.1/fail/parameter-object-header-allowReserved.yaml
+++ b/testdata/conformance/3.1/fail/parameter-object-header-allowReserved.yaml
@@ -1,0 +1,11 @@
+openapi: 3.1.0
+info:
+  title: allowReserved only permitted with in and style values that percent-encode
+  version: 1.0.0
+components:
+  parameters:
+    header:
+      name: my-header
+      in: header
+      allowReserved: false
+      schema: {}

--- a/testdata/conformance/3.1/fail/parameter-object-path-allowReserved.yaml
+++ b/testdata/conformance/3.1/fail/parameter-object-path-allowReserved.yaml
@@ -1,0 +1,11 @@
+openapi: 3.1.0
+info:
+  title: "allowReserved only permitted with in: query"
+  version: 1.0.0
+components:
+  parameters:
+    path:
+      name: my-path
+      in: path
+      allowReserved: false
+      schema: {}

--- a/testdata/conformance/3.1/fail/server_enum_empty.yaml
+++ b/testdata/conformance/3.1/fail/server_enum_empty.yaml
@@ -1,0 +1,15 @@
+openapi: 3.1.0
+
+# this example should fail as the server variable enum is empty
+# (it also does not contain the default value, but this is not checked by the schema)
+
+info:
+  title: API
+  version: 1.0.0
+servers:
+  - url: https://example.com/{var}
+    variables:
+      var:
+        enum: []
+        default: a
+components: {}

--- a/testdata/conformance/3.1/fail/servers.yaml
+++ b/testdata/conformance/3.1/fail/servers.yaml
@@ -1,0 +1,11 @@
+openapi: 3.1.0
+
+# this example should fail, as servers must be an array, not an object
+
+info:
+  title: API
+  version: 1.0.0
+paths: {}
+servers:
+  url: /v1
+  description: Run locally.

--- a/testdata/conformance/3.1/fail/unknown_container.yaml
+++ b/testdata/conformance/3.1/fail/unknown_container.yaml
@@ -1,0 +1,8 @@
+openapi: 3.1.0
+
+# this example should fail as overlays is not a valid top-level object/keyword
+
+info:
+  title: API
+  version: 1.0.0
+overlays: {}

--- a/testdata/conformance/3.1/pass/callback-object-examples.yaml
+++ b/testdata/conformance/3.1/pass/callback-object-examples.yaml
@@ -1,0 +1,32 @@
+openapi: 3.1.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  callbacks:
+    myCallback:
+      '{$request.query.queryUrl}':
+        post:
+          requestBody:
+            description: Callback payload
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/SomePayload'
+          responses:
+            '200':
+              description: callback successfully processed
+    transactionCallback:
+      'http://notificationServer.com?transactionId={$request.body#/id}&email={$request.body#/email}':
+        post:
+          requestBody:
+            description: Callback payload
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/SomePayload'
+          responses:
+            '200':
+              description: callback successfully processed
+  schemas:
+    SomePayload: {}

--- a/testdata/conformance/3.1/pass/comp_pathitems.yaml
+++ b/testdata/conformance/3.1/pass/comp_pathitems.yaml
@@ -1,0 +1,6 @@
+openapi: 3.1.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  pathItems: {}

--- a/testdata/conformance/3.1/pass/components-object-example.yaml
+++ b/testdata/conformance/3.1/pass/components-object-example.yaml
@@ -1,0 +1,71 @@
+openapi: 3.1.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  schemas:
+    GeneralError:
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string
+    Category:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+    Tag:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+  parameters:
+    skipParam:
+      name: skip
+      in: query
+      description: number of items to skip
+      required: true
+      schema:
+        type: integer
+        format: int32
+    limitParam:
+      name: limit
+      in: query
+      description: max records to return
+      required: true
+      schema:
+        type: integer
+        format: int32
+  responses:
+    NotFound:
+      description: Entity not found.
+    IllegalInput:
+      description: Illegal input for operation.
+    GeneralError:
+      description: General Error
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/GeneralError'
+  securitySchemes:
+    api_key:
+      type: apiKey
+      name: api-key
+      in: header
+    petstore_auth:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: https://example.org/api/oauth/dialog
+          scopes:
+            write:pets: modify pets in your account
+            read:pets: read your pets

--- a/testdata/conformance/3.1/pass/example-object-examples.yaml
+++ b/testdata/conformance/3.1/pass/example-object-examples.yaml
@@ -1,0 +1,69 @@
+openapi: 3.1.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  examples:
+    zip-example: {}
+    confirmation-success: {}
+  schemas:
+    SuccessResponse: {}
+    Address: {}
+  requestBodies:
+    with-example:
+      content:
+        'application/json':
+          schema:
+            $ref: '#/components/schemas/Address'
+          examples:
+            foo:
+              summary: A foo example
+              value:
+                foo: bar
+            bar:
+              summary: A bar example
+              value:
+                bar: baz
+        application/xml:
+          examples:
+            xmlExample:
+              summary: This is an example in XML
+              externalValue: https://example.org/examples/address-example.xml
+        text/plain:
+          examples:
+            textExample:
+              summary: This is a text example
+              externalValue: https://foo.bar/examples/address-example.txt
+  parameters:
+    with-example:
+      name: zipCode
+      in: query
+      schema:
+        type: string
+        format: zip-code
+      examples:
+        zip-example:
+          $ref: '#/components/examples/zip-example'
+  responses:
+    '200':
+      description: your car appointment has been booked
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/SuccessResponse'
+          examples:
+            confirmation-success:
+              $ref: '#/components/examples/confirmation-success'
+        application/x-www-form-urlencoded:
+          schema:
+            type: object
+            properties:
+              jsonValue:
+                type: string
+          encoding:
+            jsonValue:
+              contentType: application/json
+          examples:
+            jsonFormValue:
+              description: 'The JSON string "json" as a form value'
+              value: jsonValue=%22json%22

--- a/testdata/conformance/3.1/pass/header-object-examples.yaml
+++ b/testdata/conformance/3.1/pass/header-object-examples.yaml
@@ -1,0 +1,25 @@
+openapi: 3.1.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  headers:
+    X-Rate-Limit-Limit:
+      description: The number of allowed requests in the current period
+      deprecated: false
+      schema:
+        type: integer
+    ETag:
+      required: true
+      content:
+        text/plain:
+          schema:
+            type: string
+            pattern: ^"
+    Reference:
+      $ref: '#/components/headers/ETag'
+    Style:
+      schema:
+        type: array
+      style: simple
+      explode: true

--- a/testdata/conformance/3.1/pass/info-object-example.yaml
+++ b/testdata/conformance/3.1/pass/info-object-example.yaml
@@ -1,0 +1,19 @@
+# including External Documentation Object Example
+openapi: 3.1.0
+info:
+  title: Example Pet Store App
+  summary: A pet store manager.
+  description: This is an example server for a pet store.
+  termsOfService: https://example.com/terms/
+  contact:
+    name: API Support
+    url: https://www.example.com/support
+    email: support@example.com
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+  version: 1.0.1
+externalDocs:
+  description: Find more info here
+  url: https://example.com
+components: {}

--- a/testdata/conformance/3.1/pass/info_summary.yaml
+++ b/testdata/conformance/3.1/pass/info_summary.yaml
@@ -1,0 +1,6 @@
+openapi: 3.1.0
+info:
+  title: API
+  summary: My lovely API
+  version: 1.0.0
+components: {}

--- a/testdata/conformance/3.1/pass/json_schema_dialect.yaml
+++ b/testdata/conformance/3.1/pass/json_schema_dialect.yaml
@@ -1,0 +1,15 @@
+openapi: 3.1.0
+info:
+  summary: Testing jsonSchemaDialect
+  title: My API
+  version: 1.0.0
+  license:
+    name: Apache 2.0
+    identifier: Apache-2.0
+jsonSchemaDialect: https://spec.openapis.org/oas/3.1/dialect/WORK-IN-PROGRESS
+components:
+  schemas:
+    WithDollarSchema:
+      $id: "locked-metaschema"
+      $schema: https://spec.openapis.org/oas/3.1/dialect/WORK-IN-PROGRESS
+paths: {}

--- a/testdata/conformance/3.1/pass/license_identifier.yaml
+++ b/testdata/conformance/3.1/pass/license_identifier.yaml
@@ -1,0 +1,9 @@
+openapi: 3.1.0
+info:
+  title: API
+  summary: My lovely API
+  version: 1.0.0
+  license:
+    name: Apache
+    identifier: Apache-2.0
+components: {}

--- a/testdata/conformance/3.1/pass/link-object-examples.yaml
+++ b/testdata/conformance/3.1/pass/link-object-examples.yaml
@@ -1,0 +1,66 @@
+openapi: 3.1.0
+info:
+  title: API
+  version: 1.0.0
+paths:
+  /users/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        description: the user identifier, as userId
+        schema:
+          type: string
+    get:
+      responses:
+        '200':
+          description: the user being returned
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  uuid: # the unique user id
+                    type: string
+                    format: uuid
+          links:
+            address:
+              # the target link operationId
+              operationId: getUserAddress
+              parameters:
+                # get the `id` field from the request path parameter named `id`
+                userid: $request.path.id
+            address2:
+              operationId: getUserAddressByUUID
+              parameters:
+                # get the `uuid` field from the `uuid` field in the response body
+                userUuid: $response.body#/uuid
+            UserRepositories:
+              # returns array of '#/components/schemas/repository'
+              operationRef: '#/paths/~12.0~1repositories~1%7Busername%7D/get'
+              parameters:
+                username: $response.body#/username
+            UserRepositories2:
+              # returns array of '#/components/schemas/repository'
+              operationRef: https://na2.gigantic-server.com/#/paths/~12.0~1repositories~1%7Busername%7D/get
+              parameters:
+                username: $response.body#/username
+            withBody:
+              operationId: queryUserWithBody
+              requestBody:
+                userId: $request.path.id
+  # the path item of the linked operation
+  /users/{userid}/address:
+    parameters:
+      - name: userid
+        in: path
+        required: true
+        description: the user identifier, as userId
+        schema:
+          type: string
+    # linked operation
+    get:
+      operationId: getUserAddress
+      responses:
+        '200':
+          description: the user's address

--- a/testdata/conformance/3.1/pass/media-type-examples.yaml
+++ b/testdata/conformance/3.1/pass/media-type-examples.yaml
@@ -1,0 +1,123 @@
+# including Encoding Object examples
+openapi: 3.1.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  examples:
+    frog-example: {}
+  schemas:
+    Address: {}
+    Pet: {}
+paths:
+  /something:
+    put:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+            examples:
+              cat:
+                summary: An example of a cat
+                value:
+                  name: Fluffy
+                  petType: Cat
+                  color: White
+                  gender: male
+                  breed: Persian
+              dog:
+                summary: An example of a dog with a cat's name
+                value:
+                  name: Puma
+                  petType: Dog
+                  color: Black
+                  gender: Female
+                  breed: Mixed
+              frog:
+                $ref: '#/components/examples/frog-example'
+          application/xml:
+            schema:
+              type: object
+              properties:
+                foo:
+                  type: string
+                  xml:
+                    namespace: https://example.com
+                    prefix: example
+                    name: Foo
+                bar:
+                  type: array
+                  items:
+                    type: number
+                  xml:
+                    wrapped: true
+                attr:
+                  type: string
+                  xml:
+                    attribute: true
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: string
+                  format: uuid
+                address:
+                  # complex types are stringified to support RFC 1866
+                  type: object
+                  properties: {}
+                icon:
+                  # The default with "contentEncoding" is application/octet-stream,
+                  # so we need to set image media type(s) in the Encoding Object.
+                  type: string
+                  contentEncoding: base64url
+            encoding:
+              icon:
+                contentType: image/png, image/jpeg
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                id:
+                  # default is `text/plain`
+                  type: string
+                  format: uuid
+                addresses:
+                  # default based on the `items` subschema would be
+                  # `application/json`, but we want these address objects
+                  # serialized as `application/xml` instead
+                  description: addresses in XML format
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/Address'
+                profileImage:
+                  # default is application/octet-stream, but we can declare
+                  # a more specific image type or types
+                  type: string
+                  format: binary
+                forCoverage:
+                  type: string
+                forCoverage2:
+                  type: string
+            encoding:
+              addresses:
+                # require XML Content-Type in utf-8 encoding
+                # This is applied to each address part corresponding
+                # to each address in he array
+                contentType: application/xml; charset=utf-8
+              profileImage:
+                # only accept png or jpeg
+                contentType: image/png, image/jpeg
+                headers:
+                  X-Rate-Limit-Limit:
+                    description: The number of allowed requests in the current period
+                    schema:
+                      type: integer
+              forCoverage:
+                style: form
+                explode: false
+                allowReserved: true
+              forCoverage2:
+                style: spaceDelimited
+                explode: true

--- a/testdata/conformance/3.1/pass/mega.yaml
+++ b/testdata/conformance/3.1/pass/mega.yaml
@@ -1,0 +1,61 @@
+openapi: 3.1.0
+info:
+  summary: My API's summary
+  title: My API
+  version: 1.0.0
+  license:
+    name: Apache 2.0
+    identifier: Apache-2.0
+paths:
+  /:
+    get:
+      parameters: []
+  /{pathTest}: {}
+webhooks:
+  myWebhook:
+    $ref: '#/components/pathItems/myPathItem'
+    description: Overriding description
+components:
+  securitySchemes:
+    mtls:
+      type: mutualTLS
+  schemas:
+    Foo:
+      type: object
+      properties:
+        type:
+          const: foo
+  pathItems:
+    myPathItem:
+      post:
+        requestBody:
+          required: true
+          content:
+            'application/json':
+              schema:
+                externalDocs:
+                  description: More docs!
+                  url: https://example.com/elsewhere.html
+                type: object
+                properties:
+                  type:
+                    type: string
+                  int:
+                    type: integer
+                    exclusiveMaximum: 100
+                    exclusiveMinimum: 0
+                  none:
+                    type: 'null'
+                  arr:
+                    type: array
+                    $comment: Array without items keyword
+                  either:
+                    type: ['string','null']
+                discriminator:
+                  propertyName: type
+                  mapping:
+                    foo: Foo
+                  x-extension: true
+                anyOf:
+                - $ref: "#/components/schemas/Foo"
+                myArbitraryKeyword: true

--- a/testdata/conformance/3.1/pass/minimal_comp.yaml
+++ b/testdata/conformance/3.1/pass/minimal_comp.yaml
@@ -1,0 +1,5 @@
+openapi: 3.1.0
+info:
+  title: API
+  version: 1.0.0
+components: {}

--- a/testdata/conformance/3.1/pass/minimal_hooks.yaml
+++ b/testdata/conformance/3.1/pass/minimal_hooks.yaml
@@ -1,0 +1,5 @@
+openapi: 3.1.0
+info:
+  title: API
+  version: 1.0.0
+webhooks: {}

--- a/testdata/conformance/3.1/pass/minimal_paths.yaml
+++ b/testdata/conformance/3.1/pass/minimal_paths.yaml
@@ -1,0 +1,5 @@
+openapi: 3.1.0
+info:
+  title: API
+  version: 1.0.0
+paths: {}

--- a/testdata/conformance/3.1/pass/non-oauth-scopes.yaml
+++ b/testdata/conformance/3.1/pass/non-oauth-scopes.yaml
@@ -1,0 +1,19 @@
+openapi: 3.1.0
+info:
+  title: Non-oAuth Scopes example
+  version: 1.0.0
+paths:
+  /users:
+    get:
+      security:
+        - bearerAuth:
+            - 'read:users'
+            - 'public'
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: jwt
+      description: 'note: non-oauth scopes are not defined at the securityScheme level'
+

--- a/testdata/conformance/3.1/pass/operation-object-example.yaml
+++ b/testdata/conformance/3.1/pass/operation-object-example.yaml
@@ -1,0 +1,47 @@
+openapi: 3.1.0
+info:
+  title: API
+  version: 1.0.0
+paths:
+  /pets/{id}:
+    put:
+      tags:
+        - pet
+      summary: Updates a pet in the store with form data
+      operationId: updatePetWithForm
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet that needs to be updated
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: Updated name of the pet
+                  type: string
+                status:
+                  description: Updated status of the pet
+                  type: string
+              required:
+                - status
+      responses:
+        '200':
+          description: Pet updated.
+          content:
+            application/json: {}
+            application/xml: {}
+        '405':
+          description: Method Not Allowed
+          content:
+            application/json: {}
+            application/xml: {}
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets

--- a/testdata/conformance/3.1/pass/parameter-object-examples.yaml
+++ b/testdata/conformance/3.1/pass/parameter-object-examples.yaml
@@ -1,0 +1,61 @@
+openapi: 3.1.0
+info:
+  title: API
+  version: 1.0.0
+paths:
+  /user/{username}:
+    parameters:
+      - name: token
+        in: header
+        description: token to be passed as a header
+        required: true
+        explode: false
+        schema:
+          type: array
+          items:
+            type: integer
+            format: int64
+        style: simple
+      - name: usernames
+        in: path
+        description: usernames to fetch
+        required: true
+        explode: false
+        schema:
+          type: array
+      - name: id
+        in: query
+        description: IDs of the object to fetch
+        required: false
+        schema:
+          type: array
+          items:
+            type: string
+        style: form
+        explode: true
+      - in: query
+        name: freeForm
+        schema:
+          type: object
+          additionalProperties:
+            type: integer
+        style: form
+      - in: query
+        name: coordinates
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - lat
+                - long
+              properties:
+                lat:
+                  type: number
+                long:
+                  type: number
+      - in: cookie
+        name: my_cookie1
+        style: form
+        explode: false
+        schema: {}

--- a/testdata/conformance/3.1/pass/parameter-object-query-allowReserved.yaml
+++ b/testdata/conformance/3.1/pass/parameter-object-query-allowReserved.yaml
@@ -1,0 +1,11 @@
+openapi: 3.1.0
+info:
+  title: "allowReserved only permitted with in: query"
+  version: 1.0.0
+components:
+  parameters:
+    my_query:
+      name: my_query
+      in: query
+      allowReserved: true
+      schema: {}

--- a/testdata/conformance/3.1/pass/path-item-object-example.yaml
+++ b/testdata/conformance/3.1/pass/path-item-object-example.yaml
@@ -1,0 +1,39 @@
+openapi: 3.1.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  schemas:
+    Pet: {}
+    ErrorModel: {}
+paths:
+  /pets/{id}:
+    get:
+      description: Returns pets based on ID
+      summary: Find pets by ID
+      operationId: getPetsById
+      responses:
+        '200':
+          description: pet response
+          content:
+            '*/*':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+        default:
+          description: error payload
+          content:
+            text/html:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+    parameters:
+      - name: id
+        in: path
+        description: ID of pet to use
+        required: true
+        schema:
+          type: array
+          items:
+            type: string
+        style: simple

--- a/testdata/conformance/3.1/pass/path_item_servers_parameters.yaml
+++ b/testdata/conformance/3.1/pass/path_item_servers_parameters.yaml
@@ -1,0 +1,114 @@
+openapi: 3.1.0
+info:
+  title: API
+  version: 1.0.0
+paths:
+  /things:
+    summary: Lots of things
+    servers:
+      - url: https://things.example.com
+    get:
+      summary: Get a list of things
+      externalDocs:
+        description: Find more info here
+        url: https://example.com
+      parameters:
+        - $ref: '#/components/parameters/biscuit'
+          summary: The maximum number of things to return
+          description: The maximum number of things to return
+      responses:
+        default:
+          description: A list of things
+      servers:
+        - url: https://things.example.com
+    post:
+      deprecated: false
+      requestBody:
+        $ref: '#/components/requestBodies/ThingRequestBody'
+      responses:
+        '201':
+          $ref: '#/components/responses/ThingResponse'
+      callbacks:
+        myCallback:
+          '{$request.query.queryUrl}':
+            post:
+              requestBody:
+                description: Callback payload
+                content:
+                  application/json:
+                    schema:
+                      $ref: '#/components/schemas/SomePayload'
+              responses:
+                '200':
+                  description: callback successfully processed
+        transactionCallback:
+          $ref: '#/components/callbacks/transactionCallback'
+    patch: {}
+    delete: {}
+    head: {}
+    options: {}
+    trace: {}
+components:
+  callbacks:
+    transactionCallback:
+      'http://notificationServer.com?transactionId={$request.body#/id}&email={$request.body#/email}':
+        post:
+          requestBody:
+            description: Callback payload
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/SomePayload'
+          responses:
+            '200':
+              description: callback successfully processed
+  examples:
+    ThingExample:
+      summary: A thing
+      description: A thing
+      value:
+        id: 1
+        name: Thing
+  links:
+    ThingLink:
+      description: A link to a thing
+      operationId: getThing
+      parameters:
+        thingId: '$response.body#/id'
+      server:
+        url: https://things.example.com
+    ThingyLink:
+      $ref: '#/components/links/ThingLink'
+  parameters:
+    limit:
+      name: limit
+      in: query
+      required: false
+      allowEmptyValue: false
+      allowReserved: false
+      deprecated: true
+      description: The maximum number of list items to return
+      schema:
+        type: integer
+        minimum: 0
+    biscuit:
+      name: biscuit
+      in: cookie
+      style: form
+      schema:
+        type: string
+  requestBodies:
+    ThingRequestBody:
+      content:
+        application/json:
+          schema:
+            type: object
+  responses:
+    ThingResponse:
+      description: A thing
+      content:
+        application/json:
+          schema:
+            type: object
+  schemas:
+    SomePayload: {}

--- a/testdata/conformance/3.1/pass/path_no_response.yaml
+++ b/testdata/conformance/3.1/pass/path_no_response.yaml
@@ -1,0 +1,7 @@
+openapi: 3.1.0
+info:
+  title: API
+  version: 1.0.0
+paths:
+  /:
+    get: {}

--- a/testdata/conformance/3.1/pass/path_var_empty_pathitem.yaml
+++ b/testdata/conformance/3.1/pass/path_var_empty_pathitem.yaml
@@ -1,0 +1,6 @@
+openapi: 3.1.0
+info:
+  title: API
+  version: 1.0.0
+paths:
+  /{var}: {}

--- a/testdata/conformance/3.1/pass/paths-object-example.yaml
+++ b/testdata/conformance/3.1/pass/paths-object-example.yaml
@@ -1,0 +1,20 @@
+openapi: 3.1.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  schemas:
+    pet: {}
+paths:
+  /pets:
+    get:
+      description: Returns all pets from the system that the user has access to
+      responses:
+        '200':
+          description: A list of pets.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/pet'

--- a/testdata/conformance/3.1/pass/request-body-examples.yaml
+++ b/testdata/conformance/3.1/pass/request-body-examples.yaml
@@ -1,0 +1,37 @@
+openapi: 3.1.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  schemas:
+    User: {}
+paths:
+  /something:
+    put:
+      requestBody:
+        description: user to add to the system
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/User'
+            examples:
+              user:
+                summary: User example
+                externalValue: https://foo.bar/examples/user-example.json
+          application/xml:
+            schema:
+              $ref: '#/components/schemas/User'
+            examples:
+              user:
+                summary: User example in XML
+                externalValue: https://foo.bar/examples/user-example.xml
+          text/plain:
+            examples:
+              user:
+                summary: User example in plain text
+                externalValue: https://foo.bar/examples/user-example.txt
+          '*/*':
+            examples:
+              user:
+                summary: User example in other format
+                externalValue: https://foo.bar/examples/user-example.whatever

--- a/testdata/conformance/3.1/pass/response-object-examples.yaml
+++ b/testdata/conformance/3.1/pass/response-object-examples.yaml
@@ -1,0 +1,44 @@
+openapi: 3.1.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  responses:
+    complex-object-array:
+      description: A complex object array response
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/VeryComplexType'
+    simple-string:
+      description: A simple string response
+      content:
+        text/plain:
+          schema:
+            type: string
+    plain-text-with-headers:
+      description: A simple string response
+      content:
+        text/plain:
+          schema:
+            type: string
+          example: 'whoa!'
+      headers:
+        X-Rate-Limit-Limit:
+          description: The number of allowed requests in the current period
+          schema:
+            type: integer
+        X-Rate-Limit-Remaining:
+          description: The number of remaining requests in the current period
+          schema:
+            type: integer
+        X-Rate-Limit-Reset:
+          description: The number of seconds left in the current period
+          schema:
+            type: integer
+    no-return-value:
+      description: object created
+  schemas:
+    VeryComplexType: {}

--- a/testdata/conformance/3.1/pass/schema-object-deprecated-example-keyword.yaml
+++ b/testdata/conformance/3.1/pass/schema-object-deprecated-example-keyword.yaml
@@ -1,0 +1,17 @@
+openapi: 3.1.0
+info:
+  title: API
+  version: 1.0.0
+paths:
+  /user:
+    parameters:
+      - in: query
+        name: example
+        schema:
+          # Allow an arbitrary JSON object to keep
+          # the example simple
+          type: object
+          # DEPRECATED: don't use example keyword inside Schema Object
+          example:
+            numbers: [1, 2]
+            flag: null

--- a/testdata/conformance/3.1/pass/schema.yaml
+++ b/testdata/conformance/3.1/pass/schema.yaml
@@ -1,0 +1,55 @@
+openapi: 3.1.0
+info:
+  title: API
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    model:
+      type: object
+      properties:
+        one:
+          description: type array
+          type:
+            - integer
+            - string
+        two:
+          description: type 'null'
+          type: "null"
+        three:
+          description: type array including 'null'
+          type:
+            - string
+            - "null"
+        four:
+          description: array with no items
+          type: array
+        five:
+          description: singular example
+          type: string
+          examples:
+            - exampleValue
+        six:
+          description: exclusiveMinimum true
+          exclusiveMinimum: 10
+        seven:
+          description: exclusiveMinimum false
+          minimum: 10
+        eight:
+          description: exclusiveMaximum true
+          exclusiveMaximum: 20
+        nine:
+          description: exclusiveMaximum false
+          maximum: 20
+        ten:
+          description: nullable string
+          type:
+            - string
+            - "null"
+        eleven:
+          description: x-nullable string
+          type:
+            - string
+            - "null"
+        twelve:
+          description: file/binary

--- a/testdata/conformance/3.1/pass/security-scheme-object-examples.yaml
+++ b/testdata/conformance/3.1/pass/security-scheme-object-examples.yaml
@@ -1,0 +1,59 @@
+openapi: 3.1.0
+info:
+  title: API
+  version: 1.0.0
+security:
+  - basic: []
+  - apiKey: []
+  - JWT-bearer: []
+  - mutualTLS: []
+  - OAuth2:
+      - write:pets
+      - read:pets
+components:
+  securitySchemes:
+    basic:
+      type: http
+      scheme: basic
+    apiKey:
+      type: apiKey
+      name: api-key
+      in: header
+    JWT-bearer:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+    mutualTLS:
+      type: mutualTLS
+      description: Cert must be signed by example.com CA
+    OAuth2:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: https://example.com/api/oauth/dialog
+          scopes:
+            write:pets: modify pets in your account
+            read:pets: read your pets
+          refreshUrl: https://example.com/api/oauth/refresh
+        authorizationCode:
+          authorizationUrl: https://example.com/api/oauth/dialog
+          refreshUrl: https://example.com/api/oauth/refresh
+          tokenUrl: https://example.com/api/oauth/token
+          scopes:
+            write:pets: modify pets in your account
+            read:pets: read your pets
+        password:
+          tokenUrl: https://example.com/api/oauth/token
+          scopes:
+            read:pets: read your pets
+          refreshUrl: https://example.com/api/oauth/refresh
+        clientCredentials:
+          tokenUrl: https://example.com/api/oauth/token
+          scopes:
+            read:pets: read your pets
+          refreshUrl: https://example.com/api/oauth/refresh
+    OpenIdConnect:
+      type: openIdConnect
+      openIdConnectUrl: https://example.com/api/oauth/openid
+    external:
+      $ref: 'https://example.com/api/openapi.json#/components/externalDocs/ThingExternalDocs'

--- a/testdata/conformance/3.1/pass/servers.yaml
+++ b/testdata/conformance/3.1/pass/servers.yaml
@@ -1,0 +1,25 @@
+openapi: 3.1.0
+info:
+  title: API
+  version: 1.0.0
+paths: {}
+servers:
+  - url: /v1
+    description: Run locally.
+  - url: https://production.com/v1
+    description: Run on production server.
+  - url: https://{username}.gigantic-server.com:{port}/{basePath}
+    description: The production API server
+    variables:
+      username:
+        # note! no enum here means it is an open value
+        default: demo
+        description: A user-specific subdomain. Use `demo` for a free sandbox environment.
+      port:
+        enum:
+          - '8443'
+          - '443'
+        default: '8443'
+      basePath:
+        # open meaning there is the opportunity to use special base paths as assigned by the provider, default is `v2`
+        default: v2

--- a/testdata/conformance/3.1/pass/specification-extensions.yaml
+++ b/testdata/conformance/3.1/pass/specification-extensions.yaml
@@ -1,0 +1,6 @@
+openapi: 3.1.0
+info:
+  title: API
+  version: 1.0.0
+paths: {}
+x-tensions: specification extensions are prefixed with `x-`

--- a/testdata/conformance/3.1/pass/style-defaults.yaml
+++ b/testdata/conformance/3.1/pass/style-defaults.yaml
@@ -1,0 +1,102 @@
+openapi: 3.1.0
+info:
+  title: various permutations of parameter objects, with non-required values left to their defaults
+  version: 1.0.0
+components:
+  parameters:
+    encoding_object_defaults:
+      name: encoding_object_defaults
+      in: path
+      content:
+        encoding_object_defaults:   # media type name
+          encoding:
+            no_styles:              # property name
+              x-comment: "style, explode and allowReserved are not present, so contentType is used; no defaults expected as default contentType cannot be determined by the schema"
+            style_form:
+              x-comment: "expecting defaults: explode=true, allowReserved=false"
+              style: form
+            style_spaceDelimited:
+              x-comment: "expecting defaults: explode=false, allowReserved=false"
+              style: spaceDelimited
+            explode:
+              x-comment: "expecting defaults: style=form, allowReserved=false"
+              explode: false
+            allowReserved:
+              x-comment: "expecting default: style=form, explode=true"
+              allowReserved: true
+    path_media_type:
+      x-comment: "expecting defaults: deprecated=false"
+      name: path_media-type
+      in: path
+      required: true
+      content:
+        text/*:
+          schema: {}
+    path_simple:
+      x-comment: "expecting defaults: deprecated=false, style=simple, explode=false, allowReserved=false"
+      name: path_simple
+      in: path
+      required: true
+      schema: {}
+    path_matrix:
+      x-comment: "expecting defaults: deprecated=false, explode=false, allowReserved=false"
+      name: path_matrix
+      in: path
+      required: true
+      style: matrix
+      schema: {}
+    path_label:
+      x-comment: "expecting defaults: deprecated=false, explode=false, allowReserved=false"
+      name: path_label
+      in: path
+      required: true
+      style: label
+      schema: {}
+    query_media_type:
+      x-comment: "expecting defaults: required=false, deprecated=false, allowEmptyValue=false"
+      name: query_media_type
+      in: query
+      content:
+        text/*:
+          schema: {}
+    query_form:
+      x-comment: "expecting defaults: required=false, deprecated=false, allowEmptyValue=false, style=form, explode=true, allowReserved=false"
+      name: query_form
+      in: query
+      schema: {}
+    query_spaceDelimited:
+      x-comment: "expecting defaults: required=false, deprecated=false, allowEmptyValue=false, explode=false, allowReserved=false"
+      name: query_spaceDelimited
+      in: query
+      style: spaceDelimited
+      schema: {}
+    query_pipeDelimited:
+      x-comment: "expecting defaults: required=false, deprecated=false, allowEmptyValue=false, explode=false, allowReserved=false"
+      name: query_pipeDelimited
+      in: query
+      style: pipeDelimited
+      schema: {}
+    query_deepObject:
+      x-comment: "expecting defaults: required=false, deprecated=false, allowEmptyValue=false, allowReserved=false"
+      name: query_deepObject
+      in: query
+      style: deepObject
+      schema: {}
+    header:
+      x-comment: "expecting defaults: deprecated=false, style=simple, explode=false, allowReserved=false"
+      name: header
+      in: path
+      required: true
+      schema: {}
+    cookie_media_type:
+      x-comment: "expecting defaults: required=false, deprecated=false"
+      name: cookie_media_type
+      in: cookie
+      content:
+        text/*:
+          schema: {}
+    cookie_form:
+      x-comment: "expecting defaults: required=false, deprecated=false, style=form, explode=true, allowReserved=false"
+      name: cookie_form
+      in: cookie
+      schema: {}

--- a/testdata/conformance/3.1/pass/tag-object-example.yaml
+++ b/testdata/conformance/3.1/pass/tag-object-example.yaml
@@ -1,0 +1,15 @@
+openapi: 3.1.0
+info:
+  title: API
+  version: 1.0.0
+paths: {}
+tags:
+
+  - name: pet
+    description: Pets operations
+
+  - name: external
+    description: Operations available to external consumers
+    externalDocs:
+      description: Find more info here
+      url: https://example.com

--- a/testdata/conformance/3.1/pass/valid_schema_types.yaml
+++ b/testdata/conformance/3.1/pass/valid_schema_types.yaml
@@ -1,0 +1,13 @@
+openapi: 3.1.1
+
+# this example shows that top-level schemaObjects MAY be booleans
+
+info:
+  title: API
+  version: 1.0.0
+components:
+  schemas:
+    anything_boolean: true
+    nothing_boolean: false
+    anything_object: {}
+    nothing_object: { not: {} }

--- a/testdata/conformance/3.1/pass/webhook-example.yaml
+++ b/testdata/conformance/3.1/pass/webhook-example.yaml
@@ -1,0 +1,34 @@
+openapi: 3.1.0
+info:
+  title: Webhook Example
+  version: 1.0.0
+# Since OAS 3.1.0 the paths element isn't necessary. Now a valid OpenAPI Document can describe only paths, webhooks, or even only reusable components
+webhooks:
+  # Each webhook needs a name
+  newPet:
+    # This is a Path Item Object, the only difference is that the request is initiated by the API provider
+    post:
+      requestBody:
+        description: Information about a new pet in the system
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+      responses:
+        "200":
+          description: Return a 200 status to indicate that the data was received successfully
+
+components:
+  schemas:
+    Pet:
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string

--- a/testdata/conformance/3.2/fail/encoding-enc-item-exclusion.yaml
+++ b/testdata/conformance/3.2/fail/encoding-enc-item-exclusion.yaml
@@ -1,0 +1,13 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  requestBodies:
+    encoding-with-prefixEncoding-not-allowed:
+      content:
+        multipart/mixed:
+          prefixEncoding:
+          - contentType: multipart/mixed
+            encoding: {}
+            prefixEncoding: []

--- a/testdata/conformance/3.2/fail/encoding-enc-prefix-exclusion.yaml
+++ b/testdata/conformance/3.2/fail/encoding-enc-prefix-exclusion.yaml
@@ -1,0 +1,13 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  requestBodies:
+    encoding-with-itemEncoding-not-allowed:
+      content:
+        multipart/mixed:
+          prefixEncoding:
+          - contentType: multipart/mixed
+            encoding: {}
+            itemEncoding: []

--- a/testdata/conformance/3.2/fail/example-examples.yaml
+++ b/testdata/conformance/3.2/fail/example-examples.yaml
@@ -1,0 +1,17 @@
+openapi: 3.2.0
+
+# this example should fail, as example cannot be used together with examples.
+
+info:
+  title: API
+  version: 1.0.0
+components:
+  parameters:
+    animal:
+      name: animal
+      in: header
+      schema: {}
+      example: bear
+      examples:
+        a mammalian example:
+          dataValue: bear

--- a/testdata/conformance/3.2/fail/example-object-old-exclusions.yaml
+++ b/testdata/conformance/3.2/fail/example-object-old-exclusions.yaml
@@ -1,0 +1,10 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+
+components:
+  examples:
+    CannotHaveBoth:
+      value: foo
+      externalValue: https://example.com/foo

--- a/testdata/conformance/3.2/fail/example-object-old-vs-data.yaml
+++ b/testdata/conformance/3.2/fail/example-object-old-vs-data.yaml
@@ -1,0 +1,10 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+
+components:
+  examples:
+    NoValueWithDataValue:
+      value: foo
+      dataValue: foo

--- a/testdata/conformance/3.2/fail/example-object-old-vs-ser.yaml
+++ b/testdata/conformance/3.2/fail/example-object-old-vs-ser.yaml
@@ -1,0 +1,10 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+
+components:
+  examples:
+    CannotHaveBoth:
+      value: foo
+      serializedValue: foo

--- a/testdata/conformance/3.2/fail/example-object-ser-exclusions.yaml
+++ b/testdata/conformance/3.2/fail/example-object-ser-exclusions.yaml
@@ -1,0 +1,10 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+
+components:
+  examples:
+    CannotHaveBoth:
+      serializedValue: foo
+      externalValue: https://example.com/foo

--- a/testdata/conformance/3.2/fail/header-object-allowReserved.yaml
+++ b/testdata/conformance/3.2/fail/header-object-allowReserved.yaml
@@ -1,0 +1,12 @@
+openapi: 3.2.0
+info:
+  title: allowReserved only permitted with in and style values that percent-encode
+  version: 1.0.0
+components:
+  headers:
+    Style:
+      schema:
+        type: array
+      style: simple
+      explode: true
+      allowReserved: true

--- a/testdata/conformance/3.2/fail/header-object-name.yaml
+++ b/testdata/conformance/3.2/fail/header-object-name.yaml
@@ -1,0 +1,12 @@
+openapi: 3.2.0
+info:
+  title: the header name, as used in serialization, has a constrained syntax
+  version: 1.0.0
+paths:
+  /foo:
+    get:
+      responses:
+        default:
+          headers:
+            'Bad=Header':
+              schema: {}

--- a/testdata/conformance/3.2/fail/invalid_schema_types.yaml
+++ b/testdata/conformance/3.2/fail/invalid_schema_types.yaml
@@ -1,0 +1,12 @@
+openapi: 3.2.0
+
+# this example shows invalid types for the schemaObject
+
+info:
+  title: API
+  version: 1.0.0
+components:
+  schemas:
+    invalid_null: null
+    invalid_number: 0
+    invalid_array: []

--- a/testdata/conformance/3.2/fail/media-type-enc-item-exclusion.yaml
+++ b/testdata/conformance/3.2/fail/media-type-enc-item-exclusion.yaml
@@ -1,0 +1,11 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  requestBodies:
+    encoding-with-itemEncoding-not-allowed:
+      content:
+        multipart/mixed:
+          encoding: {}
+          itemEncoding: {}

--- a/testdata/conformance/3.2/fail/media-type-enc-prefix-exclusion.yaml
+++ b/testdata/conformance/3.2/fail/media-type-enc-prefix-exclusion.yaml
@@ -1,0 +1,11 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  requestBodies:
+    encoding-with-prefixEncoding-not-allowed:
+      content:
+        multipart/mixed:
+          encoding: {}
+          prefixEncoding: []

--- a/testdata/conformance/3.2/fail/no_containers.yaml
+++ b/testdata/conformance/3.2/fail/no_containers.yaml
@@ -1,0 +1,7 @@
+openapi: 3.2.0
+
+# this example should fail as there are no paths, components or webhooks containers (at least one of which must be present)
+
+info:
+  title: API
+  version: 1.0.0

--- a/testdata/conformance/3.2/fail/operation-object-query-with-querystring.yaml
+++ b/testdata/conformance/3.2/fail/operation-object-query-with-querystring.yaml
@@ -1,0 +1,20 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  pathItems:
+    my-path-item:
+      get:
+        description: a query parameter cannot be used together with a querystring parameter
+        parameters:
+          - name: myquerystring
+            in: querystring
+            content:
+              application/json:
+                schema:
+                  type: string
+          - name: myquery
+            in: query
+            schema:
+              type: string

--- a/testdata/conformance/3.2/fail/operation-object-two-querystrings.yaml
+++ b/testdata/conformance/3.2/fail/operation-object-two-querystrings.yaml
@@ -1,0 +1,20 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  pathItems:
+    my-path-item:
+      get:
+        description: querystring cannot be used twice
+        parameters:
+          - name: myquerystring1
+            in: querystring
+            content:
+              application/json:
+                schema: {}
+          - name: myquerystring2
+            in: querystring
+            content:
+              application/json:
+                schema: {}

--- a/testdata/conformance/3.2/fail/parameter-object-content-not-with-style.yaml
+++ b/testdata/conformance/3.2/fail/parameter-object-content-not-with-style.yaml
@@ -1,0 +1,14 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  parameters:
+    content-not-with-style:
+      in: querystring
+      name: json
+      content:
+        application/json:
+          schema:
+            type: object
+      style: simple

--- a/testdata/conformance/3.2/fail/parameter-object-cookie-allowReserved.yaml
+++ b/testdata/conformance/3.2/fail/parameter-object-cookie-allowReserved.yaml
@@ -1,0 +1,12 @@
+openapi: 3.2.0
+info:
+  title: allowReserved only permitted with in and style values that percent-encode
+  version: 1.0.0
+components:
+  parameters:
+    my_cookie:
+      name: my_cookie
+      in: cookie
+      style: cookie
+      allowReserved: true
+      schema: {}

--- a/testdata/conformance/3.2/fail/parameter-object-header-allowReserved.yaml
+++ b/testdata/conformance/3.2/fail/parameter-object-header-allowReserved.yaml
@@ -1,0 +1,11 @@
+openapi: 3.2.0
+info:
+  title: allowReserved only permitted with in and style values that percent-encode
+  version: 1.0.0
+components:
+  parameters:
+    header:
+      name: my-header
+      in: header
+      allowReserved: false
+      schema: {}

--- a/testdata/conformance/3.2/fail/parameter-object-header-name.yaml
+++ b/testdata/conformance/3.2/fail/parameter-object-header-name.yaml
@@ -1,0 +1,10 @@
+openapi: 3.2.0
+info:
+  title: header name has a constrained syntax
+  version: 1.0.0
+components:
+  parameters:
+    BadHeader:
+      name: 'Bad[Header]'
+      in: header
+      schema: {}

--- a/testdata/conformance/3.2/fail/parameter-object-path-name.yaml
+++ b/testdata/conformance/3.2/fail/parameter-object-path-name.yaml
@@ -1,0 +1,10 @@
+openapi: 3.2.0
+info:
+  title: path parameter name has a constrained syntax
+  version: 1.0.0
+components:
+  parameters:
+    BadPath:
+      name: 'Bad{Path}'
+      in: path
+      schema: {}

--- a/testdata/conformance/3.2/fail/parameter-object-querystring-not-with-schema.yaml
+++ b/testdata/conformance/3.2/fail/parameter-object-querystring-not-with-schema.yaml
@@ -1,0 +1,11 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  parameters:
+    querystring-not-with-schema:
+      in: querystring
+      name: json
+      schema:
+        type: object

--- a/testdata/conformance/3.2/fail/path-item-object-conflicting-additional-operation.yaml
+++ b/testdata/conformance/3.2/fail/path-item-object-conflicting-additional-operation.yaml
@@ -1,0 +1,64 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+paths:
+  /pets/{id}:
+    get:
+      description: Returns pets based on ID
+      summary: Find pets by ID
+      operationId: getPetsById
+      responses:
+        '200':
+          description: pet response
+          content:
+            '*/*':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+        default:
+          description: error payload
+          content:
+            text/html:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+    parameters:
+      - name: id
+        in: path
+        description: ID of pet to use
+        required: true
+        schema:
+          type: array
+          items:
+            type: string
+        style: simple
+    additionalOperations:
+      POST:
+        description: Returns pets based on ID
+        summary: Find pets by ID
+        operationId: postPetsById
+        requestBody:
+          description: ID of pet to use
+          required: true
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+        responses:
+          '200':
+            description: pet response
+            content:
+              '*/*':
+                schema:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/Pet'
+          default:
+            description: error payload
+            content:
+              text/html:
+                schema:
+                  $ref: '#/components/schemas/ErrorModel'

--- a/testdata/conformance/3.2/fail/path-item-object-query-with-querystring.yaml
+++ b/testdata/conformance/3.2/fail/path-item-object-query-with-querystring.yaml
@@ -1,0 +1,19 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  pathItems:
+    my-path-item:
+      parameters:
+        - name: myquerystring
+          in: querystring
+          content:
+            application/json:
+              schema:
+                type: string
+        - name: myquery
+          in: query
+          schema:
+            type: string
+      get: {}

--- a/testdata/conformance/3.2/fail/path-item-object-two-querystrings.yaml
+++ b/testdata/conformance/3.2/fail/path-item-object-two-querystrings.yaml
@@ -1,0 +1,20 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  pathItems:
+    my-path-item:
+      description: querystring cannot be used twice
+      parameters:
+        - name: myquerystring1
+          in: querystring
+          content:
+            application/json:
+              schema: {}
+        - name: myquerystring2
+          in: querystring
+          content:
+            application/json:
+              schema: {}
+      get: {}

--- a/testdata/conformance/3.2/fail/server_enum_empty.yaml
+++ b/testdata/conformance/3.2/fail/server_enum_empty.yaml
@@ -1,0 +1,15 @@
+openapi: 3.2.0
+
+# this example should fail as the server variable enum is empty
+# (it also does not contain the default value, but this is not checked by the schema)
+
+info:
+  title: API
+  version: 1.0.0
+servers:
+  - url: https://example.com/{var}
+    variables:
+      var:
+        enum: []
+        default: a
+components: {}

--- a/testdata/conformance/3.2/fail/servers.yaml
+++ b/testdata/conformance/3.2/fail/servers.yaml
@@ -1,0 +1,11 @@
+openapi: 3.2.0
+
+# this example should fail, as servers must be an array, not an object
+
+info:
+  title: API
+  version: 1.0.0
+paths: {}
+servers:
+  url: /v1
+  description: Run locally.

--- a/testdata/conformance/3.2/fail/unknown_container.yaml
+++ b/testdata/conformance/3.2/fail/unknown_container.yaml
@@ -1,0 +1,8 @@
+openapi: 3.2.0
+
+# this example should fail as overlays is not a valid top-level object/keyword
+
+info:
+  title: API
+  version: 1.0.0
+overlays: {}

--- a/testdata/conformance/3.2/fail/xml-attr-exclusion.yaml
+++ b/testdata/conformance/3.2/fail/xml-attr-exclusion.yaml
@@ -1,0 +1,11 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  schemas:
+    Attr:
+      type: string
+      xml:
+        attribute: true
+        nodeType: attribute

--- a/testdata/conformance/3.2/fail/xml-wrapped-exclusion.yaml
+++ b/testdata/conformance/3.2/fail/xml-wrapped-exclusion.yaml
@@ -1,0 +1,11 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  schemas:
+    List:
+      type: array
+      xml:
+        wrapped: true
+        nodeType: element

--- a/testdata/conformance/3.2/pass/callback-object-examples.yaml
+++ b/testdata/conformance/3.2/pass/callback-object-examples.yaml
@@ -1,0 +1,32 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  callbacks:
+    myCallback:
+      '{$request.query.queryUrl}':
+        post:
+          requestBody:
+            description: Callback payload
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/SomePayload'
+          responses:
+            '200':
+              description: callback successfully processed
+    transactionCallback:
+      'http://notificationServer.com?transactionId={$request.body#/id}&email={$request.body#/email}':
+        post:
+          requestBody:
+            description: Callback payload
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/SomePayload'
+          responses:
+            '200':
+              description: callback successfully processed
+  schemas:
+    SomePayload: {}

--- a/testdata/conformance/3.2/pass/comp_pathitems.yaml
+++ b/testdata/conformance/3.2/pass/comp_pathitems.yaml
@@ -1,0 +1,6 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  pathItems: {}

--- a/testdata/conformance/3.2/pass/components-object-example.yaml
+++ b/testdata/conformance/3.2/pass/components-object-example.yaml
@@ -1,0 +1,71 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  schemas:
+    GeneralError:
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string
+    Category:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+    Tag:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+  parameters:
+    skipParam:
+      name: skip
+      in: query
+      description: number of items to skip
+      required: true
+      schema:
+        type: integer
+        format: int32
+    limitParam:
+      name: limit
+      in: query
+      description: max records to return
+      required: true
+      schema:
+        type: integer
+        format: int32
+  responses:
+    NotFound:
+      description: Entity not found.
+    IllegalInput:
+      description: Illegal input for operation.
+    GeneralError:
+      description: General Error
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/GeneralError'
+  securitySchemes:
+    api_key:
+      type: apiKey
+      name: api-key
+      in: header
+    petstore_auth:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: https://example.org/api/oauth/dialog
+          scopes:
+            write:pets: modify pets in your account
+            read:pets: read your pets

--- a/testdata/conformance/3.2/pass/example-object-examples.yaml
+++ b/testdata/conformance/3.2/pass/example-object-examples.yaml
@@ -1,0 +1,70 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  examples:
+    zip-example: {}
+    confirmation-success: {}
+  schemas:
+    SuccessResponse: {}
+    Address: {}
+  requestBodies:
+    with-example:
+      content:
+        'application/json':
+          schema:
+            $ref: '#/components/schemas/Address'
+          examples:
+            foo:
+              summary: A foo example
+              value:
+                foo: bar
+            bar:
+              summary: A bar example
+              value:
+                bar: baz
+        application/xml:
+          examples:
+            xmlExample:
+              summary: This is an example in XML
+              externalValue: https://example.org/examples/address-example.xml
+        text/plain:
+          examples:
+            textExample:
+              summary: This is a text example
+              externalValue: https://foo.bar/examples/address-example.txt
+  parameters:
+    with-example:
+      name: zipCode
+      in: query
+      schema:
+        type: string
+        format: zip-code
+      examples:
+        zip-example:
+          $ref: '#/components/examples/zip-example'
+  responses:
+    '200':
+      description: your car appointment has been booked
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/SuccessResponse'
+          examples:
+            confirmation-success:
+              $ref: '#/components/examples/confirmation-success'
+        application/x-www-form-urlencoded:
+          schema:
+            type: object
+            properties:
+              jsonValue:
+                type: string
+          encoding:
+            jsonValue:
+              contentType: application/json
+          examples:
+            jsonFormValue:
+              description: 'The JSON string "json" as a form value'
+              dataValue: json
+              serializedValue: jsonValue=%22json%22

--- a/testdata/conformance/3.2/pass/header-object-examples.yaml
+++ b/testdata/conformance/3.2/pass/header-object-examples.yaml
@@ -1,0 +1,25 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  headers:
+    X-Rate-Limit-Limit:
+      description: The number of allowed requests in the current period
+      deprecated: false
+      schema:
+        type: integer
+    ETag:
+      required: true
+      content:
+        text/plain:
+          schema:
+            type: string
+            pattern: ^"
+    Reference:
+      $ref: '#/components/headers/ETag'
+    Style:
+      schema:
+        type: array
+      style: simple
+      explode: true

--- a/testdata/conformance/3.2/pass/info-object-example.yaml
+++ b/testdata/conformance/3.2/pass/info-object-example.yaml
@@ -1,0 +1,20 @@
+# including External Documentation Object Example
+openapi: 3.2.0
+$self: https://example.com/openapi
+info:
+  title: Example Pet Store App
+  summary: A pet store manager.
+  description: This is an example server for a pet store.
+  termsOfService: https://example.com/terms/
+  contact:
+    name: API Support
+    url: https://www.example.com/support
+    email: support@example.com
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+  version: 1.0.1
+externalDocs:
+  description: Find more info here
+  url: https://example.com
+components: {}

--- a/testdata/conformance/3.2/pass/info_summary.yaml
+++ b/testdata/conformance/3.2/pass/info_summary.yaml
@@ -1,0 +1,6 @@
+openapi: 3.2.0
+info:
+  title: API
+  summary: My lovely API
+  version: 1.0.0
+components: {}

--- a/testdata/conformance/3.2/pass/json_schema_dialect.yaml
+++ b/testdata/conformance/3.2/pass/json_schema_dialect.yaml
@@ -1,0 +1,15 @@
+openapi: 3.2.0
+info:
+  summary: Testing jsonSchemaDialect
+  title: My API
+  version: 1.0.0
+  license:
+    name: Apache 2.0
+    identifier: Apache-2.0
+jsonSchemaDialect: https://spec.openapis.org/oas/3.2/dialect/WORK-IN-PROGRESS
+components:
+  schemas:
+    WithDollarSchema:
+      $id: "locked-metaschema"
+      $schema: https://spec.openapis.org/oas/3.2/dialect/WORK-IN-PROGRESS
+paths: {}

--- a/testdata/conformance/3.2/pass/license_identifier.yaml
+++ b/testdata/conformance/3.2/pass/license_identifier.yaml
@@ -1,0 +1,9 @@
+openapi: 3.2.0
+info:
+  title: API
+  summary: My lovely API
+  version: 1.0.0
+  license:
+    name: Apache
+    identifier: Apache-2.0
+components: {}

--- a/testdata/conformance/3.2/pass/link-object-examples.yaml
+++ b/testdata/conformance/3.2/pass/link-object-examples.yaml
@@ -1,0 +1,66 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+paths:
+  /users/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        description: the user identifier, as userId
+        schema:
+          type: string
+    get:
+      responses:
+        '200':
+          description: the user being returned
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  uuid: # the unique user id
+                    type: string
+                    format: uuid
+          links:
+            address:
+              # the target link operationId
+              operationId: getUserAddress
+              parameters:
+                # get the `id` field from the request path parameter named `id`
+                userid: $request.path.id
+            address2:
+              operationId: getUserAddressByUUID
+              parameters:
+                # get the `uuid` field from the `uuid` field in the response body
+                userUuid: $response.body#/uuid
+            UserRepositories:
+              # returns array of '#/components/schemas/repository'
+              operationRef: '#/paths/~12.0~1repositories~1%7Busername%7D/get'
+              parameters:
+                username: $response.body#/username
+            UserRepositories2:
+              # returns array of '#/components/schemas/repository'
+              operationRef: https://na2.gigantic-server.com/#/paths/~12.0~1repositories~1%7Busername%7D/get
+              parameters:
+                username: $response.body#/username
+            withBody:
+              operationId: queryUserWithBody
+              requestBody:
+                userId: $request.path.id
+  # the path item of the linked operation
+  /users/{userid}/address:
+    parameters:
+      - name: userid
+        in: path
+        required: true
+        description: the user identifier, as userId
+        schema:
+          type: string
+    # linked operation
+    get:
+      operationId: getUserAddress
+      responses:
+        '200':
+          description: the user's address

--- a/testdata/conformance/3.2/pass/media-type-examples.yaml
+++ b/testdata/conformance/3.2/pass/media-type-examples.yaml
@@ -1,0 +1,178 @@
+# including Encoding Object examples
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  examples:
+    frog-example: {}
+  schemas:
+    Address: {}
+    Pet: {}
+  mediaTypes:
+    StreamingPets:
+      description: |
+        Streaming sequence of JSON pet representations,
+        suitable for use with any of the streaming JSON
+        media types.
+      itemSchema:
+        $ref: '#/components/schemas/Pet'
+paths:
+  /something:
+    put:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+            examples:
+              cat:
+                summary: An example of a cat
+                value:
+                  name: Fluffy
+                  petType: Cat
+                  color: White
+                  gender: male
+                  breed: Persian
+              dog:
+                summary: An example of a dog with a cat's name
+                value:
+                  name: Puma
+                  petType: Dog
+                  color: Black
+                  gender: Female
+                  breed: Mixed
+              frog:
+                $ref: '#/components/examples/frog-example'
+          application/jsonl:
+            $ref: '#/components/mediaTypes/StreamingPets'
+          application/x-ndjson:
+            $ref: '#/components/mediaTypes/StreamingPets'
+          application/xml:
+            schema:
+              type: object
+              properties:
+                foo:
+                  type: string
+                  xml:
+                    namespace: https://example.com
+                    prefix: example
+                    name: Foo
+                bar:
+                  type: array
+                  items:
+                    type: number
+                  xml:
+                    wrapped: true
+                attr:
+                  type: string
+                  xml:
+                    attribute: true
+                elementNode:
+                  $ref: "#/components/schemas/Pet"
+                  xml:
+                    nodeType: element
+                attributeNode:
+                  type: string
+                  xml:
+                    nodeType: attribute
+                textNode:
+                  type: string
+                  xml:
+                    nodeType: text
+                cdataNode:
+                  type: string
+                  xml:
+                    nodeType: cdata
+                noneNode:
+                  type: object
+                  xml:
+                    nodeType: none
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: string
+                  format: uuid
+                address:
+                  # complex types are stringified to support RFC 1866
+                  type: object
+                  properties: {}
+                icon:
+                  # The default with "contentEncoding" is application/octet-stream,
+                  # so we need to set image media type(s) in the Encoding Object.
+                  type: string
+                  contentEncoding: base64url
+            encoding:
+              icon:
+                contentType: image/png, image/jpeg
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                id:
+                  # default is `text/plain`
+                  type: string
+                  format: uuid
+                addresses:
+                  # default based on the `items` subschema would be
+                  # `application/json`, but we want these address objects
+                  # serialized as `application/xml` instead
+                  description: addresses in XML format
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/Address'
+                profileImage:
+                  # default is application/octet-stream, but we can declare
+                  # a more specific image type or types
+                  type: string
+                  format: binary
+                forCoverage:
+                  type: string
+                forCoverage2:
+                  type: string
+                nested1:
+                  type: object
+                nested2:
+                  type: array
+            encoding:
+              addresses:
+                # require XML Content-Type in utf-8 encoding
+                # This is applied to each address part corresponding
+                # to each address in he array
+                contentType: application/xml; charset=utf-8
+              profileImage:
+                # only accept png or jpeg
+                contentType: image/png, image/jpeg
+                headers:
+                  X-Rate-Limit-Limit:
+                    description: The number of allowed requests in the current period
+                    schema:
+                      type: integer
+              forCoverage:
+                style: form
+                explode: false
+                allowReserved: true
+              forCoverage2:
+                style: spaceDelimited
+                explode: true
+              nested1:
+                contentType: multipart/form-data
+                encoding:
+                  inner: {}
+              nested2:
+                contentType: multipart/mixed
+                prefixEncoding:
+                - {}
+                itemEncoding: {}
+          multipart/related:
+            schema:
+              type: array
+            itemEncoding:
+              contentType: text/plain
+            prefixEncoding:
+            - headers:
+                Content-Location:
+                  schema:
+                    type: string

--- a/testdata/conformance/3.2/pass/mega.yaml
+++ b/testdata/conformance/3.2/pass/mega.yaml
@@ -1,0 +1,62 @@
+openapi: 3.2.0
+info:
+  summary: My API's summary
+  title: My API
+  version: 1.0.0
+  license:
+    name: Apache 2.0
+    identifier: Apache-2.0
+paths:
+  /:
+    get:
+      parameters: []
+  /{pathTest}: {}
+webhooks:
+  myWebhook:
+    $ref: '#/components/pathItems/myPathItem'
+    description: Overriding description
+components:
+  securitySchemes:
+    mtls:
+      type: mutualTLS
+  schemas:
+    Foo:
+      type: object
+      properties:
+        type:
+          const: foo
+  pathItems:
+    myPathItem:
+      post:
+        requestBody:
+          required: true
+          content:
+            'application/json':
+              schema:
+                externalDocs:
+                  description: More docs!
+                  url: https://example.com/elsewhere.html
+                type: object
+                properties:
+                  type:
+                    type: string
+                  int:
+                    type: integer
+                    exclusiveMaximum: 100
+                    exclusiveMinimum: 0
+                  none:
+                    type: 'null'
+                  arr:
+                    type: array
+                    $comment: Array without items keyword
+                  either:
+                    type: ['string','null']
+                discriminator:
+                  propertyName: type
+                  mapping:
+                    foo: Foo
+                  defaultMapping: Bar
+                  x-extension: true
+                anyOf:
+                - $ref: "#/components/schemas/Foo"
+                myArbitraryKeyword: true

--- a/testdata/conformance/3.2/pass/minimal_comp.yaml
+++ b/testdata/conformance/3.2/pass/minimal_comp.yaml
@@ -1,0 +1,5 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+components: {}

--- a/testdata/conformance/3.2/pass/minimal_hooks.yaml
+++ b/testdata/conformance/3.2/pass/minimal_hooks.yaml
@@ -1,0 +1,5 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+webhooks: {}

--- a/testdata/conformance/3.2/pass/minimal_paths.yaml
+++ b/testdata/conformance/3.2/pass/minimal_paths.yaml
@@ -1,0 +1,5 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+paths: {}

--- a/testdata/conformance/3.2/pass/non-oauth-scopes.yaml
+++ b/testdata/conformance/3.2/pass/non-oauth-scopes.yaml
@@ -1,0 +1,19 @@
+openapi: 3.2.0
+info:
+  title: Non-oAuth Scopes example
+  version: 1.0.0
+paths:
+  /users:
+    get:
+      security:
+        - bearerAuth:
+            - 'read:users'
+            - 'public'
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: jwt
+      description: 'note: non-oauth scopes are not defined at the securityScheme level'
+

--- a/testdata/conformance/3.2/pass/operation-object-example.yaml
+++ b/testdata/conformance/3.2/pass/operation-object-example.yaml
@@ -1,0 +1,47 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+paths:
+  /pets/{id}:
+    put:
+      tags:
+        - pet
+      summary: Updates a pet in the store with form data
+      operationId: updatePetWithForm
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet that needs to be updated
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: Updated name of the pet
+                  type: string
+                status:
+                  description: Updated status of the pet
+                  type: string
+              required:
+                - status
+      responses:
+        '200':
+          description: Pet updated.
+          content:
+            application/json: {}
+            application/xml: {}
+        '405':
+          description: Method Not Allowed
+          content:
+            application/json: {}
+            application/xml: {}
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets

--- a/testdata/conformance/3.2/pass/parameter-object-cookie-form-allowReserved.yaml
+++ b/testdata/conformance/3.2/pass/parameter-object-cookie-form-allowReserved.yaml
@@ -1,0 +1,18 @@
+openapi: 3.2.0
+info:
+  title: allowReserved only permitted with in and style values that percent-encode
+  version: 1.0.0
+components:
+  parameters:
+    style_form:
+      name: my_form_cookie
+      in: cookie
+      # default style is form, therefore allowReserved is allowed
+      allowReserved: true
+      schema: {}
+    style_cookie:
+      name: my_cookie_cookie
+      in: cookie
+      style: cookie
+      # no percent decoding for style=cookie, therefore allowReserved is not allowed
+      schema: {}

--- a/testdata/conformance/3.2/pass/parameter-object-examples.yaml
+++ b/testdata/conformance/3.2/pass/parameter-object-examples.yaml
@@ -1,0 +1,79 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+paths:
+  /user/{username}:
+    parameters:
+      - name: token
+        in: header
+        description: token to be passed as a header
+        required: true
+        explode: false
+        schema:
+          type: array
+          items:
+            type: integer
+            format: int64
+        style: simple
+      - name: usernames
+        in: path
+        description: usernames to fetch
+        required: true
+        explode: false
+        schema:
+          type: array
+      - name: id
+        in: query
+        description: IDs of the object to fetch
+        required: false
+        schema:
+          type: array
+          items:
+            type: string
+        style: form
+        explode: true
+      - in: query
+        name: freeForm
+        schema:
+          type: object
+          additionalProperties:
+            type: integer
+        style: form
+      - in: query
+        name: coordinates
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - lat
+                - long
+              properties:
+                lat:
+                  type: number
+                long:
+                  type: number
+      - in: cookie
+        name: my_cookie1
+        style: form
+        explode: false
+        schema: {}
+      - in: cookie
+        name: my_cookie2
+        style: cookie
+        explode: true
+        schema: {}
+  /user:
+    parameters:
+      - in: querystring
+        name: json
+        content:
+          application/json:
+            schema:
+              # Allow an arbitrary JSON object to keep
+              # the example simple
+              type: object
+            example:
+              numbers: [1, 2]
+              flag: null

--- a/testdata/conformance/3.2/pass/parameter-object-path-allowReserved.yaml
+++ b/testdata/conformance/3.2/pass/parameter-object-path-allowReserved.yaml
@@ -1,0 +1,12 @@
+openapi: 3.2.0
+info:
+  title: api
+  version: 1.0.0
+components:
+  parameters:
+    path:
+      name: my-path
+      in: path
+      required: true
+      allowReserved: false
+      schema: {}

--- a/testdata/conformance/3.2/pass/parameter-object-query-allowReserved.yaml
+++ b/testdata/conformance/3.2/pass/parameter-object-query-allowReserved.yaml
@@ -1,0 +1,11 @@
+openapi: 3.2.0
+info:
+  title: allowReserved only permitted with in and style values that percent-encode
+  version: 1.0.0
+components:
+  parameters:
+    my_query:
+      name: my_query
+      in: query
+      allowReserved: true
+      schema: {}

--- a/testdata/conformance/3.2/pass/path-item-object-example.yaml
+++ b/testdata/conformance/3.2/pass/path-item-object-example.yaml
@@ -1,0 +1,78 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  schemas:
+    Pet: {}
+    ErrorModel: {}
+paths:
+  /pets/{id}:
+    get:
+      description: Returns pets based on ID
+      summary: Find pets by ID
+      operationId: getPetsById
+      responses:
+        '200':
+          description: pet response
+          content:
+            '*/*':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+        default:
+          description: error payload
+          content:
+            text/html:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+    query:
+      description: Returns pets based on ID
+      summary: Find pets by ID
+      operationId: queryPetsById
+      responses:
+        '200':
+          description: pet response
+          content:
+            '*/*':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+        default:
+          description: error payload
+          content:
+            text/html:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+    parameters:
+      - name: id
+        in: path
+        description: ID of pet to use
+        required: true
+        schema:
+          type: array
+          items:
+            type: string
+        style: simple
+    additionalOperations:
+      COPY:
+        description: Copies pet information based on ID
+        summary: Copies pets by ID
+        operationId: copyPetsById
+        responses:
+          '200':
+            description: pet response
+            content:
+              '*/*':
+                schema:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/Pet'
+          default:
+            description: error payload
+            content:
+              text/html:
+                schema:
+                  $ref: '#/components/schemas/ErrorModel'

--- a/testdata/conformance/3.2/pass/path_item_servers_parameters.yaml
+++ b/testdata/conformance/3.2/pass/path_item_servers_parameters.yaml
@@ -1,0 +1,114 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+paths:
+  /things:
+    summary: Lots of things
+    servers:
+      - url: https://things.example.com
+    get:
+      summary: Get a list of things
+      externalDocs:
+        description: Find more info here
+        url: https://example.com
+      parameters:
+        - $ref: '#/components/parameters/biscuit'
+          summary: The maximum number of things to return
+          description: The maximum number of things to return
+      responses:
+        default:
+          description: A list of things
+      servers:
+        - url: https://things.example.com
+    post:
+      deprecated: false
+      requestBody:
+        $ref: '#/components/requestBodies/ThingRequestBody'
+      responses:
+        '201':
+          $ref: '#/components/responses/ThingResponse'
+      callbacks:
+        myCallback:
+          '{$request.query.queryUrl}':
+            post:
+              requestBody:
+                description: Callback payload
+                content:
+                  application/json:
+                    schema:
+                      $ref: '#/components/schemas/SomePayload'
+              responses:
+                '200':
+                  description: callback successfully processed
+        transactionCallback:
+          $ref: '#/components/callbacks/transactionCallback'
+    patch: {}
+    delete: {}
+    head: {}
+    options: {}
+    trace: {}
+components:
+  callbacks:
+    transactionCallback:
+      'http://notificationServer.com?transactionId={$request.body#/id}&email={$request.body#/email}':
+        post:
+          requestBody:
+            description: Callback payload
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/SomePayload'
+          responses:
+            '200':
+              description: callback successfully processed
+  examples:
+    ThingExample:
+      summary: A thing
+      description: A thing
+      value:
+        id: 1
+        name: Thing
+  links:
+    ThingLink:
+      description: A link to a thing
+      operationId: getThing
+      parameters:
+        thingId: '$response.body#/id'
+      server:
+        url: https://things.example.com
+    ThingyLink:
+      $ref: '#/components/links/ThingLink'
+  parameters:
+    limit:
+      name: limit
+      in: query
+      required: false
+      allowEmptyValue: false
+      allowReserved: false
+      deprecated: true
+      description: The maximum number of list items to return
+      schema:
+        type: integer
+        minimum: 0
+    biscuit:
+      name: biscuit
+      in: cookie
+      style: form
+      schema:
+        type: string
+  requestBodies:
+    ThingRequestBody:
+      content:
+        application/json:
+          schema:
+            type: object
+  responses:
+    ThingResponse:
+      description: A thing
+      content:
+        application/json:
+          schema:
+            type: object
+  schemas:
+    SomePayload: {}

--- a/testdata/conformance/3.2/pass/path_no_response.yaml
+++ b/testdata/conformance/3.2/pass/path_no_response.yaml
@@ -1,0 +1,7 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+paths:
+  /:
+    get: {}

--- a/testdata/conformance/3.2/pass/path_var_empty_pathitem.yaml
+++ b/testdata/conformance/3.2/pass/path_var_empty_pathitem.yaml
@@ -1,0 +1,6 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+paths:
+  /{var}: {}

--- a/testdata/conformance/3.2/pass/paths-object-example.yaml
+++ b/testdata/conformance/3.2/pass/paths-object-example.yaml
@@ -1,0 +1,20 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  schemas:
+    pet: {}
+paths:
+  /pets:
+    get:
+      description: Returns all pets from the system that the user has access to
+      responses:
+        '200':
+          description: A list of pets.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/pet'

--- a/testdata/conformance/3.2/pass/request-body-examples.yaml
+++ b/testdata/conformance/3.2/pass/request-body-examples.yaml
@@ -1,0 +1,37 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  schemas:
+    User: {}
+paths:
+  /something:
+    put:
+      requestBody:
+        description: user to add to the system
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/User'
+            examples:
+              user:
+                summary: User example
+                externalValue: https://foo.bar/examples/user-example.json
+          application/xml:
+            schema:
+              $ref: '#/components/schemas/User'
+            examples:
+              user:
+                summary: User example in XML
+                externalValue: https://foo.bar/examples/user-example.xml
+          text/plain:
+            examples:
+              user:
+                summary: User example in plain text
+                externalValue: https://foo.bar/examples/user-example.txt
+          '*/*':
+            examples:
+              user:
+                summary: User example in other format
+                externalValue: https://foo.bar/examples/user-example.whatever

--- a/testdata/conformance/3.2/pass/response-object-examples.yaml
+++ b/testdata/conformance/3.2/pass/response-object-examples.yaml
@@ -1,0 +1,45 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  responses:
+    complex-object-array:
+      summary: Complex object array
+      description: A complex object array response
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/VeryComplexType'
+    simple-string:
+      description: A simple string response
+      content:
+        text/plain:
+          schema:
+            type: string
+    plain-text-with-headers:
+      description: A simple string response
+      content:
+        text/plain:
+          schema:
+            type: string
+          example: 'whoa!'
+      headers:
+        X-Rate-Limit-Limit:
+          description: The number of allowed requests in the current period
+          schema:
+            type: integer
+        X-Rate-Limit-Remaining:
+          description: The number of remaining requests in the current period
+          schema:
+            type: integer
+        X-Rate-Limit-Reset:
+          description: The number of seconds left in the current period
+          schema:
+            type: integer
+    no-return-value:
+      description: object created
+  schemas:
+    VeryComplexType: {}

--- a/testdata/conformance/3.2/pass/schema-object-deprecated-example-keyword.yaml
+++ b/testdata/conformance/3.2/pass/schema-object-deprecated-example-keyword.yaml
@@ -1,0 +1,17 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+paths:
+  /user:
+    parameters:
+      - in: query
+        name: example
+        schema:
+          # Allow an arbitrary JSON object to keep
+          # the example simple
+          type: object
+          # DEPRECATED: don't use example keyword inside Schema Object
+          example:
+            numbers: [1, 2]
+            flag: null

--- a/testdata/conformance/3.2/pass/schema.yaml
+++ b/testdata/conformance/3.2/pass/schema.yaml
@@ -1,0 +1,55 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    model:
+      type: object
+      properties:
+        one:
+          description: type array
+          type:
+            - integer
+            - string
+        two:
+          description: type 'null'
+          type: "null"
+        three:
+          description: type array including 'null'
+          type:
+            - string
+            - "null"
+        four:
+          description: array with no items
+          type: array
+        five:
+          description: singular example
+          type: string
+          examples:
+            - exampleValue
+        six:
+          description: exclusiveMinimum true
+          exclusiveMinimum: 10
+        seven:
+          description: exclusiveMinimum false
+          minimum: 10
+        eight:
+          description: exclusiveMaximum true
+          exclusiveMaximum: 20
+        nine:
+          description: exclusiveMaximum false
+          maximum: 20
+        ten:
+          description: nullable string
+          type:
+            - string
+            - "null"
+        eleven:
+          description: x-nullable string
+          type:
+            - string
+            - "null"
+        twelve:
+          description: file/binary

--- a/testdata/conformance/3.2/pass/security-scheme-object-examples.yaml
+++ b/testdata/conformance/3.2/pass/security-scheme-object-examples.yaml
@@ -1,0 +1,69 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+security:
+  - basic: []
+  - apiKey: []
+  - JWT-bearer: []
+  - mutualTLS: []
+  - OAuth2:
+      - write:pets
+      - read:pets
+components:
+  securitySchemes:
+    basic:
+      type: http
+      scheme: basic
+    apiKey:
+      type: apiKey
+      name: api-key
+      in: header
+    JWT-bearer:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+    mutualTLS:
+      type: mutualTLS
+      description: Cert must be signed by example.com CA
+    OAuth2:
+      type: oauth2
+      oauth2MetadataUrl: https://example.com/api/oauth/metadata
+      flows:
+        authorizationCode:
+          authorizationUrl: https://example.com/api/oauth/dialog
+          refreshUrl: https://example.com/api/oauth/refresh
+          tokenUrl: https://example.com/api/oauth/token
+          scopes:
+            write:pets: modify pets in your account
+            read:pets: read your pets
+        password:
+          tokenUrl: https://example.com/api/oauth/token
+          scopes:
+            read:pets: read your pets
+          refreshUrl: https://example.com/api/oauth/refresh
+        clientCredentials:
+          tokenUrl: https://example.com/api/oauth/token
+          scopes:
+            read:pets: read your pets
+          refreshUrl: https://example.com/api/oauth/refresh
+        deviceAuthorization:
+          deviceAuthorizationUrl: https://example.com/api/oauth/device
+          tokenUrl: https://example.com/api/oauth/token
+          scopes:
+            read:pets: read your pets
+          refreshUrl: https://example.com/api/oauth/refresh
+    OAuth2Old:
+      deprecated: true
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: https://example.com/api/oauth/dialog
+          scopes:
+            read:pets: read your pets
+          refreshUrl: https://example.com/api/oauth/refresh
+    OpenIdConnect:
+      type: openIdConnect
+      openIdConnectUrl: https://example.com/api/oauth/openid
+    external:
+      $ref: 'https://example.com/api/openapi.json#/components/externalDocs/ThingExternalDocs'

--- a/testdata/conformance/3.2/pass/servers.yaml
+++ b/testdata/conformance/3.2/pass/servers.yaml
@@ -1,0 +1,26 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+paths: {}
+servers:
+  - url: /v1
+    description: Run locally.
+    name: local
+  - url: https://production.com/v1
+    description: Run on production server.
+  - url: https://{username}.gigantic-server.com:{port}/{basePath}
+    description: The production API server
+    variables:
+      username:
+        # note! no enum here means it is an open value
+        default: demo
+        description: A user-specific subdomain. Use `demo` for a free sandbox environment.
+      port:
+        enum:
+          - '8443'
+          - '443'
+        default: '8443'
+      basePath:
+        # open meaning there is the opportunity to use special base paths as assigned by the provider, default is `v2`
+        default: v2

--- a/testdata/conformance/3.2/pass/specification-extensions.yaml
+++ b/testdata/conformance/3.2/pass/specification-extensions.yaml
@@ -1,0 +1,6 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+paths: {}
+x-tensions: specification extensions are prefixed with `x-`

--- a/testdata/conformance/3.2/pass/style-defaults.yaml
+++ b/testdata/conformance/3.2/pass/style-defaults.yaml
@@ -1,0 +1,105 @@
+openapi: 3.2.0
+info:
+  title: various permutations of parameter objects, with non-required values left to their defaults
+  version: 1.0.0
+components:
+  mediaTypes:
+    encoding_object_defaults:   # media type name
+      encoding:
+        no_styles:              # property name
+          x-comment: "style, explode and allowReserved are not present, so contentType is used; no defaults expected as default contentType cannot be determined by the schema"
+        style_form:
+          x-comment: "expecting defaults: explode=true, allowReserved=false"
+          style: form
+        style_spaceDelimited:
+          x-comment: "expecting defaults: explode=false, allowReserved=false"
+          style: spaceDelimited
+        explode:
+          x-comment: "expecting defaults: style=form, allowReserved=false"
+          explode: false
+        allowReserved:
+          x-comment: "expecting default: style=form, explode=true"
+          allowReserved: true
+  parameters:
+    path_media_type:
+      x-comment: "expecting defaults: deprecated=false"
+      name: path_media-type
+      in: path
+      required: true
+      content:
+        text/*:
+          schema: {}
+    path_simple:
+      x-comment: "expecting defaults: deprecated=false, style=simple, explode=false, allowReserved=false"
+      name: path_simple
+      in: path
+      required: true
+      schema: {}
+    path_matrix:
+      x-comment: "expecting defaults: deprecated=false, explode=false, allowReserved=false"
+      name: path_matrix
+      in: path
+      required: true
+      style: matrix
+      schema: {}
+    path_label:
+      x-comment: "expecting defaults: deprecated=false, explode=false, allowReserved=false"
+      name: path_label
+      in: path
+      required: true
+      style: label
+      schema: {}
+    query_media_type:
+      x-comment: "expecting defaults: required=false, deprecated=false, allowEmptyValue=false"
+      name: query_media_type
+      in: query
+      content:
+        text/*:
+          schema: {}
+    query_form:
+      x-comment: "expecting defaults: required=false, deprecated=false, allowEmptyValue=false, style=form, explode=true, allowReserved=false"
+      name: query_form
+      in: query
+      schema: {}
+    query_spaceDelimited:
+      x-comment: "expecting defaults: required=false, deprecated=false, allowEmptyValue=false, explode=false, allowReserved=false"
+      name: query_spaceDelimited
+      in: query
+      style: spaceDelimited
+      schema: {}
+    query_pipeDelimited:
+      x-comment: "expecting defaults: required=false, deprecated=false, allowEmptyValue=false, explode=false, allowReserved=false"
+      name: query_pipeDelimited
+      in: query
+      style: pipeDelimited
+      schema: {}
+    query_deepObject:
+      x-comment: "expecting defaults: required=false, deprecated=false, allowEmptyValue=false, allowReserved=false"
+      name: query_deepObject
+      in: query
+      style: deepObject
+      schema: {}
+    header:
+      x-comment: "expecting defaults: deprecated=false, style=simple, explode=false, allowReserved=false"
+      name: header
+      in: path
+      required: true
+      schema: {}
+    cookie_media_type:
+      x-comment: "expecting defaults: required=false, deprecated=false"
+      name: cookie_media_type
+      in: cookie
+      content:
+        text/*:
+          schema: {}
+    cookie_form:
+      x-comment: "expecting defaults: required=false, deprecated=false, style=form, explode=true, allowReserved=false"
+      name: cookie_form
+      in: cookie
+      schema: {}
+    cookie_cookie:
+      x-comment: "expecting defaults: required=false, deprecated=false, explode=true"
+      name: cookie_cookie
+      in: cookie
+      style: cookie
+      schema: {}

--- a/testdata/conformance/3.2/pass/tag-object-example.yaml
+++ b/testdata/conformance/3.2/pass/tag-object-example.yaml
@@ -1,0 +1,25 @@
+openapi: 3.2.0
+info:
+  title: API
+  version: 1.0.0
+paths: {}
+tags:
+
+  - name: account-updates
+    summary: Account Updates
+    description: Account update operations
+    kind: nav
+
+  - name: partner
+    summary: Partner
+    description: Operations available to the partners network
+    parent: external
+    kind: audience
+
+  - name: external
+    summary: External
+    description: Operations available to external consumers
+    kind: audience
+    externalDocs:
+      description: Find more info here
+      url: https://example.com

--- a/testdata/conformance/3.2/pass/valid_schema_types.yaml
+++ b/testdata/conformance/3.2/pass/valid_schema_types.yaml
@@ -1,0 +1,14 @@
+openapi: 3.2.1
+
+# this example shows that top-level schemaObjects MAY be booleans
+
+info:
+  title: API
+  version: 1.0.0
+components:
+  schemas:
+    anything_boolean: true
+    nothing_boolean: false
+    anything_object: {}
+    nothing_object: { not: {} }
+

--- a/testdata/conformance/3.2/pass/webhook-example.yaml
+++ b/testdata/conformance/3.2/pass/webhook-example.yaml
@@ -1,0 +1,35 @@
+openapi: 3.2.0
+info:
+  title: Webhook Example
+  version: 1.0.0
+# Since OAS 3.1.0 the paths element isn't necessary. Now a valid OpenAPI Document can describe only paths, webhooks, or even only reusable components
+webhooks:
+  # Each webhook needs a name
+  newPet:
+    # This is a Path Item Object, the only difference is that the request is initiated by the API provider
+    post:
+      requestBody:
+        description: Information about a new pet in the system
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+      responses:
+        "200":
+          description: Return a 200 status to indicate that the data was received successfully
+
+components:
+  schemas:
+    Pet:
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+

--- a/testdata/conformance/3.3/fail/discriminator-object-unexpected-property.yaml
+++ b/testdata/conformance/3.3/fail/discriminator-object-unexpected-property.yaml
@@ -1,0 +1,11 @@
+openapi: 3.3.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  schemas:
+    discriminator-with-unevaluated-properties:
+      type: object
+      discriminator:
+        propertyName: foo
+        not-allowed: here

--- a/testdata/conformance/3.3/fail/encoding-enc-item-exclusion.yaml
+++ b/testdata/conformance/3.3/fail/encoding-enc-item-exclusion.yaml
@@ -1,0 +1,13 @@
+openapi: 3.3.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  requestBodies:
+    encoding-with-prefixEncoding-not-allowed:
+      content:
+        multipart/mixed:
+          prefixEncoding:
+          - contentType: multipart/mixed
+            encoding: {}
+            prefixEncoding: []

--- a/testdata/conformance/3.3/fail/encoding-enc-prefix-exclusion.yaml
+++ b/testdata/conformance/3.3/fail/encoding-enc-prefix-exclusion.yaml
@@ -1,0 +1,13 @@
+openapi: 3.3.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  requestBodies:
+    encoding-with-itemEncoding-not-allowed:
+      content:
+        multipart/mixed:
+          prefixEncoding:
+          - contentType: multipart/mixed
+            encoding: {}
+            itemEncoding: []

--- a/testdata/conformance/3.3/fail/example-examples.yaml
+++ b/testdata/conformance/3.3/fail/example-examples.yaml
@@ -1,0 +1,17 @@
+openapi: 3.3.0
+
+# this example should fail, as example cannot be used together with examples.
+
+info:
+  title: API
+  version: 1.0.0
+components:
+  parameters:
+    animal:
+      name: animal
+      in: header
+      schema: {}
+      example: bear
+      examples:
+        a mammalian example:
+          dataValue: bear

--- a/testdata/conformance/3.3/fail/example-object-old-exclusions.yaml
+++ b/testdata/conformance/3.3/fail/example-object-old-exclusions.yaml
@@ -1,0 +1,10 @@
+openapi: 3.3.0
+info:
+  title: API
+  version: 1.0.0
+
+components:
+  examples:
+    CannotHaveBoth:
+      value: foo
+      externalValue: https://example.com/foo

--- a/testdata/conformance/3.3/fail/example-object-old-vs-data.yaml
+++ b/testdata/conformance/3.3/fail/example-object-old-vs-data.yaml
@@ -1,0 +1,10 @@
+openapi: 3.3.0
+info:
+  title: API
+  version: 1.0.0
+
+components:
+  examples:
+    NoValueWithDataValue:
+      value: foo
+      dataValue: foo

--- a/testdata/conformance/3.3/fail/example-object-old-vs-ser.yaml
+++ b/testdata/conformance/3.3/fail/example-object-old-vs-ser.yaml
@@ -1,0 +1,10 @@
+openapi: 3.3.0
+info:
+  title: API
+  version: 1.0.0
+
+components:
+  examples:
+    CannotHaveBoth:
+      value: foo
+      serializedValue: foo

--- a/testdata/conformance/3.3/fail/example-object-ser-exclusions.yaml
+++ b/testdata/conformance/3.3/fail/example-object-ser-exclusions.yaml
@@ -1,0 +1,10 @@
+openapi: 3.3.0
+info:
+  title: API
+  version: 1.0.0
+
+components:
+  examples:
+    CannotHaveBoth:
+      serializedValue: foo
+      externalValue: https://example.com/foo

--- a/testdata/conformance/3.3/fail/header-object-allowReserved.yaml
+++ b/testdata/conformance/3.3/fail/header-object-allowReserved.yaml
@@ -1,0 +1,12 @@
+openapi: 3.3.0
+info:
+  title: allowReserved only permitted with in and style values that percent-encode
+  version: 1.0.0
+components:
+  headers:
+    Style:
+      schema:
+        type: array
+      style: simple
+      explode: true
+      allowReserved: true

--- a/testdata/conformance/3.3/fail/header-object-name.yaml
+++ b/testdata/conformance/3.3/fail/header-object-name.yaml
@@ -1,0 +1,12 @@
+openapi: 3.3.0
+info:
+  title: the header name, as used in serialization, has a constrained syntax
+  version: 1.0.0
+paths:
+  /foo:
+    get:
+      responses:
+        default:
+          headers:
+            'Bad=Header':
+              schema: {}

--- a/testdata/conformance/3.3/fail/invalid_schema_types.yaml
+++ b/testdata/conformance/3.3/fail/invalid_schema_types.yaml
@@ -1,0 +1,12 @@
+openapi: 3.3.0
+
+# this example shows invalid types for the schemaObject
+
+info:
+  title: API
+  version: 1.0.0
+components:
+  schemas:
+    invalid_null: null
+    invalid_number: 0
+    invalid_array: []

--- a/testdata/conformance/3.3/fail/media-type-enc-item-exclusion.yaml
+++ b/testdata/conformance/3.3/fail/media-type-enc-item-exclusion.yaml
@@ -1,0 +1,11 @@
+openapi: 3.3.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  requestBodies:
+    encoding-with-itemEncoding-not-allowed:
+      content:
+        multipart/mixed:
+          encoding: {}
+          itemEncoding: {}

--- a/testdata/conformance/3.3/fail/media-type-enc-prefix-exclusion.yaml
+++ b/testdata/conformance/3.3/fail/media-type-enc-prefix-exclusion.yaml
@@ -1,0 +1,11 @@
+openapi: 3.3.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  requestBodies:
+    encoding-with-prefixEncoding-not-allowed:
+      content:
+        multipart/mixed:
+          encoding: {}
+          prefixEncoding: []

--- a/testdata/conformance/3.3/fail/no_containers.yaml
+++ b/testdata/conformance/3.3/fail/no_containers.yaml
@@ -1,0 +1,7 @@
+openapi: 3.3.0
+
+# this example should fail as there are no paths, components or webhooks containers (at least one of which must be present)
+
+info:
+  title: API
+  version: 1.0.0

--- a/testdata/conformance/3.3/fail/operation-object-query-with-querystring.yaml
+++ b/testdata/conformance/3.3/fail/operation-object-query-with-querystring.yaml
@@ -1,0 +1,20 @@
+openapi: 3.3.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  pathItems:
+    my-path-item:
+      get:
+        description: a query parameter cannot be used together with a querystring parameter
+        parameters:
+          - name: myquerystring
+            in: querystring
+            content:
+              application/json:
+                schema:
+                  type: string
+          - name: myquery
+            in: query
+            schema:
+              type: string

--- a/testdata/conformance/3.3/fail/operation-object-two-querystrings.yaml
+++ b/testdata/conformance/3.3/fail/operation-object-two-querystrings.yaml
@@ -1,0 +1,20 @@
+openapi: 3.3.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  pathItems:
+    my-path-item:
+      get:
+        description: querystring cannot be used twice
+        parameters:
+          - name: myquerystring1
+            in: querystring
+            content:
+              application/json:
+                schema: {}
+          - name: myquerystring2
+            in: querystring
+            content:
+              application/json:
+                schema: {}

--- a/testdata/conformance/3.3/fail/parameter-object-content-not-with-style.yaml
+++ b/testdata/conformance/3.3/fail/parameter-object-content-not-with-style.yaml
@@ -1,0 +1,14 @@
+openapi: 3.3.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  parameters:
+    content-not-with-style:
+      in: querystring
+      name: json
+      content:
+        application/json:
+          schema:
+            type: object
+      style: simple

--- a/testdata/conformance/3.3/fail/parameter-object-cookie-allowReserved.yaml
+++ b/testdata/conformance/3.3/fail/parameter-object-cookie-allowReserved.yaml
@@ -1,0 +1,12 @@
+openapi: 3.3.0
+info:
+  title: allowReserved only permitted with in and style values that percent-encode
+  version: 1.0.0
+components:
+  parameters:
+    my_cookie:
+      name: my_cookie
+      in: cookie
+      style: cookie
+      allowReserved: true
+      schema: {}

--- a/testdata/conformance/3.3/fail/parameter-object-header-allowReserved.yaml
+++ b/testdata/conformance/3.3/fail/parameter-object-header-allowReserved.yaml
@@ -1,0 +1,11 @@
+openapi: 3.3.0
+info:
+  title: allowReserved only permitted with in and style values that percent-encode
+  version: 1.0.0
+components:
+  parameters:
+    header:
+      name: my-header
+      in: header
+      allowReserved: false
+      schema: {}

--- a/testdata/conformance/3.3/fail/parameter-object-header-name.yaml
+++ b/testdata/conformance/3.3/fail/parameter-object-header-name.yaml
@@ -1,0 +1,10 @@
+openapi: 3.3.0
+info:
+  title: header name has a constrained syntax
+  version: 1.0.0
+components:
+  parameters:
+    BadHeader:
+      name: 'Bad[Header]'
+      in: header
+      schema: {}

--- a/testdata/conformance/3.3/fail/parameter-object-path-name.yaml
+++ b/testdata/conformance/3.3/fail/parameter-object-path-name.yaml
@@ -1,0 +1,10 @@
+openapi: 3.3.0
+info:
+  title: path parameter name has a constrained syntax
+  version: 1.0.0
+components:
+  parameters:
+    BadPath:
+      name: 'Bad{Path}'
+      in: path
+      schema: {}

--- a/testdata/conformance/3.3/fail/parameter-object-querystring-not-with-schema.yaml
+++ b/testdata/conformance/3.3/fail/parameter-object-querystring-not-with-schema.yaml
@@ -1,0 +1,11 @@
+openapi: 3.3.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  parameters:
+    querystring-not-with-schema:
+      in: querystring
+      name: json
+      schema:
+        type: object

--- a/testdata/conformance/3.3/fail/path-item-object-conflicting-additional-operation.yaml
+++ b/testdata/conformance/3.3/fail/path-item-object-conflicting-additional-operation.yaml
@@ -1,0 +1,64 @@
+openapi: 3.3.0
+info:
+  title: API
+  version: 1.0.0
+paths:
+  /pets/{id}:
+    get:
+      description: Returns pets based on ID
+      summary: Find pets by ID
+      operationId: getPetsById
+      responses:
+        '200':
+          description: pet response
+          content:
+            '*/*':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+        default:
+          description: error payload
+          content:
+            text/html:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+    parameters:
+      - name: id
+        in: path
+        description: ID of pet to use
+        required: true
+        schema:
+          type: array
+          items:
+            type: string
+        style: simple
+    additionalOperations:
+      POST:
+        description: Returns pets based on ID
+        summary: Find pets by ID
+        operationId: postPetsById
+        requestBody:
+          description: ID of pet to use
+          required: true
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+        responses:
+          '200':
+            description: pet response
+            content:
+              '*/*':
+                schema:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/Pet'
+          default:
+            description: error payload
+            content:
+              text/html:
+                schema:
+                  $ref: '#/components/schemas/ErrorModel'

--- a/testdata/conformance/3.3/fail/path-item-object-query-with-querystring.yaml
+++ b/testdata/conformance/3.3/fail/path-item-object-query-with-querystring.yaml
@@ -1,0 +1,19 @@
+openapi: 3.3.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  pathItems:
+    my-path-item:
+      parameters:
+        - name: myquerystring
+          in: querystring
+          content:
+            application/json:
+              schema:
+                type: string
+        - name: myquery
+          in: query
+          schema:
+            type: string
+      get: {}

--- a/testdata/conformance/3.3/fail/path-item-object-two-querystrings.yaml
+++ b/testdata/conformance/3.3/fail/path-item-object-two-querystrings.yaml
@@ -1,0 +1,20 @@
+openapi: 3.3.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  pathItems:
+    my-path-item:
+      description: querystring cannot be used twice
+      parameters:
+        - name: myquerystring1
+          in: querystring
+          content:
+            application/json:
+              schema: {}
+        - name: myquerystring2
+          in: querystring
+          content:
+            application/json:
+              schema: {}
+      get: {}

--- a/testdata/conformance/3.3/fail/schema-object-externalDocs-unexpected-property.yaml
+++ b/testdata/conformance/3.3/fail/schema-object-externalDocs-unexpected-property.yaml
@@ -1,0 +1,11 @@
+openapi: 3.3.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  schemas:
+    externalDocs-with-unevaluated-properties:
+      type: object
+      externalDocs:
+        url: https://example.com/docs
+        not-allowed: here

--- a/testdata/conformance/3.3/fail/server_enum_empty.yaml
+++ b/testdata/conformance/3.3/fail/server_enum_empty.yaml
@@ -1,0 +1,15 @@
+openapi: 3.3.0
+
+# this example should fail as the server variable enum is empty
+# (it also does not contain the default value, but this is not checked by the schema)
+
+info:
+  title: API
+  version: 1.0.0
+servers:
+  - url: https://example.com/{var}
+    variables:
+      var:
+        enum: []
+        default: a
+components: {}

--- a/testdata/conformance/3.3/fail/servers.yaml
+++ b/testdata/conformance/3.3/fail/servers.yaml
@@ -1,0 +1,11 @@
+openapi: 3.3.0
+
+# this example should fail, as servers must be an array, not an object
+
+info:
+  title: API
+  version: 1.0.0
+paths: {}
+servers:
+  url: /v1
+  description: Run locally.

--- a/testdata/conformance/3.3/fail/unknown_container.yaml
+++ b/testdata/conformance/3.3/fail/unknown_container.yaml
@@ -1,0 +1,8 @@
+openapi: 3.3.0
+
+# this example should fail as overlays is not a valid top-level object/keyword
+
+info:
+  title: API
+  version: 1.0.0
+overlays: {}

--- a/testdata/conformance/3.3/fail/xml-attr-exclusion.yaml
+++ b/testdata/conformance/3.3/fail/xml-attr-exclusion.yaml
@@ -1,0 +1,11 @@
+openapi: 3.3.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  schemas:
+    Attr:
+      type: string
+      xml:
+        attribute: true
+        nodeType: attribute

--- a/testdata/conformance/3.3/fail/xml-object-unexpected-property.yaml
+++ b/testdata/conformance/3.3/fail/xml-object-unexpected-property.yaml
@@ -1,0 +1,10 @@
+openapi: 3.3.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  schemas:
+    Attr:
+      type: string
+      xml:
+        not-allowed: here

--- a/testdata/conformance/3.3/fail/xml-wrapped-exclusion.yaml
+++ b/testdata/conformance/3.3/fail/xml-wrapped-exclusion.yaml
@@ -1,0 +1,11 @@
+openapi: 3.3.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  schemas:
+    List:
+      type: array
+      xml:
+        wrapped: true
+        nodeType: element

--- a/testdata/conformance/3.3/pass/callback-object-examples.yaml
+++ b/testdata/conformance/3.3/pass/callback-object-examples.yaml
@@ -1,0 +1,32 @@
+openapi: 3.3.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  callbacks:
+    myCallback:
+      '{$request.query.queryUrl}':
+        post:
+          requestBody:
+            description: Callback payload
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/SomePayload'
+          responses:
+            '200':
+              description: callback successfully processed
+    transactionCallback:
+      'http://notificationServer.com?transactionId={$request.body#/id}&email={$request.body#/email}':
+        post:
+          requestBody:
+            description: Callback payload
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/SomePayload'
+          responses:
+            '200':
+              description: callback successfully processed
+  schemas:
+    SomePayload: {}

--- a/testdata/conformance/3.3/pass/comp_pathitems.yaml
+++ b/testdata/conformance/3.3/pass/comp_pathitems.yaml
@@ -1,0 +1,6 @@
+openapi: 3.3.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  pathItems: {}

--- a/testdata/conformance/3.3/pass/components-object-example.yaml
+++ b/testdata/conformance/3.3/pass/components-object-example.yaml
@@ -1,0 +1,71 @@
+openapi: 3.3.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  schemas:
+    GeneralError:
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string
+    Category:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+    Tag:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+  parameters:
+    skipParam:
+      name: skip
+      in: query
+      description: number of items to skip
+      required: true
+      schema:
+        type: integer
+        format: int32
+    limitParam:
+      name: limit
+      in: query
+      description: max records to return
+      required: true
+      schema:
+        type: integer
+        format: int32
+  responses:
+    NotFound:
+      description: Entity not found.
+    IllegalInput:
+      description: Illegal input for operation.
+    GeneralError:
+      description: General Error
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/GeneralError'
+  securitySchemes:
+    api_key:
+      type: apiKey
+      name: api-key
+      in: header
+    petstore_auth:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: https://example.org/api/oauth/dialog
+          scopes:
+            write:pets: modify pets in your account
+            read:pets: read your pets

--- a/testdata/conformance/3.3/pass/example-object-examples.yaml
+++ b/testdata/conformance/3.3/pass/example-object-examples.yaml
@@ -1,0 +1,70 @@
+openapi: 3.3.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  examples:
+    zip-example: {}
+    confirmation-success: {}
+  schemas:
+    SuccessResponse: {}
+    Address: {}
+  requestBodies:
+    with-example:
+      content:
+        'application/json':
+          schema:
+            $ref: '#/components/schemas/Address'
+          examples:
+            foo:
+              summary: A foo example
+              value:
+                foo: bar
+            bar:
+              summary: A bar example
+              value:
+                bar: baz
+        application/xml:
+          examples:
+            xmlExample:
+              summary: This is an example in XML
+              externalValue: https://example.org/examples/address-example.xml
+        text/plain:
+          examples:
+            textExample:
+              summary: This is a text example
+              externalValue: https://foo.bar/examples/address-example.txt
+  parameters:
+    with-example:
+      name: zipCode
+      in: query
+      schema:
+        type: string
+        format: zip-code
+      examples:
+        zip-example:
+          $ref: '#/components/examples/zip-example'
+  responses:
+    '200':
+      description: your car appointment has been booked
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/SuccessResponse'
+          examples:
+            confirmation-success:
+              $ref: '#/components/examples/confirmation-success'
+        application/x-www-form-urlencoded:
+          schema:
+            type: object
+            properties:
+              jsonValue:
+                type: string
+          encoding:
+            jsonValue:
+              contentType: application/json
+          examples:
+            jsonFormValue:
+              description: 'The JSON string "json" as a form value'
+              dataValue: json
+              serializedValue: jsonValue=%22json%22

--- a/testdata/conformance/3.3/pass/header-object-examples.yaml
+++ b/testdata/conformance/3.3/pass/header-object-examples.yaml
@@ -1,0 +1,25 @@
+openapi: 3.3.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  headers:
+    X-Rate-Limit-Limit:
+      description: The number of allowed requests in the current period
+      deprecated: false
+      schema:
+        type: integer
+    ETag:
+      required: true
+      content:
+        text/plain:
+          schema:
+            type: string
+            pattern: ^"
+    Reference:
+      $ref: '#/components/headers/ETag'
+    Style:
+      schema:
+        type: array
+      style: simple
+      explode: true

--- a/testdata/conformance/3.3/pass/info-object-example.yaml
+++ b/testdata/conformance/3.3/pass/info-object-example.yaml
@@ -1,0 +1,20 @@
+# including External Documentation Object Example
+openapi: 3.3.0
+$self: https://example.com/openapi
+info:
+  title: Example Pet Store App
+  summary: A pet store manager.
+  description: This is an example server for a pet store.
+  termsOfService: https://example.com/terms/
+  contact:
+    name: API Support
+    url: https://www.example.com/support
+    email: support@example.com
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+  version: 1.0.1
+externalDocs:
+  description: Find more info here
+  url: https://example.com
+components: {}

--- a/testdata/conformance/3.3/pass/info_summary.yaml
+++ b/testdata/conformance/3.3/pass/info_summary.yaml
@@ -1,0 +1,6 @@
+openapi: 3.3.0
+info:
+  title: API
+  summary: My lovely API
+  version: 1.0.0
+components: {}

--- a/testdata/conformance/3.3/pass/json_schema_dialect.yaml
+++ b/testdata/conformance/3.3/pass/json_schema_dialect.yaml
@@ -1,0 +1,15 @@
+openapi: 3.3.0
+info:
+  summary: Testing jsonSchemaDialect
+  title: My API
+  version: 1.0.0
+  license:
+    name: Apache 2.0
+    identifier: Apache-2.0
+jsonSchemaDialect: https://spec.openapis.org/oas/3.3/dialect/WORK-IN-PROGRESS
+components:
+  schemas:
+    WithDollarSchema:
+      $id: "locked-metaschema"
+      $schema: https://spec.openapis.org/oas/3.3/dialect/WORK-IN-PROGRESS
+paths: {}

--- a/testdata/conformance/3.3/pass/license_identifier.yaml
+++ b/testdata/conformance/3.3/pass/license_identifier.yaml
@@ -1,0 +1,9 @@
+openapi: 3.3.0
+info:
+  title: API
+  summary: My lovely API
+  version: 1.0.0
+  license:
+    name: Apache
+    identifier: Apache-2.0
+components: {}

--- a/testdata/conformance/3.3/pass/link-object-examples.yaml
+++ b/testdata/conformance/3.3/pass/link-object-examples.yaml
@@ -1,0 +1,66 @@
+openapi: 3.3.0
+info:
+  title: API
+  version: 1.0.0
+paths:
+  /users/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        description: the user identifier, as userId
+        schema:
+          type: string
+    get:
+      responses:
+        '200':
+          description: the user being returned
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  uuid: # the unique user id
+                    type: string
+                    format: uuid
+          links:
+            address:
+              # the target link operationId
+              operationId: getUserAddress
+              parameters:
+                # get the `id` field from the request path parameter named `id`
+                userid: $request.path.id
+            address2:
+              operationId: getUserAddressByUUID
+              parameters:
+                # get the `uuid` field from the `uuid` field in the response body
+                userUuid: $response.body#/uuid
+            UserRepositories:
+              # returns array of '#/components/schemas/repository'
+              operationRef: '#/paths/~12.0~1repositories~1%7Busername%7D/get'
+              parameters:
+                username: $response.body#/username
+            UserRepositories2:
+              # returns array of '#/components/schemas/repository'
+              operationRef: https://na2.gigantic-server.com/#/paths/~12.0~1repositories~1%7Busername%7D/get
+              parameters:
+                username: $response.body#/username
+            withBody:
+              operationId: queryUserWithBody
+              requestBody:
+                userId: $request.path.id
+  # the path item of the linked operation
+  /users/{userid}/address:
+    parameters:
+      - name: userid
+        in: path
+        required: true
+        description: the user identifier, as userId
+        schema:
+          type: string
+    # linked operation
+    get:
+      operationId: getUserAddress
+      responses:
+        '200':
+          description: the user's address

--- a/testdata/conformance/3.3/pass/media-type-examples.yaml
+++ b/testdata/conformance/3.3/pass/media-type-examples.yaml
@@ -1,0 +1,178 @@
+# including Encoding Object examples
+openapi: 3.3.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  examples:
+    frog-example: {}
+  schemas:
+    Address: {}
+    Pet: {}
+  mediaTypes:
+    StreamingPets:
+      description: |
+        Streaming sequence of JSON pet representations,
+        suitable for use with any of the streaming JSON
+        media types.
+      itemSchema:
+        $ref: '#/components/schemas/Pet'
+paths:
+  /something:
+    put:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+            examples:
+              cat:
+                summary: An example of a cat
+                value:
+                  name: Fluffy
+                  petType: Cat
+                  color: White
+                  gender: male
+                  breed: Persian
+              dog:
+                summary: An example of a dog with a cat's name
+                value:
+                  name: Puma
+                  petType: Dog
+                  color: Black
+                  gender: Female
+                  breed: Mixed
+              frog:
+                $ref: '#/components/examples/frog-example'
+          application/jsonl:
+            $ref: '#/components/mediaTypes/StreamingPets'
+          application/x-ndjson:
+            $ref: '#/components/mediaTypes/StreamingPets'
+          application/xml:
+            schema:
+              type: object
+              properties:
+                foo:
+                  type: string
+                  xml:
+                    namespace: https://example.com
+                    prefix: example
+                    name: Foo
+                bar:
+                  type: array
+                  items:
+                    type: number
+                  xml:
+                    wrapped: true
+                attr:
+                  type: string
+                  xml:
+                    attribute: true
+                elementNode:
+                  $ref: "#/components/schemas/Pet"
+                  xml:
+                    nodeType: element
+                attributeNode:
+                  type: string
+                  xml:
+                    nodeType: attribute
+                textNode:
+                  type: string
+                  xml:
+                    nodeType: text
+                cdataNode:
+                  type: string
+                  xml:
+                    nodeType: cdata
+                noneNode:
+                  type: object
+                  xml:
+                    nodeType: none
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: string
+                  format: uuid
+                address:
+                  # complex types are stringified to support RFC 1866
+                  type: object
+                  properties: {}
+                icon:
+                  # The default with "contentEncoding" is application/octet-stream,
+                  # so we need to set image media type(s) in the Encoding Object.
+                  type: string
+                  contentEncoding: base64url
+            encoding:
+              icon:
+                contentType: image/png, image/jpeg
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                id:
+                  # default is `text/plain`
+                  type: string
+                  format: uuid
+                addresses:
+                  # default based on the `items` subschema would be
+                  # `application/json`, but we want these address objects
+                  # serialized as `application/xml` instead
+                  description: addresses in XML format
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/Address'
+                profileImage:
+                  # default is application/octet-stream, but we can declare
+                  # a more specific image type or types
+                  type: string
+                  format: binary
+                forCoverage:
+                  type: string
+                forCoverage2:
+                  type: string
+                nested1:
+                  type: object
+                nested2:
+                  type: array
+            encoding:
+              addresses:
+                # require XML Content-Type in utf-8 encoding
+                # This is applied to each address part corresponding
+                # to each address in he array
+                contentType: application/xml; charset=utf-8
+              profileImage:
+                # only accept png or jpeg
+                contentType: image/png, image/jpeg
+                headers:
+                  X-Rate-Limit-Limit:
+                    description: The number of allowed requests in the current period
+                    schema:
+                      type: integer
+              forCoverage:
+                style: form
+                explode: false
+                allowReserved: true
+              forCoverage2:
+                style: spaceDelimited
+                explode: true
+              nested1:
+                contentType: multipart/form-data
+                encoding:
+                  inner: {}
+              nested2:
+                contentType: multipart/mixed
+                prefixEncoding:
+                - {}
+                itemEncoding: {}
+          multipart/related:
+            schema:
+              type: array
+            itemEncoding:
+              contentType: text/plain
+            prefixEncoding:
+            - headers:
+                Content-Location:
+                  schema:
+                    type: string

--- a/testdata/conformance/3.3/pass/mega.yaml
+++ b/testdata/conformance/3.3/pass/mega.yaml
@@ -1,0 +1,62 @@
+openapi: 3.3.0
+info:
+  summary: My API's summary
+  title: My API
+  version: 1.0.0
+  license:
+    name: Apache 2.0
+    identifier: Apache-2.0
+paths:
+  /:
+    get:
+      parameters: []
+  /{pathTest}: {}
+webhooks:
+  myWebhook:
+    $ref: '#/components/pathItems/myPathItem'
+    description: Overriding description
+components:
+  securitySchemes:
+    mtls:
+      type: mutualTLS
+  schemas:
+    Foo:
+      type: object
+      properties:
+        type:
+          const: foo
+  pathItems:
+    myPathItem:
+      post:
+        requestBody:
+          required: true
+          content:
+            'application/json':
+              schema:
+                externalDocs:
+                  description: More docs!
+                  url: https://example.com/elsewhere.html
+                type: object
+                properties:
+                  type:
+                    type: string
+                  int:
+                    type: integer
+                    exclusiveMaximum: 100
+                    exclusiveMinimum: 0
+                  none:
+                    type: 'null'
+                  arr:
+                    type: array
+                    $comment: Array without items keyword
+                  either:
+                    type: ['string','null']
+                discriminator:
+                  propertyName: type
+                  mapping:
+                    foo: Foo
+                  defaultMapping: Bar
+                  x-extension: true
+                anyOf:
+                - $ref: "#/components/schemas/Foo"
+                myArbitraryKeyword: true

--- a/testdata/conformance/3.3/pass/minimal_comp.yaml
+++ b/testdata/conformance/3.3/pass/minimal_comp.yaml
@@ -1,0 +1,5 @@
+openapi: 3.3.0
+info:
+  title: API
+  version: 1.0.0
+components: {}

--- a/testdata/conformance/3.3/pass/minimal_hooks.yaml
+++ b/testdata/conformance/3.3/pass/minimal_hooks.yaml
@@ -1,0 +1,5 @@
+openapi: 3.3.0
+info:
+  title: API
+  version: 1.0.0
+webhooks: {}

--- a/testdata/conformance/3.3/pass/minimal_paths.yaml
+++ b/testdata/conformance/3.3/pass/minimal_paths.yaml
@@ -1,0 +1,5 @@
+openapi: 3.3.0
+info:
+  title: API
+  version: 1.0.0
+paths: {}

--- a/testdata/conformance/3.3/pass/non-oauth-scopes.yaml
+++ b/testdata/conformance/3.3/pass/non-oauth-scopes.yaml
@@ -1,0 +1,19 @@
+openapi: 3.3.0
+info:
+  title: Non-oAuth Scopes example
+  version: 1.0.0
+paths:
+  /users:
+    get:
+      security:
+        - bearerAuth:
+            - 'read:users'
+            - 'public'
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: jwt
+      description: 'note: non-oauth scopes are not defined at the securityScheme level'
+

--- a/testdata/conformance/3.3/pass/operation-object-example.yaml
+++ b/testdata/conformance/3.3/pass/operation-object-example.yaml
@@ -1,0 +1,47 @@
+openapi: 3.3.0
+info:
+  title: API
+  version: 1.0.0
+paths:
+  /pets/{id}:
+    put:
+      tags:
+        - pet
+      summary: Updates a pet in the store with form data
+      operationId: updatePetWithForm
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet that needs to be updated
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: Updated name of the pet
+                  type: string
+                status:
+                  description: Updated status of the pet
+                  type: string
+              required:
+                - status
+      responses:
+        '200':
+          description: Pet updated.
+          content:
+            application/json: {}
+            application/xml: {}
+        '405':
+          description: Method Not Allowed
+          content:
+            application/json: {}
+            application/xml: {}
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets

--- a/testdata/conformance/3.3/pass/parameter-object-cookie-form-allowReserved.yaml
+++ b/testdata/conformance/3.3/pass/parameter-object-cookie-form-allowReserved.yaml
@@ -1,0 +1,18 @@
+openapi: 3.3.0
+info:
+  title: allowReserved only permitted with in and style values that percent-encode
+  version: 1.0.0
+components:
+  parameters:
+    style_form:
+      name: my_form_cookie
+      in: cookie
+      # default style is form, therefore allowReserved is allowed
+      allowReserved: true
+      schema: {}
+    style_cookie:
+      name: my_cookie_cookie
+      in: cookie
+      style: cookie
+      # no percent decoding for style=cookie, therefore allowReserved is not allowed
+      schema: {}

--- a/testdata/conformance/3.3/pass/parameter-object-examples.yaml
+++ b/testdata/conformance/3.3/pass/parameter-object-examples.yaml
@@ -1,0 +1,79 @@
+openapi: 3.3.0
+info:
+  title: API
+  version: 1.0.0
+paths:
+  /user/{username}:
+    parameters:
+      - name: token
+        in: header
+        description: token to be passed as a header
+        required: true
+        explode: false
+        schema:
+          type: array
+          items:
+            type: integer
+            format: int64
+        style: simple
+      - name: usernames
+        in: path
+        description: usernames to fetch
+        required: true
+        explode: false
+        schema:
+          type: array
+      - name: id
+        in: query
+        description: IDs of the object to fetch
+        required: false
+        schema:
+          type: array
+          items:
+            type: string
+        style: form
+        explode: true
+      - in: query
+        name: freeForm
+        schema:
+          type: object
+          additionalProperties:
+            type: integer
+        style: form
+      - in: query
+        name: coordinates
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - lat
+                - long
+              properties:
+                lat:
+                  type: number
+                long:
+                  type: number
+      - in: cookie
+        name: my_cookie1
+        style: form
+        explode: false
+        schema: {}
+      - in: cookie
+        name: my_cookie2
+        style: cookie
+        explode: true
+        schema: {}
+  /user:
+    parameters:
+      - in: querystring
+        name: json
+        content:
+          application/json:
+            schema:
+              # Allow an arbitrary JSON object to keep
+              # the example simple
+              type: object
+            example:
+              numbers: [1, 2]
+              flag: null

--- a/testdata/conformance/3.3/pass/parameter-object-path-allowReserved.yaml
+++ b/testdata/conformance/3.3/pass/parameter-object-path-allowReserved.yaml
@@ -1,0 +1,12 @@
+openapi: 3.3.0
+info:
+  title: api
+  version: 1.0.0
+components:
+  parameters:
+    path:
+      name: my-path
+      in: path
+      required: true
+      allowReserved: false
+      schema: {}

--- a/testdata/conformance/3.3/pass/parameter-object-query-allowReserved.yaml
+++ b/testdata/conformance/3.3/pass/parameter-object-query-allowReserved.yaml
@@ -1,0 +1,11 @@
+openapi: 3.3.0
+info:
+  title: allowReserved only permitted with in and style values that percent-encode
+  version: 1.0.0
+components:
+  parameters:
+    my_query:
+      name: my_query
+      in: query
+      allowReserved: true
+      schema: {}

--- a/testdata/conformance/3.3/pass/path-item-object-example.yaml
+++ b/testdata/conformance/3.3/pass/path-item-object-example.yaml
@@ -1,0 +1,84 @@
+openapi: 3.3.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  schemas:
+    Pet: {}
+    ErrorModel: {}
+  securitySchemes:
+    Basic:
+      type: http
+      scheme: basic
+paths:
+  /pets/{id}:
+    security:
+    - Basic: []
+    get:
+      description: Returns pets based on ID
+      summary: Find pets by ID
+      operationId: getPetsById
+      responses:
+        '200':
+          description: pet response
+          content:
+            '*/*':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+        default:
+          description: error payload
+          content:
+            text/html:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+    query:
+      description: Returns pets based on ID
+      summary: Find pets by ID
+      operationId: queryPetsById
+      responses:
+        '200':
+          description: pet response
+          content:
+            '*/*':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+        default:
+          description: error payload
+          content:
+            text/html:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+    parameters:
+      - name: id
+        in: path
+        description: ID of pet to use
+        required: true
+        schema:
+          type: array
+          items:
+            type: string
+        style: simple
+    additionalOperations:
+      COPY:
+        description: Copies pet information based on ID
+        summary: Copies pets by ID
+        operationId: copyPetsById
+        responses:
+          '200':
+            description: pet response
+            content:
+              '*/*':
+                schema:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/Pet'
+          default:
+            description: error payload
+            content:
+              text/html:
+                schema:
+                  $ref: '#/components/schemas/ErrorModel'

--- a/testdata/conformance/3.3/pass/path_item_servers_parameters.yaml
+++ b/testdata/conformance/3.3/pass/path_item_servers_parameters.yaml
@@ -1,0 +1,114 @@
+openapi: 3.3.0
+info:
+  title: API
+  version: 1.0.0
+paths:
+  /things:
+    summary: Lots of things
+    servers:
+      - url: https://things.example.com
+    get:
+      summary: Get a list of things
+      externalDocs:
+        description: Find more info here
+        url: https://example.com
+      parameters:
+        - $ref: '#/components/parameters/biscuit'
+          summary: The maximum number of things to return
+          description: The maximum number of things to return
+      responses:
+        default:
+          description: A list of things
+      servers:
+        - url: https://things.example.com
+    post:
+      deprecated: false
+      requestBody:
+        $ref: '#/components/requestBodies/ThingRequestBody'
+      responses:
+        '201':
+          $ref: '#/components/responses/ThingResponse'
+      callbacks:
+        myCallback:
+          '{$request.query.queryUrl}':
+            post:
+              requestBody:
+                description: Callback payload
+                content:
+                  application/json:
+                    schema:
+                      $ref: '#/components/schemas/SomePayload'
+              responses:
+                '200':
+                  description: callback successfully processed
+        transactionCallback:
+          $ref: '#/components/callbacks/transactionCallback'
+    patch: {}
+    delete: {}
+    head: {}
+    options: {}
+    trace: {}
+components:
+  callbacks:
+    transactionCallback:
+      'http://notificationServer.com?transactionId={$request.body#/id}&email={$request.body#/email}':
+        post:
+          requestBody:
+            description: Callback payload
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/SomePayload'
+          responses:
+            '200':
+              description: callback successfully processed
+  examples:
+    ThingExample:
+      summary: A thing
+      description: A thing
+      value:
+        id: 1
+        name: Thing
+  links:
+    ThingLink:
+      description: A link to a thing
+      operationId: getThing
+      parameters:
+        thingId: '$response.body#/id'
+      server:
+        url: https://things.example.com
+    ThingyLink:
+      $ref: '#/components/links/ThingLink'
+  parameters:
+    limit:
+      name: limit
+      in: query
+      required: false
+      allowEmptyValue: false
+      allowReserved: false
+      deprecated: true
+      description: The maximum number of list items to return
+      schema:
+        type: integer
+        minimum: 0
+    biscuit:
+      name: biscuit
+      in: cookie
+      style: form
+      schema:
+        type: string
+  requestBodies:
+    ThingRequestBody:
+      content:
+        application/json:
+          schema:
+            type: object
+  responses:
+    ThingResponse:
+      description: A thing
+      content:
+        application/json:
+          schema:
+            type: object
+  schemas:
+    SomePayload: {}

--- a/testdata/conformance/3.3/pass/path_no_response.yaml
+++ b/testdata/conformance/3.3/pass/path_no_response.yaml
@@ -1,0 +1,7 @@
+openapi: 3.3.0
+info:
+  title: API
+  version: 1.0.0
+paths:
+  /:
+    get: {}

--- a/testdata/conformance/3.3/pass/path_var_empty_pathitem.yaml
+++ b/testdata/conformance/3.3/pass/path_var_empty_pathitem.yaml
@@ -1,0 +1,6 @@
+openapi: 3.3.0
+info:
+  title: API
+  version: 1.0.0
+paths:
+  /{var}: {}

--- a/testdata/conformance/3.3/pass/paths-object-example.yaml
+++ b/testdata/conformance/3.3/pass/paths-object-example.yaml
@@ -1,0 +1,20 @@
+openapi: 3.3.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  schemas:
+    pet: {}
+paths:
+  /pets:
+    get:
+      description: Returns all pets from the system that the user has access to
+      responses:
+        '200':
+          description: A list of pets.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/pet'

--- a/testdata/conformance/3.3/pass/request-body-examples.yaml
+++ b/testdata/conformance/3.3/pass/request-body-examples.yaml
@@ -1,0 +1,37 @@
+openapi: 3.3.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  schemas:
+    User: {}
+paths:
+  /something:
+    put:
+      requestBody:
+        description: user to add to the system
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/User'
+            examples:
+              user:
+                summary: User example
+                externalValue: https://foo.bar/examples/user-example.json
+          application/xml:
+            schema:
+              $ref: '#/components/schemas/User'
+            examples:
+              user:
+                summary: User example in XML
+                externalValue: https://foo.bar/examples/user-example.xml
+          text/plain:
+            examples:
+              user:
+                summary: User example in plain text
+                externalValue: https://foo.bar/examples/user-example.txt
+          '*/*':
+            examples:
+              user:
+                summary: User example in other format
+                externalValue: https://foo.bar/examples/user-example.whatever

--- a/testdata/conformance/3.3/pass/response-object-examples.yaml
+++ b/testdata/conformance/3.3/pass/response-object-examples.yaml
@@ -1,0 +1,45 @@
+openapi: 3.3.0
+info:
+  title: API
+  version: 1.0.0
+components:
+  responses:
+    complex-object-array:
+      summary: Complex object array
+      description: A complex object array response
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/VeryComplexType'
+    simple-string:
+      description: A simple string response
+      content:
+        text/plain:
+          schema:
+            type: string
+    plain-text-with-headers:
+      description: A simple string response
+      content:
+        text/plain:
+          schema:
+            type: string
+          example: 'whoa!'
+      headers:
+        X-Rate-Limit-Limit:
+          description: The number of allowed requests in the current period
+          schema:
+            type: integer
+        X-Rate-Limit-Remaining:
+          description: The number of remaining requests in the current period
+          schema:
+            type: integer
+        X-Rate-Limit-Reset:
+          description: The number of seconds left in the current period
+          schema:
+            type: integer
+    no-return-value:
+      description: object created
+  schemas:
+    VeryComplexType: {}

--- a/testdata/conformance/3.3/pass/schema-object-deprecated-example-keyword.yaml
+++ b/testdata/conformance/3.3/pass/schema-object-deprecated-example-keyword.yaml
@@ -1,0 +1,17 @@
+openapi: 3.3.0
+info:
+  title: API
+  version: 1.0.0
+paths:
+  /user:
+    parameters:
+      - in: query
+        name: example
+        schema:
+          # Allow an arbitrary JSON object to keep
+          # the example simple
+          type: object
+          # DEPRECATED: don't use example keyword inside Schema Object
+          example:
+            numbers: [1, 2]
+            flag: null

--- a/testdata/conformance/3.3/pass/schema.yaml
+++ b/testdata/conformance/3.3/pass/schema.yaml
@@ -1,0 +1,55 @@
+openapi: 3.3.0
+info:
+  title: API
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    model:
+      type: object
+      properties:
+        one:
+          description: type array
+          type:
+            - integer
+            - string
+        two:
+          description: type 'null'
+          type: "null"
+        three:
+          description: type array including 'null'
+          type:
+            - string
+            - "null"
+        four:
+          description: array with no items
+          type: array
+        five:
+          description: singular example
+          type: string
+          examples:
+            - exampleValue
+        six:
+          description: exclusiveMinimum true
+          exclusiveMinimum: 10
+        seven:
+          description: exclusiveMinimum false
+          minimum: 10
+        eight:
+          description: exclusiveMaximum true
+          exclusiveMaximum: 20
+        nine:
+          description: exclusiveMaximum false
+          maximum: 20
+        ten:
+          description: nullable string
+          type:
+            - string
+            - "null"
+        eleven:
+          description: x-nullable string
+          type:
+            - string
+            - "null"
+        twelve:
+          description: file/binary

--- a/testdata/conformance/3.3/pass/security-scheme-object-examples.yaml
+++ b/testdata/conformance/3.3/pass/security-scheme-object-examples.yaml
@@ -1,0 +1,69 @@
+openapi: 3.3.0
+info:
+  title: API
+  version: 1.0.0
+security:
+  - basic: []
+  - apiKey: []
+  - JWT-bearer: []
+  - mutualTLS: []
+  - OAuth2:
+      - write:pets
+      - read:pets
+components:
+  securitySchemes:
+    basic:
+      type: http
+      scheme: basic
+    apiKey:
+      type: apiKey
+      name: api-key
+      in: header
+    JWT-bearer:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+    mutualTLS:
+      type: mutualTLS
+      description: Cert must be signed by example.com CA
+    OAuth2:
+      type: oauth2
+      oauth2MetadataUrl: https://example.com/api/oauth/metadata
+      flows:
+        authorizationCode:
+          authorizationUrl: https://example.com/api/oauth/dialog
+          refreshUrl: https://example.com/api/oauth/refresh
+          tokenUrl: https://example.com/api/oauth/token
+          scopes:
+            write:pets: modify pets in your account
+            read:pets: read your pets
+        password:
+          tokenUrl: https://example.com/api/oauth/token
+          scopes:
+            read:pets: read your pets
+          refreshUrl: https://example.com/api/oauth/refresh
+        clientCredentials:
+          tokenUrl: https://example.com/api/oauth/token
+          scopes:
+            read:pets: read your pets
+          refreshUrl: https://example.com/api/oauth/refresh
+        deviceAuthorization:
+          deviceAuthorizationUrl: https://example.com/api/oauth/device
+          tokenUrl: https://example.com/api/oauth/token
+          scopes:
+            read:pets: read your pets
+          refreshUrl: https://example.com/api/oauth/refresh
+    OAuth2Old:
+      deprecated: true
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: https://example.com/api/oauth/dialog
+          scopes:
+            read:pets: read your pets
+          refreshUrl: https://example.com/api/oauth/refresh
+    OpenIdConnect:
+      type: openIdConnect
+      openIdConnectUrl: https://example.com/api/oauth/openid
+    external:
+      $ref: 'https://example.com/api/openapi.json#/components/externalDocs/ThingExternalDocs'

--- a/testdata/conformance/3.3/pass/servers.yaml
+++ b/testdata/conformance/3.3/pass/servers.yaml
@@ -1,0 +1,26 @@
+openapi: 3.3.0
+info:
+  title: API
+  version: 1.0.0
+paths: {}
+servers:
+  - url: /v1
+    description: Run locally.
+    name: local
+  - url: https://production.com/v1
+    description: Run on production server.
+  - url: https://{username}.gigantic-server.com:{port}/{basePath}
+    description: The production API server
+    variables:
+      username:
+        # note! no enum here means it is an open value
+        default: demo
+        description: A user-specific subdomain. Use `demo` for a free sandbox environment.
+      port:
+        enum:
+          - '8443'
+          - '443'
+        default: '8443'
+      basePath:
+        # open meaning there is the opportunity to use special base paths as assigned by the provider, default is `v2`
+        default: v2

--- a/testdata/conformance/3.3/pass/specification-extensions.yaml
+++ b/testdata/conformance/3.3/pass/specification-extensions.yaml
@@ -1,0 +1,6 @@
+openapi: 3.3.0
+info:
+  title: API
+  version: 1.0.0
+paths: {}
+x-tensions: specification extensions are prefixed with `x-`

--- a/testdata/conformance/3.3/pass/style-defaults.yaml
+++ b/testdata/conformance/3.3/pass/style-defaults.yaml
@@ -1,0 +1,105 @@
+openapi: 3.3.0
+info:
+  title: various permutations of parameter objects, with non-required values left to their defaults
+  version: 1.0.0
+components:
+  mediaTypes:
+    encoding_object_defaults:   # media type name
+      encoding:
+        no_styles:              # property name
+          x-comment: "style, explode and allowReserved are not present, so contentType is used; no defaults expected as default contentType cannot be determined by the schema"
+        style_form:
+          x-comment: "expecting defaults: explode=true, allowReserved=false"
+          style: form
+        style_spaceDelimited:
+          x-comment: "expecting defaults: explode=false, allowReserved=false"
+          style: spaceDelimited
+        explode:
+          x-comment: "expecting defaults: style=form, allowReserved=false"
+          explode: false
+        allowReserved:
+          x-comment: "expecting default: style=form, explode=true"
+          allowReserved: true
+  parameters:
+    path_media_type:
+      x-comment: "expecting defaults: deprecated=false"
+      name: path_media-type
+      in: path
+      required: true
+      content:
+        text/*:
+          schema: {}
+    path_simple:
+      x-comment: "expecting defaults: deprecated=false, style=simple, explode=false, allowReserved=false"
+      name: path_simple
+      in: path
+      required: true
+      schema: {}
+    path_matrix:
+      x-comment: "expecting defaults: deprecated=false, explode=false, allowReserved=false"
+      name: path_matrix
+      in: path
+      required: true
+      style: matrix
+      schema: {}
+    path_label:
+      x-comment: "expecting defaults: deprecated=false, explode=false, allowReserved=false"
+      name: path_label
+      in: path
+      required: true
+      style: label
+      schema: {}
+    query_media_type:
+      x-comment: "expecting defaults: required=false, deprecated=false, allowEmptyValue=false"
+      name: query_media_type
+      in: query
+      content:
+        text/*:
+          schema: {}
+    query_form:
+      x-comment: "expecting defaults: required=false, deprecated=false, allowEmptyValue=false, style=form, explode=true, allowReserved=false"
+      name: query_form
+      in: query
+      schema: {}
+    query_spaceDelimited:
+      x-comment: "expecting defaults: required=false, deprecated=false, allowEmptyValue=false, explode=false, allowReserved=false"
+      name: query_spaceDelimited
+      in: query
+      style: spaceDelimited
+      schema: {}
+    query_pipeDelimited:
+      x-comment: "expecting defaults: required=false, deprecated=false, allowEmptyValue=false, explode=false, allowReserved=false"
+      name: query_pipeDelimited
+      in: query
+      style: pipeDelimited
+      schema: {}
+    query_deepObject:
+      x-comment: "expecting defaults: required=false, deprecated=false, allowEmptyValue=false, allowReserved=false"
+      name: query_deepObject
+      in: query
+      style: deepObject
+      schema: {}
+    header:
+      x-comment: "expecting defaults: deprecated=false, style=simple, explode=false, allowReserved=false"
+      name: header
+      in: path
+      required: true
+      schema: {}
+    cookie_media_type:
+      x-comment: "expecting defaults: required=false, deprecated=false"
+      name: cookie_media_type
+      in: cookie
+      content:
+        text/*:
+          schema: {}
+    cookie_form:
+      x-comment: "expecting defaults: required=false, deprecated=false, style=form, explode=true, allowReserved=false"
+      name: cookie_form
+      in: cookie
+      schema: {}
+    cookie_cookie:
+      x-comment: "expecting defaults: required=false, deprecated=false, explode=true"
+      name: cookie_cookie
+      in: cookie
+      style: cookie
+      schema: {}

--- a/testdata/conformance/3.3/pass/tag-object-example.yaml
+++ b/testdata/conformance/3.3/pass/tag-object-example.yaml
@@ -1,0 +1,25 @@
+openapi: 3.3.0
+info:
+  title: API
+  version: 1.0.0
+paths: {}
+tags:
+
+  - name: account-updates
+    summary: Account Updates
+    description: Account update operations
+    kind: nav
+
+  - name: partner
+    summary: Partner
+    description: Operations available to the partners network
+    parent: external
+    kind: audience
+
+  - name: external
+    summary: External
+    description: Operations available to external consumers
+    kind: audience
+    externalDocs:
+      description: Find more info here
+      url: https://example.com

--- a/testdata/conformance/3.3/pass/valid_schema_types.yaml
+++ b/testdata/conformance/3.3/pass/valid_schema_types.yaml
@@ -1,0 +1,14 @@
+openapi: 3.3.987 # non-existing patch version, accepted by the schema
+
+# this example shows that top-level Schema Objects MAY be booleans
+
+info:
+  title: API
+  version: 1.0.0
+components:
+  schemas:
+    anything_boolean: true
+    nothing_boolean: false
+    anything_object: {}
+    nothing_object: { not: {} }
+

--- a/testdata/conformance/3.3/pass/webhook-example.yaml
+++ b/testdata/conformance/3.3/pass/webhook-example.yaml
@@ -1,0 +1,35 @@
+openapi: 3.3.0
+info:
+  title: Webhook Example
+  version: 1.0.0
+# Since OAS 3.1.0 the paths element isn't necessary. Now a valid OpenAPI Document can describe only paths, webhooks, or even only reusable components
+webhooks:
+  # Each webhook needs a name
+  newPet:
+    # This is a Path Item Object, the only difference is that the request is initiated by the API provider
+    post:
+      requestBody:
+        description: Information about a new pet in the system
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+      responses:
+        "200":
+          description: Return a 200 status to indicate that the data was received successfully
+
+components:
+  schemas:
+    Pet:
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+

--- a/testdata/conformance/README.md
+++ b/testdata/conformance/README.md
@@ -7,9 +7,11 @@ upstream branch moved.
 
 - **Source**: <https://github.com/OAI/OpenAPI-Specification>
 - **License**: Apache-2.0, the upstream project's own
-- **Pins**: [sources.txt](sources.txt), one record per version
-- **Refresh**: `make conformance-vendor` re-materializes the tree at those pins;
-  `make conformance-update` moves the pins to each branch's current head
+- **Pins**: [sources.txt](sources.txt), one record per version, carrying the
+  commit, the fixture counts and a digest over every fixture's name and content
+- **Refresh**: `make conformance-vendor` re-materializes the tree at those pins
+  and fails if the result does not match them; `make conformance-update` moves
+  the pins to each branch's current head
 
 ```
 3.0/pass/    3.1/pass/  3.1/fail/    3.2/pass/  3.2/fail/    3.3/pass/  3.3/fail/
@@ -42,15 +44,18 @@ rejection".
 ## Where the fixtures come from
 
 3.1, 3.2 and 3.3 publish `tests/schema/{pass,fail}` on their version branches.
-`main` carries no such tree; its only fixtures are the six archived 3.0 documents
-under `_archive_/schemas/v3.0/pass`, which are vendored here because they exist.
+`main` has a `tests/schema` directory but no `pass` or `fail` beneath it; its
+only fixtures are the six archived 3.0 documents under
+`_archive_/schemas/v3.0/pass`, which are vendored here because they exist.
 
 2.0 publishes no fixtures at all, and none are authored here: a hand-written
 suite would measure this project's reading of the specification rather than OAI's.
 
-Only `.yaml` documents are vendored. Upstream keeps its own JavaScript harness
-beside the fixtures, and 3.3 keeps `minimal-objects.yaml`, a table of object
-stubs rather than an OpenAPI document.
+Only the `pass` and `fail` directories are vendored, so upstream's own JavaScript
+harness and 3.3's `minimal-objects.yaml` (a table of object stubs rather than an
+OpenAPI document) are left behind by directory scope. Nothing else in those two
+directories is filtered out today; the vendor script restricts itself to `.yaml`
+so that a future upstream reshuffle cannot quietly widen what lands here.
 
 ## Known upstream defect
 

--- a/testdata/conformance/README.md
+++ b/testdata/conformance/README.md
@@ -1,0 +1,66 @@
+# OpenAPI Specification conformance suite (vendored)
+
+OAI's own conformance fixtures, vendored at a pinned commit. Unlike
+`testdata/corpus`, which is downloaded and gitignored, these files are committed:
+measuring conformance should need no network, and should not change because an
+upstream branch moved.
+
+- **Source**: <https://github.com/OAI/OpenAPI-Specification>
+- **License**: Apache-2.0, the upstream project's own
+- **Pins**: [sources.txt](sources.txt), one record per version
+- **Refresh**: `make conformance-vendor` re-materializes the tree at those pins;
+  `make conformance-update` moves the pins to each branch's current head
+
+```
+3.0/pass/    3.1/pass/  3.1/fail/    3.2/pass/  3.2/fail/    3.3/pass/  3.3/fail/
+```
+
+## What the suite is an oracle for
+
+The fixtures assert validity **against the published JSON Schema**, not against
+the prose. The upstream directory is `tests/schema`, and the schema's own README
+says it validates only the mandatory aspects of the OAS. A document can therefore
+be a legitimate `pass` fixture while violating a prose MUST that no schema can
+express.
+
+So the suite is sound in the rejection direction and incomplete in the acceptance
+one:
+
+| Result | Reading |
+|---|---|
+| a `fail` fixture that oastools accepts | a gap in oastools |
+| a `pass` fixture that oastools rejects | a triage item, which may be correct |
+
+`3.2/pass/operation-object-example.yaml` is the known case of the second kind. It
+is schema-valid and specification-invalid, violating both path-template parameter
+correspondence and the requirement that a security requirement name a declared
+scheme, so oastools is right to reject it.
+
+The number to watch is not "every pass fixture passes" but "no *unexplained*
+rejection".
+
+## Where the fixtures come from
+
+3.1, 3.2 and 3.3 publish `tests/schema/{pass,fail}` on their version branches.
+`main` carries no such tree; its only fixtures are the six archived 3.0 documents
+under `_archive_/schemas/v3.0/pass`, which are vendored here because they exist.
+
+2.0 publishes no fixtures at all, and none are authored here: a hand-written
+suite would measure this project's reading of the specification rather than OAI's.
+
+Only `.yaml` documents are vendored. Upstream keeps its own JavaScript harness
+beside the fixtures, and 3.3 keeps `minimal-objects.yaml`, a table of object
+stubs rather than an OpenAPI document.
+
+## Known upstream defect
+
+`tests/schema/failparameter-object-path-allowReserved.yaml` on `v3.1-dev` is a
+negative fixture whose path is missing a separator, so it sits beside the `fail`
+directory rather than inside it and upstream's own harness never runs it. It is
+not a copy of `fail/parameter-object-path-allowReserved.yaml`: the skipped file
+sets `required: true`, so `allowReserved` is the only violation it carries, while
+the one that does run omits `required` on an `in: path` parameter and can be
+rejected for that instead.
+
+It is not vendored here, since vendoring a file upstream does not test would
+misrepresent the suite.

--- a/testdata/conformance/sources.txt
+++ b/testdata/conformance/sources.txt
@@ -12,11 +12,17 @@
 # repository: https://github.com/OAI/OpenAPI-Specification
 # license:    Apache-2.0
 #
-# Fixtures live on the version branches; main carries only the archived 3.0 and
-# 2.0 material. 2.0 publishes no fixtures at all and none are authored here.
+# Fixtures live on the version branches; main carries no tests/schema/{pass,fail}
+# tree, only the archived 3.0 documents. 2.0 publishes no fixtures at all and
+# none are authored here.
 #
-# Fields: version ref commit subpath pass fail
-3.0 main 5423da4b0c16a563a7226663018fcd9294be279d _archive_/schemas/v3.0 6 0
-3.1 v3.1-dev 10bb2949c386c88e9a9c1d22b3998d20a8c7ef49 tests/schema 35 11
-3.2 v3.2-dev 70e1e8876d8e2d166696d3f3c642daad85643d9e tests/schema 37 29
-3.3 v3.3-dev f12826523a8fafea73ce133e43401a0d6fef6f4f tests/schema 37 32
+# The digest covers every fixture's name and content for that version, in a
+# byte-stable order. Counts cannot see a fixture edited in place, nor one
+# version's fixtures vendored into another's directory: 3.2 and 3.3 publish the
+# same 37 pass fixture names, and all 37 differ in content.
+#
+# Fields: version ref commit subpath pass fail digest
+3.0 main 5423da4b0c16a563a7226663018fcd9294be279d _archive_/schemas/v3.0 6 0 d1fe82bdd6909d31a6c5f501559ab5a88b9dc9b590adf63fe4054e55bc028fa8
+3.1 v3.1-dev 10bb2949c386c88e9a9c1d22b3998d20a8c7ef49 tests/schema 35 11 fec899a455f8e27a3f0d0f67def33612fb6701df0fb92a55d60abecf3f55ff94
+3.2 v3.2-dev 70e1e8876d8e2d166696d3f3c642daad85643d9e tests/schema 37 29 2975536589fb18e886418b9840f5bc25b10ce411c604af0f3dabf05e98040299
+3.3 v3.3-dev f12826523a8fafea73ce133e43401a0d6fef6f4f tests/schema 37 32 d1a860310479bbe12bb7ff4c3a40be5b26ff7e4b2fe00dfef57ee159375c3c15

--- a/testdata/conformance/sources.txt
+++ b/testdata/conformance/sources.txt
@@ -1,0 +1,22 @@
+# Pinned sources for the vendored OpenAPI Specification conformance suite.
+#
+# Fixtures are vendored at an exact commit, never fetched live: the schemas
+# version independently of the specification and carry a dated $id, and OAI
+# publishes no "latest date" endpoint (OAI/OpenAPI-Specification#4152). Moving a
+# pin is a deliberate act, done with `make conformance-update` and reviewed as a
+# diff.
+#
+# Refresh with `make conformance-vendor`, which re-materializes the tree at the
+# commits below. If the pins have not moved, that leaves no diff.
+#
+# repository: https://github.com/OAI/OpenAPI-Specification
+# license:    Apache-2.0
+#
+# Fixtures live on the version branches; main carries only the archived 3.0 and
+# 2.0 material. 2.0 publishes no fixtures at all and none are authored here.
+#
+# Fields: version ref commit subpath pass fail
+3.0 main 5423da4b0c16a563a7226663018fcd9294be279d _archive_/schemas/v3.0 6 0
+3.1 v3.1-dev 10bb2949c386c88e9a9c1d22b3998d20a8c7ef49 tests/schema 35 11
+3.2 v3.2-dev 70e1e8876d8e2d166696d3f3c642daad85643d9e tests/schema 37 29
+3.3 v3.3-dev f12826523a8fafea73ce133e43401a0d6fef6f4f tests/schema 37 32


### PR DESCRIPTION
Refs #435. Epic B1.

## Why

The conformance numbers that motivated this project were measured against a throwaway clone. Nothing in the repository preserved them, so nothing stopped them regressing, and every measurement since has re-cloned OAI's repository by hand. That workaround is also how a stray `cd` once sent a comment to the wrong public repository.

## What is vendored

187 fixtures, committed rather than downloaded, so measuring conformance needs no network:

| Version | Pass | Fail | Upstream location |
|---|---|---|---|
| 3.0 | 6 | 0 | `_archive_/schemas/v3.0` on `main` |
| 3.1 | 35 | 11 | `tests/schema` on `v3.1-dev` |
| 3.2 | 37 | 29 | `tests/schema` on `v3.2-dev` |
| 3.3 | 37 | 32 | `tests/schema` on `v3.3-dev` |

Counts were verified against upstream rather than taken from the issue, and they match it. 2.0 publishes no fixtures and none are authored here, per D-001: a hand-written 2.0 suite would measure this project's reading of the specification rather than OAI's.

## Pinned by commit, not by branch

The schemas version independently of the specification and carry a dated `$id`, and OAI publishes no endpoint naming the current one ([OAI/OpenAPI-Specification#4152](https://github.com/OAI/OpenAPI-Specification/issues/4152)). Following a branch would mean the suite changed under us with no diff to review.

`testdata/conformance/sources.txt` records the pins and the counts. `make conformance-vendor` re-materializes the tree from them; `make conformance-update` is what moves a pin, and it is always a reviewed diff.

**Re-vendoring is byte-reproducible**: running `make conformance-vendor` against this commit leaves `git status` clean.

## Failing loudly

A short vendor is the failure worth designing against, because it looks exactly like a successful one. That is what #391 and #401 were in `corpus-download`. The script fetches by commit, treats every git failure as fatal, and compares what landed against the recorded counts.

Verified by feeding it a wrong count:

```
error: 3.2: sources.txt records 37/30 pass/fail, upstream gave 37/29
Vendoring failed: the fixture counts do not match sources.txt.
EXIT CODE: 1
```

## The offline guard

`internal/conformance` reads the tree with no network, so `make check` covers it. Counts are the obvious check and are **not sufficient alone**: vendoring one branch into all three version directories would reproduce every recorded count exactly.

What catches that is two fixtures that change sides between versions. 3.2 widened where `allowReserved` may appear, so `parameter-object-path-allowReserved.yaml` and `parameter-object-cookie-form-allowReserved.yaml` are negative fixtures at 3.1 and positive ones at 3.2 and 3.3. A copied branch cannot satisfy both.

## An upstream defect found while vendoring

`tests/schema/failparameter-object-path-allowReserved.yaml` on `v3.1-dev` is a negative fixture whose path is missing a separator, so it sits beside the `fail` directory rather than inside it and upstream's harness never runs it.

It is not a duplicate of `fail/parameter-object-path-allowReserved.yaml`. The skipped file sets `required: true`, so `allowReserved` is the only violation it carries; the one that does run omits `required` on an `in: path` parameter and can therefore be rejected for the wrong reason. Not vendored here, and recorded in the README. Worth reporting upstream separately.

## Scope

The vendor, its refresh and its guard. Running oastools over the fixtures and gating CI on the verdicts is **#436**, which needs a per-fixture expectation rather than a blanket assertion that every `pass` fixture exits zero: `3.2/pass/operation-object-example.yaml` is schema-valid and specification-invalid, and oastools is right to reject it. The README and the package doc both carry that caveat, since it governs how any result here is read.

## Verification

- `make check` green, **10,646 tests**.
- `make conformance-vendor` reproduces the committed tree byte for byte.
- Count mismatch exits non-zero, shown above.
- No behavior change: nothing outside `testdata/`, `scripts/`, `Makefile` and the new internal package is touched.
