### PR TITLE
fix(scripts): compare epoch seconds for release notes issue linking

### DIFF
--- a/.claude/scripts/prepare-release.sh
+++ b/.claude/scripts/prepare-release.sh
@@ -284,11 +284,14 @@ AUTO_NOTES=$(gh api "repos/$REPO/releases/generate-notes" \
     --jq '.body')
 
 # Get linked issues
-LAST_TAG_DATE=$(git log -1 --format=%cI "$PREV_TAG")
+# Compare epoch seconds, not ISO8601 strings: git %cI keeps the committer's local
+# offset while the GitHub API returns UTC "Z" timestamps, so string comparison
+# sorts them incorrectly whenever the offset digits diverge from real order.
+LAST_TAG_EPOCH=$(git log -1 --format=%ct "$PREV_TAG")
 LINKED_ISSUES=$(gh pr list --state merged --base main --limit 50 \
     --json number,title,mergedAt,closingIssuesReferences | \
-    jq -r --arg since "$LAST_TAG_DATE" '
-        [.[] | select(.mergedAt > $since and (.closingIssuesReferences | length > 0))] |
+    jq -r --argjson since "$LAST_TAG_EPOCH" '
+        [.[] | select((.mergedAt | fromdateiso8601) > $since and (.closingIssuesReferences | length > 0))] |
         if length == 0 then "None"
         else .[] | "- #\(.closingIssuesReferences[0].number) - Fixed by PR #\(.number)"
         end')


### PR DESCRIPTION
## Summary
- `prepare-release.sh`'s "Issues Fixed" section compared PR `mergedAt` (UTC, GitHub API) against the previous tag's commit date (`git log --format=%cI`, local offset) as plain ISO8601 strings.
- Lexicographic comparison of ISO8601 timestamps only agrees with chronological order when both share the same offset representation. Mixing UTC `Z` and local offsets can sort backwards.
- Discovered while generating v1.60.1's release notes: PRs #472, #471, #469, #464 (all merged before the v1.60.0 tag) were misattributed to v1.60.1's "Issues Fixed" list.

## Fix
Compare epoch seconds instead: `git log --format=%ct` (timezone-agnostic) against `mergedAt | fromdateiso8601` in jq.

## Test plan
- [x] Manually re-ran the corrected query against this repo's real PR history — confirms only `#474 - Fixed by PR #475` for the v1.60.0..v1.60.1 window (previously included 4 stale entries)
- [x] v1.60.1's release notes were hand-corrected using this same logic before publishing