### PR TITLE
docs: publish Sourcey-generated agent indexes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,6 +27,11 @@ jobs:
         with:
           python-version: 3.x
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
       - name: Install MkDocs and Material Theme
         run: pip install mkdocs-material mkdocs-exclude
 
@@ -48,6 +53,9 @@ jobs:
         with:
           args: --no-progress docs/
           fail: true
+
+      - name: Generate agent documentation indexes
+        run: npm run generate:llms
 
       - name: Deploy to GitHub Pages
         run: mkdocs gh-deploy --force

--- a/.gitignore
+++ b/.gitignore
@@ -73,9 +73,13 @@ testdata/corpus/*.yml
 # Generated Documentation
 site/
 .tmp/
+.sourcey-dist/
+node_modules/
 docs/LICENSE.md
 docs/CONTRIBUTORS.md
 docs/benchmarks.md
+docs/llms.txt
+docs/llms-full.txt
 docs/packages/
 docs/examples/
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "oastools-docs",
+  "private": true,
+  "scripts": {
+    "build:sourcey": "npx --yes sourcey@3.6.5 build -o .sourcey-dist",
+    "generate:llms": "npm run build:sourcey && node scripts/publish-sourcey-indexes.mjs"
+  }
+}

--- a/scripts/publish-sourcey-indexes.mjs
+++ b/scripts/publish-sourcey-indexes.mjs
@@ -1,0 +1,25 @@
+import { readFile, writeFile } from "node:fs/promises";
+
+// Sourcey uses URL-safe slugs while MkDocs preserves index routes, case, and
+// underscores. Keep the generated content intact and map those exceptional
+// paths to the canonical URLs already served by the oastools documentation.
+const canonicalPaths = new Map([
+  ["/oastools/generator-beyond-boilerplate/", "/oastools/generator_beyond_boilerplate/"],
+  ["/oastools/examples/index/", "/oastools/examples/"],
+  ["/oastools/examples/workflows/index/", "/oastools/examples/workflows/"],
+  ["/oastools/examples/programmatic-api/index/", "/oastools/examples/programmatic-api/"],
+  ["/oastools/examples/walker/index/", "/oastools/examples/walker/"],
+  ["/oastools/examples/petstore/index/", "/oastools/examples/petstore/"],
+  ["/oastools/contributors/", "/oastools/CONTRIBUTORS/"],
+  ["/oastools/license/", "/oastools/LICENSE/"],
+]);
+
+for (const name of ["llms.txt", "llms-full.txt"]) {
+  let content = await readFile(new URL(`../.sourcey-dist/${name}`, import.meta.url), "utf8");
+
+  for (const [generated, canonical] of canonicalPaths) {
+    content = content.replaceAll(generated, canonical);
+  }
+
+  await writeFile(new URL(`../docs/${name}`, import.meta.url), content);
+}

--- a/sourcey.config.ts
+++ b/sourcey.config.ts
@@ -1,0 +1,16 @@
+export default {
+  name: "oastools",
+  repo: "https://github.com/erraggy/oastools",
+  siteUrl: "https://erraggy.github.io",
+  baseUrl: "/oastools",
+  prettyUrls: "slash",
+  navigation: {
+    tabs: [
+      {
+        tab: "Documentation",
+        slug: "",
+        mkdocs: "./mkdocs.yml",
+      },
+    ],
+  },
+};


### PR DESCRIPTION
## Summary

- generate llms.txt and llms-full.txt from the existing MkDocs navigation during the docs deployment
- pin Sourcey CLI 3.6.5 in the build command and keep generated files out of the source branch
- normalize the eight routes where Sourcey slug rules differ from the canonical MkDocs URLs

The existing MkDocs site remains the human-facing documentation. This adds machine-readable indexes at the site root so coding agents can discover the same 54 pages without a separate hosted mirror.

## Validation

- npm run generate:llms
- 54 entries generated from the current prepared docs tree
- all 54 llms.txt targets return HTTP 200 on the canonical oastools documentation site
- clean Sourcey 3.6.5 install audited with zero known vulnerabilities
- git diff --check

## Incentive disclosure

I prepared this in response to a third-party Frantic bounty sponsored by Sourcey's operator. I have not claimed the bounty, and no payment is due unless the change is merged and the indexes are live on the project site. Please assess this solely on whether the generated indexes are useful and the build cost is acceptable for oastools.