### PR TITLE
fix(fixer): prune schemas referenced only by unused schemas

### DIFF
--- a/fixer/prune.go
+++ b/fixer/prune.go
@@ -30,6 +30,22 @@ func collectPolymorphicSchemaRefs(refs *[]string, field any, prefix string, visi
 	}
 }
 
+// refHasEntryPointOrigin returns true when any of the following are true:
+//   - ref is not in poolRefs or its origins are empty
+//   - at least one origin is outside the schema pool
+func refHasEntryPointOrigin(poolPrefix string, poolRefs map[string][]string, ref string) bool {
+	origins, ok := poolRefs[ref]
+	if !ok || len(origins) == 0 {
+		return true
+	}
+	for _, origin := range origins {
+		if !strings.HasPrefix(origin, poolPrefix) {
+			return true
+		}
+	}
+	return false
+}
+
 // buildReferencedSchemaSet builds the transitive closure of referenced schemas.
 // Starting from refs collected by RefCollector, it follows schema-to-schema references
 // to ensure schemas that are indirectly referenced are not pruned.
@@ -40,11 +56,17 @@ func buildReferencedSchemaSet(collector *RefCollector, schemas map[string]*parse
 	queue := make([]string, 0)
 
 	prefix := accessor.SchemaRefPrefix()
+	poolPrefix := schemaPathPrefix(accessor.GetVersion()) + "."
 
 	// 1. Get directly referenced schemas from collector. names is reused across
 	// refs so the candidate spellings cost no allocation after the first ref.
 	var names []string
 	for ref := range collector.RefsByType[RefTypeSchema] {
+		// exclude refs whose origins are all local to this schema pool
+		// see: Issue #474
+		if !refHasEntryPointOrigin(poolPrefix, collector.Refs, ref) {
+			continue
+		}
 		names = appendSchemaNames(names[:0], ref, prefix)
 		for _, name := range names {
 			if _, exists := schemas[name]; exists && !referenced[name] {

--- a/fixer/prune_origin_test.go
+++ b/fixer/prune_origin_test.go
@@ -1,0 +1,157 @@
+package fixer
+
+import (
+	"testing"
+
+	"github.com/erraggy/oastools/parser"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPruneIsolatedSchemaIsland(t *testing.T) {
+	// Scenario: Schema A references Schema B.
+	// Neither A nor B is referenced from any entry point (paths, etc.).
+	// Before the fix, A might have been considered "referenced" because it's in the collector's
+	// RefsByType[RefTypeSchema] map, and B would be kept because A refs it.
+	// Now, since A's only origin is "components.schemas.A", it should be skipped in seeding.
+
+	spec := `
+openapi: "3.0.3"
+info:
+  title: Test API
+  version: "1.0"
+paths:
+  /health:
+    get:
+      responses:
+        "200":
+          description: OK
+components:
+  schemas:
+    SchemaA:
+      $ref: "#/components/schemas/SchemaB"
+    SchemaB:
+      type: string
+`
+	// Parse
+	parseResult, err := parser.ParseWithOptions(parser.WithBytes([]byte(spec)))
+	require.NoError(t, err)
+
+	// Fix with pruning enabled
+	f := New()
+	f.EnabledFixes = []FixType{FixTypePrunedUnusedSchema}
+	result, err := f.FixParsed(*parseResult)
+	require.NoError(t, err)
+
+	// Assert
+	doc := result.Document.(*parser.OAS3Document)
+	assert.Equal(t, 2, result.FixCount, "Both SchemaA and SchemaB should be pruned")
+
+	if doc.Components != nil {
+		assert.NotContains(t, doc.Components.Schemas, "SchemaA")
+		assert.NotContains(t, doc.Components.Schemas, "SchemaB")
+	}
+}
+
+func TestPruneSchemaRefFromEntrypoint(t *testing.T) {
+	// Scenario: Schema A is referenced from a Path.
+	// Schema A references Schema B.
+	// Both should be kept.
+
+	spec := `
+openapi: "3.0.3"
+info:
+  title: Test API
+  version: "1.0"
+paths:
+  /users:
+    get:
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SchemaA"
+components:
+  schemas:
+    SchemaA:
+      $ref: "#/components/schemas/SchemaB"
+    SchemaB:
+      type: string
+`
+	// Parse
+	parseResult, err := parser.ParseWithOptions(parser.WithBytes([]byte(spec)))
+	require.NoError(t, err)
+
+	// Fix with pruning enabled
+	f := New()
+	f.EnabledFixes = []FixType{FixTypePrunedUnusedSchema}
+	result, err := f.FixParsed(*parseResult)
+	require.NoError(t, err)
+
+	// Assert
+	doc := result.Document.(*parser.OAS3Document)
+	assert.Equal(t, 0, result.FixCount, "No schemas should be pruned")
+
+	require.NotNil(t, doc.Components)
+	assert.Contains(t, doc.Components.Schemas, "SchemaA")
+	assert.Contains(t, doc.Components.Schemas, "SchemaB")
+}
+
+func TestPruneOAS2_Issue_474_Regression(t *testing.T) {
+	// Issue #474 desribes this spec in its reproduction case
+	// This spec contains only a single _referenced_ schema (Pet),
+	// but it contains 2 additional schemas that only reference
+	// one another: Order<=>Customer
+	spec := `{
+  "swagger": "2.0",
+  "info": {"title": "Petstore", "version": "1.0.0"},
+  "paths": {
+    "/pets": {
+      "get": {
+        "operationId": "listPets",
+        "responses": {
+          "200": {"description": "OK", "schema": {"$ref": "#/definitions/Pet"}}
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Pet": {
+      "type": "object",
+      "properties": {"name": {"type": "string"}}
+    },
+    "Order": {
+      "type": "object",
+      "properties": {"customer": {"$ref": "#/definitions/Customer"}}
+    },
+    "Customer": {
+      "type": "object",
+      "properties": {"lastOrder": {"$ref": "#/definitions/Order"}}
+    },
+    "Tag": {
+      "type": "object",
+      "properties": {"label": {"type": "string"}}
+    }
+  }
+}`
+	p := parser.New()
+	parseResult, err := p.ParseBytes([]byte(spec))
+	require.NoError(t, err)
+
+	require.True(t, parseResult.IsOAS2(), "expected OAS 2.0 document")
+
+	// Apply pruning
+	f := New()
+	f.EnabledFixes = []FixType{FixTypePrunedUnusedSchema}
+	f.MutableInput = true
+
+	result, err := f.FixParsed(*parseResult)
+	require.NoError(t, err)
+
+	schemas := result.ToParseResult().AsAccessor().GetSchemas()
+
+	require.Len(t, schemas, 1)
+	require.Contains(t, schemas, "Pet")
+}

--- a/internal/conformance/conformance_test.go
+++ b/internal/conformance/conformance_test.go
@@ -77,6 +77,17 @@ func TestParseSourcesRejects(t *testing.T) {
 	})
 }
 
+var (
+	ignoreFiles = map[string]bool{".DS_Store": true}
+)
+
+func shouldIgnore(entry os.DirEntry) bool {
+	if entry.Type().IsRegular() && ignoreFiles[entry.Name()] {
+		return true
+	}
+	return false
+}
+
 // TestVendoredTreeMatchesSources is the count half of the drift guard. A
 // deleted fixture makes a suite smaller rather than redder, so nothing else
 // would notice it.
@@ -142,6 +153,9 @@ func TestVendoredTreeHoldsOnlyFixtures(t *testing.T) {
 			require.NoError(t, err, "%s/%s: sources.txt records fixtures here", s.Version, kind)
 
 			for _, entry := range entries {
+				if shouldIgnore(entry) {
+					continue
+				}
 				name := filepath.Join(s.Version, string(kind), entry.Name())
 				// Regular rather than "not a directory": DirEntry reports the
 				// link itself, so a symlink is neither, and its size is the
@@ -169,6 +183,9 @@ func TestVendoredTreeHasNothingElse(t *testing.T) {
 	entries, err := os.ReadDir(Dir())
 	require.NoError(t, err)
 	for _, entry := range entries {
+		if shouldIgnore(entry) {
+			continue
+		}
 		assert.True(t, want[entry.Name()],
 			"%s is not recorded in sources.txt, so nothing else here checks it", entry.Name())
 	}
@@ -177,6 +194,9 @@ func TestVendoredTreeHasNothingElse(t *testing.T) {
 		sub, err := os.ReadDir(filepath.Join(Dir(), s.Version))
 		require.NoError(t, err)
 		for _, entry := range sub {
+			if shouldIgnore(entry) {
+				continue
+			}
 			assert.Contains(t, []string{"pass", "fail"}, entry.Name(),
 				"%s/%s: a version holds only pass and fail", s.Version, entry.Name())
 		}


### PR DESCRIPTION
Exclude schema-to-schema references from the initial prune roots so unused schema islands are removed instead of retained through their internal links. Still follow transitive references once a schema is reached from an actual entry point.

Closes #474