### PR TITLE
fix(parser,validator,differ): tell Responses Object keys apart by kind

### DIFF
--- a/differ/responses_default_test.go
+++ b/differ/responses_default_test.go
@@ -27,31 +27,51 @@ func TestDiffResponsesUnifiedObservesDefault(t *testing.T) {
 	}
 
 	tests := []struct {
-		name       string
-		source     *parser.Responses
-		target     *parser.Responses
-		wantPath   string
-		wantType   ChangeType
-		wantNoDiff bool
+		name         string
+		source       *parser.Responses
+		target       *parser.Responses
+		mode         DiffMode
+		wantPath     string
+		wantType     ChangeType
+		wantSeverity *Severity
+		wantNoDiff   bool
 	}{
 		{
-			name:     "default removed",
+			// Graded like a removed success code: the default covers every
+			// code not listed individually, so losing it can leave the
+			// operation with no documented success response at all.
+			name:         "default removed is breaking",
+			source:       withDefault("fallback"),
+			target:       withoutDefault(),
+			mode:         ModeBreaking,
+			wantPath:     "test[default]",
+			wantType:     ChangeTypeRemoved,
+			wantSeverity: SeverityPtr(SeverityError),
+		},
+		{
+			// Still reported outside breaking mode, where severity is not
+			// graded at all: addChange zeroes it for every change.
+			name:     "default removed outside breaking mode",
 			source:   withDefault("fallback"),
 			target:   withoutDefault(),
+			mode:     ModeSimple,
 			wantPath: "test[default]",
 			wantType: ChangeTypeRemoved,
 		},
 		{
-			name:     "default added",
-			source:   withoutDefault(),
-			target:   withDefault("fallback"),
-			wantPath: "test[default]",
-			wantType: ChangeTypeAdded,
+			name:         "default added",
+			source:       withoutDefault(),
+			target:       withDefault("fallback"),
+			mode:         ModeBreaking,
+			wantPath:     "test[default]",
+			wantType:     ChangeTypeAdded,
+			wantSeverity: SeverityPtr(SeverityInfo),
 		},
 		{
 			name:     "default description changed",
 			source:   withDefault("fallback"),
 			target:   withDefault("something else"),
+			mode:     ModeBreaking,
 			wantPath: "test[default].description",
 			wantType: ChangeTypeModified,
 		},
@@ -59,6 +79,7 @@ func TestDiffResponsesUnifiedObservesDefault(t *testing.T) {
 			name:       "default unchanged",
 			source:     withDefault("fallback"),
 			target:     withDefault("fallback"),
+			mode:       ModeBreaking,
 			wantNoDiff: true,
 		},
 	}
@@ -66,7 +87,7 @@ func TestDiffResponsesUnifiedObservesDefault(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			d := New()
-			d.Mode = ModeBreaking
+			d.Mode = tt.mode
 			result := &DiffResult{}
 
 			d.diffResponsesUnified(tt.source, tt.target, "test", result)
@@ -76,15 +97,20 @@ func TestDiffResponsesUnifiedObservesDefault(t *testing.T) {
 				return
 			}
 
-			paths := make([]string, 0, len(result.Changes))
-			found := false
-			for _, c := range result.Changes {
-				paths = append(paths, string(c.Type)+" "+c.Path)
+			seen := make([]string, 0, len(result.Changes))
+			var match *Change
+			for i, c := range result.Changes {
+				seen = append(seen, string(c.Type)+" "+c.Path)
 				if c.Path == tt.wantPath && c.Type == tt.wantType {
-					found = true
+					match = &result.Changes[i]
 				}
 			}
-			assert.True(t, found, "want a %s change at %q; got %v", tt.wantType, tt.wantPath, paths)
+			require.NotNil(t, match, "want a %s change at %q; got %v", tt.wantType, tt.wantPath, seen)
+
+			if tt.wantSeverity != nil {
+				assert.Equal(t, *tt.wantSeverity, match.Severity,
+					"severity of %s at %q", tt.wantType, tt.wantPath)
+			}
 		})
 	}
 }

--- a/differ/responses_default_test.go
+++ b/differ/responses_default_test.go
@@ -1,6 +1,7 @@
 package differ
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -119,27 +120,68 @@ func TestDiffResponsesUnifiedObservesDefault(t *testing.T) {
 // Object itself. They are held apart from the status codes, so the Codes loops
 // do not see them either.
 func TestDiffResponsesUnifiedObservesExtensions(t *testing.T) {
-	source := &parser.Responses{
-		Codes: map[string]*parser.Response{"200": {Description: "OK"}},
-		Extra: map[string]any{"x-note": "one"},
-	}
-	target := &parser.Responses{
-		Codes: map[string]*parser.Response{"200": {Description: "OK"}},
-		Extra: map[string]any{"x-note": "two"},
-	}
-
-	d := New()
-	d.Mode = ModeBreaking
-	result := &DiffResult{}
-
-	d.diffResponsesUnified(source, target, "test", result)
-
-	require.NotEmpty(t, result.Changes, "a changed extension value is a change")
-	found := false
-	for _, c := range result.Changes {
-		if c.Type == ChangeTypeModified {
-			found = true
+	withExtra := func(extra map[string]any) *parser.Responses {
+		return &parser.Responses{
+			Codes: map[string]*parser.Response{"200": {Description: "OK"}},
+			Extra: extra,
 		}
 	}
-	assert.True(t, found, "want the extension reported as modified; got %+v", result.Changes)
+
+	tests := []struct {
+		name       string
+		source     *parser.Responses
+		target     *parser.Responses
+		wantType   ChangeType
+		wantNoDiff bool
+	}{
+		{
+			name:     "extension value modified",
+			source:   withExtra(map[string]any{"x-note": "one"}),
+			target:   withExtra(map[string]any{"x-note": "two"}),
+			wantType: ChangeTypeModified,
+		},
+		{
+			name:     "extension added",
+			source:   withExtra(nil),
+			target:   withExtra(map[string]any{"x-note": "one"}),
+			wantType: ChangeTypeAdded,
+		},
+		{
+			name:     "extension removed",
+			source:   withExtra(map[string]any{"x-note": "one"}),
+			target:   withExtra(nil),
+			wantType: ChangeTypeRemoved,
+		},
+		{
+			name:       "extension unchanged",
+			source:     withExtra(map[string]any{"x-note": "one"}),
+			target:     withExtra(map[string]any{"x-note": "one"}),
+			wantNoDiff: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := New()
+			d.Mode = ModeBreaking
+			result := &DiffResult{}
+
+			d.diffResponsesUnified(tt.source, tt.target, "test", result)
+
+			if tt.wantNoDiff {
+				assert.Empty(t, result.Changes)
+				return
+			}
+
+			seen := make([]string, 0, len(result.Changes))
+			found := false
+			for _, c := range result.Changes {
+				seen = append(seen, string(c.Type)+" "+c.Path)
+				if c.Type == tt.wantType && strings.Contains(c.Path, "x-note") {
+					found = true
+				}
+			}
+			assert.True(t, found, "want a %s change naming x-note; got %v", tt.wantType, seen)
+		})
+	}
 }

--- a/differ/responses_default_test.go
+++ b/differ/responses_default_test.go
@@ -1,0 +1,119 @@
+package differ
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erraggy/oastools/parser"
+)
+
+// TestDiffResponsesUnifiedObservesDefault covers the default response, which
+// has its own field on parser.Responses rather than a Codes entry. A scan of
+// Codes alone cannot see it, so removing one would be reported as no change at
+// all: the two documents would be called identical.
+func TestDiffResponsesUnifiedObservesDefault(t *testing.T) {
+	withDefault := func(description string) *parser.Responses {
+		return &parser.Responses{
+			Default: &parser.Response{Description: description},
+			Codes:   map[string]*parser.Response{"200": {Description: "OK"}},
+		}
+	}
+	withoutDefault := func() *parser.Responses {
+		return &parser.Responses{
+			Codes: map[string]*parser.Response{"200": {Description: "OK"}},
+		}
+	}
+
+	tests := []struct {
+		name       string
+		source     *parser.Responses
+		target     *parser.Responses
+		wantPath   string
+		wantType   ChangeType
+		wantNoDiff bool
+	}{
+		{
+			name:     "default removed",
+			source:   withDefault("fallback"),
+			target:   withoutDefault(),
+			wantPath: "test[default]",
+			wantType: ChangeTypeRemoved,
+		},
+		{
+			name:     "default added",
+			source:   withoutDefault(),
+			target:   withDefault("fallback"),
+			wantPath: "test[default]",
+			wantType: ChangeTypeAdded,
+		},
+		{
+			name:     "default description changed",
+			source:   withDefault("fallback"),
+			target:   withDefault("something else"),
+			wantPath: "test[default].description",
+			wantType: ChangeTypeModified,
+		},
+		{
+			name:       "default unchanged",
+			source:     withDefault("fallback"),
+			target:     withDefault("fallback"),
+			wantNoDiff: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := New()
+			d.Mode = ModeBreaking
+			result := &DiffResult{}
+
+			d.diffResponsesUnified(tt.source, tt.target, "test", result)
+
+			if tt.wantNoDiff {
+				assert.Empty(t, result.Changes)
+				return
+			}
+
+			paths := make([]string, 0, len(result.Changes))
+			found := false
+			for _, c := range result.Changes {
+				paths = append(paths, string(c.Type)+" "+c.Path)
+				if c.Path == tt.wantPath && c.Type == tt.wantType {
+					found = true
+				}
+			}
+			assert.True(t, found, "want a %s change at %q; got %v", tt.wantType, tt.wantPath, paths)
+		})
+	}
+}
+
+// TestDiffResponsesUnifiedObservesExtensions covers extensions on the Responses
+// Object itself. They are held apart from the status codes, so the Codes loops
+// do not see them either.
+func TestDiffResponsesUnifiedObservesExtensions(t *testing.T) {
+	source := &parser.Responses{
+		Codes: map[string]*parser.Response{"200": {Description: "OK"}},
+		Extra: map[string]any{"x-note": "one"},
+	}
+	target := &parser.Responses{
+		Codes: map[string]*parser.Response{"200": {Description: "OK"}},
+		Extra: map[string]any{"x-note": "two"},
+	}
+
+	d := New()
+	d.Mode = ModeBreaking
+	result := &DiffResult{}
+
+	d.diffResponsesUnified(source, target, "test", result)
+
+	require.NotEmpty(t, result.Changes, "a changed extension value is a change")
+	found := false
+	for _, c := range result.Changes {
+		if c.Type == ChangeTypeModified {
+			found = true
+		}
+	}
+	assert.True(t, found, "want the extension reported as modified; got %+v", result.Changes)
+}

--- a/differ/unified_response.go
+++ b/differ/unified_response.go
@@ -235,6 +235,23 @@ func (d *Differ) diffResponsesUnified(source, target *parser.Responses, path str
 		return
 	}
 
+	// Compare the default response, which covers every code not listed
+	// individually. It has its own field rather than a Codes entry, so the
+	// loops below cannot see it.
+	switch {
+	case source.Default != nil && target.Default != nil:
+		d.diffResponseUnified(source.Default, target.Default, path+"[default]", result)
+	case source.Default != nil:
+		d.addChange(result, path+"[default]", ChangeTypeRemoved, CategoryResponse,
+			SeverityWarning, source.Default, nil, "default response removed")
+	case target.Default != nil:
+		d.addChange(result, path+"[default]", ChangeTypeAdded, CategoryResponse,
+			SeverityInfo, nil, target.Default, "default response added")
+	}
+
+	// Compare Responses Object extensions
+	d.diffExtrasUnified(source.Extra, target.Extra, path, result)
+
 	// Compare individual response codes
 	for code, sourceResp := range source.Codes {
 		targetResp, exists := target.Codes[code]

--- a/differ/unified_response.go
+++ b/differ/unified_response.go
@@ -242,8 +242,12 @@ func (d *Differ) diffResponsesUnified(source, target *parser.Responses, path str
 	case source.Default != nil && target.Default != nil:
 		d.diffResponseUnified(source.Default, target.Default, path+"[default]", result)
 	case source.Default != nil:
+		// Removing the default takes the documented behavior of every code not
+		// listed individually with it, including the success case when no 2XX
+		// is declared, so it is graded like a removed success code. The
+		// severity applies in ModeBreaking; addChange discards it otherwise.
 		d.addChange(result, path+"[default]", ChangeTypeRemoved, CategoryResponse,
-			SeverityWarning, source.Default, nil, "default response removed")
+			SeverityError, source.Default, nil, "default response removed")
 	case target.Default != nil:
 		d.addChange(result, path+"[default]", ChangeTypeAdded, CategoryResponse,
 			SeverityInfo, nil, target.Default, "default response added")

--- a/internal/codegen/decode/main.go
+++ b/internal/codegen/decode/main.go
@@ -595,7 +595,7 @@ func (x *Responses) decodeFromMap(m map[string]any) {
 			continue
 		}
 		// A key that is not a status code is kept, not discarded. This method
-		// has no error channel, so validateStructure is what reports it, and
+		// cannot return an error, so validateStructure is what reports it, and
 		// discarding the key here would take the response with it.
 		resp := new(Response)
 		resp.decodeFromMap(sub)

--- a/internal/codegen/decode/main.go
+++ b/internal/codegen/decode/main.go
@@ -579,27 +579,38 @@ func (x *{{.Name}}) decodeFromMap(m map[string]any) {
 }
 {{end}}
 func (x *Responses) decodeFromMap(m map[string]any) {
+	// Every field describes this map alone, so decoding into a reused value
+	// carries nothing forward from the one it held before.
 	x.Codes = make(map[string]*Response)
 	x.Extra = extractExtensionsFromMap(m)
+	x.Default = nil
+
 	for key, value := range m {
 		if isExtensionKey(key) {
 			continue
 		}
-		sub, ok := value.(map[string]any)
-		if !ok {
-			continue
+		sub, isObject := value.(map[string]any)
+		switch {
+		case key == httputil.ResponsesKeyDefault:
+			if isObject {
+				x.Default = new(Response)
+				x.Default.decodeFromMap(sub)
+			}
+		case isObject:
+			// A key that is not a status code is kept, not discarded. This
+			// method cannot return an error, so validateStructure is what
+			// reports it, and discarding the key would take the response too.
+			resp := new(Response)
+			resp.decodeFromMap(sub)
+			x.Codes[key] = resp
+		case !httputil.IsStatusCode(key):
+			// The key is reportable even though its value is not a Response,
+			// so it is kept for validateStructure to name. A well-formed
+			// status code whose value is not an object is left out instead:
+			// nothing here validates the value, and inventing an empty
+			// Response would report a response the document does not declare.
+			x.Codes[key] = new(Response)
 		}
-		if key == httputil.ResponsesKeyDefault {
-			x.Default = new(Response)
-			x.Default.decodeFromMap(sub)
-			continue
-		}
-		// A key that is not a status code is kept, not discarded. This method
-		// cannot return an error, so validateStructure is what reports it, and
-		// discarding the key here would take the response with it.
-		resp := new(Response)
-		resp.decodeFromMap(sub)
-		x.Codes[key] = resp
 	}
 }
 `

--- a/internal/codegen/decode/main.go
+++ b/internal/codegen/decode/main.go
@@ -580,19 +580,26 @@ func (x *{{.Name}}) decodeFromMap(m map[string]any) {
 {{end}}
 func (x *Responses) decodeFromMap(m map[string]any) {
 	x.Codes = make(map[string]*Response)
+	x.Extra = extractExtensionsFromMap(m)
 	for key, value := range m {
+		if isExtensionKey(key) {
+			continue
+		}
 		sub, ok := value.(map[string]any)
 		if !ok {
 			continue
 		}
-		if key == "default" {
+		if key == httputil.ResponsesKeyDefault {
 			x.Default = new(Response)
 			x.Default.decodeFromMap(sub)
-		} else if httputil.ValidateStatusCode(key) {
-			resp := new(Response)
-			resp.decodeFromMap(sub)
-			x.Codes[key] = resp
+			continue
 		}
+		// A key that is not a status code is kept, not discarded. This method
+		// has no error channel, so validateStructure is what reports it, and
+		// discarding the key here would take the response with it.
+		resp := new(Response)
+		resp.decodeFromMap(sub)
+		x.Codes[key] = resp
 	}
 }
 `

--- a/internal/codegen/deepcopy/main.go
+++ b/internal/codegen/deepcopy/main.go
@@ -353,6 +353,7 @@ var typeConfigs = []TypeConfig{
 		Fields: []FieldConfig{
 			{Name: "Default", Type: "*Response", CopyMethod: "pointer"},
 			{Name: "Codes", Type: "map[string]*Response", CopyMethod: "map", KeyType: "string", ElemType: "*Response"},
+			{Name: "Extra", Type: "map[string]any", CopyMethod: "helper", Helper: "deepCopyExtensions"},
 		},
 	},
 	{

--- a/internal/codegen/deepcopy/main.go
+++ b/internal/codegen/deepcopy/main.go
@@ -519,8 +519,14 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Write to file
+	// Write to file. go generate runs this with the working directory set to
+	// the directive's own, which is parser/, so the package directory is only
+	// below the working directory when the generator is run from the module
+	// root. The decode generator probes the same way.
 	outputPath := filepath.Join("parser", "zz_generated_deepcopy.go")
+	if _, err := os.Stat("parser"); os.IsNotExist(err) {
+		outputPath = "zz_generated_deepcopy.go"
+	}
 	if err := os.WriteFile(outputPath, formatted, 0644); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Error writing file: %v\n", err)
 		os.Exit(1)

--- a/internal/driftguard/marshal_test.go
+++ b/internal/driftguard/marshal_test.go
@@ -55,7 +55,17 @@ var marshalMerges = map[string]map[string]string{
 	// marshal paths merge them back. See parser.Callback.
 	"Operation":  {"CallbackRefs": "callbacks"},
 	"Components": {"CallbackRefs": "callbacks"},
+
+	// The Responses Object has no wrapping key of its own: its status codes are
+	// members of the object itself, beside `default`. See parser.Responses.
+	"Responses": {"Codes": mergeIntoEnclosingObject},
 }
+
+// mergeIntoEnclosingObject marks a field whose content is emitted as members of
+// the object being marshaled rather than under a key of its own.
+//
+// It is not a legal JSON member name, so it cannot collide with a real key.
+const mergeIntoEnclosingObject = "."
 
 // marshalSubjects pairs each type carrying a hand-built MarshalJSON with a fresh
 // value and its field list. A guard cannot reflect over a package, so this list
@@ -68,6 +78,7 @@ func marshalSubjects() map[string]func() (any, []field) {
 		"PathItem":       func() (any, []field) { return &parser.PathItem{}, fieldsOf[parser.PathItem]() },
 		"Operation":      func() (any, []field) { return &parser.Operation{}, fieldsOf[parser.Operation]() },
 		"Response":       func() (any, []field) { return &parser.Response{}, fieldsOf[parser.Response]() },
+		"Responses":      func() (any, []field) { return &parser.Responses{}, fieldsOf[parser.Responses]() },
 		"MediaType":      func() (any, []field) { return &parser.MediaType{}, fieldsOf[parser.MediaType]() },
 		"Example":        func() (any, []field) { return &parser.Example{}, fieldsOf[parser.Example]() },
 		"Encoding":       func() (any, []field) { return &parser.Encoding{}, fieldsOf[parser.Encoding]() },
@@ -146,6 +157,16 @@ func runMarshalGuard(t *testing.T, withExtension bool, message string) {
 				// Checked before the json:"-" branch below, which would otherwise
 				// pass it on the strength of its own name being absent.
 				if mergeKey, isMerged := marshalMerges[typeName][f.name]; isMerged {
+					// A field merging into the enclosing object has no wrapping
+					// key, so its members are asserted at this level directly.
+					if mergeKey == mergeIntoEnclosingObject {
+						assert.Contains(t, decoded, markerKey,
+							"%s.%s is set but its content never reached the enclosing "+
+								"object; the merge is missing from this marshal path",
+							typeName, f.name)
+						return
+					}
+
 					require.Contains(t, decoded, mergeKey,
 						"%s.%s merges into %q, but that key was not emitted at all",
 						typeName, f.name, mergeKey)

--- a/internal/driftguard/marshal_test.go
+++ b/internal/driftguard/marshal_test.go
@@ -59,19 +59,20 @@ var marshalMerges = map[string]map[string]string{
 	// The Responses Object has no wrapping key of its own: its status codes are
 	// members of the object itself, beside `default`. See parser.Responses.
 	//
-	// Extra carries no entry because fieldsOf excludes it for every type, so
-	// one here would never be reached. Expressing it would take more than a
-	// registration: the fast-path control marshals through struct tags, which
-	// emit no Extra content at all, so the same assertion cannot hold on both
-	// paths. parser.TestResponsesRoundTripPreservesExtensions covers the merge
-	// for this type in the meantime.
+	// Extra merges the same way but carries no entry, because fieldsOf never
+	// enumerates Extra for any type, so the case would not run and the entry
+	// would read as coverage while asserting nothing. Covering it means
+	// extending field enumeration, which is a change to the guard rather than
+	// to this registration. parser.TestResponsesRoundTripPreservesExtensions
+	// covers the merge for this type in the meantime.
 	"Responses": {"Codes": mergeIntoEnclosingObject},
 }
 
 // mergeIntoEnclosingObject marks a field whose content is emitted as members of
 // the object being marshaled rather than under a key of its own.
 //
-// It is not a legal JSON member name, so it cannot collide with a real key.
+// The value only has to differ from every key a subject can emit, and no OAS
+// field marshals under ".", so it cannot be mistaken for one.
 const mergeIntoEnclosingObject = "."
 
 // marshalSubjects pairs each type carrying a hand-built MarshalJSON with a fresh

--- a/internal/driftguard/marshal_test.go
+++ b/internal/driftguard/marshal_test.go
@@ -58,6 +58,13 @@ var marshalMerges = map[string]map[string]string{
 
 	// The Responses Object has no wrapping key of its own: its status codes are
 	// members of the object itself, beside `default`. See parser.Responses.
+	//
+	// Extra carries no entry because fieldsOf excludes it for every type, so
+	// one here would never be reached. Expressing it would take more than a
+	// registration: the fast-path control marshals through struct tags, which
+	// emit no Extra content at all, so the same assertion cannot hold on both
+	// paths. parser.TestResponsesRoundTripPreservesExtensions covers the merge
+	// for this type in the meantime.
 	"Responses": {"Codes": mergeIntoEnclosingObject},
 }
 

--- a/internal/httputil/httputil.go
+++ b/internal/httputil/httputil.go
@@ -110,6 +110,16 @@ func IsStatusCode(code string) bool {
 	return false
 }
 
+// IsSuccessStatusCode reports whether code denotes a successful response: a
+// numeric 2xx code, or the 2XX wildcard range.
+//
+// Only a status code can be a successful one, so anything [IsStatusCode]
+// rejects is rejected here too. That matters for a caller ranging
+// Responses.Codes, which may hold a key no decoder validated.
+func IsSuccessStatusCode(code string) bool {
+	return IsStatusCode(code) && code[0] == '2'
+}
+
 // IsStandardStatusCode checks if a status code is a well-defined standard HTTP code.
 // Returns true only for codes in StandardHTTPStatusCodes map.
 func IsStandardStatusCode(code string) bool {

--- a/internal/httputil/httputil.go
+++ b/internal/httputil/httputil.go
@@ -57,21 +57,36 @@ var StandardHTTPStatusCodes = map[string]bool{
 	"506": true, "507": true, "508": true, "510": true, "511": true,
 }
 
-// ValidateStatusCode checks if a status code string is valid according to OpenAPI spec.
-// Valid values are:
-//   - "default" for default response
-//   - Extension fields starting with "x-"
+// ResponsesKeyDefault is the Responses Object key holding the default response.
+const ResponsesKeyDefault = "default"
+
+// ExtensionPrefix marks a specification extension field.
+const ExtensionPrefix = "x-"
+
+// IsExtensionKey reports whether key names a specification extension.
+func IsExtensionKey(key string) bool {
+	return strings.HasPrefix(key, ExtensionPrefix)
+}
+
+// IsValidResponsesKey reports whether key may appear in a Responses Object.
+// That is a broader question than [IsStatusCode]: the Responses Object also
+// admits "default" and specification extensions.
+//
+// Use this to accept or reject a key while decoding. Use [IsStatusCode] to ask
+// whether the key denotes a status code, which is what a caller ranging
+// Responses.Codes means.
+func IsValidResponsesKey(key string) bool {
+	return key == ResponsesKeyDefault || IsExtensionKey(key) || IsStatusCode(key)
+}
+
+// IsStatusCode reports whether code is an HTTP status code or a wildcard range:
 //   - Wildcard patterns: 1XX, 2XX, 3XX, 4XX, 5XX
 //   - Numeric codes: 100-599
-func ValidateStatusCode(code string) bool {
-	if code == "default" {
-		return true
-	}
-
-	if strings.HasPrefix(code, "x-") {
-		return true
-	}
-
+//
+// It is deliberately narrow. "default" and specification extensions are legal
+// Responses Object keys but are not status codes, so both return false here;
+// [IsValidResponsesKey] is the predicate that accepts them.
+func IsStatusCode(code string) bool {
 	if len(code) == StatusCodeLength {
 		// Check for wildcard patterns (e.g., "2XX", "4XX")
 		if code[1] == WildcardChar && code[2] == WildcardChar {

--- a/internal/httputil/httputil_test.go
+++ b/internal/httputil/httputil_test.go
@@ -341,3 +341,40 @@ func TestStandardHTTPStatusCodesCompleteness(t *testing.T) {
 	assert.Greater(t, len(StandardHTTPStatusCodes), 40, "Should have at least 40 standard codes")
 	assert.Less(t, len(StandardHTTPStatusCodes), 100, "Should have fewer than 100 codes")
 }
+
+// TestIsSuccessStatusCode covers the narrower of the three questions: which
+// keys denote a successful response. A key that is not a status code cannot,
+// which matters because Responses.Codes may hold one.
+func TestIsSuccessStatusCode(t *testing.T) {
+	tests := []struct {
+		name     string
+		code     string
+		expected bool
+	}{
+		{"wildcard 2XX", "2XX", true},
+		{"numeric 200", "200", true},
+		{"numeric 204", "204", true},
+		{"numeric 299", "299", true},
+
+		{"numeric 199", "199", false},
+		{"numeric 300", "300", false},
+		{"wildcard 3XX", "3XX", false},
+		{"wildcard 5XX", "5XX", false},
+
+		// Not status codes at all, so not successful ones either. The leading
+		// 2 is what a bare prefix check would accept.
+		{"malformed 2foo", "2foo", false},
+		{"malformed 2X", "2X", false},
+		{"extension x-2xx", "x-2xx", false},
+		{"default", "default", false},
+		{"empty string", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsSuccessStatusCode(tt.code)
+			assert.Equal(t, tt.expected, got,
+				"IsSuccessStatusCode(%q) = %v, want %v", tt.code, got, tt.expected)
+		})
+	}
+}

--- a/internal/httputil/httputil_test.go
+++ b/internal/httputil/httputil_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestValidateStatusCode(t *testing.T) {
+func TestIsValidResponsesKey(t *testing.T) {
 	tests := []struct {
 		name     string
 		code     string
@@ -93,10 +93,64 @@ func TestValidateStatusCode(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := ValidateStatusCode(tt.code)
-			assert.Equal(t, tt.expected, result, "ValidateStatusCode(%q) = %v, want %v", tt.code, result, tt.expected)
+			result := IsValidResponsesKey(tt.code)
+			assert.Equal(t, tt.expected, result, "IsValidResponsesKey(%q) = %v, want %v", tt.code, result, tt.expected)
 		})
 	}
+}
+
+// TestIsStatusCode pins the narrow predicate against the broad one. The two
+// disagree on exactly the keys a Responses Object admits without their being
+// status codes, and a caller ranging Responses.Codes needs the narrow answer.
+func TestIsStatusCode(t *testing.T) {
+	tests := []struct {
+		name     string
+		code     string
+		expected bool
+	}{
+		// The keys that separate this predicate from IsValidResponsesKey.
+		{"default is not a status code", "default", false},
+		{"extension x-custom is not a status code", "x-custom", false},
+		{"extension x-200 is not a status code", "x-200", false},
+		{"extension x- is not a status code", "x-", false},
+
+		// Wildcard ranges.
+		{"wildcard 1XX", "1XX", true},
+		{"wildcard 5XX", "5XX", true},
+		{"wildcard 0XX", "0XX", false},
+		{"wildcard 6XX", "6XX", false},
+
+		// Numeric codes and their boundaries.
+		{"numeric 100", "100", true},
+		{"numeric 200", "200", true},
+		{"numeric 599", "599", true},
+		{"numeric 099", "099", false},
+		{"numeric 600", "600", false},
+		{"numeric 999", "999", false},
+
+		// Shape.
+		{"empty string", "", false},
+		{"too short", "99", false},
+		{"too long", "1000", false},
+		{"alphabetic", "abc", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsStatusCode(tt.code)
+			assert.Equal(t, tt.expected, got,
+				"IsStatusCode(%q) = %v, want %v", tt.code, got, tt.expected)
+		})
+	}
+}
+
+func TestIsExtensionKey(t *testing.T) {
+	assert.True(t, IsExtensionKey("x-custom"))
+	assert.True(t, IsExtensionKey("x-"))
+	assert.False(t, IsExtensionKey("default"))
+	assert.False(t, IsExtensionKey("200"))
+	assert.False(t, IsExtensionKey("x"))
+	assert.False(t, IsExtensionKey(""))
 }
 
 func TestIsStandardStatusCode(t *testing.T) {

--- a/parser/conformance_relaxed_test.go
+++ b/parser/conformance_relaxed_test.go
@@ -254,8 +254,9 @@ paths:
 //
 // The third decode path, decodeFromMap, is not reachable from here: it runs
 // only under ResolveRefs, has no error channel, and keeps the key so the
-// structure validator reports it instead. TestResponsesKeyClassification covers
-// that route and the channel it reports through.
+// structure validator reports it instead.
+// TestResponsesInvalidStatusCodeIsReportedOnEveryDecodePath covers that route
+// and the channel it reports through.
 func TestOperationResponsesStatusCodesStillChecked(t *testing.T) {
 	const want = "invalid status code '999'"
 

--- a/parser/conformance_relaxed_test.go
+++ b/parser/conformance_relaxed_test.go
@@ -248,15 +248,14 @@ paths:
 // present.
 //
 // Note that the check which fires here is the decoder's, not the structure
-// validator's. Every decode path — paths.go (YAML), paths_json.go (JSON) and
-// the generated decodeFromMap — filters status codes before a Responses object
-// is built, so validateOAS3Operation's own loop over Responses.Codes can never
-// see an invalid one. That loop is unreachable, and predates this change.
+// validator's. paths.go (YAML) and paths_json.go (JSON) both reject an invalid
+// status code outright, so a Responses object is never built and the structure
+// validator's loop over Responses.Codes never sees one by this route.
 //
-// The two paths ParseBytes can reach are both covered below. The third,
-// decodeFromMap, is not reachable from here and does not agree with them — it
-// drops the offending key silently rather than erroring. That inconsistency and
-// the dead loop are tracked in issue #449, not fixed here.
+// The third decode path, decodeFromMap, is not reachable from here: it runs
+// only under ResolveRefs, has no error channel, and keeps the key so the
+// structure validator reports it instead. TestResponsesKeyClassification covers
+// that route and the channel it reports through.
 func TestOperationResponsesStatusCodesStillChecked(t *testing.T) {
 	const want = "invalid status code '999'"
 

--- a/parser/conformance_relaxed_test.go
+++ b/parser/conformance_relaxed_test.go
@@ -253,10 +253,10 @@ paths:
 // validator's loop over Responses.Codes never sees one by this route.
 //
 // The third decode path, decodeFromMap, is not reachable from here: it runs
-// only under ResolveRefs, has no error channel, and keeps the key so the
+// only under ResolveRefs, cannot return an error, and keeps the key so the
 // structure validator reports it instead.
 // TestResponsesInvalidStatusCodeIsReportedOnEveryDecodePath covers that route
-// and the channel it reports through.
+// and how it reports.
 func TestOperationResponsesStatusCodesStillChecked(t *testing.T) {
 	const want = "invalid status code '999'"
 
@@ -302,11 +302,12 @@ paths:
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Pinned to the channel that actually carries this today: the
+			// Pinned to how this is actually reported today: the
 			// decoder rejects an invalid status code, so ParseBytes returns a
 			// hard error and never reaches structure validation.
 			//
-			// Asserting the channel and not just the message is deliberate. If
+			// Asserting where the diagnostic arrives, and not just its message,
+			// is deliberate. If
 			// a change moves this diagnostic into the collected result.Errors
 			// instead, that is a change to ParseBytes's external contract —
 			// callers today can rely on a non-nil error for this input — and

--- a/parser/decode_helpers.go
+++ b/parser/decode_helpers.go
@@ -2,7 +2,8 @@ package parser
 
 import (
 	"math"
-	"strings"
+
+	"github.com/erraggy/oastools/internal/httputil"
 )
 
 // extractExtensionsFromMap collects x-* keys from a map into an extension map.
@@ -348,5 +349,5 @@ func decodeSecurityRequirements(arr []any) []SecurityRequirement {
 
 // isExtensionKey returns true if the key starts with "x-".
 func isExtensionKey(key string) bool {
-	return strings.HasPrefix(key, "x-")
+	return httputil.IsExtensionKey(key)
 }

--- a/parser/json_test.go
+++ b/parser/json_test.go
@@ -453,12 +453,17 @@ func TestValidExtensionFieldsInResponses(t *testing.T) {
 	// Verify standard codes are present
 	assert.NotNil(t, responses.Codes["200"])
 
-	// Verify extension fields are captured
-	assert.NotNil(t, responses.Codes["x-custom"])
-	assert.NotNil(t, responses.Codes["x-rate-limit"])
+	// Extensions are captured apart from the status codes. A caller ranging
+	// Codes is asking about status codes, so an extension appearing there
+	// would be reported as one.
+	assert.NotNil(t, responses.Extra["x-custom"])
+	assert.NotNil(t, responses.Extra["x-rate-limit"])
+	assert.NotContains(t, responses.Codes, "x-custom")
+	assert.NotContains(t, responses.Codes, "x-rate-limit")
 
 	// Verify default is present
 	assert.NotNil(t, responses.Default)
+	assert.NotContains(t, responses.Codes, "default")
 }
 
 func TestMarshalUnmarshalErrors(t *testing.T) {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -883,9 +883,12 @@ func (p *Parser) validateOAS2Operation(op *Operation, opPath string, operationID
 	if op.Responses == nil {
 		errors = append(errors, fmt.Errorf("oas 2.0: missing required field '%s.responses': Operation must have a responses object", opPath))
 	} else {
-		// Validate status codes in responses
+		// Validate status codes in responses. Codes holds only status-code keys
+		// on the YAML and JSON decode paths, which reject anything else outright;
+		// this loop is what reports them on the decodeFromMap path, which has no
+		// error channel of its own.
 		for code := range op.Responses.Codes {
-			if !httputil.ValidateStatusCode(code) {
+			if !httputil.IsStatusCode(code) {
 				errors = append(errors, fmt.Errorf("oas 2.0: invalid status code '%s' in '%s.responses': must be a valid HTTP status code (e.g., \"200\", \"404\") or wildcard pattern (e.g., \"2XX\")", code, opPath))
 			}
 		}
@@ -1067,9 +1070,12 @@ func (p *Parser) validateOAS3Operation(op *Operation, opPath string, operationID
 			errors = append(errors, fmt.Errorf("oas %s: missing required field '%s.responses': Operation must have a responses object (https://spec.openapis.org/oas/v3.0.0.html#operation-object)", version, opPath))
 		}
 	} else {
-		// Validate status codes in responses
+		// Validate status codes in responses. Codes holds only status-code keys
+		// on the YAML and JSON decode paths, which reject anything else outright;
+		// this loop is what reports them on the decodeFromMap path, which has no
+		// error channel of its own.
 		for code := range op.Responses.Codes {
-			if !httputil.ValidateStatusCode(code) {
+			if !httputil.IsStatusCode(code) {
 				errors = append(errors, fmt.Errorf("oas %s: invalid status code '%s' in '%s.responses': must be a valid HTTP status code (e.g., \"200\", \"404\") or wildcard pattern (e.g., \"2XX\")", version, code, opPath))
 			}
 		}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -885,8 +885,8 @@ func (p *Parser) validateOAS2Operation(op *Operation, opPath string, operationID
 	} else {
 		// Validate status codes in responses. Codes holds only status-code keys
 		// on the YAML and JSON decode paths, which reject anything else outright;
-		// this loop is what reports them on the decodeFromMap path, which has no
-		// error channel of its own.
+		// this loop is what reports them on the decodeFromMap path, which cannot
+		// return an error of its own.
 		for code := range op.Responses.Codes {
 			if !httputil.IsStatusCode(code) {
 				errors = append(errors, fmt.Errorf("oas 2.0: invalid status code '%s' in '%s.responses': must be a valid HTTP status code (e.g., \"200\", \"404\") or wildcard pattern (e.g., \"2XX\")", code, opPath))
@@ -1072,8 +1072,8 @@ func (p *Parser) validateOAS3Operation(op *Operation, opPath string, operationID
 	} else {
 		// Validate status codes in responses. Codes holds only status-code keys
 		// on the YAML and JSON decode paths, which reject anything else outright;
-		// this loop is what reports them on the decodeFromMap path, which has no
-		// error channel of its own.
+		// this loop is what reports them on the decodeFromMap path, which cannot
+		// return an error of its own.
 		for code := range op.Responses.Codes {
 			if !httputil.IsStatusCode(code) {
 				errors = append(errors, fmt.Errorf("oas %s: invalid status code '%s' in '%s.responses': must be a valid HTTP status code (e.g., \"200\", \"404\") or wildcard pattern (e.g., \"2XX\")", version, code, opPath))

--- a/parser/paths.go
+++ b/parser/paths.go
@@ -131,9 +131,9 @@ func (r *Responses) UnmarshalYAML(unmarshal func(any) error) error {
 // Codes and Extra back into the single object the specification describes.
 //
 // Key order is fixed rather than left to map iteration: `default` first, then
-// the status codes and extensions together in sorted order. That reproduces
-// what the `,inline` tag on Codes emitted before Extra existed, so a document
-// that round-trips through the parser serializes byte-identically.
+// the status codes and extensions together in sorted order. A result that
+// varies between runs of the same binary makes any diff of the output useless
+// (#425).
 func (r *Responses) MarshalYAML() (any, error) {
 	out := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
 

--- a/parser/paths.go
+++ b/parser/paths.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"fmt"
+	"slices"
 
 	"go.yaml.in/yaml/v4"
 
@@ -61,7 +62,17 @@ type Operation struct {
 // Responses is a container for the expected responses of an operation
 type Responses struct {
 	Default *Response            `yaml:"default,omitempty" json:"default,omitempty"`
-	Codes   map[string]*Response `yaml:",inline" json:"-"` // Handled by custom marshaler
+	Codes   map[string]*Response `yaml:"-" json:"-"` // Handled by custom marshaler
+	// Extra captures specification extensions (fields starting with "x-").
+	// The Responses Object admits them like any other OAS object, and they are
+	// not status codes, so they are held apart from Codes: a caller ranging
+	// Codes is asking about status codes and must not be handed an extension.
+	//
+	// Both marshalers merge Default, Codes and Extra back into the single
+	// object the specification describes. Codes cannot carry the `,inline`
+	// tag alongside this field because the YAML library permits only one
+	// inline map per struct.
+	Extra map[string]any `yaml:"-" json:"-"`
 }
 
 // UnmarshalYAML implements custom unmarshaling for Responses to validate status codes during parsing.
@@ -89,9 +100,16 @@ func (r *Responses) UnmarshalYAML(unmarshal func(any) error) error {
 				return fmt.Errorf("failed to unmarshal default response: %w", err)
 			}
 			r.Default = &defaultResp
+		} else if httputil.IsExtensionKey(key) {
+			// A specification extension, which the Responses Object admits.
+			// It is not a status code, so it does not belong in Codes.
+			if r.Extra == nil {
+				r.Extra = make(map[string]any)
+			}
+			r.Extra[key] = value
 		} else {
-			// All other fields should be valid status codes or extension fields
-			if !httputil.ValidateStatusCode(key) {
+			// Everything else must be a status code or a wildcard range.
+			if !httputil.IsStatusCode(key) {
 				return fmt.Errorf("invalid status code '%s' in responses: must be a valid HTTP status code (e.g., \"200\", \"404\"), wildcard pattern (e.g., \"2XX\"), or extension field (e.g., \"x-custom\")", key)
 			}
 			valueBytes, err := yamlMarshalValue(value)
@@ -107,6 +125,63 @@ func (r *Responses) UnmarshalYAML(unmarshal func(any) error) error {
 	}
 
 	return nil
+}
+
+// MarshalYAML implements custom YAML marshaling for Responses, merging Default,
+// Codes and Extra back into the single object the specification describes.
+//
+// Key order is fixed rather than left to map iteration: `default` first, then
+// the status codes and extensions together in sorted order. That reproduces
+// what the `,inline` tag on Codes emitted before Extra existed, so a document
+// that round-trips through the parser serializes byte-identically.
+func (r *Responses) MarshalYAML() (any, error) {
+	out := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+
+	appendPair := func(key string, value any) error {
+		keyNode := &yaml.Node{}
+		if err := keyNode.Encode(key); err != nil {
+			return fmt.Errorf("failed to encode responses key %s: %w", key, err)
+		}
+		valueNode := &yaml.Node{}
+		if err := valueNode.Encode(value); err != nil {
+			return fmt.Errorf("failed to encode response for key %s: %w", key, err)
+		}
+		out.Content = append(out.Content, keyNode, valueNode)
+		return nil
+	}
+
+	if r.Default != nil {
+		if err := appendPair(jsonKeyDefault, r.Default); err != nil {
+			return nil, err
+		}
+	}
+
+	keys := make([]string, 0, len(r.Codes)+len(r.Extra))
+	for code := range r.Codes {
+		keys = append(keys, code)
+	}
+	for key := range r.Extra {
+		// A caller-assembled document can hold one key in both maps. Codes
+		// wins, and emitting the key once keeps the output a valid mapping.
+		if _, dup := r.Codes[key]; !dup {
+			keys = append(keys, key)
+		}
+	}
+	slices.Sort(keys)
+
+	for _, key := range keys {
+		var value any
+		if resp, ok := r.Codes[key]; ok {
+			value = resp
+		} else {
+			value = r.Extra[key]
+		}
+		if err := appendPair(key, value); err != nil {
+			return nil, err
+		}
+	}
+
+	return out, nil
 }
 
 // Response describes a single response from an API Operation.

--- a/parser/paths.go
+++ b/parser/paths.go
@@ -84,8 +84,10 @@ func (r *Responses) UnmarshalYAML(unmarshal func(any) error) error {
 		return err
 	}
 
-	// Initialize the Codes map
+	// Reset both maps, so decoding into a reused value reflects this document
+	// alone rather than merging with whatever it held before.
 	r.Codes = make(map[string]*Response)
+	r.Extra = nil
 
 	// Process each field
 	for key, value := range raw {
@@ -127,6 +129,23 @@ func (r *Responses) UnmarshalYAML(unmarshal func(any) error) error {
 	return nil
 }
 
+// defaultValue resolves the `default` key, which the Default field holds for
+// any parsed document and which a caller-assembled one may also place in Codes
+// or Extra. Codes wins, then Default, then Extra, which is the order
+// [Responses.MarshalJSON] produces by construction.
+//
+// No decode path can produce a clash: all three route `default` to the field.
+func (r *Responses) defaultValue() (any, bool) {
+	if resp, ok := r.Codes[jsonKeyDefault]; ok {
+		return resp, true
+	}
+	if r.Default != nil {
+		return r.Default, true
+	}
+	value, ok := r.Extra[jsonKeyDefault]
+	return value, ok
+}
+
 // MarshalYAML implements custom YAML marshaling for Responses, merging Default,
 // Codes and Extra back into the single object the specification describes.
 //
@@ -150,22 +169,29 @@ func (r *Responses) MarshalYAML() (any, error) {
 		return nil
 	}
 
-	if r.Default != nil {
-		if err := appendPair(jsonKeyDefault, r.Default); err != nil {
+	// `default` has a field of its own and can also be held as a map entry by
+	// a caller-assembled document. Resolve it to one value, with the same
+	// precedence [Responses.MarshalJSON] applies, and emit it once: a mapping
+	// carrying the key twice does not parse back.
+	if value, ok := r.defaultValue(); ok {
+		if err := appendPair(jsonKeyDefault, value); err != nil {
 			return nil, err
 		}
 	}
 
 	keys := make([]string, 0, len(r.Codes)+len(r.Extra))
 	for code := range r.Codes {
-		keys = append(keys, code)
+		if code != jsonKeyDefault {
+			keys = append(keys, code)
+		}
 	}
 	for key := range r.Extra {
 		// A caller-assembled document can hold one key in both maps. Codes
 		// wins, and emitting the key once keeps the output a valid mapping.
-		if _, dup := r.Codes[key]; !dup {
-			keys = append(keys, key)
+		if _, dup := r.Codes[key]; dup || key == jsonKeyDefault {
+			continue
 		}
+		keys = append(keys, key)
 	}
 	slices.Sort(keys)
 

--- a/parser/paths.go
+++ b/parser/paths.go
@@ -84,10 +84,11 @@ func (r *Responses) UnmarshalYAML(unmarshal func(any) error) error {
 		return err
 	}
 
-	// Reset both maps, so decoding into a reused value reflects this document
+	// Reset every field, so decoding into a reused value reflects this document
 	// alone rather than merging with whatever it held before.
 	r.Codes = make(map[string]*Response)
 	r.Extra = nil
+	r.Default = nil
 
 	// Process each field
 	for key, value := range raw {

--- a/parser/paths_equals.go
+++ b/parser/paths_equals.go
@@ -208,6 +208,12 @@ func equalResponses(a, b *Responses) bool {
 	if !equalResponseMap(a.Codes, b.Codes) {
 		return false
 	}
+
+	// Extensions
+	if !equalMapStringAny(a.Extra, b.Extra) {
+		return false
+	}
+
 	return true
 }
 

--- a/parser/paths_json.go
+++ b/parser/paths_json.go
@@ -331,7 +331,10 @@ func (r *Responses) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Reset both maps, so decoding into a reused value reflects this document
+	// alone rather than merging with whatever it held before.
 	r.Codes = make(map[string]*Response)
+	r.Extra = nil
 
 	for key, value := range m {
 		if key == jsonKeyDefault {

--- a/parser/paths_json.go
+++ b/parser/paths_json.go
@@ -331,10 +331,11 @@ func (r *Responses) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Reset both maps, so decoding into a reused value reflects this document
+	// Reset every field, so decoding into a reused value reflects this document
 	// alone rather than merging with whatever it held before.
 	r.Codes = make(map[string]*Response)
 	r.Extra = nil
+	r.Default = nil
 
 	for key, value := range m {
 		if key == jsonKeyDefault {

--- a/parser/paths_json.go
+++ b/parser/paths_json.go
@@ -309,6 +309,14 @@ func (r *Responses) MarshalJSON() ([]byte, error) {
 		m[code] = response
 	}
 
+	// Specification extensions belong in the same object. Codes wins a clash,
+	// which only a caller-assembled document can produce.
+	for key, value := range r.Extra {
+		if _, dup := m[key]; !dup {
+			m[key] = value
+		}
+	}
+
 	return marshalToJSON(m)
 }
 
@@ -332,9 +340,20 @@ func (r *Responses) UnmarshalJSON(data []byte) error {
 				return err
 			}
 			r.Default = &defaultResp
+		} else if httputil.IsExtensionKey(key) {
+			// A specification extension, which the Responses Object admits.
+			// It is not a status code, so it does not belong in Codes.
+			var ext any
+			if err := json.Unmarshal(value, &ext); err != nil {
+				return err
+			}
+			if r.Extra == nil {
+				r.Extra = make(map[string]any)
+			}
+			r.Extra[key] = ext
 		} else {
-			// Validate status code - must be valid HTTP status code or extension field
-			if !httputil.ValidateStatusCode(key) {
+			// Everything else must be a status code or a wildcard range.
+			if !httputil.IsStatusCode(key) {
 				return fmt.Errorf("invalid status code '%s' in responses: must be a valid HTTP status code (e.g., \"200\", \"404\"), wildcard pattern (e.g., \"2XX\"), or extension field (e.g., \"x-custom\")", key)
 			}
 			var resp Response

--- a/parser/responses_keys_test.go
+++ b/parser/responses_keys_test.go
@@ -194,6 +194,140 @@ paths:
 	}
 }
 
+// TestResponsesInvalidKeyWithNonObjectValueIsStillReported covers an invalid
+// status code whose value is not a Response Object either, which is two faults
+// in one entry. decodeFromMap classifies the key before it looks at the value,
+// so the reportable fault is not lost to the unreportable one.
+//
+// Reachable only under ResolveRefs: the YAML and JSON decoders reject the key
+// outright, before its value matters.
+func TestResponsesInvalidKeyWithNonObjectValueIsStillReported(t *testing.T) {
+	const specYAML = `openapi: 3.0.3
+info:
+  title: T
+  version: "1.0.0"
+paths:
+  /a:
+    get:
+      operationId: a
+      responses:
+        "200":
+          description: OK
+        "999": 100
+`
+
+	const specJSON = `{
+  "openapi": "3.0.3",
+  "info": {"title": "T", "version": "1.0.0"},
+  "paths": {
+    "/a": {
+      "get": {
+        "operationId": "a",
+        "responses": {
+          "200": {"description": "OK"},
+          "999": 100
+        }
+      }
+    }
+  }
+}`
+
+	for _, tt := range []struct {
+		name string
+		spec string
+	}{
+		{name: "yaml", spec: specYAML},
+		{name: "json", spec: specJSON},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			p := New()
+			p.ResolveRefs = true
+			res, err := p.ParseBytes([]byte(tt.spec))
+			require.NoError(t, err)
+
+			assert.True(t, hasErrorContaining(res.Errors, "invalid status code '999'"),
+				"a scalar value must not hide the invalid key; got %v", res.Errors)
+
+			r := responsesOf(t, res)
+			assert.Contains(t, r.Codes, "999")
+			assert.Contains(t, r.Codes, "200")
+		})
+	}
+}
+
+// TestResponsesWellFormedCodeWithNonObjectValueIsNotInvented is the counterpart:
+// a valid status code whose value is not an object is left out rather than
+// turned into an empty Response. Nothing here validates the value, so keeping
+// the key would report a response the document does not declare.
+func TestResponsesWellFormedCodeWithNonObjectValueIsNotInvented(t *testing.T) {
+	const spec = `openapi: 3.0.3
+info:
+  title: T
+  version: "1.0.0"
+paths:
+  /a:
+    get:
+      operationId: a
+      responses:
+        "200":
+          description: OK
+        "404": 100
+`
+
+	p := New()
+	p.ResolveRefs = true
+	res, err := p.ParseBytes([]byte(spec))
+	require.NoError(t, err)
+
+	r := responsesOf(t, res)
+	assert.Contains(t, r.Codes, "200")
+	assert.NotContains(t, r.Codes, "404")
+}
+
+// TestResponsesDecodeFromMapResetsDefault covers the third decode path for the
+// same reuse question the format decoders answer: a value that already holds a
+// default response must not keep it when the next map declares none.
+func TestResponsesDecodeFromMapResetsDefault(t *testing.T) {
+	const withDefault = `openapi: 3.0.3
+info: {title: T, version: "1.0.0"}
+paths:
+  /a:
+    get:
+      operationId: a
+      responses:
+        default: {description: fallback}
+        "200": {description: OK}
+`
+	const withoutDefault = `openapi: 3.0.3
+info: {title: T, version: "1.0.0"}
+paths:
+  /a:
+    get:
+      operationId: a
+      responses:
+        "200": {description: OK}
+`
+
+	p := New()
+	p.ResolveRefs = true
+
+	first, err := p.ParseBytes([]byte(withDefault))
+	require.NoError(t, err)
+	require.NotNil(t, responsesOf(t, first).Default)
+
+	// Reuse the same value, which is what a caller pooling documents does.
+	target := responsesOf(t, first)
+	second, err := p.ParseBytes([]byte(withoutDefault))
+	require.NoError(t, err)
+	source := responsesOf(t, second)
+	assert.Nil(t, source.Default, "the second document declares no default")
+
+	// And directly, since the pooled case above depends on the parser not
+	// reusing the value at all.
+	target.decodeFromMap(map[string]any{"200": map[string]any{"description": "OK"}})
+	assert.Nil(t, target.Default, "decodeFromMap must clear a default it does not find")
+}
+
 // TestResponsesRoundTripPreservesExtensions asserts that splitting extensions
 // out of Codes does not lose them on the way back out, and that both marshalers
 // emit them in the one object the specification describes.

--- a/parser/responses_keys_test.go
+++ b/parser/responses_keys_test.go
@@ -323,9 +323,18 @@ paths:
 	assert.Nil(t, source.Default, "the second document declares no default")
 
 	// And directly, since the pooled case above depends on the parser not
-	// reusing the value at all.
+	// reusing the value at all. Every field is checked, not just Default: a
+	// reset that cleared one and not the others would still merge documents.
+	require.NotNil(t, target.Default, "precondition: the value holds a default")
+	target.Extra = map[string]any{"x-note": "carried over?"}
+	target.Codes["404"] = &Response{Description: "Not Found"}
+
 	target.decodeFromMap(map[string]any{"200": map[string]any{"description": "OK"}})
+
 	assert.Nil(t, target.Default, "decodeFromMap must clear a default it does not find")
+	assert.NotContains(t, target.Extra, "x-note", "and an extension it does not find")
+	assert.NotContains(t, target.Codes, "404", "and a status code it does not find")
+	assert.Contains(t, target.Codes, "200")
 }
 
 // TestResponsesDeepCopyIsolatesExtensions asserts that a copied Responses does

--- a/parser/responses_keys_test.go
+++ b/parser/responses_keys_test.go
@@ -1,0 +1,323 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	yaml "go.yaml.in/yaml/v4"
+)
+
+// responsesOf returns the Responses object of GET /a, which every fixture in
+// this file declares.
+func responsesOf(t *testing.T, res *ParseResult) *Responses {
+	t.Helper()
+	doc, ok := res.Document.(*OAS3Document)
+	require.True(t, ok, "expected an OAS3Document, got %T", res.Document)
+	require.Contains(t, doc.Paths, "/a")
+	require.NotNil(t, doc.Paths["/a"].Get)
+	require.NotNil(t, doc.Paths["/a"].Get.Responses)
+	return doc.Paths["/a"].Get.Responses
+}
+
+// TestResponsesKeyClassification pins how each of the three decode paths sorts
+// the keys of a Responses Object into Default, Codes and Extra.
+//
+// All three are exercised because they are separate implementations: YAML in
+// paths.go, JSON in paths_json.go, and decodeFromMap in the generated decoder,
+// which runs only under ResolveRefs. Covering one would leave the other two
+// free to drift.
+func TestResponsesKeyClassification(t *testing.T) {
+	const specYAML = `openapi: 3.0.3
+info:
+  title: T
+  version: "1.0.0"
+paths:
+  /a:
+    get:
+      operationId: a
+      responses:
+        default:
+          description: fallback
+        "200":
+          description: OK
+        "4XX":
+          description: client error
+        x-object-ext:
+          description: an extension whose value is an object
+        x-scalar-ext: 100
+`
+
+	const specJSON = `{
+  "openapi": "3.0.3",
+  "info": {"title": "T", "version": "1.0.0"},
+  "paths": {
+    "/a": {
+      "get": {
+        "operationId": "a",
+        "responses": {
+          "default": {"description": "fallback"},
+          "200": {"description": "OK"},
+          "4XX": {"description": "client error"},
+          "x-object-ext": {"description": "an extension whose value is an object"},
+          "x-scalar-ext": 100
+        }
+      }
+    }
+  }
+}`
+
+	tests := []struct {
+		name        string
+		spec        string
+		resolveRefs bool
+	}{
+		{name: "yaml", spec: specYAML},
+		{name: "json", spec: specJSON},
+		// ResolveRefs routes the document through decodeFromMap instead of the
+		// format-specific decoders.
+		{name: "yaml via decodeFromMap", spec: specYAML, resolveRefs: true},
+		{name: "json via decodeFromMap", spec: specJSON, resolveRefs: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := New()
+			p.ResolveRefs = tt.resolveRefs
+			res, err := p.ParseBytes([]byte(tt.spec))
+			require.NoError(t, err)
+			require.Empty(t, res.Errors)
+
+			r := responsesOf(t, res)
+
+			// The default response has its own field.
+			require.NotNil(t, r.Default)
+			assert.Equal(t, "fallback", r.Default.Description)
+			assert.NotContains(t, r.Codes, "default")
+
+			// Status codes and wildcard ranges are the only Codes entries.
+			assert.Len(t, r.Codes, 2)
+			require.Contains(t, r.Codes, "200")
+			require.Contains(t, r.Codes, "4XX")
+			assert.Equal(t, "OK", r.Codes["200"].Description)
+			assert.Equal(t, "client error", r.Codes["4XX"].Description)
+
+			// Extensions are held apart from the status codes, whatever the
+			// shape of their value. A scalar extension is as legal as an
+			// object one, and neither is a response.
+			assert.NotContains(t, r.Codes, "x-object-ext")
+			assert.NotContains(t, r.Codes, "x-scalar-ext")
+			assert.Contains(t, r.Extra, "x-object-ext")
+			assert.Contains(t, r.Extra, "x-scalar-ext")
+		})
+	}
+}
+
+// TestResponsesInvalidStatusCodeIsReportedOnEveryDecodePath asserts that no
+// decode path accepts an invalid status code in silence.
+//
+// The channel differs by path and that difference is deliberate: the YAML and
+// JSON decoders can fail the parse, so they do, and callers can rely on a
+// non-nil error. decodeFromMap has no error return, so it keeps the key and
+// the structure validator reports it. Dropping the key there would lose the
+// response and report nothing at all.
+func TestResponsesInvalidStatusCodeIsReportedOnEveryDecodePath(t *testing.T) {
+	const specYAML = `openapi: 3.0.3
+info:
+  title: T
+  version: "1.0.0"
+paths:
+  /a:
+    get:
+      operationId: a
+      responses:
+        "200":
+          description: OK
+        "999":
+          description: not a status code
+`
+
+	const specJSON = `{
+  "openapi": "3.0.3",
+  "info": {"title": "T", "version": "1.0.0"},
+  "paths": {
+    "/a": {
+      "get": {
+        "operationId": "a",
+        "responses": {
+          "200": {"description": "OK"},
+          "999": {"description": "not a status code"}
+        }
+      }
+    }
+  }
+}`
+
+	const want = "invalid status code '999'"
+
+	t.Run("yaml decoder fails the parse", func(t *testing.T) {
+		_, err := New().ParseBytes([]byte(specYAML))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), want)
+	})
+
+	t.Run("json decoder fails the parse", func(t *testing.T) {
+		_, err := New().ParseBytes([]byte(specJSON))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), want)
+	})
+
+	for _, tt := range []struct {
+		name string
+		spec string
+	}{
+		{name: "yaml", spec: specYAML},
+		{name: "json", spec: specJSON},
+	} {
+		t.Run("decodeFromMap reports and keeps: "+tt.name, func(t *testing.T) {
+			p := New()
+			p.ResolveRefs = true
+			res, err := p.ParseBytes([]byte(tt.spec))
+			require.NoError(t, err, "this path collects the error rather than failing the parse")
+			assert.True(t, hasErrorContaining(res.Errors, want),
+				"want a collected error containing %q; got %v", want, res.Errors)
+
+			// The response itself survives. Reporting the key while discarding
+			// its value would be a quieter form of the same data loss.
+			r := responsesOf(t, res)
+			require.Contains(t, r.Codes, "999")
+			assert.Equal(t, "not a status code", r.Codes["999"].Description)
+		})
+	}
+}
+
+// TestResponsesRoundTripPreservesExtensions asserts that splitting extensions
+// out of Codes does not lose them on the way back out, and that both marshalers
+// emit them in the one object the specification describes.
+func TestResponsesRoundTripPreservesExtensions(t *testing.T) {
+	const spec = `openapi: 3.0.3
+info:
+  title: T
+  version: "1.0.0"
+paths:
+  /a:
+    get:
+      operationId: a
+      responses:
+        default:
+          description: fallback
+        "200":
+          description: OK
+        x-object-ext:
+          description: an extension
+        x-scalar-ext: 100
+`
+
+	res, err := New().ParseBytes([]byte(spec))
+	require.NoError(t, err)
+	doc, ok := res.Document.(*OAS3Document)
+	require.True(t, ok)
+
+	out, err := yaml.Marshal(doc)
+	require.NoError(t, err)
+
+	reparsed, err := New().ParseBytes(out)
+	require.NoError(t, err)
+
+	r := responsesOf(t, reparsed)
+	require.NotNil(t, r.Default)
+	assert.Equal(t, "fallback", r.Default.Description)
+	require.Contains(t, r.Codes, "200")
+	assert.Contains(t, r.Extra, "x-object-ext")
+	assert.Contains(t, r.Extra, "x-scalar-ext")
+	assert.NotContains(t, r.Codes, "x-object-ext")
+	assert.NotContains(t, r.Codes, "x-scalar-ext")
+}
+
+// TestResponsesMarshalYAMLKeyOrder pins the emitted key order: `default` first,
+// then the status codes and extensions together in sorted order.
+//
+// The order is asserted rather than left to map iteration because a result that
+// varies between runs of the same binary makes any diff of validator or
+// converter output useless (#425).
+func TestResponsesMarshalYAMLKeyOrder(t *testing.T) {
+	r := &Responses{
+		Default: &Response{Description: "fallback"},
+		Codes: map[string]*Response{
+			"500": {Description: "server error"},
+			"200": {Description: "OK"},
+			"4XX": {Description: "client error"},
+		},
+		Extra: map[string]any{
+			"x-note":  "an extension",
+			"x-first": "another",
+		},
+	}
+
+	// Quoting is the YAML encoder's own: a key that would otherwise read as an
+	// integer is quoted, and 4XX cannot, so it is not.
+	const want = `default:
+    description: fallback
+"200":
+    description: OK
+4XX:
+    description: client error
+"500":
+    description: server error
+x-first: another
+x-note: an extension
+`
+
+	// Repeated to catch an ordering that depends on map iteration: a single
+	// run can agree with the expectation by luck.
+	for range 8 {
+		out, err := yaml.Marshal(r)
+		require.NoError(t, err)
+		assert.Equal(t, want, string(out))
+	}
+}
+
+// TestResponsesMarshalPrefersCodesOnAClash covers a document assembled in Go
+// rather than parsed: no decode path can put one key in both maps, so the
+// only way to reach this is to build it. The key must still be emitted once,
+// or the output is not a valid mapping.
+func TestResponsesMarshalPrefersCodesOnAClash(t *testing.T) {
+	r := &Responses{
+		Codes: map[string]*Response{"x-clash": {Description: "from codes"}},
+		Extra: map[string]any{"x-clash": "from extra"},
+	}
+
+	out, err := yaml.Marshal(r)
+	require.NoError(t, err)
+	assert.Equal(t, "x-clash:\n    description: from codes\n", string(out))
+
+	j, err := r.MarshalJSON()
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"x-clash":{"description":"from codes"}}`, string(j))
+}
+
+// TestResponsesEqualityObservesExtensions pins Extra as part of a Responses
+// value's identity. Two documents differing only in a response extension are
+// different documents, and a comparison that ignored Extra would report them
+// equal.
+func TestResponsesEqualityObservesExtensions(t *testing.T) {
+	base := func() *Responses {
+		return &Responses{
+			Default: &Response{Description: "fallback"},
+			Codes:   map[string]*Response{"200": {Description: "OK"}},
+			Extra:   map[string]any{"x-note": "one"},
+		}
+	}
+
+	assert.True(t, equalResponses(base(), base()), "identical values must compare equal")
+
+	differentValue := base()
+	differentValue.Extra["x-note"] = "two"
+	assert.False(t, equalResponses(base(), differentValue),
+		"an extension with a different value makes the objects different")
+
+	missingExtension := base()
+	missingExtension.Extra = nil
+	assert.False(t, equalResponses(base(), missingExtension),
+		"an absent extension makes the objects different")
+}

--- a/parser/responses_keys_test.go
+++ b/parser/responses_keys_test.go
@@ -118,11 +118,12 @@ paths:
 // TestResponsesInvalidStatusCodeIsReportedOnEveryDecodePath asserts that no
 // decode path accepts an invalid status code in silence.
 //
-// The channel differs by path and that difference is deliberate: the YAML and
-// JSON decoders can fail the parse, so they do, and callers can rely on a
-// non-nil error. decodeFromMap has no error return, so it keeps the key and
-// the structure validator reports it. Dropping the key there would lose the
-// response and report nothing at all.
+// Where the diagnostic arrives differs by path, and that difference is
+// deliberate. The YAML and JSON decoders can fail the parse, so they do:
+// ParseBytes returns a non-nil error and no document. decodeFromMap cannot
+// return an error, so it keeps the key and the structure validator reports it
+// in ParseResult.Errors. Dropping the key there would lose the response and
+// report nothing at all.
 func TestResponsesInvalidStatusCodeIsReportedOnEveryDecodePath(t *testing.T) {
 	const specYAML = `openapi: 3.0.3
 info:

--- a/parser/responses_keys_test.go
+++ b/parser/responses_keys_test.go
@@ -1,6 +1,8 @@
 package parser
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -218,20 +220,128 @@ paths:
 	doc, ok := res.Document.(*OAS3Document)
 	require.True(t, ok)
 
-	out, err := yaml.Marshal(doc)
-	require.NoError(t, err)
+	assertRoundTripped := func(t *testing.T, r *Responses) {
+		t.Helper()
+		require.NotNil(t, r.Default)
+		assert.Equal(t, "fallback", r.Default.Description)
+		require.Contains(t, r.Codes, "200")
+		assert.Contains(t, r.Extra, "x-object-ext")
+		assert.Contains(t, r.Extra, "x-scalar-ext")
+		assert.NotContains(t, r.Codes, "x-object-ext")
+		assert.NotContains(t, r.Codes, "x-scalar-ext")
+	}
 
-	reparsed, err := New().ParseBytes(out)
-	require.NoError(t, err)
+	t.Run("yaml", func(t *testing.T) {
+		out, err := yaml.Marshal(doc)
+		require.NoError(t, err)
 
-	r := responsesOf(t, reparsed)
-	require.NotNil(t, r.Default)
-	assert.Equal(t, "fallback", r.Default.Description)
-	require.Contains(t, r.Codes, "200")
-	assert.Contains(t, r.Extra, "x-object-ext")
-	assert.Contains(t, r.Extra, "x-scalar-ext")
-	assert.NotContains(t, r.Codes, "x-object-ext")
-	assert.NotContains(t, r.Codes, "x-scalar-ext")
+		reparsed, err := New().ParseBytes(out)
+		require.NoError(t, err)
+		assertRoundTripped(t, responsesOf(t, reparsed))
+	})
+
+	// The two marshalers are separate implementations, so a merge present in
+	// one says nothing about the other.
+	t.Run("json", func(t *testing.T) {
+		out, err := json.Marshal(doc)
+		require.NoError(t, err)
+
+		reparsed, err := New().ParseBytes(out)
+		require.NoError(t, err)
+		assertRoundTripped(t, responsesOf(t, reparsed))
+	})
+}
+
+// TestResponsesMarshalResolvesDefaultOnce covers a caller-assembled document
+// holding `default` both in its own field and as a map entry. Emitting it twice
+// produces a mapping that does not parse back, so the key is resolved to one
+// value, and both marshalers resolve it the same way.
+func TestResponsesMarshalResolvesDefaultOnce(t *testing.T) {
+	tests := []struct {
+		name string
+		in   *Responses
+		want string
+	}{
+		{
+			name: "Codes wins over the Default field",
+			in: &Responses{
+				Default: &Response{Description: "from Default"},
+				Codes:   map[string]*Response{"default": {Description: "from Codes"}},
+			},
+			want: "from Codes",
+		},
+		{
+			name: "the Default field wins over Extra",
+			in: &Responses{
+				Default: &Response{Description: "from Default"},
+				Extra:   map[string]any{"default": map[string]any{"description": "from Extra"}},
+			},
+			want: "from Default",
+		},
+		{
+			name: "Extra supplies it when nothing else does",
+			in: &Responses{
+				Extra: map[string]any{"default": map[string]any{"description": "from Extra"}},
+			},
+			want: "from Extra",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := yaml.Marshal(tt.in)
+			require.NoError(t, err)
+			assert.Equal(t, 1, strings.Count(string(out), "default:"),
+				"want exactly one default key; got:\n%s", out)
+			assert.Contains(t, string(out), tt.want)
+
+			// The duplicate this guards against is only visible on the way
+			// back in: a repeated mapping key is a decode error.
+			var back Responses
+			require.NoError(t, yaml.Unmarshal(out, &back), "emitted YAML must parse back")
+
+			encoded, err := tt.in.MarshalJSON()
+			require.NoError(t, err)
+			var decoded map[string]json.RawMessage
+			require.NoError(t, json.Unmarshal(encoded, &decoded))
+			require.Contains(t, decoded, "default")
+			assert.Contains(t, string(decoded["default"]), tt.want,
+				"both marshalers must resolve `default` the same way")
+		})
+	}
+}
+
+// TestResponsesDecodeIntoReusedValueResets covers decoding a second document
+// into a value that already holds one. Both maps describe the document just
+// decoded, so neither may carry an entry forward from the previous one.
+func TestResponsesDecodeIntoReusedValueResets(t *testing.T) {
+	const withExtension = `
+"200": {description: OK}
+x-note: carried over?
+`
+	const withoutExtension = `
+"200": {description: OK}
+`
+
+	t.Run("yaml", func(t *testing.T) {
+		var r Responses
+		require.NoError(t, yaml.Unmarshal([]byte(withExtension), &r))
+		require.Contains(t, r.Extra, "x-note")
+
+		require.NoError(t, yaml.Unmarshal([]byte(withoutExtension), &r))
+		assert.NotContains(t, r.Extra, "x-note",
+			"the second document declares no extension, so none may survive")
+	})
+
+	t.Run("json", func(t *testing.T) {
+		var r Responses
+		require.NoError(t, json.Unmarshal([]byte(`{"200":{"description":"OK"},"x-note":"carried over?"}`), &r))
+		require.Contains(t, r.Extra, "x-note")
+
+		require.NoError(t, json.Unmarshal([]byte(`{"200":{"description":"OK"}}`), &r))
+		assert.NotContains(t, r.Extra, "x-note",
+			"the second document declares no extension, so none may survive")
+	})
 }
 
 // TestResponsesMarshalYAMLKeyOrder pins the emitted key order: `default` first,

--- a/parser/responses_keys_test.go
+++ b/parser/responses_keys_test.go
@@ -328,6 +328,37 @@ paths:
 	assert.Nil(t, target.Default, "decodeFromMap must clear a default it does not find")
 }
 
+// TestResponsesDeepCopyIsolatesExtensions asserts that a copied Responses does
+// not share the inside of its extensions with the original. An extension value
+// is arbitrary JSON, so it can nest maps and slices, and a copy that duplicated
+// only the outer map would let a mutation reach across.
+func TestResponsesDeepCopyIsolatesExtensions(t *testing.T) {
+	original := &Responses{
+		Default: &Response{Description: "fallback"},
+		Codes:   map[string]*Response{"200": {Description: "OK"}},
+		Extra: map[string]any{
+			"x-nested": map[string]any{"inner": "before"},
+			"x-list":   []any{"first"},
+		},
+	}
+
+	copied := original.DeepCopy()
+	require.NotNil(t, copied)
+
+	nested, ok := copied.Extra["x-nested"].(map[string]any)
+	require.True(t, ok, "expected a nested map, got %T", copied.Extra["x-nested"])
+	nested["inner"] = "after"
+
+	list, ok := copied.Extra["x-list"].([]any)
+	require.True(t, ok, "expected a nested slice, got %T", copied.Extra["x-list"])
+	list[0] = "changed"
+
+	assert.Equal(t, map[string]any{"inner": "before"}, original.Extra["x-nested"],
+		"mutating the copy must not reach the original")
+	assert.Equal(t, []any{"first"}, original.Extra["x-list"],
+		"mutating the copy must not reach the original")
+}
+
 // TestResponsesRoundTripPreservesExtensions asserts that splitting extensions
 // out of Codes does not lose them on the way back out, and that both marshalers
 // emit them in the one object the specification describes.

--- a/parser/responses_keys_test.go
+++ b/parser/responses_keys_test.go
@@ -225,8 +225,16 @@ paths:
 		require.NotNil(t, r.Default)
 		assert.Equal(t, "fallback", r.Default.Description)
 		require.Contains(t, r.Codes, "200")
-		assert.Contains(t, r.Extra, "x-object-ext")
-		assert.Contains(t, r.Extra, "x-scalar-ext")
+		assert.Equal(t, "OK", r.Codes["200"].Description)
+
+		// The values are asserted, not just the keys: an extension that
+		// survives under the right name with the wrong content has still
+		// been lost, and a key-only check cannot tell the difference.
+		require.Contains(t, r.Extra, "x-object-ext")
+		assert.Equal(t, map[string]any{"description": "an extension"}, r.Extra["x-object-ext"])
+		require.Contains(t, r.Extra, "x-scalar-ext")
+		assert.EqualValues(t, 100, r.Extra["x-scalar-ext"])
+
 		assert.NotContains(t, r.Codes, "x-object-ext")
 		assert.NotContains(t, r.Codes, "x-scalar-ext")
 	}
@@ -312,35 +320,57 @@ func TestResponsesMarshalResolvesDefaultOnce(t *testing.T) {
 }
 
 // TestResponsesDecodeIntoReusedValueResets covers decoding a second document
-// into a value that already holds one. Both maps describe the document just
-// decoded, so neither may carry an entry forward from the previous one.
+// into a value that already holds one. Every field describes the document just
+// decoded, so none may carry anything forward from the previous one: not an
+// extension, not a status code, and not the default response.
 func TestResponsesDecodeIntoReusedValueResets(t *testing.T) {
-	const withExtension = `
+	const populatedYAML = `
 "200": {description: OK}
+"404": {description: Not Found}
+default: {description: fallback}
 x-note: carried over?
 `
-	const withoutExtension = `
+	const sparseYAML = `
 "200": {description: OK}
 `
+
+	const populatedJSON = `{
+  "200": {"description": "OK"},
+  "404": {"description": "Not Found"},
+  "default": {"description": "fallback"},
+  "x-note": "carried over?"
+}`
+	const sparseJSON = `{"200": {"description": "OK"}}`
+
+	assertOnlySparse := func(t *testing.T, r *Responses) {
+		t.Helper()
+		assert.NotContains(t, r.Extra, "x-note",
+			"the second document declares no extension, so none may survive")
+		assert.NotContains(t, r.Codes, "404",
+			"the second document declares no 404, so none may survive")
+		assert.Nil(t, r.Default,
+			"the second document declares no default, so none may survive")
+		assert.Contains(t, r.Codes, "200")
+	}
 
 	t.Run("yaml", func(t *testing.T) {
 		var r Responses
-		require.NoError(t, yaml.Unmarshal([]byte(withExtension), &r))
+		require.NoError(t, yaml.Unmarshal([]byte(populatedYAML), &r))
 		require.Contains(t, r.Extra, "x-note")
+		require.NotNil(t, r.Default)
 
-		require.NoError(t, yaml.Unmarshal([]byte(withoutExtension), &r))
-		assert.NotContains(t, r.Extra, "x-note",
-			"the second document declares no extension, so none may survive")
+		require.NoError(t, yaml.Unmarshal([]byte(sparseYAML), &r))
+		assertOnlySparse(t, &r)
 	})
 
 	t.Run("json", func(t *testing.T) {
 		var r Responses
-		require.NoError(t, json.Unmarshal([]byte(`{"200":{"description":"OK"},"x-note":"carried over?"}`), &r))
+		require.NoError(t, json.Unmarshal([]byte(populatedJSON), &r))
 		require.Contains(t, r.Extra, "x-note")
+		require.NotNil(t, r.Default)
 
-		require.NoError(t, json.Unmarshal([]byte(`{"200":{"description":"OK"}}`), &r))
-		assert.NotContains(t, r.Extra, "x-note",
-			"the second document declares no extension, so none may survive")
+		require.NoError(t, json.Unmarshal([]byte(sparseJSON), &r))
+		assertOnlySparse(t, &r)
 	})
 }
 

--- a/parser/zz_generated_decode.go
+++ b/parser/zz_generated_decode.go
@@ -958,18 +958,25 @@ func (x *XML) decodeFromMap(m map[string]any) {
 
 func (x *Responses) decodeFromMap(m map[string]any) {
 	x.Codes = make(map[string]*Response)
+	x.Extra = extractExtensionsFromMap(m)
 	for key, value := range m {
+		if isExtensionKey(key) {
+			continue
+		}
 		sub, ok := value.(map[string]any)
 		if !ok {
 			continue
 		}
-		if key == "default" {
+		if key == httputil.ResponsesKeyDefault {
 			x.Default = new(Response)
 			x.Default.decodeFromMap(sub)
-		} else if httputil.ValidateStatusCode(key) {
-			resp := new(Response)
-			resp.decodeFromMap(sub)
-			x.Codes[key] = resp
+			continue
 		}
+		// A key that is not a status code is kept, not discarded. This method
+		// has no error channel, so validateStructure is what reports it, and
+		// discarding the key here would take the response with it.
+		resp := new(Response)
+		resp.decodeFromMap(sub)
+		x.Codes[key] = resp
 	}
 }

--- a/parser/zz_generated_decode.go
+++ b/parser/zz_generated_decode.go
@@ -973,7 +973,7 @@ func (x *Responses) decodeFromMap(m map[string]any) {
 			continue
 		}
 		// A key that is not a status code is kept, not discarded. This method
-		// has no error channel, so validateStructure is what reports it, and
+		// cannot return an error, so validateStructure is what reports it, and
 		// discarding the key here would take the response with it.
 		resp := new(Response)
 		resp.decodeFromMap(sub)

--- a/parser/zz_generated_decode.go
+++ b/parser/zz_generated_decode.go
@@ -957,26 +957,37 @@ func (x *XML) decodeFromMap(m map[string]any) {
 }
 
 func (x *Responses) decodeFromMap(m map[string]any) {
+	// Every field describes this map alone, so decoding into a reused value
+	// carries nothing forward from the one it held before.
 	x.Codes = make(map[string]*Response)
 	x.Extra = extractExtensionsFromMap(m)
+	x.Default = nil
+
 	for key, value := range m {
 		if isExtensionKey(key) {
 			continue
 		}
-		sub, ok := value.(map[string]any)
-		if !ok {
-			continue
+		sub, isObject := value.(map[string]any)
+		switch {
+		case key == httputil.ResponsesKeyDefault:
+			if isObject {
+				x.Default = new(Response)
+				x.Default.decodeFromMap(sub)
+			}
+		case isObject:
+			// A key that is not a status code is kept, not discarded. This
+			// method cannot return an error, so validateStructure is what
+			// reports it, and discarding the key would take the response too.
+			resp := new(Response)
+			resp.decodeFromMap(sub)
+			x.Codes[key] = resp
+		case !httputil.IsStatusCode(key):
+			// The key is reportable even though its value is not a Response,
+			// so it is kept for validateStructure to name. A well-formed
+			// status code whose value is not an object is left out instead:
+			// nothing here validates the value, and inventing an empty
+			// Response would report a response the document does not declare.
+			x.Codes[key] = new(Response)
 		}
-		if key == httputil.ResponsesKeyDefault {
-			x.Default = new(Response)
-			x.Default.decodeFromMap(sub)
-			continue
-		}
-		// A key that is not a status code is kept, not discarded. This method
-		// cannot return an error, so validateStructure is what reports it, and
-		// discarding the key here would take the response with it.
-		resp := new(Response)
-		resp.decodeFromMap(sub)
-		x.Codes[key] = resp
 	}
 }

--- a/parser/zz_generated_deepcopy.go
+++ b/parser/zz_generated_deepcopy.go
@@ -1101,6 +1101,8 @@ func (in *Responses) DeepCopyInto(out *Responses) {
 			}
 		}
 	}
+
+	out.Extra = deepCopyExtensions(in.Extra)
 }
 
 // DeepCopy creates a deep copy of Schema.

--- a/validator/helpers.go
+++ b/validator/helpers.go
@@ -66,14 +66,18 @@ func (v *Validator) validateInfoObject(info *parser.Info, result *ValidationResu
 // validateResponseStatusCodes validates HTTP status codes in an operation's responses.
 // This helper is shared by both OAS 2.0 and OAS 3.x operation validators.
 func (v *Validator) validateResponseStatusCodes(responses *parser.Responses, path string, result *ValidationResult, baseURL string) {
-	if responses == nil || responses.Codes == nil {
+	if responses == nil {
 		return
 	}
 
-	hasSuccess := false
+	// A document declaring only `default` covers every code, so it satisfies
+	// the success check below. The decoders route that key to Responses.Default
+	// rather than into Codes, so it is not observable from the loop.
+	hasSuccess := responses.Default != nil
+
 	for code := range responses.Codes {
 		// Validate HTTP status code format
-		if !httputil.ValidateStatusCode(code) {
+		if !httputil.IsStatusCode(code) {
 			v.addError(result, path+".responses."+code,
 				fmt.Sprintf("Invalid HTTP status code: %s", code),
 				withSpecRef(fmt.Sprintf("%s#responses-object", baseURL)),
@@ -88,7 +92,7 @@ func (v *Validator) validateResponseStatusCodes(responses *parser.Responses, pat
 			)
 		}
 
-		if strings.HasPrefix(code, "2") || code == "default" {
+		if strings.HasPrefix(code, "2") {
 			hasSuccess = true
 		}
 	}

--- a/validator/helpers.go
+++ b/validator/helpers.go
@@ -83,7 +83,13 @@ func (v *Validator) validateResponseStatusCodes(responses *parser.Responses, pat
 				withSpecRef(fmt.Sprintf("%s#responses-object", baseURL)),
 				withValue(code),
 			)
-		} else if v.StrictMode && !httputil.IsStandardStatusCode(code) {
+			// A key already reported as malformed says nothing about which
+			// responses the operation defines, so it cannot answer the success
+			// question below either.
+			continue
+		}
+
+		if v.StrictMode && !httputil.IsStandardStatusCode(code) {
 			// In strict mode, warn about non-standard status codes
 			v.addWarning(result, path+".responses."+code,
 				fmt.Sprintf("Non-standard HTTP status code: %s (not defined in HTTP RFCs)", code),

--- a/validator/helpers.go
+++ b/validator/helpers.go
@@ -98,7 +98,7 @@ func (v *Validator) validateResponseStatusCodes(responses *parser.Responses, pat
 			)
 		}
 
-		if strings.HasPrefix(code, "2") {
+		if httputil.IsSuccessStatusCode(code) {
 			hasSuccess = true
 		}
 	}

--- a/validator/responses_status_codes_test.go
+++ b/validator/responses_status_codes_test.go
@@ -135,8 +135,9 @@ func TestInvalidStatusCodeInCodesIsReported(t *testing.T) {
 // operation's success response, or reporting it would suppress a second,
 // unrelated diagnostic.
 //
-// decodeFromMap keeps such a key rather than discarding it, so this reaches the
-// validator from a parsed document and not only from an assembled one.
+// The value is assembled in Go so the check can be exercised on its own.
+// TestMalformedCodeFromAParsedDocument covers the same input arriving through
+// the parser, which is what makes the case reachable in practice.
 func TestMalformedCodeDoesNotSatisfyTheSuccessCheck(t *testing.T) {
 	doc := &parser.OAS3Document{
 		OpenAPI:    "3.1.0",
@@ -234,4 +235,56 @@ func TestExtensionKeyInCodesIsReportedAsInvalid(t *testing.T) {
 	assert.Contains(t, joined, "Invalid HTTP status code: x-note")
 	assert.Contains(t, joined, "Invalid HTTP status code: default")
 	assert.NotContains(t, joined, "Invalid HTTP status code: 200")
+}
+
+// TestMalformedCodeFromAParsedDocument is the parsed counterpart to
+// TestMalformedCodeDoesNotSatisfyTheSuccessCheck. decodeFromMap keeps a key
+// that is not a status code rather than discarding it, so a real document can
+// put one in front of the validator, and this asserts it arrives that way
+// rather than only when a test builds the value by hand.
+//
+// ResolveRefs selects that decode path. The YAML and JSON decoders reject the
+// key outright, so neither can deliver this input.
+func TestMalformedCodeFromAParsedDocument(t *testing.T) {
+	const spec = `
+openapi: 3.1.0
+info: {title: T, version: "1.0.0"}
+paths:
+  /a:
+    get:
+      operationId: a
+      summary: only a malformed code
+      responses:
+        "2foo": {description: not a status code}
+`
+
+	p := parser.New()
+	p.ResolveRefs = true
+	p.ValidateStructure = false
+	parsed, err := p.ParseBytes([]byte(spec))
+	require.NoError(t, err)
+
+	doc, ok := parsed.Document.(*parser.OAS3Document)
+	require.True(t, ok)
+	require.Contains(t, doc.Paths["/a"].Get.Responses.Codes, "2foo",
+		"the decoder must keep the key, or the validator never sees it")
+
+	v := New()
+	v.IncludeWarnings = true
+	v.StrictMode = true
+	result, err := v.ValidateParsed(*parsed)
+	require.NoError(t, err)
+
+	errs := make([]string, 0, len(result.Errors))
+	for _, e := range result.Errors {
+		errs = append(errs, e.Message)
+	}
+	warnings := make([]string, 0, len(result.Warnings))
+	for _, w := range result.Warnings {
+		warnings = append(warnings, w.Message)
+	}
+
+	assert.Contains(t, strings.Join(errs, "\n"), "Invalid HTTP status code: 2foo")
+	assert.Contains(t, strings.Join(warnings, "\n"),
+		"Operation should define at least one successful response")
 }

--- a/validator/responses_status_codes_test.go
+++ b/validator/responses_status_codes_test.go
@@ -1,0 +1,179 @@
+package validator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erraggy/oastools/parser"
+)
+
+// TestDefaultOnlyResponsesSatisfiesTheSuccessCheck covers an operation whose
+// only response is `default`. The strict-mode warning names default as
+// sufficient, and it is: the Responses Object's default covers every code not
+// listed individually.
+//
+// The check reads Responses.Default because every decode path routes that key
+// to its own field, so it is never observable from a scan of Responses.Codes.
+func TestDefaultOnlyResponsesSatisfiesTheSuccessCheck(t *testing.T) {
+	spec := `
+openapi: 3.1.0
+info: {title: T, version: "1.0.0"}
+paths:
+  /a:
+    get:
+      operationId: a
+      summary: only a default response
+      responses:
+        default: {description: covers every code}
+`
+	warnings := strings.Join(warningsWithStrict(t, spec, true), "\n")
+
+	assert.NotContains(t, warnings, "successful response",
+		"a default response covers every code, so the success check is satisfied")
+}
+
+// TestNonSuccessResponsesStillWarn is the counterpart: without a 2XX and
+// without a default, the warning must still fire. Without this, a change that
+// simply deleted the check would pass the test above.
+func TestNonSuccessResponsesStillWarn(t *testing.T) {
+	spec := `
+openapi: 3.1.0
+info: {title: T, version: "1.0.0"}
+paths:
+  /a:
+    get:
+      operationId: a
+      summary: no success response
+      responses:
+        "404": {description: Not Found}
+`
+	warnings := strings.Join(warningsWithStrict(t, spec, true), "\n")
+
+	assert.Contains(t, warnings, "Operation should define at least one successful response")
+}
+
+// TestResponseExtensionsAreNotTreatedAsStatusCodes covers a specification
+// extension on the Responses Object, which OAS admits like any other object.
+// It is not a status code, so neither the format check nor strict mode's
+// non-standard-code check may say anything about it.
+//
+// This asserts the end-to-end result for a parsed document, which the decoders
+// deliver by keeping extensions out of Responses.Codes entirely. The validator's
+// own predicate is pinned separately, by
+// TestExtensionKeyInCodesIsReportedAsInvalid, because no parsed document can
+// present it with the input that exercises it.
+func TestResponseExtensionsAreNotTreatedAsStatusCodes(t *testing.T) {
+	spec := `
+openapi: 3.1.0
+info: {title: T, version: "1.0.0"}
+paths:
+  /a:
+    get:
+      operationId: a
+      summary: carries an extension
+      responses:
+        "200": {description: OK}
+        x-rate-limit: {description: not a response}
+        x-scalar: 100
+`
+	warnings := strings.Join(warningsWithStrict(t, spec, true), "\n")
+
+	assert.NotContains(t, warnings, "x-rate-limit")
+	assert.NotContains(t, warnings, "x-scalar")
+	assert.NotContains(t, warnings, "Non-standard HTTP status code")
+}
+
+// TestInvalidStatusCodeInCodesIsReported pins the format check itself. Reaching
+// it takes a Responses object holding a key no decoder would have accepted,
+// which is why the value is built here rather than parsed: the YAML and JSON
+// decoders reject such a key outright.
+func TestInvalidStatusCodeInCodesIsReported(t *testing.T) {
+	doc := &parser.OAS3Document{
+		OpenAPI:    "3.1.0",
+		OASVersion: parser.OASVersion310,
+		Info:       &parser.Info{Title: "T", Version: "1.0.0"},
+		Paths: parser.Paths{
+			"/a": {
+				Get: &parser.Operation{
+					OperationID: "a",
+					Responses: &parser.Responses{
+						Codes: map[string]*parser.Response{
+							"200": {Description: "OK"},
+							"999": {Description: "not a status code"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	v := New()
+	v.IncludeWarnings = true
+	result, err := v.ValidateParsed(parser.ParseResult{
+		Document:   doc,
+		Version:    "3.1.0",
+		OASVersion: parser.OASVersion310,
+	})
+	require.NoError(t, err)
+
+	messages := make([]string, 0, len(result.Errors))
+	for _, e := range result.Errors {
+		messages = append(messages, e.Path+": "+e.Message)
+	}
+	joined := strings.Join(messages, "\n")
+
+	assert.Contains(t, joined, "Invalid HTTP status code: 999")
+	assert.NotContains(t, joined, "Invalid HTTP status code: 200")
+}
+
+// TestExtensionKeyInCodesIsReportedAsInvalid pins which question the validator
+// asks of a Responses.Codes key. Codes holds status codes, so an extension
+// sitting there is a defect in whatever assembled it and must be reported,
+// even though the key would be perfectly legal one level up in the Responses
+// Object itself.
+//
+// Only a caller-assembled document can reach this: the decoders route
+// extensions to Responses.Extra, so no parsed document puts one in Codes.
+func TestExtensionKeyInCodesIsReportedAsInvalid(t *testing.T) {
+	doc := &parser.OAS3Document{
+		OpenAPI:    "3.1.0",
+		OASVersion: parser.OASVersion310,
+		Info:       &parser.Info{Title: "T", Version: "1.0.0"},
+		Paths: parser.Paths{
+			"/a": {
+				Get: &parser.Operation{
+					OperationID: "a",
+					Responses: &parser.Responses{
+						Codes: map[string]*parser.Response{
+							"200":     {Description: "OK"},
+							"x-note":  {Description: "an extension, misfiled"},
+							"default": {Description: "misfiled too"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	v := New()
+	v.IncludeWarnings = true
+	result, err := v.ValidateParsed(parser.ParseResult{
+		Document:   doc,
+		Version:    "3.1.0",
+		OASVersion: parser.OASVersion310,
+	})
+	require.NoError(t, err)
+
+	messages := make([]string, 0, len(result.Errors))
+	for _, e := range result.Errors {
+		messages = append(messages, e.Path+": "+e.Message)
+	}
+	joined := strings.Join(messages, "\n")
+
+	assert.Contains(t, joined, "Invalid HTTP status code: x-note")
+	assert.Contains(t, joined, "Invalid HTTP status code: default")
+	assert.NotContains(t, joined, "Invalid HTTP status code: 200")
+}

--- a/validator/responses_status_codes_test.go
+++ b/validator/responses_status_codes_test.go
@@ -129,6 +129,64 @@ func TestInvalidStatusCodeInCodesIsReported(t *testing.T) {
 	assert.NotContains(t, joined, "Invalid HTTP status code: 200")
 }
 
+// TestMalformedCodeDoesNotSatisfyTheSuccessCheck covers a key that is not a
+// status code but begins with a 2, which is how the success check recognises
+// one. A key already reported as malformed must not also be accepted as the
+// operation's success response, or reporting it would suppress a second,
+// unrelated diagnostic.
+//
+// decodeFromMap keeps such a key rather than discarding it, so this reaches the
+// validator from a parsed document and not only from an assembled one.
+func TestMalformedCodeDoesNotSatisfyTheSuccessCheck(t *testing.T) {
+	doc := &parser.OAS3Document{
+		OpenAPI:    "3.1.0",
+		OASVersion: parser.OASVersion310,
+		Info:       &parser.Info{Title: "T", Version: "1.0.0"},
+		Paths: parser.Paths{
+			"/a": {
+				Get: &parser.Operation{
+					OperationID: "a",
+					Summary:     "only a malformed code",
+					Responses: &parser.Responses{
+						Codes: map[string]*parser.Response{
+							"2foo": {Description: "not a status code"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	v := New()
+	v.IncludeWarnings = true
+	v.StrictMode = true
+	result, err := v.ValidateParsed(parser.ParseResult{
+		Document:   doc,
+		Version:    "3.1.0",
+		OASVersion: parser.OASVersion310,
+	})
+	require.NoError(t, err)
+
+	errs := make([]string, 0, len(result.Errors))
+	for _, e := range result.Errors {
+		errs = append(errs, e.Message)
+	}
+	warnings := make([]string, 0, len(result.Warnings))
+	for _, w := range result.Warnings {
+		warnings = append(warnings, w.Message)
+	}
+
+	assert.Contains(t, strings.Join(errs, "\n"), "Invalid HTTP status code: 2foo")
+	assert.Contains(t, strings.Join(warnings, "\n"),
+		"Operation should define at least one successful response",
+		"a malformed key cannot stand in for a 2XX response")
+
+	// The non-standard-code warning is for keys that are status codes but not
+	// registered ones. A malformed key is already reported as an error, so
+	// saying it twice in two different vocabularies helps nobody.
+	assert.NotContains(t, strings.Join(warnings, "\n"), "Non-standard HTTP status code: 2foo")
+}
+
 // TestExtensionKeyInCodesIsReportedAsInvalid pins which question the validator
 // asks of a Responses.Codes key. Codes holds status codes, so an extension
 // sitting there is a defect in whatever assembled it and must be reported,


### PR DESCRIPTION
Closes: #455
Closes: #462
Closes: #465
Closes: #466
Refs: #449

A Responses Object admits three kinds of key: `default`, an HTTP status code or wildcard range, and a specification extension. One predicate answered for all three, so every caller that meant *"is this a status code?"* was handed *"may this key appear here?"* instead. `parser.Responses` also had no `Extra` field, so extensions had nowhere to go but `Codes`, which is what let the conflation through.

Six user visible defects came out of that, all reproduced before the fix and re-run after.

## What was broken

**1. `--resolve-refs` dropped a response and exited 0**

```console
$ oastools walk responses --resolve-refs bad.yaml
STATUS  DESCRIPTION                   PATH  METHOD  EXTENSIONS
200     OK                            /a    GET
x-note  an extension, not a response  /a    GET
exit=0
```

The `"999"` response is gone, silently. The generated `decodeFromMap` filtered the key out, and the same file without the flag exits 1: the same document, opposite verdicts depending on the decode route.

**2. Extensions were listed as status codes.** `x-note` appears above under a column headed STATUS, beside an EXTENSIONS column that should have held it.

**3. A scalar extension made a document unparseable.** `x-rate-limit: 100` under `responses` is legal and cost the whole document:

```
line 10: failed to unmarshal response for status code x-rate-limit:
  cannot construct !!int `100` into parser.Response
```

**4. Strict mode warned about a legal extension:** `⚠ Non-standard HTTP status code: x-note`.

**5. Strict mode warned that a `default`-only operation had no success response.** The message names `default` as sufficient, and it is, but the check scanned `Codes`, which never holds that key, so the `code == "default"` arm was dead. **Five real instances in the corpus:** four in `petstore-swagger.json` (`/user.post`, `/user/createWithArray.post`, `/user/createWithList.post`, `/user/logout.get`, all `default`-only) and one in `nws-openapi.json` (`301` plus `default`).

**6. `oastools diff` did not compare the default response at all.**

```console
$ oastools diff with-default.yaml without-default.yaml
✓ No differences found - specifications are identical
```

A default response covers every code not listed individually, so dropping it changes what a client can expect from any unlisted status. Pre-existing and independent of the rest; it lives in the same function the extension comparison needed.

## What changed

`internal/httputil` now states which question each predicate answers: `IsStatusCode` is the narrow one, `IsValidResponsesKey` the broad one, and `IsExtensionKey` is the single definition of the prefix that `parser.isExtensionKey` delegates to.

`parser.Responses` gains `Extra`, matching every other OAS container. The 3.2 prose is explicit that the object takes extensions ("This object MAY be extended with Specification Extensions"), verified against the published HTML rather than recalled.

**The two structure-validation loops in `parser.go` were unreachable** because all three decoders filtered before a `Responses` value existed. They now report an invalid key on the `decodeFromMap` path, which cannot return an error: it keeps a non status code key rather than discarding it, and the loop reports it into `ParseResult.Errors`. The YAML and JSON decoders still fail the parse outright, so the contract callers rely on is unchanged.

Where the diagnostic arrives therefore differs by path, deliberately, and the tests assert it. That is the one acceptance criterion of #449 this does not fully meet, which is why the trailer is `Refs` and not `Closes`: the issue asks for one decision applied to all three paths, and `decodeFromMap` cannot return an error without changing the signature of every generated decoder. The alternatives are laid out in a comment on the issue.

## Serialization is unchanged

Both marshalers merge `Default`, `Codes` and `Extra` back into the one object the specification describes, and `MarshalYAML` fixes the key order (`default` first, then sorted). The YAML library permits only one inline map per struct, which is why `Codes` gave up its `,inline` tag and the marshaler became explicit.

Output was verified **byte identical against `main` across all 78 vendored pass fixtures**, and the empty and `default`-only cases were compared separately.

`Responses` also joins the driftguard's marshal subjects: it was the one type with a hand built `MarshalJSON` missing from that list. Its `Codes` merges into the enclosing object rather than a named key, which the guard now expresses.

## Review

Three CodeRabbit CLI rounds plus a PR review, 22 findings, 17 taken and 5 declined with evidence.

The PR review found two more instances of this branch's own subject. `decodeFromMap` required an object value before it classified the key, so `"999": 100` under `ResolveRefs` lost both the key and any report of it, exactly the silent drop #449 is about; and it cleared `Codes` and `Extra` on reuse but not `Default`.

The three worth naming were defects in code this branch introduced. `MarshalYAML` emitted `default` twice for a caller-assembled document, producing YAML that failed to re-parse. Neither decoder reset `Extra` or `Default`, so decoding into a reused value merged two documents. And a malformed key beginning with `2` satisfied the strict-mode success check, because `decodeFromMap` now keeps such a key and the check recognises a success response by its leading digit.

The declines: an overflow guard on `len(a)+len(b)` for two maps that cannot both fit in memory; pointing `parser.jsonKeyDefault` at `httputil.ResponsesKeyDefault`, which would conflate it with `Schema.Default`, a different specification field it also serves; and registering `Responses.Extra` as a driftguard merge, which was written, mutation tested, and found to assert nothing because `fieldsOf` never enumerates `Extra`.

## Verification

- `make check` green: **10730 tests**, from 10661 on `main`.
- `make test-corpus` green across all 10 specs.
- Corpus validator verdicts diffed against `main` with operationId attribution normalized and sorted. **The only differences are the five false warnings above disappearing.** No verdict was added.
- **Every new guard was mutation tested**: each was removed in turn and the corresponding test watched to fail. That found a real problem, kept in the diff: `TestResponseExtensionsAreNotTreatedAsStatusCodes` passes whether or not the validator uses the narrow predicate, because with the parser fixed no parsed document can put an extension in `Codes`. `TestExtensionKeyInCodesIsReportedAsInvalid` builds the value in Go and is what actually pins that line.

## Out of scope, and deliberately so

`fix(codegen)` is its own commit and can be dropped independently. `go generate ./parser` failed outright because the deepcopy generator resolved its output path from its own working directory, and since `go generate` stops at the first failure, neither generator ran. It is the probe the decode generator already uses. This is #455, hit while regenerating for this change.

**OAS 2.0 does not permit wildcard range keys.** `2XX` is a 3.0 addition: the 2.0 Responses Object says only "Any HTTP status code can be used as the property name (one property per HTTP status code)", and the string "uppercase wildcard" appears nowhere in that document. Both before and after this change the 2.0 paths accept a range key, so it is pre-existing rather than introduced here, and correcting it tightens verdicts across every 2.0 decode path. Filed as #467.

**The converter drops specification extensions**, which this PR does not change and does not fix. Of five extension positions in a 2.0 document, only `info` survives conversion; root, PathItem, Operation, Response and Responses extensions are all discarded. Verified identical on `main` and on this branch, so it is pre-existing and orthogonal. Filed as #463.
