### PR TITLE
fix(parser): report an invalid status code instead of refusing the document

### DIFF
--- a/parser/conformance_relaxed_test.go
+++ b/parser/conformance_relaxed_test.go
@@ -247,16 +247,16 @@ paths:
 // must not stop an invalid status code being reported when `responses` *is*
 // present.
 //
-// Note that the check which fires here is the decoder's, not the structure
-// validator's. paths.go (YAML) and paths_json.go (JSON) both reject an invalid
-// status code outright, so a Responses object is never built and the structure
-// validator's loop over Responses.Codes never sees one by this route.
+// The check that fires is the structure validator's, for every decode path
+// alike: each one keeps a key that is no legal status code, and
+// validateStructure reports it into ParseResult.Errors.
 //
-// The third decode path, decodeFromMap, is not reachable from here: it runs
-// only under ResolveRefs, cannot return an error, and keeps the key so the
-// structure validator reports it instead.
-// TestResponsesInvalidStatusCodeIsReportedOnEveryDecodePath covers that route
-// and how it reports.
+// Asserting where the diagnostic arrives, and not only its message, is
+// deliberate. Moving it back out of ParseResult.Errors would change
+// ParseBytes's contract, and this test should fail if that happens so the move
+// is a decision rather than a side effect.
+// TestResponsesInvalidStatusCodeIsReportedOnEveryDecodePath covers all three
+// decoders against the same input.
 func TestOperationResponsesStatusCodesStillChecked(t *testing.T) {
 	const want = "invalid status code '999'"
 
@@ -302,20 +302,11 @@ paths:
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Pinned to how this is actually reported today: the
-			// decoder rejects an invalid status code, so ParseBytes returns a
-			// hard error and never reaches structure validation.
-			//
-			// Asserting where the diagnostic arrives, and not just its message,
-			// is deliberate. If
-			// a change moves this diagnostic into the collected result.Errors
-			// instead, that is a change to ParseBytes's external contract —
-			// callers today can rely on a non-nil error for this input — and
-			// the test should fail so the move is a decision rather than a
-			// side effect.
-			_, err := New().ParseBytes([]byte(tt.spec))
-			require.Error(t, err, "want a hard ParseBytes error containing %q", want)
-			assert.Contains(t, err.Error(), want)
+			res, err := New().ParseBytes([]byte(tt.spec))
+			require.NoError(t, err, "the document decodes; the status code is a structural fault")
+			require.NotNil(t, res)
+			assert.True(t, hasErrorContaining(res.Errors, want),
+				"want a collected error containing %q; got %v", want, res.Errors)
 		})
 	}
 }

--- a/parser/deep_dive.md
+++ b/parser/deep_dive.md
@@ -411,6 +411,17 @@ if len(result.Errors) > 0 {
 fmt.Printf("Parsed %s v%s\n", result.Version, result.OASVersion)
 ```
 
+Check both, because they answer different questions. A returned `err` means the
+input could not be decoded: malformed YAML or JSON, an unsupported version, a
+value of the wrong type for its field. A document that decodes but breaks a rule
+of the specification comes back with the problem in `result.Errors`, and an
+invalid response status code is one of those. Treating a nil `err` as "this
+document is valid" misses every structural fault.
+
+`result.Errors` is filled by structure validation, which
+`WithValidateStructure(false)` turns off. Disable it and these findings go with
+it; the `validator` package reports them independently.
+
 ### HTTP Reference Resolution
 
 See also: [HTTP refs example](https://pkg.go.dev/github.com/erraggy/oastools/parser#example-package-ParseWithHTTPRefs), [Parse from URL example](https://pkg.go.dev/github.com/erraggy/oastools/parser#example-package-ParseFromURL) on pkg.go.dev
@@ -488,7 +499,7 @@ fmt.Println(doc.Info.Title) // Original title
 | `OASVersion` | `OASVersion` | Parsed version constant |
 | `SourceFormat` | `SourceFormat` | Detected format (JSON or YAML) |
 | `SourcePath` | `string` | Original file path |
-| `Errors` | `[]error` | Parse errors |
+| `Errors` | `[]error` | Structural faults found in a document that decoded; decode failures come back as the returned error instead |
 | `Warnings` | `[]string` | Non-fatal warnings |
 
 [Back to top](#top)

--- a/parser/deep_dive.md
+++ b/parser/deep_dive.md
@@ -411,12 +411,13 @@ if len(result.Errors) > 0 {
 fmt.Printf("Parsed %s v%s\n", result.Version, result.OASVersion)
 ```
 
-Check both, because they answer different questions. A returned `err` means the
-input could not be decoded: malformed YAML or JSON, an unsupported version, a
-value of the wrong type for its field. A document that decodes but breaks a rule
-of the specification comes back with the problem in `result.Errors`, and an
-invalid response status code is one of those. Treating a nil `err` as "this
-document is valid" misses every structural fault.
+Check both, because they answer different questions. A returned `err` means no
+document was produced: the input could not be read (a missing file, a failed
+fetch, a size limit) or could not be decoded (malformed YAML or JSON, an
+unsupported version, a value of the wrong type for its field). A document that
+decodes but breaks a rule of the specification comes back with the problem in
+`result.Errors`, and an invalid response status code is one of those. Treating a
+nil `err` as "this document is valid" misses every structural fault.
 
 `result.Errors` is filled by structure validation, which
 `WithValidateStructure(false)` turns off. Disable it and these findings go with
@@ -499,7 +500,7 @@ fmt.Println(doc.Info.Title) // Original title
 | `OASVersion` | `OASVersion` | Parsed version constant |
 | `SourceFormat` | `SourceFormat` | Detected format (JSON or YAML) |
 | `SourcePath` | `string` | Original file path |
-| `Errors` | `[]error` | Structural faults found in a document that decoded; decode failures come back as the returned error instead |
+| `Errors` | `[]error` | Structural faults in a document that was produced; a document that could not be read or decoded comes back as the returned error instead |
 | `Warnings` | `[]string` | Non-fatal warnings |
 
 [Back to top](#top)

--- a/parser/doc.go
+++ b/parser/doc.go
@@ -46,10 +46,11 @@
 //
 // # Where a problem is reported
 //
-// A returned error means the input could not be decoded: malformed YAML or
-// JSON, an unsupported version, a value of the wrong type for its field. A
-// document that decodes but breaks a rule of the specification is returned,
-// with the problem in ParseResult.Errors:
+// A returned error means no document was produced: the input could not be read
+// (a missing file, a failed fetch, a size limit) or could not be decoded
+// (malformed YAML or JSON, an unsupported version, a value of the wrong type
+// for its field). A document that decodes but breaks a rule of the
+// specification is returned, with the problem in ParseResult.Errors:
 //
 //	result, err := p.Parse("api.yaml")
 //	if err != nil {

--- a/parser/doc.go
+++ b/parser/doc.go
@@ -44,6 +44,29 @@
 // access to the base directory and subdirectories. Reference resolution caches
 // up to 100 documents by default to prevent memory exhaustion.
 //
+// # Where a problem is reported
+//
+// A returned error means the input could not be decoded: malformed YAML or
+// JSON, an unsupported version, a value of the wrong type for its field. A
+// document that decodes but breaks a rule of the specification is returned,
+// with the problem in ParseResult.Errors:
+//
+//	result, err := p.Parse("api.yaml")
+//	if err != nil {
+//		// the bytes could not be read as an OAS document
+//	}
+//	if len(result.Errors) > 0 {
+//		// the document was read and something in it is wrong
+//	}
+//
+// Check both. Treating a nil error as "this document is valid" misses every
+// structural fault, and an invalid response status code is one of them.
+//
+// ParseResult.Errors is populated by structure validation, which
+// WithValidateStructure(false) turns off. A caller that disables it and wants
+// these findings should run the validator package, which reports them
+// independently.
+//
 // HTTP/HTTPS $ref resolution is available via WithResolveHTTPRefs (opt-in for
 // security). Use WithInsecureSkipVerify for self-signed certificates. HTTP
 // responses are cached, size-limited, and protected against circular references.

--- a/parser/json_test.go
+++ b/parser/json_test.go
@@ -383,8 +383,11 @@ func TestExtraFieldConflicts(t *testing.T) {
 	assert.Equal(t, "value", result["x-safe"])
 }
 
+// TestInvalidStatusCodeInJSON asserts that the decoder keeps a key that is no
+// legal status code rather than rejecting the document. Keeping it is what lets
+// validateStructure report it, and what makes every decode path agree on the
+// verdict for one document (#449).
 func TestInvalidStatusCodeInJSON(t *testing.T) {
-	// Test that invalid status codes in JSON cause unmarshal errors
 	invalidJSON := `{
 		"200": {"description": "OK"},
 		"999": {"description": "Invalid"},
@@ -392,48 +395,71 @@ func TestInvalidStatusCodeInJSON(t *testing.T) {
 	}`
 
 	var responses Responses
-	err := json.Unmarshal([]byte(invalidJSON), &responses)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid status code")
+	require.NoError(t, json.Unmarshal([]byte(invalidJSON), &responses))
+
+	// The offending key survives with its value, so nothing is lost silently.
+	require.Contains(t, responses.Codes, "999")
+	assert.Equal(t, "Invalid", responses.Codes["999"].Description)
+
+	// And the well-formed entries are unaffected.
+	assert.Contains(t, responses.Codes, "200")
+	assert.NotNil(t, responses.Default)
 }
 
+// TestInvalidStatusCodePatternInJSON covers the shapes a response key can take
+// that are not status codes. Each is kept in Codes for validateStructure to
+// report, rather than failing the decode.
+//
+// The names are asserted to reach Codes specifically, since an extension goes
+// to Extra instead and "custom" is here precisely because it lacks the `x-`
+// prefix that would send it there.
 func TestInvalidStatusCodePatternInJSON(t *testing.T) {
-	// Test various invalid status code patterns
 	testCases := []struct {
 		name string
 		json string
+		key  string
 	}{
 		{
 			name: "Too low status code",
 			json: `{"99": {"description": "Too low"}}`,
+			key:  "99",
 		},
 		{
 			name: "Too high status code",
 			json: `{"600": {"description": "Too high"}}`,
+			key:  "600",
 		},
 		{
 			name: "Invalid wildcard",
 			json: `{"6XX": {"description": "Invalid wildcard"}}`,
+			key:  "6XX",
 		},
 		{
 			name: "All wildcards",
 			json: `{"XXX": {"description": "All wildcards"}}`,
+			key:  "XXX",
 		},
 		{
 			name: "Non-numeric",
 			json: `{"abc": {"description": "Non-numeric"}}`,
+			key:  "abc",
 		},
 		{
 			name: "Extension without x- prefix",
 			json: `{"custom": {"description": "Invalid extension"}}`,
+			key:  "custom",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			var responses Responses
-			err := json.Unmarshal([]byte(tc.json), &responses)
-			assert.Error(t, err)
+			require.NoError(t, json.Unmarshal([]byte(tc.json), &responses))
+
+			assert.Contains(t, responses.Codes, tc.key,
+				"a key that is no status code is kept for validateStructure to report")
+			assert.NotContains(t, responses.Extra, tc.key,
+				"and it is not an extension either")
 		})
 	}
 }

--- a/parser/paths.go
+++ b/parser/paths.go
@@ -75,8 +75,15 @@ type Responses struct {
 	Extra map[string]any `yaml:"-" json:"-"`
 }
 
-// UnmarshalYAML implements custom unmarshaling for Responses to validate status codes during parsing.
-// This prevents invalid fields from being captured in the Codes map and provides clearer error messages.
+// UnmarshalYAML implements custom unmarshaling for Responses. It sorts the
+// mapping's keys into Default, Extra and Codes: `default` to its own field, a
+// specification extension (e.g. "x-custom") to Extra, and everything else to
+// Codes.
+//
+// A key that is no legal status code is not rejected here. It lands in Codes and
+// validateStructure reports it, so that a document's verdict does not depend on
+// which decoder read it. It returns an error only when a value cannot be decoded
+// into the type its key calls for.
 func (r *Responses) UnmarshalYAML(unmarshal func(any) error) error {
 	// First unmarshal into a raw map to inspect all fields
 	var raw map[string]any
@@ -111,10 +118,11 @@ func (r *Responses) UnmarshalYAML(unmarshal func(any) error) error {
 			}
 			r.Extra[key] = value
 		} else {
-			// Everything else must be a status code or a wildcard range.
-			if !httputil.IsStatusCode(key) {
-				return fmt.Errorf("invalid status code '%s' in responses: must be a valid HTTP status code (e.g., \"200\", \"404\"), wildcard pattern (e.g., \"2XX\"), or extension field (e.g., \"x-custom\")", key)
-			}
+			// Everything else is a status code, and a key that is not one is
+			// kept rather than rejected here: validateStructure reports it, the
+			// way it does for a document decoded from a map. Rejecting at this
+			// depth is what made the same document pass or fail depending on
+			// which decoder ran (#449).
 			valueBytes, err := yamlMarshalValue(value)
 			if err != nil {
 				return fmt.Errorf("failed to marshal response for status code %s: %w", key, err)

--- a/parser/paths_json.go
+++ b/parser/paths_json.go
@@ -2,7 +2,6 @@ package parser
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/erraggy/oastools/internal/httputil"
 	"github.com/erraggy/oastools/parser/internal/jsonhelpers"
@@ -320,11 +319,15 @@ func (r *Responses) MarshalJSON() ([]byte, error) {
 	return marshalToJSON(m)
 }
 
-// UnmarshalJSON implements custom JSON unmarshaling for Responses.
-// This captures status code fields in the Codes map and validates that each
-// status code is either a valid HTTP status code (e.g., "200", "404"), a
-// wildcard pattern (e.g., "2XX"), or a specification extension (e.g., "x-custom").
-// Returns an error if an invalid status code is encountered.
+// UnmarshalJSON implements custom JSON unmarshaling for Responses. It sorts the
+// object's keys into Default, Extra and Codes: `default` to its own field, a
+// specification extension (e.g. "x-custom") to Extra, and everything else to
+// Codes.
+//
+// A key that is no legal status code is not rejected here. It lands in Codes and
+// validateStructure reports it, so that a document's verdict does not depend on
+// which decoder read it. It returns an error only when a value cannot be decoded
+// into the type its key calls for.
 func (r *Responses) UnmarshalJSON(data []byte) error {
 	var m map[string]json.RawMessage
 	if err := json.Unmarshal(data, &m); err != nil {
@@ -356,10 +359,11 @@ func (r *Responses) UnmarshalJSON(data []byte) error {
 			}
 			r.Extra[key] = ext
 		} else {
-			// Everything else must be a status code or a wildcard range.
-			if !httputil.IsStatusCode(key) {
-				return fmt.Errorf("invalid status code '%s' in responses: must be a valid HTTP status code (e.g., \"200\", \"404\"), wildcard pattern (e.g., \"2XX\"), or extension field (e.g., \"x-custom\")", key)
-			}
+			// Everything else is a status code, and a key that is not one is
+			// kept rather than rejected here: validateStructure reports it, the
+			// way it does for a document decoded from a map. Rejecting at this
+			// depth is what made the same document pass or fail depending on
+			// which decoder ran (#449).
 			var resp Response
 			if err := json.Unmarshal(value, &resp); err != nil {
 				return err

--- a/parser/responses_keys_test.go
+++ b/parser/responses_keys_test.go
@@ -221,13 +221,15 @@ paths:
 	assert.Error(t, err, "malformed input must still fail the parse")
 }
 
-// TestStructureValidationOffLeavesTheStatusCodeToTheValidator documents the one
-// place this reports nothing: a caller that turns off structure validation gets
-// no parse-time diagnostic, because that is what the flag switches off.
+// TestStructureValidationOffReportsNothingAtParseTime documents the one place
+// this reports nothing: a caller that turns off structure validation gets no
+// parse-time diagnostic, because that is what the flag switches off.
 //
-// The validator still reports it, independently of the flag, so the check is
-// only lost by a caller who also never validates.
-func TestStructureValidationOffLeavesTheStatusCodeToTheValidator(t *testing.T) {
+// What it asserts here is that the key survives anyway, which is what leaves
+// something for the validator to find. That the validator does find it is
+// asserted by validator.TestValidatorReportsStatusCodeWhenStructureValidationIsOff,
+// since validator imports parser and this package cannot import it back.
+func TestStructureValidationOffReportsNothingAtParseTime(t *testing.T) {
 	const spec = `openapi: 3.0.3
 info:
   title: T

--- a/parser/responses_keys_test.go
+++ b/parser/responses_keys_test.go
@@ -115,15 +115,15 @@ paths:
 	}
 }
 
-// TestResponsesInvalidStatusCodeIsReportedOnEveryDecodePath asserts that no
-// decode path accepts an invalid status code in silence.
+// TestResponsesInvalidStatusCodeIsReportedOnEveryDecodePath asserts that all
+// three decoders agree about an invalid status code: each keeps the key, and
+// validateStructure reports it into ParseResult.Errors.
 //
-// Where the diagnostic arrives differs by path, and that difference is
-// deliberate. The YAML and JSON decoders can fail the parse, so they do:
-// ParseBytes returns a non-nil error and no document. decodeFromMap cannot
-// return an error, so it keeps the key and the structure validator reports it
-// in ParseResult.Errors. Dropping the key there would lose the response and
-// report nothing at all.
+// Agreement is the point (#449). While the YAML and JSON decoders failed the
+// parse and decodeFromMap did not, one document had two verdicts depending on
+// which decoder read it, which is a property of the caller rather than of the
+// document. The table below runs the same two documents through every path,
+// so a decoder that starts rejecting again fails here.
 func TestResponsesInvalidStatusCodeIsReportedOnEveryDecodePath(t *testing.T) {
 	const specYAML = `openapi: 3.0.3
 info:
@@ -158,30 +158,25 @@ paths:
 
 	const want = "invalid status code '999'"
 
-	t.Run("yaml decoder fails the parse", func(t *testing.T) {
-		_, err := New().ParseBytes([]byte(specYAML))
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), want)
-	})
-
-	t.Run("json decoder fails the parse", func(t *testing.T) {
-		_, err := New().ParseBytes([]byte(specJSON))
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), want)
-	})
-
 	for _, tt := range []struct {
-		name string
-		spec string
+		name        string
+		spec        string
+		resolveRefs bool
 	}{
 		{name: "yaml", spec: specYAML},
 		{name: "json", spec: specJSON},
+		// ResolveRefs selects decodeFromMap over the format decoders.
+		{name: "yaml via decodeFromMap", spec: specYAML, resolveRefs: true},
+		{name: "json via decodeFromMap", spec: specJSON, resolveRefs: true},
 	} {
-		t.Run("decodeFromMap reports and keeps: "+tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			p := New()
-			p.ResolveRefs = true
+			p.ResolveRefs = tt.resolveRefs
 			res, err := p.ParseBytes([]byte(tt.spec))
-			require.NoError(t, err, "this path collects the error rather than failing the parse")
+
+			// The document decodes: an unusable status code is a structural
+			// fault, not a reason to refuse the bytes.
+			require.NoError(t, err)
 			assert.True(t, hasErrorContaining(res.Errors, want),
 				"want a collected error containing %q; got %v", want, res.Errors)
 
@@ -192,6 +187,68 @@ paths:
 			assert.Equal(t, "not a status code", r.Codes["999"].Description)
 		})
 	}
+}
+
+// TestParseBytesDoesNotFailOnAStructuralFault pins the contract change #449's
+// last criterion required, at the level a caller sees it.
+//
+// ParseBytes returns a non-nil error when the bytes cannot be decoded, not when
+// the decoded document breaks a rule. A caller that treated any invalid document
+// as a parse failure must read ParseResult.Errors instead.
+func TestParseBytesDoesNotFailOnAStructuralFault(t *testing.T) {
+	const spec = `openapi: 3.0.3
+info:
+  title: T
+  version: "1.0.0"
+paths:
+  /a:
+    get:
+      operationId: a
+      responses:
+        "999":
+          description: not a status code
+`
+
+	res, err := New().ParseBytes([]byte(spec))
+	require.NoError(t, err, "a structural fault is reported, not returned")
+	require.NotNil(t, res.Document, "and the document is still handed back")
+	assert.NotEmpty(t, res.Errors)
+
+	// The counterpart: bytes that are not YAML at all still fail outright, so
+	// this is a narrowing of what the error channel carries rather than its
+	// removal.
+	_, err = New().ParseBytes([]byte("openapi: 3.0.3\n\tinfo: broken"))
+	assert.Error(t, err, "malformed input must still fail the parse")
+}
+
+// TestStructureValidationOffLeavesTheStatusCodeToTheValidator documents the one
+// place this reports nothing: a caller that turns off structure validation gets
+// no parse-time diagnostic, because that is what the flag switches off.
+//
+// The validator still reports it, independently of the flag, so the check is
+// only lost by a caller who also never validates.
+func TestStructureValidationOffLeavesTheStatusCodeToTheValidator(t *testing.T) {
+	const spec = `openapi: 3.0.3
+info:
+  title: T
+  version: "1.0.0"
+paths:
+  /a:
+    get:
+      operationId: a
+      responses:
+        "999":
+          description: not a status code
+`
+
+	p := New()
+	p.ValidateStructure = false
+	res, err := p.ParseBytes([]byte(spec))
+	require.NoError(t, err)
+	assert.Empty(t, res.Errors, "structure validation is off, so nothing reports here")
+
+	// The key is still present, which is what lets the validator find it.
+	assert.Contains(t, responsesOf(t, res).Codes, "999")
 }
 
 // TestResponsesInvalidKeyWithNonObjectValueIsStillReported covers an invalid

--- a/validator/responses_status_codes_test.go
+++ b/validator/responses_status_codes_test.go
@@ -288,3 +288,47 @@ paths:
 	assert.Contains(t, strings.Join(warnings, "\n"),
 		"Operation should define at least one successful response")
 }
+
+// TestValidatorReportsStatusCodeWhenStructureValidationIsOff completes the
+// chain the parser package cannot assert on its own, since validator imports
+// parser and not the other way round.
+//
+// WithValidateStructure(false) turns off the parse-time report of an invalid
+// status code, which is what that flag is for. This asserts the finding is not
+// lost with it: the key stays in Responses.Codes and the validator names it
+// independently of how the document was parsed.
+func TestValidatorReportsStatusCodeWhenStructureValidationIsOff(t *testing.T) {
+	const spec = `
+openapi: 3.0.3
+info: {title: T, version: "1.0.0"}
+paths:
+  /a:
+    get:
+      operationId: a
+      summary: carries an unusable status code
+      responses:
+        "999": {description: not a status code}
+`
+
+	p := parser.New()
+	p.ValidateStructure = false
+	parsed, err := p.ParseBytes([]byte(spec))
+	require.NoError(t, err)
+	require.Empty(t, parsed.Errors, "structure validation is off, so the parser reports nothing")
+
+	doc, ok := parsed.Document.(*parser.OAS3Document)
+	require.True(t, ok)
+	require.Contains(t, doc.Paths["/a"].Get.Responses.Codes, "999",
+		"the decoder must keep the key, or there is nothing left to report")
+
+	v := New()
+	result, err := v.ValidateParsed(*parsed)
+	require.NoError(t, err)
+
+	messages := make([]string, 0, len(result.Errors))
+	for _, e := range result.Errors {
+		messages = append(messages, e.Path+": "+e.Message)
+	}
+	assert.Contains(t, strings.Join(messages, "\n"), "Invalid HTTP status code: 999")
+	assert.False(t, result.Valid, "a document with an unusable status code is not valid")
+}


### PR DESCRIPTION
Closes: #449

The last acceptance criterion of #449: the three decode paths now agree about a response key that is no legal status code.

Before, the YAML and JSON decoders rejected the document while the generated map decoder kept the key for `validateStructure` to report. One document had two verdicts depending on which decoder read it, which is a property of the caller rather than of the document.

## The change

Both decoders stop rejecting. The key lands in `Codes` and structure validation reports it, exactly as the map path already did.

```
parser/paths.go      | guard removed
parser/paths_json.go | guard removed
```

**This changes `ParseBytes`'s contract**, which is why the test added in #433 existed to catch it. A returned error now means no document was produced: input that could not be read, or could not be decoded. A document that decodes and breaks a rule comes back with the problem in `ParseResult.Errors`. Malformed input still fails outright, and `TestParseBytesDoesNotFailOnAStructuralFault` pins both halves so the narrowing cannot widen by accident.

## Why this is smaller than it sounds

The worry was that it breaks a parser-wide convention. It does not. Of **34 custom unmarshalers** in `parser`, only **3** reject on a content rule, and 2 of those 3 are this pair. The third is `Discriminator.UnmarshalYAML`, which rejects a node kind, the same class as `cannot construct !!int into parser.Response`.

**The status-code check was the only decoder in the parser enforcing a specification rule.** This removes an outlier rather than breaking a pattern.

## The diagnostic improves

```console
# before: a YAML line number, from the decoder
Error: ... yaml: construct errors:
  line 8: invalid status code '999' in responses: must be a valid HTTP status code...

# after: the same paths every other structural fault uses
✗ document: oas 3.0.3: invalid status code '999' in 'paths./a.get.responses': ...
✗ paths./a.get.responses.999 (operationId: a): Invalid HTTP status code: 999
    Spec: https://spec.openapis.org/oas/v3.0.3.html#responses-object
```

`oastools validate` still exits 1. `convert` still refuses, because it checks `ParseResult.Errors`.

## Three decisions, recorded on the issue

**`ValidateStructure=false` now leaves this unreported at parse time**, which is what that flag switches off. The validator reports it independently, so the finding is lost only to a caller who also never validates. Two tests document it, one per package, because `validator` imports `parser` and the end-to-end assertion has only one legal home.

**`fix` exits 0 on such a document.** Unchanged by this work: it already exits 0 for every other collected parse error, unlike `converter`, which refuses. Verified against `main` with a document missing `responses`. Pre-existing asymmetry, filed separately.

**The fault reports twice**, once from structure validation and once from the validator. They are different layers and both are wanted: the first is what a caller parsing without the validator sees, the second carries the JSON path and the specification link.

## Verification

- `make check` green: **10749 tests**, from 10746 on `main`.
- `make test-corpus` green, and corpus validator verdicts are **identical to `main`** across all ten specs.
- Four existing tests were rewritten rather than deleted, keeping what each was for. `TestOperationResponsesStatusCodesStillChecked` still guards A1's relaxation; the two JSON tests still assert these keys are not treated as status codes, now at the layer where that is observable.
- Three CodeRabbit CLI rounds: 1, 1 and 0 findings, both taken. Neither was about the code, which matches what the spike predicted.
