### PR TITLE
fix(parser,validator,converter): scope wildcard response ranges to OAS 3.0 and later

### DIFF
--- a/converter/oas3_to_oas2.go
+++ b/converter/oas3_to_oas2.go
@@ -3,8 +3,31 @@ package converter
 import (
 	"fmt"
 
+	"github.com/erraggy/oastools/internal/httputil"
 	"github.com/erraggy/oastools/parser"
 )
+
+// oas2ResponseKey maps a Responses Object key from an OAS 3.x document to the
+// key an OAS 2.0 document may use for it.
+//
+// Wildcard ranges were introduced in OAS 3.0, and the 2.0 Responses Object
+// admits one property per HTTP status code, so a range cannot be carried across
+// as written. It becomes the first code it covers, "2XX" to "200", which is how
+// the generator already reads a range.
+//
+// The second result is false when the range must be dropped instead, because
+// codes already declares the code it would become. That entry is the more
+// specific of the two and describes the same response, so it wins.
+func oas2ResponseKey(code string, codes map[string]*parser.Response) (string, bool) {
+	if !httputil.IsWildcardStatusCode(code) {
+		return code, true
+	}
+	base := string(code[0]) + "00"
+	if _, taken := codes[base]; taken {
+		return "", false
+	}
+	return base, true
+}
 
 // convertOAS3ToOAS2 converts an OAS 3.x document to OAS 2.0
 func (c *Converter) convertOAS3ToOAS2(parseResult parser.ParseResult, result *ConversionResult) error {
@@ -227,8 +250,23 @@ func (c *Converter) convertOAS3OperationToOAS2(src *parser.Operation, doc *parse
 		}
 
 		for code, response := range src.Responses.Codes {
-			convertedResponse, produces := c.convertOAS3ResponseToOAS2(response, result, fmt.Sprintf("%s.responses.%s", opPath, code))
-			dst.Responses.Codes[code] = convertedResponse
+			codePath := fmt.Sprintf("%s.responses.%s", opPath, code)
+
+			targetCode, carried := oas2ResponseKey(code, src.Responses.Codes)
+			if !carried {
+				c.addIssueWithContext(result, codePath,
+					fmt.Sprintf("Wildcard response range '%s' is not supported in OAS 2.0", code),
+					fmt.Sprintf("The operation also declares '%s00', which is more specific, so the range was dropped", string(code[0])))
+				continue
+			}
+			if targetCode != code {
+				c.addIssueWithContext(result, codePath,
+					fmt.Sprintf("Wildcard response range '%s' is not supported in OAS 2.0", code),
+					fmt.Sprintf("Converted to '%s', the first code the range covers", targetCode))
+			}
+
+			convertedResponse, produces := c.convertOAS3ResponseToOAS2(response, result, codePath)
+			dst.Responses.Codes[targetCode] = convertedResponse
 			if len(produces) > 0 {
 				dst.Produces = mergeStringArrays(dst.Produces, produces)
 				doc.Produces = mergeStringArrays(doc.Produces, produces)

--- a/converter/oas3_to_oas2_test.go
+++ b/converter/oas3_to_oas2_test.go
@@ -893,3 +893,177 @@ func TestConvertOAS3ToOAS2_NestedSchemaFeatureDetection(t *testing.T) {
 	assert.True(t, found,
 		"Should detect writeOnly in nested property User.properties.password")
 }
+
+// TestOAS2ResponseKey pins the mapping a wildcard range takes on its way to OAS
+// 2.0, which admits one property per HTTP status code and so cannot spell a
+// range. The collision case is what makes the result order-independent: map
+// iteration is random, so the decision has to read the source map rather than
+// whatever the destination happens to hold when the range is reached.
+func TestOAS2ResponseKey(t *testing.T) {
+	tests := []struct {
+		name        string
+		code        string
+		codes       map[string]*parser.Response
+		wantKey     string
+		wantCarried bool
+	}{
+		{
+			name:        "numeric code is carried as written",
+			code:        "404",
+			codes:       map[string]*parser.Response{"404": {}},
+			wantKey:     "404",
+			wantCarried: true,
+		},
+		{
+			name:        "2XX becomes 200",
+			code:        "2XX",
+			codes:       map[string]*parser.Response{"2XX": {}},
+			wantKey:     "200",
+			wantCarried: true,
+		},
+		{
+			name:        "5XX becomes 500",
+			code:        "5XX",
+			codes:       map[string]*parser.Response{"5XX": {}},
+			wantKey:     "500",
+			wantCarried: true,
+		},
+		{
+			name:        "1XX becomes 100",
+			code:        "1XX",
+			codes:       map[string]*parser.Response{"1XX": {}},
+			wantKey:     "100",
+			wantCarried: true,
+		},
+		{
+			name:        "2XX is dropped when 200 is already declared",
+			code:        "2XX",
+			codes:       map[string]*parser.Response{"200": {}, "2XX": {}},
+			wantCarried: false,
+		},
+		{
+			name:        "2XX survives a 201 that does not collide with it",
+			code:        "2XX",
+			codes:       map[string]*parser.Response{"201": {}, "2XX": {}},
+			wantKey:     "200",
+			wantCarried: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key, carried := oas2ResponseKey(tt.code, tt.codes)
+			assert.Equal(t, tt.wantCarried, carried)
+			if tt.wantCarried {
+				assert.Equal(t, tt.wantKey, key)
+			}
+		})
+	}
+}
+
+// TestDownconvertWildcardRangesProduceValidOAS2 is the end-to-end assertion the
+// unit table above cannot make: the converted document must be one OAS 2.0
+// accepts. Carrying "2XX" across as written produced a document oastools itself
+// rejects while reporting the conversion successful.
+func TestDownconvertWildcardRangesProduceValidOAS2(t *testing.T) {
+	doc := &parser.OAS3Document{
+		OpenAPI:    "3.0.4",
+		OASVersion: parser.OASVersion304,
+		Info:       &parser.Info{Title: "Test API", Version: "1.0.0"},
+		Paths: parser.Paths{
+			"/pets": {
+				Get: &parser.Operation{
+					OperationID: "listPets",
+					Responses: &parser.Responses{
+						Codes: map[string]*parser.Response{
+							"2XX": {Description: "ranged success"},
+							"5XX": {Description: "ranged failure"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	c := New()
+	result, err := c.ConvertParsed(parser.ParseResult{
+		Document:   doc,
+		Version:    "3.0.4",
+		OASVersion: parser.OASVersion304,
+		Data:       make(map[string]any),
+		SourcePath: "test.yaml",
+	}, "2.0")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	converted, ok := result.Document.(*parser.OAS2Document)
+	require.True(t, ok, "converting to 2.0 must produce an OAS2Document")
+
+	codes := converted.Paths["/pets"].Get.Responses.Codes
+	assert.Contains(t, codes, "200", "2XX carries across as the first code it covers")
+	assert.Contains(t, codes, "500", "5XX carries across as the first code it covers")
+	assert.NotContains(t, codes, "2XX", "OAS 2.0 cannot spell a wildcard range")
+	assert.NotContains(t, codes, "5XX", "OAS 2.0 cannot spell a wildcard range")
+
+	// The response itself must survive the rename, or the conversion has
+	// dropped what the document described.
+	require.NotNil(t, codes["200"])
+	assert.Equal(t, "ranged success", codes["200"].Description)
+
+	messages := make([]string, 0, len(result.Issues))
+	for _, issue := range result.Issues {
+		messages = append(messages, issue.Message)
+	}
+	joined := strings.Join(messages, "\n")
+	assert.Contains(t, joined, "Wildcard response range '2XX' is not supported in OAS 2.0")
+	assert.Contains(t, joined, "Wildcard response range '5XX' is not supported in OAS 2.0")
+}
+
+// TestDownconvertWildcardRangeYieldsToASpecificCode covers the collision: the
+// document declares both the range and the code the range would become, and the
+// specific one describes the same response more precisely.
+func TestDownconvertWildcardRangeYieldsToASpecificCode(t *testing.T) {
+	doc := &parser.OAS3Document{
+		OpenAPI:    "3.0.4",
+		OASVersion: parser.OASVersion304,
+		Info:       &parser.Info{Title: "Test API", Version: "1.0.0"},
+		Paths: parser.Paths{
+			"/pets": {
+				Get: &parser.Operation{
+					OperationID: "listPets",
+					Responses: &parser.Responses{
+						Codes: map[string]*parser.Response{
+							"200": {Description: "the specific one"},
+							"2XX": {Description: "the range"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	c := New()
+	result, err := c.ConvertParsed(parser.ParseResult{
+		Document:   doc,
+		Version:    "3.0.4",
+		OASVersion: parser.OASVersion304,
+		Data:       make(map[string]any),
+		SourcePath: "test.yaml",
+	}, "2.0")
+	require.NoError(t, err)
+
+	converted, ok := result.Document.(*parser.OAS2Document)
+	require.True(t, ok)
+
+	codes := converted.Paths["/pets"].Get.Responses.Codes
+	require.NotNil(t, codes["200"])
+	assert.Equal(t, "the specific one", codes["200"].Description,
+		"the declared code wins over the range that would overwrite it")
+	assert.Len(t, codes, 1)
+
+	messages := make([]string, 0, len(result.Issues))
+	for _, issue := range result.Issues {
+		messages = append(messages, issue.Message+" "+issue.Context)
+	}
+	assert.Contains(t, strings.Join(messages, "\n"), "more specific, so the range was dropped")
+}

--- a/generator/server_extensions_test.go
+++ b/generator/server_extensions_test.go
@@ -1374,7 +1374,45 @@ func TestServerBinder_OAS2_HeaderParams(t *testing.T) {
 	assert.Contains(t, content, `result.HeaderParams["X-Page-Size"]`)
 }
 
-// OAS 2.0 spec with wildcard responses (2XX, 4XX, 5XX)
+// OAS 3.0 spec with wildcard responses (2XX, 4XX, 5XX). OAS 3.0 introduced the
+// wildcard range, so it is the earliest version that can carry one.
+const testWildcardResponsesOAS3Spec = `openapi: 3.0.4
+info:
+  title: Wildcard Responses API
+  version: "1.0.0"
+paths:
+  /resources:
+    get:
+      operationId: listResources
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+        '2XX':
+          description: Other success
+          content:
+            application/json:
+              schema:
+                type: object
+        '4XX':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                type: object
+        '5XX':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                type: object
+`
+
+// OAS 2.0 spec with wildcard responses (2XX, 4XX, 5XX), which 2.0 does not
+// define. Used only by TestServerResponses_OAS2_WildcardCodesAreRefused.
 const testWildcardResponsesOAS2Spec = `swagger: "2.0"
 info:
   title: Wildcard Responses API
@@ -1403,10 +1441,10 @@ paths:
             type: object
 `
 
-func TestServerResponses_OAS2_WildcardCodes(t *testing.T) {
+func TestServerResponses_OAS3_WildcardCodes(t *testing.T) {
 	tmpDir := t.TempDir()
 	tmpFile := filepath.Join(tmpDir, "api.json")
-	err := os.WriteFile(tmpFile, []byte(testWildcardResponsesOAS2Spec), 0600)
+	err := os.WriteFile(tmpFile, []byte(testWildcardResponsesOAS3Spec), 0600)
 	require.NoError(t, err)
 
 	result, err := GenerateWithOptions(
@@ -1418,14 +1456,40 @@ func TestServerResponses_OAS2_WildcardCodes(t *testing.T) {
 	require.NoError(t, err)
 
 	respFile := result.GetFile("server_responses.go")
-	require.NotNil(t, respFile, "server_responses.go not generated for OAS 2.0")
+	require.NotNil(t, respFile, "server_responses.go not generated")
 	content := string(respFile.Content)
 
-	// Check that wildcard response codes are handled
-	// Note: The implementation may convert 2XX/4XX/5XX to StatusDefault or skip them
-	// This test validates the generator doesn't crash on wildcard codes
 	assert.Contains(t, content, "type ListResourcesResponse struct")
 	assert.Contains(t, content, "func (ListResourcesResponse) Status200(")
+
+	// Each wildcard range gets its own constructor, so the numeric code above
+	// cannot be what satisfies these.
+	assert.Contains(t, content, "func (ListResourcesResponse) Status2XX(")
+	assert.Contains(t, content, "func (ListResourcesResponse) Status4XX(")
+	assert.Contains(t, content, "func (ListResourcesResponse) Status5XX(")
+}
+
+// TestServerResponses_OAS2_WildcardCodesAreRefused covers #467 from the
+// generator's side. Wildcard ranges were introduced in OAS 3.0, so a 2.0
+// document carrying one reports a parse error, and the generator declines a
+// document with parse errors rather than generating from it.
+//
+// The wildcard code generation itself is covered by the OAS 3.0 case above,
+// which is the earliest version that can reach it with a valid document.
+func TestServerResponses_OAS2_WildcardCodesAreRefused(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "api.json")
+	err := os.WriteFile(tmpFile, []byte(testWildcardResponsesOAS2Spec), 0600)
+	require.NoError(t, err)
+
+	_, err = GenerateWithOptions(
+		WithFilePath(tmpFile),
+		WithPackageName("api"),
+		WithServer(true),
+		WithServerResponses(true),
+	)
+	require.Error(t, err, "a 2.0 document keyed by wildcard ranges must not generate")
+	assert.Contains(t, err.Error(), "parse error")
 }
 
 func TestGetOAS2ParamSchemaType(t *testing.T) {

--- a/internal/httputil/httputil.go
+++ b/internal/httputil/httputil.go
@@ -67,24 +67,13 @@ func IsExtensionKey(key string) bool {
 	return strings.HasPrefix(key, ExtensionPrefix)
 }
 
-// IsValidResponsesKey reports whether key may appear in a Responses Object.
-// That is a broader question than [IsStatusCode]: the Responses Object also
-// admits "default" and specification extensions.
-//
-// Use this to accept or reject a key while decoding. Use [IsStatusCode] to ask
-// whether the key denotes a status code, which is what a caller ranging
-// Responses.Codes means.
-func IsValidResponsesKey(key string) bool {
-	return key == ResponsesKeyDefault || IsExtensionKey(key) || IsStatusCode(key)
-}
-
 // IsStatusCode reports whether code is an HTTP status code or a wildcard range:
 //   - Wildcard patterns: 1XX, 2XX, 3XX, 4XX, 5XX
 //   - Numeric codes: 100-599
 //
-// It is deliberately narrow. "default" and specification extensions are legal
-// Responses Object keys but are not status codes, so both return false here;
-// [IsValidResponsesKey] is the predicate that accepts them.
+// It is deliberately narrow, which is what a caller ranging Responses.Codes
+// needs. "default" and specification extensions are legal Responses Object keys
+// but are not status codes, so both return false here.
 //
 // It is also version-blind, and the two forms it accepts are not defined by the
 // same OAS versions. A caller that knows the document version wants

--- a/internal/httputil/httputil.go
+++ b/internal/httputil/httputil.go
@@ -3,7 +3,6 @@ package httputil
 
 import (
 	"mime"
-	"strconv"
 	"strings"
 )
 
@@ -86,28 +85,48 @@ func IsValidResponsesKey(key string) bool {
 // It is deliberately narrow. "default" and specification extensions are legal
 // Responses Object keys but are not status codes, so both return false here;
 // [IsValidResponsesKey] is the predicate that accepts them.
+//
+// It is also version-blind, and the two forms it accepts are not defined by the
+// same OAS versions. A caller that knows the document version wants
+// [IsNumericStatusCode] and [IsWildcardStatusCode] instead.
 func IsStatusCode(code string) bool {
-	if len(code) == StatusCodeLength {
-		// Check for wildcard patterns (e.g., "2XX", "4XX")
-		if code[1] == WildcardChar && code[2] == WildcardChar {
-			firstChar := code[0]
-			if firstChar >= minWildcardBoundary && firstChar <= maxWildcardBoundary {
-				return true
-			}
-		}
+	return IsNumericStatusCode(code) || IsWildcardStatusCode(code)
+}
 
-		// Check for numeric codes
-		if code[0] >= '0' && code[0] <= '9' &&
-			code[1] >= '0' && code[1] <= '9' &&
-			code[2] >= '0' && code[2] <= '9' {
-			statusCode, err := strconv.Atoi(code)
-			if err == nil && statusCode >= MinStatusCode && statusCode <= MaxStatusCode {
-				return true
-			}
-		}
+// IsWildcardStatusCode reports whether code is a wildcard response range: 1XX,
+// 2XX, 3XX, 4XX or 5XX.
+//
+// OAS 3.0 introduced these. The OAS 2.0 Responses Object states only that "any
+// HTTP status code can be used as the property name (one property per HTTP
+// status code)", so a 2.0 document may not use one.
+//
+// https://spec.openapis.org/oas/v2.0.html#responses-object
+func IsWildcardStatusCode(code string) bool {
+	if len(code) != StatusCodeLength {
+		return false
 	}
+	if code[1] != WildcardChar || code[2] != WildcardChar {
+		return false
+	}
+	return code[0] >= minWildcardBoundary && code[0] <= maxWildcardBoundary
+}
 
-	return false
+// IsNumericStatusCode reports whether code is a numeric HTTP status code from
+// [MinStatusCode] to [MaxStatusCode]. Every OAS version defines these, unlike
+// the wildcard ranges [IsWildcardStatusCode] recognizes.
+func IsNumericStatusCode(code string) bool {
+	if len(code) != StatusCodeLength {
+		return false
+	}
+	if code[0] < '0' || code[0] > '9' ||
+		code[1] < '0' || code[1] > '9' ||
+		code[2] < '0' || code[2] > '9' {
+		return false
+	}
+	// Three ASCII digits, so the value is computed rather than parsed: strconv
+	// could not fail here, and there would be no answer to give if it did.
+	value := int(code[0]-'0')*100 + int(code[1]-'0')*10 + int(code[2]-'0')
+	return value >= MinStatusCode && value <= MaxStatusCode
 }
 
 // IsSuccessStatusCode reports whether code denotes a successful response: a

--- a/internal/httputil/httputil_test.go
+++ b/internal/httputil/httputil_test.go
@@ -144,6 +144,116 @@ func TestIsStatusCode(t *testing.T) {
 	}
 }
 
+// TestIsWildcardStatusCode pins the form OAS 3.0 introduced and OAS 2.0 does not
+// define. A caller that knows the document version uses it to reject "2XX" in a
+// 2.0 document, so the lowercase and partial cases matter: the specification
+// says the wildcard is the uppercase X.
+func TestIsWildcardStatusCode(t *testing.T) {
+	tests := []struct {
+		name     string
+		code     string
+		expected bool
+	}{
+		{"wildcard 1XX", "1XX", true},
+		{"wildcard 2XX", "2XX", true},
+		{"wildcard 5XX", "5XX", true},
+
+		// Boundaries of the leading digit.
+		{"wildcard 0XX below range", "0XX", false},
+		{"wildcard 6XX above range", "6XX", false},
+
+		// The wildcard is uppercase, per the specification.
+		{"lowercase 2xx", "2xx", false},
+		{"mixed 2Xx", "2Xx", false},
+
+		// Shape.
+		{"numeric 200 is not a range", "200", false},
+		{"partial 2X", "2X", false},
+		{"partial 20X", "20X", false},
+		{"reversed XX2", "XX2", false},
+		{"all wildcards XXX", "XXX", false},
+		{"default", "default", false},
+		{"empty string", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsWildcardStatusCode(tt.code)
+			assert.Equal(t, tt.expected, got,
+				"IsWildcardStatusCode(%q) = %v, want %v", tt.code, got, tt.expected)
+		})
+	}
+}
+
+// TestIsNumericStatusCode pins the form every OAS version defines, which is what
+// a caller falls back to when the version does not admit a wildcard range.
+func TestIsNumericStatusCode(t *testing.T) {
+	tests := []struct {
+		name     string
+		code     string
+		expected bool
+	}{
+		{"numeric 100 lower boundary", "100", true},
+		{"numeric 200", "200", true},
+		{"numeric 599 upper boundary", "599", true},
+		{"numeric 099 below range", "099", false},
+		{"numeric 600 above range", "600", false},
+		{"numeric 999", "999", false},
+
+		{"wildcard 2XX is not numeric", "2XX", false},
+		{"empty string", "", false},
+		{"too short", "99", false},
+		{"too long", "1000", false},
+		{"alphabetic", "abc", false},
+		{"mixed 2a0", "2a0", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsNumericStatusCode(tt.code)
+			assert.Equal(t, tt.expected, got,
+				"IsNumericStatusCode(%q) = %v, want %v", tt.code, got, tt.expected)
+		})
+	}
+}
+
+// TestStatusCodeFormsPartitionIsStatusCode holds the two narrow predicates to
+// the property their callers depend on: every key [IsStatusCode] accepts is
+// either a numeric code or a wildcard range and never both, and neither narrow
+// predicate accepts a key [IsStatusCode] rejects.
+//
+// A version-scoped caller rejects wildcard ranges and keeps numeric codes. An
+// overlap would therefore reject a numeric code that OAS 2.0 defines, and a gap
+// would let a key through with no diagnostic at all. Exhaustive over every
+// three-byte string, which is the only length either predicate can accept.
+func TestStatusCodeFormsPartitionIsStatusCode(t *testing.T) {
+	buf := make([]byte, StatusCodeLength)
+	for a := range 256 {
+		for b := range 256 {
+			for c := range 256 {
+				buf[0], buf[1], buf[2] = byte(a), byte(b), byte(c)
+				code := string(buf)
+				numeric := IsNumericStatusCode(code)
+				wildcard := IsWildcardStatusCode(code)
+				if numeric && wildcard {
+					t.Fatalf("%q is both a numeric code and a wildcard range", code)
+				}
+				if got := IsStatusCode(code); got != (numeric || wildcard) {
+					t.Fatalf("IsStatusCode(%q) = %v, but numeric = %v and wildcard = %v",
+						code, got, numeric, wildcard)
+				}
+			}
+		}
+	}
+
+	// No other length can be accepted, so the union holds there trivially.
+	for _, code := range []string{"", "2", "20", "2000", "2XXX", "default", "x-note"} {
+		if IsNumericStatusCode(code) || IsWildcardStatusCode(code) || IsStatusCode(code) {
+			t.Fatalf("%q was accepted by a status code predicate", code)
+		}
+	}
+}
+
 func TestIsExtensionKey(t *testing.T) {
 	assert.True(t, IsExtensionKey("x-custom"))
 	assert.True(t, IsExtensionKey("x-"))

--- a/internal/httputil/httputil_test.go
+++ b/internal/httputil/httputil_test.go
@@ -6,109 +6,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestIsValidResponsesKey(t *testing.T) {
-	tests := []struct {
-		name     string
-		code     string
-		expected bool
-	}{
-		// Valid: "default" keyword
-		{"default keyword", "default", true},
-
-		// Valid: Extension fields (x-)
-		{"extension x-custom", "x-custom", true},
-		{"extension x-200", "x-200", true},
-		{"extension x-", "x-", true},
-
-		// Valid: Wildcard patterns (1XX-5XX)
-		{"wildcard 1XX", "1XX", true},
-		{"wildcard 2XX", "2XX", true},
-		{"wildcard 3XX", "3XX", true},
-		{"wildcard 4XX", "4XX", true},
-		{"wildcard 5XX", "5XX", true},
-
-		// Invalid: Wildcards outside 1-5 range
-		{"invalid wildcard 0XX", "0XX", false},
-		{"invalid wildcard 6XX", "6XX", false},
-		{"invalid wildcard 7XX", "7XX", false},
-		{"invalid wildcard 9XX", "9XX", false},
-
-		// Invalid: Partial wildcards
-		{"partial wildcard 2X", "2X", false},
-		{"partial wildcard 20X", "20X", false},
-		{"partial wildcard X2X", "X2X", false},
-		{"partial wildcard XX2", "XX2", false},
-
-		// Valid: Numeric codes in valid range (100-599)
-		{"valid 100", "100", true},
-		{"valid 200", "200", true},
-		{"valid 201", "201", true},
-		{"valid 204", "204", true},
-		{"valid 301", "301", true},
-		{"valid 400", "400", true},
-		{"valid 404", "404", true},
-		{"valid 418", "418", true}, // I'm a teapot
-		{"valid 500", "500", true},
-		{"valid 503", "503", true},
-		{"valid 599", "599", true},
-
-		// Invalid: Numeric codes outside valid range
-		{"invalid 099", "099", false}, // Below MinStatusCode
-		{"invalid 600", "600", false}, // Above MaxStatusCode
-		{"invalid 999", "999", false},
-		{"invalid 000", "000", false},
-
-		// Invalid: Too short or too long
-		{"too short 99", "99", false},
-		{"too short 1", "1", false},
-		{"too long 1000", "1000", false},
-		{"too long 20000", "20000", false},
-
-		// Invalid: Empty and whitespace
-		{"empty string", "", false},
-		{"whitespace", "   ", false},
-		{"space in code", "2 00", false},
-
-		// Invalid: Non-numeric characters
-		{"alphabetic abc", "abc", false},
-		{"alphanumeric 2a0", "2a0", false},
-		{"alphanumeric a00", "a00", false},
-		{"alphanumeric 00a", "00a", false},
-
-		// Invalid: Special characters
-		{"special char @00", "@00", false},
-		{"special char 2-0", "2-0", false},
-		{"special char 20!", "20!", false},
-
-		// Edge cases: Boundary values
-		{"boundary 100", "100", true},  // MinStatusCode
-		{"boundary 599", "599", true},  // MaxStatusCode
-		{"boundary 99", "99", false},   // Just below min
-		{"boundary 600", "600", false}, // Just above max
-
-		// Edge cases: Extensions that might look like codes
-		{"not extension x", "x", false},       // Too short
-		{"not extension x200", "x200", false}, // Wrong format (4 chars but not wildcard)
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := IsValidResponsesKey(tt.code)
-			assert.Equal(t, tt.expected, result, "IsValidResponsesKey(%q) = %v, want %v", tt.code, result, tt.expected)
-		})
-	}
-}
-
-// TestIsStatusCode pins the narrow predicate against the broad one. The two
-// disagree on exactly the keys a Responses Object admits without their being
-// status codes, and a caller ranging Responses.Codes needs the narrow answer.
+// TestIsStatusCode pins the predicate a caller ranging Responses.Codes needs.
+// The Responses Object admits "default" and specification extensions as well,
+// and neither of those is a status code.
 func TestIsStatusCode(t *testing.T) {
 	tests := []struct {
 		name     string
 		code     string
 		expected bool
 	}{
-		// The keys that separate this predicate from IsValidResponsesKey.
+		// Responses Object keys that are not status codes.
 		{"default is not a status code", "default", false},
 		{"extension x-custom is not a status code", "x-custom", false},
 		{"extension x-200 is not a status code", "x-200", false},

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -883,14 +883,21 @@ func (p *Parser) validateOAS2Operation(op *Operation, opPath string, operationID
 	if op.Responses == nil {
 		errors = append(errors, fmt.Errorf("oas 2.0: missing required field '%s.responses': Operation must have a responses object", opPath))
 	} else {
-		// Validate status codes in responses. Codes holds only status-code keys
-		// on the YAML and JSON decode paths, which reject anything else outright;
-		// this loop is what reports them on the decodeFromMap path, which cannot
-		// return an error of its own.
+		// Validate status codes in responses. Every decode path keeps a key it
+		// cannot use rather than refusing the document (#449), so this loop is
+		// what reports one whichever decoder ran.
+		//
+		// Wildcard ranges are not among them: OAS 3.0 introduced those, and 2.0
+		// admits one property per HTTP status code (#467).
 		for code := range op.Responses.Codes {
-			if !httputil.IsStatusCode(code) {
-				errors = append(errors, fmt.Errorf("oas 2.0: invalid status code '%s' in '%s.responses': must be a valid HTTP status code (e.g., \"200\", \"404\") or wildcard pattern (e.g., \"2XX\")", code, opPath))
+			if httputil.IsNumericStatusCode(code) {
+				continue
 			}
+			if httputil.IsWildcardStatusCode(code) {
+				errors = append(errors, fmt.Errorf("oas 2.0: invalid status code '%s' in '%s.responses': wildcard ranges were introduced in OAS 3.0, and OAS 2.0 defines one property per HTTP status code (e.g., \"200\", \"404\")", code, opPath))
+				continue
+			}
+			errors = append(errors, fmt.Errorf("oas 2.0: invalid status code '%s' in '%s.responses': must be a valid HTTP status code (e.g., \"200\", \"404\")", code, opPath))
 		}
 	}
 
@@ -1070,10 +1077,10 @@ func (p *Parser) validateOAS3Operation(op *Operation, opPath string, operationID
 			errors = append(errors, fmt.Errorf("oas %s: missing required field '%s.responses': Operation must have a responses object (https://spec.openapis.org/oas/v3.0.0.html#operation-object)", version, opPath))
 		}
 	} else {
-		// Validate status codes in responses. Codes holds only status-code keys
-		// on the YAML and JSON decode paths, which reject anything else outright;
-		// this loop is what reports them on the decodeFromMap path, which cannot
-		// return an error of its own.
+		// Validate status codes in responses. Every decode path keeps a key it
+		// cannot use rather than refusing the document (#449), so this loop is
+		// what reports one whichever decoder ran. Every 3.x version defines the
+		// wildcard ranges, so both forms are accepted here.
 		for code := range op.Responses.Codes {
 			if !httputil.IsStatusCode(code) {
 				errors = append(errors, fmt.Errorf("oas %s: invalid status code '%s' in '%s.responses': must be a valid HTTP status code (e.g., \"200\", \"404\") or wildcard pattern (e.g., \"2XX\")", version, code, opPath))

--- a/parser/parser_validation_test.go
+++ b/parser/parser_validation_test.go
@@ -336,7 +336,12 @@ func TestInvalidStatusCodes(t *testing.T) {
 		{"Valid 200", "200", "2.0", false},
 		{"Valid 404", "404", "3.0.0", false},
 		{"Valid 2XX wildcard", "2XX", "3.0.0", false},
-		{"Valid 5XX wildcard", "5XX", "2.0", false},
+		{"Valid 5XX wildcard", "5XX", "3.1.0", false},
+		// Wildcard ranges are an OAS 3.0 addition, so 2.0 does not define them
+		// (#467). This case flipping back to false would mean a 2.0 document had
+		// regained a key its own version never described.
+		{"Invalid 5XX wildcard in 2.0", "5XX", "2.0", true},
+		{"Invalid 2XX wildcard in 2.0", "2XX", "2.0", true},
 		{"Valid default", "default", "3.0.0", false},
 		{"Valid extension field x-custom", "x-custom", "3.0.0", false},
 		{"Valid extension field x-rate-limit", "x-rate-limit", "2.0", false},

--- a/parser/responses_keys_test.go
+++ b/parser/responses_keys_test.go
@@ -258,8 +258,9 @@ paths:
 // in one entry. decodeFromMap classifies the key before it looks at the value,
 // so the reportable fault is not lost to the unreportable one.
 //
-// Reachable only under ResolveRefs: the YAML and JSON decoders reject the key
-// outright, before its value matters.
+// Reachable only under ResolveRefs, but because of the value rather than the
+// key: the YAML and JSON decoders keep an unusable key, and then fail to decode
+// a non-object into a Response, so neither can deliver this pair.
 func TestResponsesInvalidKeyWithNonObjectValueIsStillReported(t *testing.T) {
 	const specYAML = `openapi: 3.0.3
 info:

--- a/validator/component_path_items_test.go
+++ b/validator/component_path_items_test.go
@@ -20,11 +20,10 @@ func validationWarnings(t *testing.T, spec string) []string {
 }
 
 // warningsWithStrict is validationWarnings with StrictMode selectable, because
-// the response-status-code arm of validateResponseStatusCodes is only reachable
-// as a warning: the parser's own decoder rejects a malformed status code as a
-// construct error before any document carrying one reaches the validator, so the
-// strict-mode non-standard-code and missing-2xx warnings are what prove the
-// responses check runs at all for a given call site.
+// the specs below key their responses by well-formed status codes. The error arm
+// of validateResponseStatusCodes therefore never fires for them, and strict
+// mode's non-standard-code and missing-2xx warnings are what prove the responses
+// check runs at all for a given call site.
 func warningsWithStrict(t *testing.T, spec string, strict bool) []string {
 	t.Helper()
 
@@ -171,10 +170,10 @@ components:
 }
 
 // TestComponentPathItemsResponsesAreValidated covers the responses half of #392
-// separately, because validateResponseStatusCodes only ever reports warnings for
-// a document that parses: a malformed code is rejected by the parser's decoder
-// first. Strict mode's non-standard-code and missing-2xx warnings are therefore
-// the observable proof that the check reaches these operations.
+// separately, because this spec keys its responses by well-formed status codes,
+// so the error arm of validateResponseStatusCodes never fires. Strict mode's
+// non-standard-code and missing-2xx warnings are therefore the observable proof
+// that the check reaches these operations.
 func TestComponentPathItemsResponsesAreValidated(t *testing.T) {
 	spec := `
 openapi: 3.1.0

--- a/validator/helpers.go
+++ b/validator/helpers.go
@@ -124,8 +124,11 @@ func (v *Validator) validateResponseStatusCodes(responses *parser.Responses, pat
 			continue
 		}
 
-		if v.StrictMode && !httputil.IsStandardStatusCode(code) {
-			// In strict mode, warn about non-standard status codes
+		// In strict mode, warn about non-standard status codes. The question is
+		// whether the code is one the HTTP RFCs register, which only a numeric
+		// code can be: a wildcard range names a class of codes, so the registry
+		// has nothing to say about it and a permitted range is not irregular.
+		if v.StrictMode && httputil.IsNumericStatusCode(code) && !httputil.IsStandardStatusCode(code) {
 			v.addWarning(result, path+".responses."+code,
 				fmt.Sprintf("Non-standard HTTP status code: %s (not defined in HTTP RFCs)", code),
 				withSpecRef(fmt.Sprintf("%s#responses-object", baseURL)),

--- a/validator/helpers.go
+++ b/validator/helpers.go
@@ -63,8 +63,41 @@ func (v *Validator) validateInfoObject(info *parser.Info, result *ValidationResu
 	}
 }
 
+// wildcardResponseRangesPermitted reports whether the document version defines
+// wildcard response ranges (1XX through 5XX) as Responses Object keys.
+//
+// OAS 3.0 introduced them. The 2.0 Responses Object admits one property per HTTP
+// status code and says nothing about ranges, so a 2.0 document writing "2XX"
+// names a key its own version does not define. An unrecognized version permits
+// them, matching the other version gates.
+func wildcardResponseRangesPermitted(version parser.OASVersion) bool {
+	return !version.IsValid() || version >= parser.OASVersion300
+}
+
+// statusCodeKeyProblem returns the diagnostic for a Responses Object key that is
+// no status code, or "" when the key is one. Pass the answer of
+// [wildcardResponseRangesPermitted] as allowWildcards.
+//
+// A numeric code is legal in every version, so only the wildcard range needs the
+// version, and it gets its own message: "2XX" is a key most tooling accepts, and
+// naming the version that introduced it says more than calling it malformed.
+func statusCodeKeyProblem(code string, allowWildcards bool) string {
+	switch {
+	case httputil.IsNumericStatusCode(code):
+		return ""
+	case httputil.IsWildcardStatusCode(code):
+		if allowWildcards {
+			return ""
+		}
+		return fmt.Sprintf("Invalid HTTP status code: %s (wildcard ranges were introduced in OAS 3.0; OAS 2.0 defines one property per HTTP status code)", code)
+	default:
+		return fmt.Sprintf("Invalid HTTP status code: %s", code)
+	}
+}
+
 // validateResponseStatusCodes validates HTTP status codes in an operation's responses.
-// This helper is shared by both OAS 2.0 and OAS 3.x operation validators.
+// This helper is shared by both OAS 2.0 and OAS 3.x operation validators, so it
+// reads the version off the Validator rather than taking it as an argument.
 func (v *Validator) validateResponseStatusCodes(responses *parser.Responses, path string, result *ValidationResult, baseURL string) {
 	if responses == nil {
 		return
@@ -75,11 +108,13 @@ func (v *Validator) validateResponseStatusCodes(responses *parser.Responses, pat
 	// rather than into Codes, so it is not observable from the loop.
 	hasSuccess := responses.Default != nil
 
+	allowWildcards := wildcardResponseRangesPermitted(v.oasVersion)
+
 	for code := range responses.Codes {
-		// Validate HTTP status code format
-		if !httputil.IsStatusCode(code) {
-			v.addError(result, path+".responses."+code,
-				fmt.Sprintf("Invalid HTTP status code: %s", code),
+		// Validate the HTTP status code format, which the document's version
+		// scopes: a numeric code is legal everywhere, a wildcard only from 3.0.
+		if problem := statusCodeKeyProblem(code, allowWildcards); problem != "" {
+			v.addError(result, path+".responses."+code, problem,
 				withSpecRef(fmt.Sprintf("%s#responses-object", baseURL)),
 				withValue(code),
 			)

--- a/validator/responses_status_codes_test.go
+++ b/validator/responses_status_codes_test.go
@@ -332,3 +332,156 @@ paths:
 	assert.Contains(t, strings.Join(messages, "\n"), "Invalid HTTP status code: 999")
 	assert.False(t, result.Valid, "a document with an unusable status code is not valid")
 }
+
+// TestWildcardResponseRangesPermitted pins the version boundary the wildcard
+// range sits on. OAS 3.0 introduced it, so 2.0 is the only released version
+// that does not define it, and an unrecognized version permits it the way the
+// other version gates do.
+func TestWildcardResponseRangesPermitted(t *testing.T) {
+	tests := []struct {
+		name     string
+		version  parser.OASVersion
+		expected bool
+	}{
+		{"2.0 predates the wildcard range", parser.OASVersion20, false},
+		{"3.0.0 introduced it", parser.OASVersion300, true},
+		{"3.0.4", parser.OASVersion304, true},
+		{"3.1.0", parser.OASVersion310, true},
+		{"3.2.0", parser.OASVersion320, true},
+		{"an unrecognized version permits it", parser.Unknown, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, wildcardResponseRangesPermitted(tt.version))
+		})
+	}
+}
+
+// TestWildcardRangeIsReportedInOAS2 covers a 2.0 document keyed by a wildcard
+// range. The 2.0 Responses Object admits one property per HTTP status code and
+// describes no ranges, so "2XX" names a key its own version does not define
+// (#467). The numeric key beside it must stay unreported, or the check would be
+// rejecting the Responses Object rather than the range.
+func TestWildcardRangeIsReportedInOAS2(t *testing.T) {
+	doc := &parser.OAS2Document{
+		Swagger: "2.0",
+		Info:    &parser.Info{Title: "T", Version: "1.0.0"},
+		Paths: map[string]*parser.PathItem{
+			"/a": {
+				Get: &parser.Operation{
+					OperationID: "a",
+					Responses: &parser.Responses{
+						Codes: map[string]*parser.Response{
+							"200": {Description: "OK"},
+							"2XX": {Description: "a range 2.0 does not define"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	v := New()
+	result, err := v.ValidateParsed(parser.ParseResult{
+		Document:   doc,
+		Version:    "2.0",
+		OASVersion: parser.OASVersion20,
+	})
+	require.NoError(t, err)
+
+	messages := make([]string, 0, len(result.Errors))
+	for _, e := range result.Errors {
+		messages = append(messages, e.Path+": "+e.Message)
+	}
+	joined := strings.Join(messages, "\n")
+
+	assert.Contains(t, joined, "Invalid HTTP status code: 2XX")
+	assert.Contains(t, joined, "wildcard ranges were introduced in OAS 3.0",
+		"the message must name the version that defines the key, since most tooling accepts it")
+	assert.NotContains(t, joined, "Invalid HTTP status code: 200",
+		"a numeric code is legal in every version")
+	assert.False(t, result.Valid)
+}
+
+// TestWildcardRangeIsAcceptedInOAS3 is the counterpart. Without it, a change
+// that rejected the wildcard range in every version would pass the test above.
+func TestWildcardRangeIsAcceptedInOAS3(t *testing.T) {
+	doc := &parser.OAS3Document{
+		OpenAPI:    "3.0.4",
+		OASVersion: parser.OASVersion304,
+		Info:       &parser.Info{Title: "T", Version: "1.0.0"},
+		Paths: parser.Paths{
+			"/a": {
+				Get: &parser.Operation{
+					OperationID: "a",
+					Responses: &parser.Responses{
+						Codes: map[string]*parser.Response{
+							"2XX": {Description: "a range 3.0 defines"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	v := New()
+	result, err := v.ValidateParsed(parser.ParseResult{
+		Document:   doc,
+		Version:    "3.0.4",
+		OASVersion: parser.OASVersion304,
+	})
+	require.NoError(t, err)
+
+	messages := make([]string, 0, len(result.Errors))
+	for _, e := range result.Errors {
+		messages = append(messages, e.Message)
+	}
+	assert.NotContains(t, strings.Join(messages, "\n"), "Invalid HTTP status code: 2XX")
+}
+
+// TestWildcardRangeInOAS2DoesNotSatisfyTheSuccessCheck applies the rule the
+// malformed-key case already establishes: a key reported as unusable cannot
+// also stand in as the operation's success response. "2XX" begins with a 2,
+// which is how the success check recognises one, so a version that does not
+// define the key must not count it either.
+func TestWildcardRangeInOAS2DoesNotSatisfyTheSuccessCheck(t *testing.T) {
+	doc := &parser.OAS2Document{
+		Swagger: "2.0",
+		Info:    &parser.Info{Title: "T", Version: "1.0.0"},
+		Paths: map[string]*parser.PathItem{
+			"/a": {
+				Get: &parser.Operation{
+					OperationID: "a",
+					Summary:     "only a range 2.0 does not define",
+					Responses: &parser.Responses{
+						Codes: map[string]*parser.Response{
+							"2XX": {Description: "a range 2.0 does not define"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	v := New()
+	v.IncludeWarnings = true
+	v.StrictMode = true
+	result, err := v.ValidateParsed(parser.ParseResult{
+		Document:   doc,
+		Version:    "2.0",
+		OASVersion: parser.OASVersion20,
+	})
+	require.NoError(t, err)
+
+	warnings := make([]string, 0, len(result.Warnings))
+	for _, w := range result.Warnings {
+		warnings = append(warnings, w.Message)
+	}
+	joined := strings.Join(warnings, "\n")
+
+	assert.Contains(t, joined, "Operation should define at least one successful response",
+		"a key 2.0 does not define cannot stand in for a 2XX response")
+	assert.NotContains(t, joined, "Non-standard HTTP status code: 2XX",
+		"the key is already reported as an error, so saying it twice helps nobody")
+}

--- a/validator/responses_status_codes_test.go
+++ b/validator/responses_status_codes_test.go
@@ -86,10 +86,10 @@ paths:
 	assert.NotContains(t, warnings, "Non-standard HTTP status code")
 }
 
-// TestInvalidStatusCodeInCodesIsReported pins the format check itself. Reaching
-// it takes a Responses object holding a key no decoder would have accepted,
-// which is why the value is built here rather than parsed: the YAML and JSON
-// decoders reject such a key outright.
+// TestInvalidStatusCodeInCodesIsReported pins the format check itself. The
+// value is built here rather than parsed so the check can be exercised on its
+// own, without the parser reporting the same key first.
+// TestMalformedCodeFromAParsedDocument covers it arriving through the parser.
 func TestInvalidStatusCodeInCodesIsReported(t *testing.T) {
 	doc := &parser.OAS3Document{
 		OpenAPI:    "3.1.0",
@@ -243,8 +243,9 @@ func TestExtensionKeyInCodesIsReportedAsInvalid(t *testing.T) {
 // put one in front of the validator, and this asserts it arrives that way
 // rather than only when a test builds the value by hand.
 //
-// ResolveRefs selects that decode path. The YAML and JSON decoders reject the
-// key outright, so neither can deliver this input.
+// ResolveRefs selects decodeFromMap, which is the path under test here. The
+// YAML and JSON decoders keep the key too, so the input is not exclusive to
+// this path; pinning one of the three is what makes the assertion specific.
 func TestMalformedCodeFromAParsedDocument(t *testing.T) {
 	const spec = `
 openapi: 3.1.0
@@ -489,4 +490,94 @@ func TestWildcardRangeInOAS2DoesNotSatisfyTheSuccessCheck(t *testing.T) {
 		"a key 2.0 does not define cannot stand in for a 2XX response")
 	assert.NotContains(t, joined, "Non-standard HTTP status code: 2XX",
 		"the key is already reported as an error, so saying it twice helps nobody")
+}
+
+// TestPermittedWildcardRangeDrawsNoNonStandardWarning covers strict mode's
+// non-standard-code warning, which asks whether a code is one the HTTP RFCs
+// register. Only a numeric code can be: a wildcard range names a class of codes,
+// so the registry has nothing to say about it and a range the version permits is
+// not irregular. Microsoft Graph keys every operation this way, so warning on it
+// buries the findings that matter.
+func TestPermittedWildcardRangeDrawsNoNonStandardWarning(t *testing.T) {
+	doc := &parser.OAS3Document{
+		OpenAPI:    "3.0.4",
+		OASVersion: parser.OASVersion304,
+		Info:       &parser.Info{Title: "T", Version: "1.0.0"},
+		Paths: parser.Paths{
+			"/a": {
+				Get: &parser.Operation{
+					OperationID: "a",
+					Summary:     "keyed by ranges",
+					Responses: &parser.Responses{
+						Codes: map[string]*parser.Response{
+							"2XX": {Description: "ranged success"},
+							"5XX": {Description: "ranged failure"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	v := New()
+	v.IncludeWarnings = true
+	v.StrictMode = true
+	result, err := v.ValidateParsed(parser.ParseResult{
+		Document:   doc,
+		Version:    "3.0.4",
+		OASVersion: parser.OASVersion304,
+	})
+	require.NoError(t, err)
+
+	warnings := make([]string, 0, len(result.Warnings))
+	for _, w := range result.Warnings {
+		warnings = append(warnings, w.Message)
+	}
+	joined := strings.Join(warnings, "\n")
+
+	assert.NotContains(t, joined, "Non-standard HTTP status code: 2XX")
+	assert.NotContains(t, joined, "Non-standard HTTP status code: 5XX")
+
+	// 2XX is a success response, so the missing-success warning must not fire
+	// either: the range covers every code the check is looking for.
+	assert.NotContains(t, joined, "Operation should define at least one successful response")
+}
+
+// TestNonStandardNumericCodeStillWarns is the counterpart. Without it, a change
+// that deleted the non-standard-code warning outright would pass the test above.
+func TestNonStandardNumericCodeStillWarns(t *testing.T) {
+	doc := &parser.OAS3Document{
+		OpenAPI:    "3.0.4",
+		OASVersion: parser.OASVersion304,
+		Info:       &parser.Info{Title: "T", Version: "1.0.0"},
+		Paths: parser.Paths{
+			"/a": {
+				Get: &parser.Operation{
+					OperationID: "a",
+					Summary:     "keyed by an unregistered code",
+					Responses: &parser.Responses{
+						Codes: map[string]*parser.Response{
+							"299": {Description: "valid format, not a registered code"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	v := New()
+	v.IncludeWarnings = true
+	v.StrictMode = true
+	result, err := v.ValidateParsed(parser.ParseResult{
+		Document:   doc,
+		Version:    "3.0.4",
+		OASVersion: parser.OASVersion304,
+	})
+	require.NoError(t, err)
+
+	warnings := make([]string, 0, len(result.Warnings))
+	for _, w := range result.Warnings {
+		warnings = append(warnings, w.Message)
+	}
+	assert.Contains(t, strings.Join(warnings, "\n"), "Non-standard HTTP status code: 299")
 }

--- a/validator/responses_status_codes_test.go
+++ b/validator/responses_status_codes_test.go
@@ -438,6 +438,11 @@ func TestWildcardRangeIsAcceptedInOAS3(t *testing.T) {
 		messages = append(messages, e.Message)
 	}
 	assert.NotContains(t, strings.Join(messages, "\n"), "Invalid HTTP status code: 2XX")
+
+	// Asserting the whole verdict as well, so that reporting the range under
+	// some other message would fail here too.
+	assert.Empty(t, result.Errors)
+	assert.True(t, result.Valid, "a 3.0 document may key its responses by a wildcard range")
 }
 
 // TestWildcardRangeInOAS2DoesNotSatisfyTheSuccessCheck applies the rule the


### PR DESCRIPTION
## Summary

- Wildcard response ranges (`1XX` through `5XX`) are an OAS 3.0 addition, and oastools accepted them in OAS 2.0 documents. It no longer does. 🎯
- Fixing that exposed three related defects downstream, all of them fixed here: `convert` emitted an invalid 2.0 document while reporting success, strict mode called a legal `2XX` a non-standard status code, and one predicate had been left with no callers.
- Verdicts change for OAS 2.0 documents only. No corpus spec is affected, and no conformance row moves.

## Changes

**The rule itself (#467)**

`httputil.IsStatusCode` stays version-blind, because a decoder cannot see the document version. It is now the union of two narrower predicates, `IsNumericStatusCode` and `IsWildcardStatusCode`, and the two callers that do know the version pick between them:

- `parser.validateOAS2Operation` reports a wildcard range. `validateOAS3Operation` accepts both forms, since every 3.x version defines them.
- `validator.validateResponseStatusCodes` reads `v.oasVersion`, which already exists for version-sensitive checks, so no signature changed.

The wildcard case gets its own message naming the version that introduced the key, because most tooling accepts `2XX` and "invalid status code" alone would not explain why. The OAS 2.0 message also stops offering a wildcard pattern as the remedy for a bad key, which 2.0 cannot use.

**Downconversion produced an invalid document**

Converting 3.x to 2.0 copied a wildcard key across as written, so `convert` reported success while emitting a document its own `validate` rejects. This was invisible before, because oastools wrongly accepted the result. A range now becomes the first code it covers (`2XX` to `200`, the same reading the generator already applies), with a warning per substitution. When the operation already declares that code, the range is dropped instead and the warning says so.

**Strict mode warned about legal ranges**

The non-standard-code warning asks whether a code is one the HTTP RFCs register, which only a numeric code can be. Against the corpus in strict mode:

| spec | before | after |
|---|---|---|
| `msgraph-openapi.yaml` | 45277 | 0 |
| `discord-openapi.json` | 227 | 0 |

No numeric-code warning changed on any of the ten specs.

**Dead code**

`httputil.IsValidResponsesKey` told callers to use it to accept or reject a key while decoding. No decoder has done that since #449, and nothing called it. Removed, along with its test table.

**Comment corrections**

Five comments justified themselves with a decoder that rejects an unusable response key before the validator sees it. None has done that since #449. Each was probed rather than assumed, and one turned out to be right for the wrong reason: an unusable key with a non-object value really is reachable only through `decodeFromMap`, but because the other two decoders cannot decode the value, not because they reject the key.

## Context

The issue's implementation notes predicted that both the decode paths and the validator would need the version-aware predicate. That was written before a2a6446, which made all three decoders keep an unusable key and defer to `validateStructure`. So no decode path needed to change, and the version rule only had to land where the version is already known.

Verifying the spec claim first: `curl`ing the published 2.0 document shows "uppercase wildcard" appears zero times, and so does any `1XX` through `5XX` pattern. 3.0.4 and 3.2.0 each state it explicitly.

## Testing

- `make check` green. **10759 tests**, the same count as `main`: this branch adds 42 and removes the 53-case table belonging to the deleted predicate.
- All ten corpus specs produce identical `validate` output, normalized for operationId attribution and sorted. The only 2.0 spec in the corpus carries no wildcard keys, and the two that do are 3.x.
- `IsStatusCode` was differential-tested against its previous implementation over every three-byte string before the old one was removed, and `TestStatusCodeFormsPartitionIsStatusCode` keeps the two new predicates disjoint and their union equal to it.
- Every guard and version gate was mutation-tested in both directions, and each mutation was confirmed to fail the specific test meant to catch it.
- The vendored conformance fixtures are 3.0 through 3.3, so no scoreboard row moves.
- [x] All tests pass (`make check`)
- [x] Corpus green (`make test-corpus`)
- [x] Security scan clean (`govulncheck`): no vulnerabilities found

## Related Issues

Closes #467
