### PR TITLE
fix(joiner): scope schema renames to the documents they concern

### DIFF
--- a/.claude/docs/benchmark-guide.md
+++ b/.claude/docs/benchmark-guide.md
@@ -14,6 +14,7 @@ func BenchmarkOperation(b *testing.B) {
         parser.WithValidateStructure(true),
     )
 
+    b.ReportAllocs()
     for b.Loop() {  // ✅ Modern Go 1.24+ pattern
         _, err := Operation(source)
         if err != nil {
@@ -23,10 +24,15 @@ func BenchmarkOperation(b *testing.B) {
 }
 ```
 
+### DO
+
+- Call `b.ReportAllocs()`. `b.Loop()` does not report allocations on its own, so
+  without it `go test -bench` shows no B/op or allocs/op unless `-benchmem` is
+  passed. `make bench` passes it, an ad hoc run does not.
+
 ### DO NOT
 
 - Use `for i := 0; i < b.N; i++` (old pattern)
-- Call `b.ReportAllocs()` manually (handled by `b.Loop()`)
 - Call `b.ResetTimer()` for trivial setup
 
 ## Benchmark Reliability

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -206,6 +206,7 @@ func BenchmarkOperation(b *testing.B) {
         parser.WithValidateStructure(true),
     )
 
+    b.ReportAllocs()
     for b.Loop() {  // ✅ Modern Go 1.24+ pattern
         _, err := Operation(source)
         if err != nil {

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -215,10 +215,13 @@ func BenchmarkOperation(b *testing.B) {
 }
 ```
 
+**DO:**
+
+- Call `b.ReportAllocs()`. `b.Loop()` does not report allocations on its own.
+
 **DO NOT:**
 
 - Use `for i := 0; i < b.N; i++` (old pattern)
-- Call `b.ReportAllocs()` manually (handled by `b.Loop()`)
 - Call `b.ResetTimer()` for trivial setup
 
 ## Security

--- a/joiner/collision_handler.go
+++ b/joiner/collision_handler.go
@@ -238,6 +238,11 @@ func FailWithMessage(message string) CollisionResolution {
 }
 
 // UseCustomValue returns a resolution that uses a caller-provided merged value.
+//
+// Renames are otherwise scoped to the document that wrote the reference, but a
+// value built by the handler came from no document, so every rename in the join
+// applies to its references. A handler that wants one document's naming should
+// return that document's value (AcceptLeft or AcceptRight) rather than a copy.
 func UseCustomValue(value any) CollisionResolution {
 	return CollisionResolution{Action: ResolutionCustom, CustomValue: value}
 }

--- a/joiner/collision_handler.go
+++ b/joiner/collision_handler.go
@@ -302,7 +302,7 @@ func (j *Joiner) applySchemaResolution(p schemaResolutionParams) (bool, error) {
 
 	case ResolutionRename:
 		// Rename right schema/definition
-		newName := j.generateRenamedSchemaName(p.collision.Name, p.ctx.filePath, p.ctx.docIndex, p.sourceGraph)
+		newName := uniqueSchemaName(p.target, j.generateRenamedSchemaName(p.collision.Name, p.ctx.filePath, p.ctx.docIndex, p.sourceGraph))
 		p.target[newName] = schema
 		p.result.recordOrigin(newName, p.ctx)
 		// Only the incoming document referenced the schema being renamed.

--- a/joiner/collision_handler.go
+++ b/joiner/collision_handler.go
@@ -250,11 +250,15 @@ func UseCustomValueWithMessage(value any, message string) CollisionResolution {
 // schemaResolutionParams contains parameters for applySchemaResolution.
 // This allows sharing the resolution logic between OAS2 definitions and OAS3 schemas.
 type schemaResolutionParams struct {
-	collision   CollisionContext
-	resolution  CollisionResolution
-	target      map[string]*parser.Schema
-	result      *JoinResult
-	ctx         documentContext
+	collision  CollisionContext
+	resolution CollisionResolution
+	target     map[string]*parser.Schema
+	result     *JoinResult
+	ctx        documentContext
+	// sourceName is the schema's name in its own document, which may differ from
+	// collision.Name when a namespace prefix has already been applied. Renames are
+	// recorded against it because that is what the document's references spell.
+	sourceName  string
 	sourceGraph *RefGraph
 	label       string // "schema" for OAS3, "definition" for OAS2
 }
@@ -287,6 +291,7 @@ func (j *Joiner) applySchemaResolution(p schemaResolutionParams) (bool, error) {
 	case ResolutionAcceptRight:
 		// Replace with incoming (right)
 		p.target[p.collision.Name] = schema
+		p.result.recordOrigin(p.collision.Name, p.ctx)
 		j.recordCollisionEvent(p.result, p.collision.Name, p.collision.LeftSource, p.collision.RightSource, p.collision.ConfiguredStrategy, resolutionKeptRight, "")
 		return true, nil
 
@@ -294,10 +299,9 @@ func (j *Joiner) applySchemaResolution(p schemaResolutionParams) (bool, error) {
 		// Rename right schema/definition
 		newName := j.generateRenamedSchemaName(p.collision.Name, p.ctx.filePath, p.ctx.docIndex, p.sourceGraph)
 		p.target[newName] = schema
-		if p.result.rewriter == nil {
-			p.result.rewriter = NewSchemaRewriter()
-		}
-		p.result.rewriter.RegisterRename(p.collision.Name, newName, p.result.OASVersion)
+		p.result.recordOrigin(newName, p.ctx)
+		// Only the incoming document referenced the schema being renamed.
+		p.result.scope.registerRight(p.ctx.docIndex, p.sourceName, newName)
 		line, col := j.getLocation(p.ctx.filePath, p.collision.JSONPath)
 		p.result.AddWarning(NewSchemaRenamedWarning(p.collision.Name, newName, p.label, p.ctx.filePath, line, col, false))
 		j.recordCollisionEvent(p.result, p.collision.Name, p.collision.LeftSource, p.collision.RightSource, p.collision.ConfiguredStrategy, resolutionRenamed, newName)
@@ -327,6 +331,7 @@ func (j *Joiner) applySchemaResolution(p schemaResolutionParams) (bool, error) {
 			return true, fmt.Errorf("collision handler: CustomValue is %T, expected *parser.Schema for %s collisions", p.resolution.CustomValue, p.label)
 		}
 		p.target[p.collision.Name] = customSchema
+		p.result.recordOrigin(p.collision.Name, p.ctx)
 		j.recordCollisionEvent(p.result, p.collision.Name, p.collision.LeftSource, p.collision.RightSource, p.collision.ConfiguredStrategy, "custom", "")
 		return true, nil
 

--- a/joiner/collision_handler.go
+++ b/joiner/collision_handler.go
@@ -239,10 +239,9 @@ func FailWithMessage(message string) CollisionResolution {
 
 // UseCustomValue returns a resolution that uses a caller-provided merged value.
 //
-// Renames are otherwise scoped to the document that wrote the reference, but a
-// value built by the handler came from no document, so every rename in the join
-// applies to its references. A handler that wants one document's naming should
-// return that document's value (AcceptLeft or AcceptRight) rather than a copy.
+// Any $ref in the value is rewritten using every rename in the join, because the
+// value belongs to no one document. To get a single document's renames, return
+// its value with AcceptLeft or AcceptRight instead.
 func UseCustomValue(value any) CollisionResolution {
 	return CollisionResolution{Action: ResolutionCustom, CustomValue: value}
 }
@@ -260,9 +259,8 @@ type schemaResolutionParams struct {
 	target     map[string]*parser.Schema
 	result     *JoinResult
 	ctx        documentContext
-	// sourceName is the schema's name in its own document, which may differ from
-	// collision.Name when a namespace prefix has already been applied. Renames are
-	// recorded against it because that is what the document's references spell.
+	// sourceName is the schema's name in its own document, which differs from
+	// collision.Name once a namespace prefix is applied. Its references spell this.
 	sourceName  string
 	sourceGraph *RefGraph
 	label       string // "schema" for OAS3, "definition" for OAS2
@@ -305,7 +303,7 @@ func (j *Joiner) applySchemaResolution(p schemaResolutionParams) (bool, error) {
 		newName := uniqueSchemaName(p.target, j.generateRenamedSchemaName(p.collision.Name, p.ctx.filePath, p.ctx.docIndex, p.sourceGraph))
 		p.target[newName] = schema
 		p.result.recordOrigin(newName, p.ctx)
-		// Only the incoming document referenced the schema being renamed.
+		// Only the incoming document referenced the renamed schema.
 		p.result.scope.registerRight(p.ctx.docIndex, p.sourceName, newName)
 		line, col := j.getLocation(p.ctx.filePath, p.collision.JSONPath)
 		p.result.AddWarning(NewSchemaRenamedWarning(p.collision.Name, newName, p.label, p.ctx.filePath, line, col, false))

--- a/joiner/deep_dive.md
+++ b/joiner/deep_dive.md
@@ -70,14 +70,14 @@ Beyond handling same-named collisions, the joiner can identify and consolidate s
 
 ### Reference Rewriting
 
-When schemas are renamed or deduplicated, `$ref` references are updated automatically, so the merged document keeps valid internal references without manual intervention.
+When schemas are renamed or deduplicated, `$ref` references are updated automatically.
 
-Renames are scoped to the documents they concern. A rename resolves a collision between two documents, and it only speaks for the documents that were written against the renamed name:
+A rename only rewrites the references of documents that used the renamed name:
 
-- Renaming an incoming schema (`StrategyRenameRight`, or a namespace prefix) rewrites that document's references. A document merged earlier keeps its references, because the schema it named is still in the document under its original name.
-- Renaming a schema already in the merged document (`StrategyRenameLeft`) rewrites the references of the documents merged before it, which are the ones that named the schema being moved. The incoming document keeps its references, because its schema takes over the original name.
+- `StrategyRenameRight` and namespace prefixes rewrite the incoming document. Earlier documents keep their references.
+- `StrategyRenameLeft` rewrites the earlier documents. The incoming document keeps its references, since its schema takes the original name.
 
-Semantic deduplication is the exception: it consolidates schemas it found equivalent, so every reference to a removed name is rewritten regardless of which document wrote it.
+Semantic deduplication rewrites every reference to a removed name, because the schemas were equivalent.
 
 [↑ Back to top](#top)
 
@@ -322,7 +322,7 @@ Collisions resolved: 1
   schema 'User' collision: right renamed to 'User_orders-api'
 ```
 
-A rename template can generate a name the documents already use, and a template that discards `{{.Name}}` generates one name for every schema of a source. The generated name is made unique with a `_2`, `_3` suffix rather than replacing whatever is stored under it, so a join never drops a schema. The rename warning reports the name that was used.
+If a generated name is already taken, a `_2`, `_3` suffix is added rather than replacing the schema under it. The rename warning reports the name that was used.
 
 [Back to top](#top)
 

--- a/joiner/deep_dive.md
+++ b/joiner/deep_dive.md
@@ -70,7 +70,14 @@ Beyond handling same-named collisions, the joiner can identify and consolidate s
 
 ### Reference Rewriting
 
-When schemas are renamed or deduplicated, all `$ref` references throughout the merged document are automatically updated. This ensures the resulting document maintains valid internal references without manual intervention.
+When schemas are renamed or deduplicated, `$ref` references are updated automatically, so the merged document keeps valid internal references without manual intervention.
+
+Renames are scoped to the documents they concern. A rename resolves a collision between two documents, and it only speaks for the documents that were written against the renamed name:
+
+- Renaming an incoming schema (`StrategyRenameRight`, or a namespace prefix) rewrites that document's references. A document merged earlier keeps its references, because the schema it named is still in the document under its original name.
+- Renaming a schema already in the merged document (`StrategyRenameLeft`) rewrites the references of the documents merged before it, which are the ones that named the schema being moved. The incoming document keeps its references, because its schema takes over the original name.
+
+Semantic deduplication is the exception: it consolidates schemas it found equivalent, so every reference to a removed name is rewritten regardless of which document wrote it.
 
 [↑ Back to top](#top)
 

--- a/joiner/deep_dive.md
+++ b/joiner/deep_dive.md
@@ -322,6 +322,8 @@ Collisions resolved: 1
   schema 'User' collision: right renamed to 'User_orders-api'
 ```
 
+A rename template can generate a name the documents already use, and a template that discards `{{.Name}}` generates one name for every schema of a source. The generated name is made unique with a `_2`, `_3` suffix rather than replacing whatever is stored under it, so a join never drops a schema. The rename warning reports the name that was used.
+
 [Back to top](#top)
 
 ## Operation-Aware Schema Renaming

--- a/joiner/joiner.go
+++ b/joiner/joiner.go
@@ -192,34 +192,28 @@ type JoinResult struct {
 	firstFilePath string
 	// scope accumulates schema renames per source document for reference rewriting
 	scope *renameScope
-	// origins records which document contributed the schema currently held under
-	// each name of the joined document. It stays nil unless the join can consult
-	// it: see Joiner.tracksSchemaOrigins.
+	// origins records which document contributed the schema under each name.
+	// Nil unless Joiner.tracksSchemaOrigins.
 	origins map[string]schemaOrigin
 }
 
 // tracksSchemaOrigins reports whether the join needs to know which document
-// contributed each merged schema.
-//
-// Only rename-left consults it, to name the schema it moves aside after that
-// schema's own document, and a collision handler, which is told the left side's
-// source. Every other path leaves the left side under its original name, so the
-// bookkeeping would go unread.
+// contributed each merged schema. Only rename-left and a collision handler read
+// it, so other strategies skip the bookkeeping.
 func (j *Joiner) tracksSchemaOrigins() bool {
 	return j.getEffectiveStrategy(j.config.SchemaStrategy) == StrategyRenameLeft ||
 		j.shouldInvokeHandler(CollisionTypeSchema)
 }
 
-// schemaOrigin identifies the document that contributed a schema, so that
-// renaming it can name it after its own source rather than after the first
-// document in the join (#479).
+// schemaOrigin identifies the document that contributed a schema, so a rename
+// can name it after its own source (#479).
 type schemaOrigin struct {
 	filePath string
 	docIndex int
 }
 
-// recordOrigin notes that a document contributed the schema now held under name.
-// It is a no-op when the join does not track origins.
+// recordOrigin notes which document contributed the schema now under name.
+// No-op when origins are not tracked.
 func (r *JoinResult) recordOrigin(name string, ctx documentContext) {
 	if r.origins == nil {
 		return
@@ -234,9 +228,8 @@ func (r *JoinResult) moveOrigin(oldName, newName string) {
 	}
 }
 
-// originOf returns the document that contributed the schema held under name. It
-// falls back to the first document, which is the only contributor a two document
-// join can have on the left.
+// originOf returns the document that contributed the schema under name, falling
+// back to the first document.
 func (r *JoinResult) originOf(name string) schemaOrigin {
 	if origin, ok := r.origins[name]; ok {
 		return origin
@@ -618,20 +611,15 @@ func (j *Joiner) generateRenamedSchemaName(originalName, sourcePath string, docI
 	return buf.String()
 }
 
-// uniqueSchemaName returns candidate when no schema is stored under it, and
-// otherwise the first of candidate_2, candidate_3 and so on that is free.
-//
-// A rename template can generate a name the documents already use, and can
-// generate the same name twice. Storing the schema anyway drops whatever was
-// there, which leaves a schema missing from the join with nothing said about it,
-// a worse outcome than a name the caller did not predict (#483). The rename
-// warning reports the name that was used, so the suffix is not silent.
+// uniqueSchemaName returns candidate, or the first free candidate_2,
+// candidate_3 and so on. A rename template can generate a name that is already
+// taken, and storing the schema there would drop the one under it (#483). The
+// rename warning reports the name that was used.
 func uniqueSchemaName(taken map[string]*parser.Schema, candidate string) string {
 	if _, exists := taken[candidate]; !exists {
 		return candidate
 	}
-	// Bounded by the number of schemas already stored: one of the first
-	// len(taken)+2 names is necessarily free.
+	// One of the first len(taken)+2 names is free.
 	for n := 2; ; n++ {
 		name := candidate + "_" + strconv.Itoa(n)
 		if _, exists := taken[name]; !exists {

--- a/joiner/joiner.go
+++ b/joiner/joiner.go
@@ -189,8 +189,58 @@ type JoinResult struct {
 	CollisionDetails *CollisionReport
 	// firstFilePath stores the path of the first document for error reporting
 	firstFilePath string
-	// rewriter accumulates schema renames for reference rewriting
-	rewriter *SchemaRewriter
+	// scope accumulates schema renames per source document for reference rewriting
+	scope *renameScope
+	// origins records which document contributed the schema currently held under
+	// each name of the joined document. It stays nil unless the join can consult
+	// it: see Joiner.tracksSchemaOrigins.
+	origins map[string]schemaOrigin
+}
+
+// tracksSchemaOrigins reports whether the join needs to know which document
+// contributed each merged schema.
+//
+// Only rename-left consults it, to name the schema it moves aside after that
+// schema's own document, and a collision handler, which is told the left side's
+// source. Every other path leaves the left side under its original name, so the
+// bookkeeping would go unread.
+func (j *Joiner) tracksSchemaOrigins() bool {
+	return j.getEffectiveStrategy(j.config.SchemaStrategy) == StrategyRenameLeft ||
+		j.shouldInvokeHandler(CollisionTypeSchema)
+}
+
+// schemaOrigin identifies the document that contributed a schema, so that
+// renaming it can name it after its own source rather than after the first
+// document in the join (#479).
+type schemaOrigin struct {
+	filePath string
+	docIndex int
+}
+
+// recordOrigin notes that a document contributed the schema now held under name.
+// It is a no-op when the join does not track origins.
+func (r *JoinResult) recordOrigin(name string, ctx documentContext) {
+	if r.origins == nil {
+		return
+	}
+	r.origins[name] = schemaOrigin{filePath: ctx.filePath, docIndex: ctx.docIndex}
+}
+
+// moveOrigin follows a schema's origin when the join stores it under a new name.
+func (r *JoinResult) moveOrigin(oldName, newName string) {
+	if origin, ok := r.origins[oldName]; ok {
+		r.origins[newName] = origin
+	}
+}
+
+// originOf returns the document that contributed the schema held under name. It
+// falls back to the first document, which is the only contributor a two document
+// join can have on the left.
+func (r *JoinResult) originOf(name string) schemaOrigin {
+	if origin, ok := r.origins[name]; ok {
+		return origin
+	}
+	return schemaOrigin{filePath: r.firstFilePath}
 }
 
 // AddWarning adds a structured warning and populates the legacy Warnings slice.

--- a/joiner/joiner.go
+++ b/joiner/joiner.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strconv"
 	"text/template"
 
 	"github.com/erraggy/oastools/internal/fileutil"
@@ -615,6 +616,28 @@ func (j *Joiner) generateRenamedSchemaName(originalName, sourcePath string, docI
 	}
 
 	return buf.String()
+}
+
+// uniqueSchemaName returns candidate when no schema is stored under it, and
+// otherwise the first of candidate_2, candidate_3 and so on that is free.
+//
+// A rename template can generate a name the documents already use, and can
+// generate the same name twice. Storing the schema anyway drops whatever was
+// there, which leaves a schema missing from the join with nothing said about it,
+// a worse outcome than a name the caller did not predict (#483). The rename
+// warning reports the name that was used, so the suffix is not silent.
+func uniqueSchemaName(taken map[string]*parser.Schema, candidate string) string {
+	if _, exists := taken[candidate]; !exists {
+		return candidate
+	}
+	// Bounded by the number of schemas already stored: one of the first
+	// len(taken)+2 names is necessarily free.
+	for n := 2; ; n++ {
+		name := candidate + "_" + strconv.Itoa(n)
+		if _, exists := taken[name]; !exists {
+			return name
+		}
+	}
 }
 
 // recordCollisionEvent records a collision event if reporting is enabled

--- a/joiner/joiner_bench_test.go
+++ b/joiner/joiner_bench_test.go
@@ -195,22 +195,29 @@ func renameBenchDoc(name string, schemaCount int) parser.ParseResult {
 // that records renames per source document and then rewrites references one
 // document at a time. The other JoinParsed benchmarks use accept-left over
 // documents with disjoint schema names, so they never reach it.
+// Fixtures are rebuilt every iteration because joining rewrites the references
+// of the documents it was handed (#480): reusing them would leave every
+// iteration after the first with references that no longer match any rename, so
+// the benchmark would measure a degraded fixture. The rebuild is outside the
+// timed section.
 func BenchmarkJoinRenames(b *testing.B) {
-	docs := make([]parser.ParseResult, 5)
-	for i := range docs {
-		docs[i] = renameBenchDoc(fmt.Sprintf("doc%d", i), renameBenchSchemaCount)
-	}
-
 	run := func(b *testing.B, strategy CollisionStrategy, count int) {
 		config := DefaultConfig()
 		config.PathStrategy = StrategyAcceptLeft
 		config.SchemaStrategy = strategy
 		config.RenameTemplate = "{{.Name}}.{{.Source}}"
 		j := New(config)
+		docs := make([]parser.ParseResult, count)
 
 		b.ReportAllocs()
 		for b.Loop() {
-			if _, err := j.JoinParsed(docs[:count]); err != nil {
+			b.StopTimer()
+			for i := range docs {
+				docs[i] = renameBenchDoc(fmt.Sprintf("doc%d", i), renameBenchSchemaCount)
+			}
+			b.StartTimer()
+
+			if _, err := j.JoinParsed(docs); err != nil {
 				b.Fatalf("Failed to join: %v", err)
 			}
 		}

--- a/joiner/joiner_bench_test.go
+++ b/joiner/joiner_bench_test.go
@@ -1,6 +1,7 @@
 package joiner
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -137,6 +138,90 @@ func BenchmarkJoinParsed(b *testing.B) {
 			}
 		}
 	})
+}
+
+// renameBenchSchemaCount is the number of schemas each renameBenchDoc defines.
+const renameBenchSchemaCount = 20
+
+// renameBenchDoc builds an OAS 3 document that shares every schema name with the
+// others this function returns, so joining them collides on all of them.
+//
+// The join fixtures in testdata define disjoint schema names (User, Post,
+// Comment), so joining them renames nothing regardless of strategy and never
+// reaches the rename path.
+func renameBenchDoc(name string, schemaCount int) parser.ParseResult {
+	schemas := make(map[string]*parser.Schema, schemaCount)
+	for i := range schemaCount {
+		schemas[fmt.Sprintf("Model%d", i)] = &parser.Schema{
+			Type: "object",
+			Properties: map[string]*parser.Schema{
+				"id": {Type: "string"},
+				// A reference to the next schema, so every rename has a reference to
+				// find and rewrite.
+				"next": {Ref: fmt.Sprintf("#/components/schemas/Model%d", (i+1)%schemaCount)},
+				// A property named after the document, so the schemas genuinely differ.
+				"from" + name: {Type: "string"},
+			},
+		}
+	}
+
+	return parser.ParseResult{
+		Document: &parser.OAS3Document{
+			OpenAPI: "3.0.3",
+			Info:    &parser.Info{Title: name, Version: "1.0.0"},
+			Paths: parser.Paths{
+				"/" + name: &parser.PathItem{Get: &parser.Operation{
+					Responses: &parser.Responses{Codes: map[string]*parser.Response{
+						"200": {
+							Description: "ok",
+							Content: map[string]*parser.MediaType{
+								"application/json": {Schema: &parser.Schema{Ref: "#/components/schemas/Model0"}},
+							},
+						},
+					}},
+				}},
+			},
+			Components: &parser.Components{Schemas: schemas},
+			OASVersion: parser.OASVersion303,
+		},
+		Version:      "3.0.3",
+		OASVersion:   parser.OASVersion303,
+		SourcePath:   name,
+		SourceFormat: parser.SourceFormatJSON,
+	}
+}
+
+// BenchmarkJoinRenames benchmarks joins that actually rename, which is the path
+// that records renames per source document and then rewrites references one
+// document at a time. The other JoinParsed benchmarks use accept-left over
+// documents with disjoint schema names, so they never reach it.
+func BenchmarkJoinRenames(b *testing.B) {
+	docs := make([]parser.ParseResult, 5)
+	for i := range docs {
+		docs[i] = renameBenchDoc(fmt.Sprintf("doc%d", i), renameBenchSchemaCount)
+	}
+
+	run := func(b *testing.B, strategy CollisionStrategy, count int) {
+		config := DefaultConfig()
+		config.PathStrategy = StrategyAcceptLeft
+		config.SchemaStrategy = strategy
+		config.RenameTemplate = "{{.Name}}.{{.Source}}"
+		j := New(config)
+
+		b.ReportAllocs()
+		for b.Loop() {
+			if _, err := j.JoinParsed(docs[:count]); err != nil {
+				b.Fatalf("Failed to join: %v", err)
+			}
+		}
+	}
+
+	b.Run("RenameRightTwoDocs", func(b *testing.B) { run(b, StrategyRenameRight, 2) })
+	b.Run("RenameRightThreeDocs", func(b *testing.B) { run(b, StrategyRenameRight, 3) })
+	b.Run("RenameRightFiveDocs", func(b *testing.B) { run(b, StrategyRenameRight, 5) })
+	// rename-left also tracks which document contributed each merged schema, so it
+	// exercises the origin bookkeeping the other strategies skip.
+	b.Run("RenameLeftFiveDocs", func(b *testing.B) { run(b, StrategyRenameLeft, 5) })
 }
 
 // BenchmarkJoinStrategy benchmarks different merge strategies

--- a/joiner/joiner_bench_test.go
+++ b/joiner/joiner_bench_test.go
@@ -89,6 +89,19 @@ func BenchmarkJoinParsed(b *testing.B) {
 	if err != nil {
 		b.Fatalf("Failed to parse doc3: %v", err)
 	}
+	// FiveDocs needs five distinct documents. Reusing doc1 and doc2 would hand the
+	// joiner the same document at two positions, which it deep copies so the two
+	// positions stay independent (#481), so the benchmark would be measuring that
+	// copy rather than a five document join. Parsing again gives distinct
+	// documents with the same content.
+	doc4, err := parser.ParseWithOptions(parser.WithFilePath(joinBaseOAS3Path))
+	if err != nil {
+		b.Fatalf("Failed to parse doc4: %v", err)
+	}
+	doc5, err := parser.ParseWithOptions(parser.WithFilePath(joinExt1OAS3Path))
+	if err != nil {
+		b.Fatalf("Failed to parse doc5: %v", err)
+	}
 
 	config := DefaultConfig()
 	config.PathStrategy = StrategyAcceptLeft
@@ -118,7 +131,7 @@ func BenchmarkJoinParsed(b *testing.B) {
 	b.Run("FiveDocs", func(b *testing.B) {
 		b.ReportAllocs()
 		for b.Loop() {
-			_, err := j.JoinParsed([]parser.ParseResult{*doc1, *doc2, *doc3, *doc1, *doc2})
+			_, err := j.JoinParsed([]parser.ParseResult{*doc1, *doc2, *doc3, *doc4, *doc5})
 			if err != nil {
 				b.Fatalf("Failed to join: %v", err)
 			}

--- a/joiner/joiner_bench_test.go
+++ b/joiner/joiner_bench_test.go
@@ -90,11 +90,8 @@ func BenchmarkJoinParsed(b *testing.B) {
 	if err != nil {
 		b.Fatalf("Failed to parse doc3: %v", err)
 	}
-	// FiveDocs needs five distinct documents. Reusing doc1 and doc2 would hand the
-	// joiner the same document at two positions, which it deep copies so the two
-	// positions stay independent (#481), so the benchmark would be measuring that
-	// copy rather than a five document join. Parsing again gives distinct
-	// documents with the same content.
+	// FiveDocs needs five distinct documents: the same document at two positions
+	// is deep copied (#481), which is not what this measures.
 	doc4, err := parser.ParseWithOptions(parser.WithFilePath(joinBaseOAS3Path))
 	if err != nil {
 		b.Fatalf("Failed to parse doc4: %v", err)
@@ -145,10 +142,6 @@ const renameBenchSchemaCount = 20
 
 // renameBenchDoc builds an OAS 3 document that shares every schema name with the
 // others this function returns, so joining them collides on all of them.
-//
-// The join fixtures in testdata define disjoint schema names (User, Post,
-// Comment), so joining them renames nothing regardless of strategy and never
-// reaches the rename path.
 func renameBenchDoc(name string, schemaCount int) parser.ParseResult {
 	schemas := make(map[string]*parser.Schema, schemaCount)
 	for i := range schemaCount {
@@ -156,8 +149,7 @@ func renameBenchDoc(name string, schemaCount int) parser.ParseResult {
 			Type: "object",
 			Properties: map[string]*parser.Schema{
 				"id": {Type: "string"},
-				// A reference to the next schema, so every rename has a reference to
-				// find and rewrite.
+				// So every rename has a reference to find and rewrite.
 				"next": {Ref: fmt.Sprintf("#/components/schemas/Model%d", (i+1)%schemaCount)},
 				// A property named after the document, so the schemas genuinely differ.
 				"from" + name: {Type: "string"},
@@ -191,15 +183,11 @@ func renameBenchDoc(name string, schemaCount int) parser.ParseResult {
 	}
 }
 
-// BenchmarkJoinRenames benchmarks joins that actually rename, which is the path
-// that records renames per source document and then rewrites references one
-// document at a time. The other JoinParsed benchmarks use accept-left over
-// documents with disjoint schema names, so they never reach it.
-// Fixtures are rebuilt every iteration because joining rewrites the references
-// of the documents it was handed (#480): reusing them would leave every
-// iteration after the first with references that no longer match any rename, so
-// the benchmark would measure a degraded fixture. The rebuild is outside the
-// timed section.
+// BenchmarkJoinRenames benchmarks joins that rename. The other benchmarks use
+// accept-left over documents with disjoint schema names and never rename.
+//
+// Fixtures are rebuilt each iteration, outside the timed section, because
+// joining rewrites the references of the documents it was handed (#480).
 func BenchmarkJoinRenames(b *testing.B) {
 	run := func(b *testing.B, strategy CollisionStrategy, count int) {
 		config := DefaultConfig()
@@ -226,8 +214,7 @@ func BenchmarkJoinRenames(b *testing.B) {
 	b.Run("RenameRightTwoDocs", func(b *testing.B) { run(b, StrategyRenameRight, 2) })
 	b.Run("RenameRightThreeDocs", func(b *testing.B) { run(b, StrategyRenameRight, 3) })
 	b.Run("RenameRightFiveDocs", func(b *testing.B) { run(b, StrategyRenameRight, 5) })
-	// rename-left also tracks which document contributed each merged schema, so it
-	// exercises the origin bookkeeping the other strategies skip.
+	// rename-left also tracks which document contributed each merged schema.
 	b.Run("RenameLeftFiveDocs", func(b *testing.B) { run(b, StrategyRenameLeft, 5) })
 }
 

--- a/joiner/oas2.go
+++ b/joiner/oas2.go
@@ -273,6 +273,7 @@ func (j *Joiner) mergeOAS2Definitions(joined, source *parser.OAS2Document, ctx d
 				} else {
 					newName = j.generateRenamedSchemaName(effectiveName, leftOrigin.filePath, leftOrigin.docIndex, nil)
 				}
+				newName = uniqueSchemaName(joined.Definitions, newName)
 
 				// Move existing definition to new name
 				joined.Definitions[newName] = joined.Definitions[effectiveName]
@@ -300,6 +301,7 @@ func (j *Joiner) mergeOAS2Definitions(joined, source *parser.OAS2Document, ctx d
 				} else {
 					newName = j.generateRenamedSchemaName(effectiveName, ctx.filePath, ctx.docIndex, sourceGraph)
 				}
+				newName = uniqueSchemaName(joined.Definitions, newName)
 
 				// Add new definition under renamed name
 				joined.Definitions[newName] = schema

--- a/joiner/oas2.go
+++ b/joiner/oas2.go
@@ -17,18 +17,16 @@ func (j *Joiner) joinOAS2Documents(docs []parser.ParseResult) (*JoinResult, erro
 		return nil, fmt.Errorf("joiner: first document is not a valid OAS 2.0 document")
 	}
 
-	// Collect the typed documents up front: the reference rewriting after the
-	// merge needs to know which of them contributed each part of the join.
+	// The rewriting after the merge needs to know which document contributed what.
 	sources := make([]*parser.OAS2Document, len(docs))
 	for i, doc := range docs {
 		oas2Doc, ok := doc.OAS2Document()
 		if !ok || oas2Doc == nil {
 			return nil, fmt.Errorf("joiner: document at index %d (path: %s) is not a valid OAS 2.0 document", i, doc.SourcePath)
 		}
-		// A document handed in twice would share every definition with its other
-		// position, so a strategy that keeps both sides would store one schema
-		// under two names. Copy the repeat so the two positions are independent
-		// and each can be told apart by the rewriting below (#481).
+		// If already present, store a copy: the two positions would otherwise share
+		// every definition, and keeping both sides would store one schema under two
+		// names (#481).
 		if slices.Contains(sources[:i], oas2Doc) {
 			oas2Doc = oas2Doc.DeepCopy()
 		}
@@ -87,9 +85,7 @@ func (j *Joiner) joinOAS2Documents(docs []parser.ParseResult) (*JoinResult, erro
 
 	result.Document = joined
 
-	// Rewrite each document's references using the renames recorded against that
-	// document. This runs before deduplication so that comparison sees references
-	// in their final form.
+	// Before deduplication, so comparison sees references in their final form.
 	if err := result.scope.applyOAS2(joined, sources); err != nil {
 		return nil, fmt.Errorf("joiner: failed to rewrite references after definition renames: %w", err)
 	}
@@ -187,8 +183,7 @@ func (j *Joiner) mergeOAS2Definitions(joined, source *parser.OAS2Document, ctx d
 
 			// Invoke collision handler if configured for schemas
 			if j.shouldInvokeHandler(CollisionTypeSchema) {
-				// The left side belongs to whichever document contributed the
-				// definition now under this name, not necessarily the first (#479).
+				// The left side is whichever document contributed this definition (#479).
 				leftSource := result.originOf(effectiveName).filePath
 				collision := CollisionContext{
 					Type:               CollisionTypeSchema,
@@ -263,8 +258,7 @@ func (j *Joiner) mergeOAS2Definitions(joined, source *parser.OAS2Document, ctx d
 
 			case StrategyRenameLeft:
 				// Rename the existing (left) definition and keep the new (right) definition under original name
-				// Name it after the document that contributed it, which is the first
-				// document only in a two document join (#479).
+				// Name it after the contributing document, not always the first (#479).
 				leftOrigin := result.originOf(effectiveName)
 				leftPrefix := j.getNamespacePrefix(leftOrigin.filePath)
 				var newName string
@@ -283,8 +277,7 @@ func (j *Joiner) mergeOAS2Definitions(joined, source *parser.OAS2Document, ctx d
 				joined.Definitions[effectiveName] = schema
 				result.recordOrigin(effectiveName, ctx)
 
-				// Register rename for reference rewriting. Only the documents merged
-				// before this one referenced the definition being moved.
+				// Only documents merged before this one referenced the moved definition.
 				result.scope.registerLeft(ctx.docIndex, effectiveName, newName)
 
 				line, col := j.getLocation(leftOrigin.filePath, fmt.Sprintf("$.definitions.%s", effectiveName))
@@ -309,8 +302,7 @@ func (j *Joiner) mergeOAS2Definitions(joined, source *parser.OAS2Document, ctx d
 
 				// Keep existing definition under original name (no change needed)
 
-				// Register rename for reference rewriting. Only this document
-				// referenced the definition being renamed.
+				// Only this document referenced the renamed definition.
 				result.scope.registerRight(ctx.docIndex, name, newName)
 
 				line, col := j.getLocation(ctx.filePath, fmt.Sprintf("$.definitions.%s", effectiveName))

--- a/joiner/oas2.go
+++ b/joiner/oas2.go
@@ -3,6 +3,7 @@ package joiner
 import (
 	"fmt"
 	"math"
+	"slices"
 
 	"github.com/erraggy/oastools/internal/schemautil"
 	"github.com/erraggy/oastools/parser"
@@ -16,12 +17,34 @@ func (j *Joiner) joinOAS2Documents(docs []parser.ParseResult) (*JoinResult, erro
 		return nil, fmt.Errorf("joiner: first document is not a valid OAS 2.0 document")
 	}
 
+	// Collect the typed documents up front: the reference rewriting after the
+	// merge needs to know which of them contributed each part of the join.
+	sources := make([]*parser.OAS2Document, len(docs))
+	for i, doc := range docs {
+		oas2Doc, ok := doc.OAS2Document()
+		if !ok || oas2Doc == nil {
+			return nil, fmt.Errorf("joiner: document at index %d (path: %s) is not a valid OAS 2.0 document", i, doc.SourcePath)
+		}
+		// A document handed in twice would share every definition with its other
+		// position, so a strategy that keeps both sides would store one schema
+		// under two names. Copy the repeat so the two positions are independent
+		// and each can be told apart by the rewriting below (#481).
+		if slices.Contains(sources[:i], oas2Doc) {
+			oas2Doc = oas2Doc.DeepCopy()
+		}
+		sources[i] = oas2Doc
+	}
+
 	result := &JoinResult{
 		Version:       docs[0].Version,
 		OASVersion:    docs[0].OASVersion,
 		SourceFormat:  docs[0].SourceFormat,
 		Warnings:      make([]string, 0),
 		firstFilePath: docs[0].SourcePath,
+		scope:         newRenameScope(len(docs), docs[0].OASVersion),
+	}
+	if j.tracksSchemaOrigins() {
+		result.origins = make(map[string]schemaOrigin)
 	}
 
 	// Initialize collision report if enabled
@@ -51,22 +74,25 @@ func (j *Joiner) joinOAS2Documents(docs []parser.ParseResult) (*JoinResult, erro
 
 	// Merge all documents
 	for i, doc := range docs {
-		oas2Doc, ok := doc.OAS2Document()
-		if !ok || oas2Doc == nil {
-			return nil, fmt.Errorf("joiner: document at index %d (path: %s) is not a valid OAS 2.0 document", i, doc.SourcePath)
-		}
 		ctx := documentContext{
 			filePath: doc.SourcePath,
 			docIndex: i,
 			result:   &doc,
 		}
 
-		if err := j.mergeOAS2Document(joined, oas2Doc, ctx, result); err != nil {
+		if err := j.mergeOAS2Document(joined, sources[i], ctx, result); err != nil {
 			return nil, err
 		}
 	}
 
 	result.Document = joined
+
+	// Rewrite each document's references using the renames recorded against that
+	// document. This runs before deduplication so that comparison sees references
+	// in their final form.
+	if err := result.scope.applyOAS2(joined, sources); err != nil {
+		return nil, fmt.Errorf("joiner: failed to rewrite references after definition renames: %w", err)
+	}
 
 	// Apply semantic deduplication if enabled
 	if j.config.SemanticDeduplication && len(joined.Definitions) > 1 {
@@ -85,26 +111,23 @@ func (j *Joiner) joinOAS2Documents(docs []parser.ParseResult) (*JoinResult, erro
 		// Apply results: replace definitions map with canonical schemas only
 		joined.Definitions = dedupeResult.CanonicalSchemas
 
-		// Register aliases for reference rewriting
+		// Rewrite aliases to their canonical name. Deduplication collapses
+		// definitions it found equivalent, so a reference to an alias means the
+		// canonical definition no matter which document wrote it: this rewrite is
+		// document-wide, unlike the collision renames above.
 		if len(dedupeResult.Aliases) > 0 {
-			if result.rewriter == nil {
-				result.rewriter = NewSchemaRewriter()
-			}
+			rewriter := NewSchemaRewriter()
 			for alias, canonical := range dedupeResult.Aliases {
-				result.rewriter.RegisterRename(alias, canonical, joined.OASVersion)
+				rewriter.RegisterRename(alias, canonical, joined.OASVersion)
+			}
+			if err := rewriter.RewriteDocument(joined); err != nil {
+				return nil, fmt.Errorf("joiner: failed to rewrite references after semantic deduplication: %w", err)
 			}
 			result.AddWarning(NewSemanticDedupSummaryWarning(dedupeResult.RemovedCount, "definition"))
 		}
 	}
 
 	result.Stats = parser.GetDocumentStats(joined)
-
-	// Apply reference rewriting if definitions were renamed
-	if result.rewriter != nil {
-		if err := result.rewriter.RewriteDocument(joined); err != nil {
-			return nil, fmt.Errorf("joiner: failed to rewrite references after definition renames: %w", err)
-		}
-	}
 
 	return result, nil
 }
@@ -160,10 +183,7 @@ func (j *Joiner) mergeOAS2Definitions(joined, source *parser.OAS2Document, ctx d
 			effectiveName = j.generatePrefixedSchemaName(name, sourcePrefix)
 
 			// Register rename for reference rewriting (original name -> prefixed name)
-			if result.rewriter == nil {
-				result.rewriter = NewSchemaRewriter()
-			}
-			result.rewriter.RegisterRename(name, effectiveName, result.OASVersion)
+			result.scope.registerRight(ctx.docIndex, name, effectiveName)
 
 			line, col := j.getLocation(ctx.filePath, fmt.Sprintf("$.definitions.%s", name))
 			result.AddWarning(NewNamespacePrefixWarning(name, effectiveName, "definition", ctx.filePath, line, col))
@@ -175,12 +195,15 @@ func (j *Joiner) mergeOAS2Definitions(joined, source *parser.OAS2Document, ctx d
 
 			// Invoke collision handler if configured for schemas
 			if j.shouldInvokeHandler(CollisionTypeSchema) {
+				// The left side belongs to whichever document contributed the
+				// definition now under this name, not necessarily the first (#479).
+				leftSource := result.originOf(effectiveName).filePath
 				collision := CollisionContext{
 					Type:               CollisionTypeSchema,
 					Name:               effectiveName,
 					JSONPath:           fmt.Sprintf("$.definitions.%s", effectiveName),
-					LeftSource:         result.firstFilePath,
-					LeftLocation:       j.getLocationPtr(result.firstFilePath, fmt.Sprintf("$.definitions.%s", effectiveName)),
+					LeftSource:         leftSource,
+					LeftLocation:       j.getLocationPtr(leftSource, fmt.Sprintf("$.definitions.%s", effectiveName)),
 					LeftValue:          joined.Definitions[effectiveName],
 					RightSource:        ctx.filePath,
 					RightLocation:      j.getLocationPtr(ctx.filePath, fmt.Sprintf("$.definitions.%s", name)),
@@ -207,6 +230,7 @@ func (j *Joiner) mergeOAS2Definitions(joined, source *parser.OAS2Document, ctx d
 						target:      joined.Definitions,
 						result:      result,
 						ctx:         ctx,
+						sourceName:  name,
 						sourceGraph: sourceGraph,
 						label:       "definition",
 					})
@@ -247,30 +271,32 @@ func (j *Joiner) mergeOAS2Definitions(joined, source *parser.OAS2Document, ctx d
 
 			case StrategyRenameLeft:
 				// Rename the existing (left) definition and keep the new (right) definition under original name
-				// Use namespace prefix if available for the left source, otherwise use template
-				leftPrefix := j.getNamespacePrefix(result.firstFilePath)
+				// Name it after the document that contributed it, which is the first
+				// document only in a two document join (#479).
+				leftOrigin := result.originOf(effectiveName)
+				leftPrefix := j.getNamespacePrefix(leftOrigin.filePath)
 				var newName string
 				if leftPrefix != "" {
 					newName = j.generatePrefixedSchemaName(effectiveName, leftPrefix)
 				} else {
-					newName = j.generateRenamedSchemaName(effectiveName, result.firstFilePath, 0, nil)
+					newName = j.generateRenamedSchemaName(effectiveName, leftOrigin.filePath, leftOrigin.docIndex, nil)
 				}
 
 				// Move existing definition to new name
 				joined.Definitions[newName] = joined.Definitions[effectiveName]
+				result.moveOrigin(effectiveName, newName)
 
 				// Add new definition under original name
 				joined.Definitions[effectiveName] = schema
+				result.recordOrigin(effectiveName, ctx)
 
-				// Register rename for reference rewriting
-				if result.rewriter == nil {
-					result.rewriter = NewSchemaRewriter()
-				}
-				result.rewriter.RegisterRename(effectiveName, newName, result.OASVersion)
+				// Register rename for reference rewriting. Only the documents merged
+				// before this one referenced the definition being moved.
+				result.scope.registerLeft(ctx.docIndex, effectiveName, newName)
 
-				line, col := j.getLocation(ctx.filePath, fmt.Sprintf("$.definitions.%s", effectiveName))
-				result.AddWarning(NewSchemaRenamedWarning(effectiveName, newName, "definition", ctx.filePath, line, col, true))
-				j.recordCollisionEvent(result, effectiveName, result.firstFilePath, ctx.filePath, schemaStrategy, resolutionRenamed, newName)
+				line, col := j.getLocation(leftOrigin.filePath, fmt.Sprintf("$.definitions.%s", effectiveName))
+				result.AddWarning(NewSchemaRenamedWarning(effectiveName, newName, "definition", leftOrigin.filePath, line, col, true))
+				j.recordCollisionEvent(result, effectiveName, leftOrigin.filePath, ctx.filePath, schemaStrategy, resolutionRenamed, newName)
 
 			case StrategyRenameRight:
 				// Rename the new (right) definition and keep existing (left) definition under original name
@@ -285,14 +311,13 @@ func (j *Joiner) mergeOAS2Definitions(joined, source *parser.OAS2Document, ctx d
 
 				// Add new definition under renamed name
 				joined.Definitions[newName] = schema
+				result.recordOrigin(newName, ctx)
 
 				// Keep existing definition under original name (no change needed)
 
-				// Register rename for reference rewriting
-				if result.rewriter == nil {
-					result.rewriter = NewSchemaRewriter()
-				}
-				result.rewriter.RegisterRename(effectiveName, newName, result.OASVersion)
+				// Register rename for reference rewriting. Only this document
+				// referenced the definition being renamed.
+				result.scope.registerRight(ctx.docIndex, name, newName)
 
 				line, col := j.getLocation(ctx.filePath, fmt.Sprintf("$.definitions.%s", effectiveName))
 				result.AddWarning(NewSchemaRenamedWarning(effectiveName, newName, "definition", ctx.filePath, line, col, false))
@@ -306,6 +331,7 @@ func (j *Joiner) mergeOAS2Definitions(joined, source *parser.OAS2Document, ctx d
 				line, col := j.getLocation(ctx.filePath, fmt.Sprintf("$.definitions.%s", effectiveName))
 				if j.shouldOverwrite(schemaStrategy) {
 					joined.Definitions[effectiveName] = schema
+					result.recordOrigin(effectiveName, ctx)
 					result.AddWarning(NewSchemaCollisionWarning(effectiveName, "overwritten", "definitions", result.firstFilePath, ctx.filePath, line, col))
 					j.recordCollisionEvent(result, effectiveName, result.firstFilePath, ctx.filePath, schemaStrategy, resolutionKeptRight, "")
 				} else {
@@ -315,6 +341,7 @@ func (j *Joiner) mergeOAS2Definitions(joined, source *parser.OAS2Document, ctx d
 			}
 		} else {
 			joined.Definitions[effectiveName] = schema
+			result.recordOrigin(effectiveName, ctx)
 		}
 	}
 	return nil

--- a/joiner/oas2.go
+++ b/joiner/oas2.go
@@ -111,16 +111,8 @@ func (j *Joiner) joinOAS2Documents(docs []parser.ParseResult) (*JoinResult, erro
 		// Apply results: replace definitions map with canonical schemas only
 		joined.Definitions = dedupeResult.CanonicalSchemas
 
-		// Rewrite aliases to their canonical name. Deduplication collapses
-		// definitions it found equivalent, so a reference to an alias means the
-		// canonical definition no matter which document wrote it: this rewrite is
-		// document-wide, unlike the collision renames above.
 		if len(dedupeResult.Aliases) > 0 {
-			rewriter := NewSchemaRewriter()
-			for alias, canonical := range dedupeResult.Aliases {
-				rewriter.RegisterRename(alias, canonical, joined.OASVersion)
-			}
-			if err := rewriter.RewriteDocument(joined); err != nil {
+			if err := rewriteDedupeAliases(joined, dedupeResult.Aliases, joined.OASVersion); err != nil {
 				return nil, fmt.Errorf("joiner: failed to rewrite references after semantic deduplication: %w", err)
 			}
 			result.AddWarning(NewSemanticDedupSummaryWarning(dedupeResult.RemovedCount, "definition"))

--- a/joiner/oas3.go
+++ b/joiner/oas3.go
@@ -225,16 +225,8 @@ func (j *Joiner) joinOAS3Documents(docs []parser.ParseResult) (*JoinResult, erro
 		// Apply results: replace schemas map with canonical schemas only
 		joined.Components.Schemas = dedupeResult.CanonicalSchemas
 
-		// Rewrite aliases to their canonical name. Deduplication collapses schemas
-		// it found equivalent, so a reference to an alias means the canonical
-		// schema no matter which document wrote it: this rewrite is document-wide,
-		// unlike the collision renames above.
 		if len(dedupeResult.Aliases) > 0 {
-			rewriter := NewSchemaRewriter()
-			for alias, canonical := range dedupeResult.Aliases {
-				rewriter.RegisterRename(alias, canonical, joined.OASVersion)
-			}
-			if err := rewriter.RewriteDocument(joined); err != nil {
+			if err := rewriteDedupeAliases(joined, dedupeResult.Aliases, joined.OASVersion); err != nil {
 				return nil, fmt.Errorf("joiner: failed to rewrite references after semantic deduplication: %w", err)
 			}
 			result.AddWarning(NewSemanticDedupSummaryWarning(dedupeResult.RemovedCount, "schema"))
@@ -398,7 +390,9 @@ func (j *Joiner) mergeSchemas(target, source map[string]*parser.Schema, strategy
 				if leftPrefix != "" {
 					newName = j.generatePrefixedSchemaName(effectiveName, leftPrefix)
 				} else {
-					// Pass nil for graph since we don't have the original document's graph readily available
+					// No graph: operation-aware rename templates are not wired up for
+					// the left side, which would need that document's graph built here.
+					// See #482.
 					newName = j.generateRenamedSchemaName(effectiveName, leftOrigin.filePath, leftOrigin.docIndex, nil)
 				}
 

--- a/joiner/oas3.go
+++ b/joiner/oas3.go
@@ -16,18 +16,16 @@ func (j *Joiner) joinOAS3Documents(docs []parser.ParseResult) (*JoinResult, erro
 		return nil, fmt.Errorf("joiner: first document is not a valid OAS 3.x document")
 	}
 
-	// Collect the typed documents up front: the reference rewriting after the
-	// merge needs to know which of them contributed each part of the join.
+	// The rewriting after the merge needs to know which document contributed what.
 	sources := make([]*parser.OAS3Document, len(docs))
 	for i, doc := range docs {
 		oas3Doc, ok := doc.OAS3Document()
 		if !ok || oas3Doc == nil {
 			return nil, fmt.Errorf("joiner: document at index %d (path: %s) is not a valid OAS 3.x document", i, doc.SourcePath)
 		}
-		// A document handed in twice would share every schema with its other
-		// position, so a strategy that keeps both sides would store one schema
-		// under two names. Copy the repeat so the two positions are independent
-		// and each can be told apart by the rewriting below (#481).
+		// If already present, store a copy: the two positions would otherwise share
+		// every schema, and keeping both sides would store one schema under two
+		// names (#481).
 		if slices.Contains(sources[:i], oas3Doc) {
 			oas3Doc = oas3Doc.DeepCopy()
 		}
@@ -201,9 +199,7 @@ func (j *Joiner) joinOAS3Documents(docs []parser.ParseResult) (*JoinResult, erro
 
 	result.Document = joined
 
-	// Rewrite each document's references using the renames recorded against that
-	// document. This runs before deduplication so that comparison sees references
-	// in their final form.
+	// Before deduplication, so comparison sees references in their final form.
 	if err := result.scope.applyOAS3(joined, sources); err != nil {
 		return nil, fmt.Errorf("joiner: failed to rewrite references after schema renames: %w", err)
 	}
@@ -306,8 +302,7 @@ func (j *Joiner) mergeSchemas(target, source map[string]*parser.Schema, strategy
 
 			// Invoke collision handler if configured
 			if j.shouldInvokeHandler(CollisionTypeSchema) {
-				// The left side belongs to whichever document contributed the schema
-				// now under this name, not necessarily the first (#479).
+				// The left side is whichever document contributed this schema (#479).
 				leftSource := result.originOf(effectiveName).filePath
 				collision := CollisionContext{
 					Type:               CollisionTypeSchema,
@@ -382,17 +377,14 @@ func (j *Joiner) mergeSchemas(target, source map[string]*parser.Schema, strategy
 
 			case StrategyRenameLeft:
 				// Rename the existing (left) schema and keep the new (right) schema under original name
-				// Name it after the document that contributed it, which is the first
-				// document only in a two document join (#479).
+				// Name it after the contributing document, not always the first (#479).
 				leftOrigin := result.originOf(effectiveName)
 				leftPrefix := j.getNamespacePrefix(leftOrigin.filePath)
 				var newName string
 				if leftPrefix != "" {
 					newName = j.generatePrefixedSchemaName(effectiveName, leftPrefix)
 				} else {
-					// No graph: operation-aware rename templates are not wired up for
-					// the left side, which would need that document's graph built here.
-					// See #482.
+					// No graph: operation-aware templates are not wired up here (#482).
 					newName = j.generateRenamedSchemaName(effectiveName, leftOrigin.filePath, leftOrigin.docIndex, nil)
 				}
 				newName = uniqueSchemaName(target, newName)
@@ -405,8 +397,7 @@ func (j *Joiner) mergeSchemas(target, source map[string]*parser.Schema, strategy
 				target[effectiveName] = schema
 				result.recordOrigin(effectiveName, ctx)
 
-				// Register rename for reference rewriting. Only the documents merged
-				// before this one referenced the schema being moved.
+				// Only documents merged before this one referenced the moved schema.
 				result.scope.registerLeft(ctx.docIndex, effectiveName, newName)
 
 				line, col := j.getLocation(leftOrigin.filePath, fmt.Sprintf("$.components.schemas.%s", effectiveName))
@@ -432,8 +423,7 @@ func (j *Joiner) mergeSchemas(target, source map[string]*parser.Schema, strategy
 
 				// Keep existing schema under original name (no change needed)
 
-				// Register rename for reference rewriting. Only this document
-				// referenced the schema being renamed.
+				// Only this document referenced the renamed schema.
 				result.scope.registerRight(ctx.docIndex, name, newName)
 
 				line, col := j.getLocation(ctx.filePath, fmt.Sprintf("$.components.schemas.%s", effectiveName))

--- a/joiner/oas3.go
+++ b/joiner/oas3.go
@@ -2,6 +2,7 @@ package joiner
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/erraggy/oastools/internal/schemautil"
 	"github.com/erraggy/oastools/parser"
@@ -15,12 +16,34 @@ func (j *Joiner) joinOAS3Documents(docs []parser.ParseResult) (*JoinResult, erro
 		return nil, fmt.Errorf("joiner: first document is not a valid OAS 3.x document")
 	}
 
+	// Collect the typed documents up front: the reference rewriting after the
+	// merge needs to know which of them contributed each part of the join.
+	sources := make([]*parser.OAS3Document, len(docs))
+	for i, doc := range docs {
+		oas3Doc, ok := doc.OAS3Document()
+		if !ok || oas3Doc == nil {
+			return nil, fmt.Errorf("joiner: document at index %d (path: %s) is not a valid OAS 3.x document", i, doc.SourcePath)
+		}
+		// A document handed in twice would share every schema with its other
+		// position, so a strategy that keeps both sides would store one schema
+		// under two names. Copy the repeat so the two positions are independent
+		// and each can be told apart by the rewriting below (#481).
+		if slices.Contains(sources[:i], oas3Doc) {
+			oas3Doc = oas3Doc.DeepCopy()
+		}
+		sources[i] = oas3Doc
+	}
+
 	result := &JoinResult{
 		Version:       docs[0].Version,
 		OASVersion:    docs[0].OASVersion,
 		SourceFormat:  docs[0].SourceFormat,
 		Warnings:      make([]string, 0),
 		firstFilePath: docs[0].SourcePath,
+		scope:         newRenameScope(len(docs), docs[0].OASVersion),
+	}
+	if j.tracksSchemaOrigins() {
+		result.origins = make(map[string]schemaOrigin)
 	}
 
 	// Initialize collision report if enabled
@@ -61,10 +84,7 @@ func (j *Joiner) joinOAS3Documents(docs []parser.ParseResult) (*JoinResult, erro
 
 	// Merge all documents
 	for i, doc := range docs {
-		oas3Doc, ok := doc.OAS3Document()
-		if !ok || oas3Doc == nil {
-			return nil, fmt.Errorf("joiner: document at index %d (path: %s) is not a valid OAS 3.x document", i, doc.SourcePath)
-		}
+		oas3Doc := sources[i]
 		ctx := documentContext{
 			filePath: doc.SourcePath,
 			docIndex: i,
@@ -181,6 +201,13 @@ func (j *Joiner) joinOAS3Documents(docs []parser.ParseResult) (*JoinResult, erro
 
 	result.Document = joined
 
+	// Rewrite each document's references using the renames recorded against that
+	// document. This runs before deduplication so that comparison sees references
+	// in their final form.
+	if err := result.scope.applyOAS3(joined, sources); err != nil {
+		return nil, fmt.Errorf("joiner: failed to rewrite references after schema renames: %w", err)
+	}
+
 	// Apply semantic deduplication if enabled
 	if j.config.SemanticDeduplication && len(joined.Components.Schemas) > 1 {
 		compareOpts := j.buildCompareOptions(EquivalenceModeDeep)
@@ -198,26 +225,23 @@ func (j *Joiner) joinOAS3Documents(docs []parser.ParseResult) (*JoinResult, erro
 		// Apply results: replace schemas map with canonical schemas only
 		joined.Components.Schemas = dedupeResult.CanonicalSchemas
 
-		// Register aliases for reference rewriting
+		// Rewrite aliases to their canonical name. Deduplication collapses schemas
+		// it found equivalent, so a reference to an alias means the canonical
+		// schema no matter which document wrote it: this rewrite is document-wide,
+		// unlike the collision renames above.
 		if len(dedupeResult.Aliases) > 0 {
-			if result.rewriter == nil {
-				result.rewriter = NewSchemaRewriter()
-			}
+			rewriter := NewSchemaRewriter()
 			for alias, canonical := range dedupeResult.Aliases {
-				result.rewriter.RegisterRename(alias, canonical, joined.OASVersion)
+				rewriter.RegisterRename(alias, canonical, joined.OASVersion)
+			}
+			if err := rewriter.RewriteDocument(joined); err != nil {
+				return nil, fmt.Errorf("joiner: failed to rewrite references after semantic deduplication: %w", err)
 			}
 			result.AddWarning(NewSemanticDedupSummaryWarning(dedupeResult.RemovedCount, "schema"))
 		}
 	}
 
 	result.Stats = parser.GetDocumentStats(joined)
-
-	// Apply reference rewriting if schemas were renamed
-	if result.rewriter != nil {
-		if err := result.rewriter.RewriteDocument(joined); err != nil {
-			return nil, fmt.Errorf("joiner: failed to rewrite references after schema renames: %w", err)
-		}
-	}
 
 	return result, nil
 }
@@ -278,10 +302,7 @@ func (j *Joiner) mergeSchemas(target, source map[string]*parser.Schema, strategy
 			effectiveName = j.generatePrefixedSchemaName(name, sourcePrefix)
 
 			// Register rename for reference rewriting (original name -> prefixed name)
-			if result.rewriter == nil {
-				result.rewriter = NewSchemaRewriter()
-			}
-			result.rewriter.RegisterRename(name, effectiveName, result.OASVersion)
+			result.scope.registerRight(ctx.docIndex, name, effectiveName)
 
 			line, col := j.getLocation(ctx.filePath, fmt.Sprintf("$.components.schemas.%s", name))
 			result.AddWarning(NewNamespacePrefixWarning(name, effectiveName, "schema", ctx.filePath, line, col))
@@ -293,12 +314,15 @@ func (j *Joiner) mergeSchemas(target, source map[string]*parser.Schema, strategy
 
 			// Invoke collision handler if configured
 			if j.shouldInvokeHandler(CollisionTypeSchema) {
+				// The left side belongs to whichever document contributed the schema
+				// now under this name, not necessarily the first (#479).
+				leftSource := result.originOf(effectiveName).filePath
 				collision := CollisionContext{
 					Type:               CollisionTypeSchema,
 					Name:               effectiveName,
 					JSONPath:           fmt.Sprintf("$.components.schemas.%s", effectiveName),
-					LeftSource:         result.firstFilePath,
-					LeftLocation:       j.getLocationPtr(result.firstFilePath, fmt.Sprintf("$.components.schemas.%s", effectiveName)),
+					LeftSource:         leftSource,
+					LeftLocation:       j.getLocationPtr(leftSource, fmt.Sprintf("$.components.schemas.%s", effectiveName)),
 					LeftValue:          target[effectiveName],
 					RightSource:        ctx.filePath,
 					RightLocation:      j.getLocationPtr(ctx.filePath, fmt.Sprintf("$.components.schemas.%s", name)),
@@ -325,6 +349,7 @@ func (j *Joiner) mergeSchemas(target, source map[string]*parser.Schema, strategy
 						target:      target,
 						result:      result,
 						ctx:         ctx,
+						sourceName:  name,
 						sourceGraph: sourceGraph,
 						label:       "schema",
 					})
@@ -365,31 +390,33 @@ func (j *Joiner) mergeSchemas(target, source map[string]*parser.Schema, strategy
 
 			case StrategyRenameLeft:
 				// Rename the existing (left) schema and keep the new (right) schema under original name
-				// Use namespace prefix if available for the left source, otherwise use template
-				leftPrefix := j.getNamespacePrefix(result.firstFilePath)
+				// Name it after the document that contributed it, which is the first
+				// document only in a two document join (#479).
+				leftOrigin := result.originOf(effectiveName)
+				leftPrefix := j.getNamespacePrefix(leftOrigin.filePath)
 				var newName string
 				if leftPrefix != "" {
 					newName = j.generatePrefixedSchemaName(effectiveName, leftPrefix)
 				} else {
 					// Pass nil for graph since we don't have the original document's graph readily available
-					newName = j.generateRenamedSchemaName(effectiveName, result.firstFilePath, 0, nil)
+					newName = j.generateRenamedSchemaName(effectiveName, leftOrigin.filePath, leftOrigin.docIndex, nil)
 				}
 
 				// Move existing schema to new name
 				target[newName] = target[effectiveName]
+				result.moveOrigin(effectiveName, newName)
 
 				// Add new schema under original name
 				target[effectiveName] = schema
+				result.recordOrigin(effectiveName, ctx)
 
-				// Register rename for reference rewriting (will be applied at end of join)
-				if result.rewriter == nil {
-					result.rewriter = NewSchemaRewriter()
-				}
-				result.rewriter.RegisterRename(effectiveName, newName, result.OASVersion)
+				// Register rename for reference rewriting. Only the documents merged
+				// before this one referenced the schema being moved.
+				result.scope.registerLeft(ctx.docIndex, effectiveName, newName)
 
-				line, col := j.getLocation(ctx.filePath, fmt.Sprintf("$.components.schemas.%s", effectiveName))
-				result.AddWarning(NewSchemaRenamedWarning(effectiveName, newName, "schema", ctx.filePath, line, col, true))
-				j.recordCollisionEvent(result, effectiveName, result.firstFilePath, ctx.filePath, strategy, resolutionRenamed, newName)
+				line, col := j.getLocation(leftOrigin.filePath, fmt.Sprintf("$.components.schemas.%s", effectiveName))
+				result.AddWarning(NewSchemaRenamedWarning(effectiveName, newName, "schema", leftOrigin.filePath, line, col, true))
+				j.recordCollisionEvent(result, effectiveName, leftOrigin.filePath, ctx.filePath, strategy, resolutionRenamed, newName)
 
 			case StrategyRenameRight:
 				// Rename the new (right) schema and keep existing (left) schema under original name
@@ -405,14 +432,13 @@ func (j *Joiner) mergeSchemas(target, source map[string]*parser.Schema, strategy
 
 				// Add new schema under renamed name
 				target[newName] = schema
+				result.recordOrigin(newName, ctx)
 
 				// Keep existing schema under original name (no change needed)
 
-				// Register rename for reference rewriting
-				if result.rewriter == nil {
-					result.rewriter = NewSchemaRewriter()
-				}
-				result.rewriter.RegisterRename(effectiveName, newName, result.OASVersion)
+				// Register rename for reference rewriting. Only this document
+				// referenced the schema being renamed.
+				result.scope.registerRight(ctx.docIndex, name, newName)
 
 				line, col := j.getLocation(ctx.filePath, fmt.Sprintf("$.components.schemas.%s", effectiveName))
 				result.AddWarning(NewSchemaRenamedWarning(effectiveName, newName, "schema", ctx.filePath, line, col, false))
@@ -425,6 +451,7 @@ func (j *Joiner) mergeSchemas(target, source map[string]*parser.Schema, strategy
 				}
 				if j.shouldOverwrite(strategy) {
 					target[effectiveName] = schema
+					result.recordOrigin(effectiveName, ctx)
 					line, col := j.getLocation(ctx.filePath, fmt.Sprintf("$.components.schemas.%s", effectiveName))
 					result.AddWarning(NewSchemaCollisionWarning(effectiveName, "overwritten", "components.schemas", result.firstFilePath, ctx.filePath, line, col))
 					j.recordCollisionEvent(result, effectiveName, result.firstFilePath, ctx.filePath, strategy, resolutionKeptRight, "")
@@ -436,6 +463,7 @@ func (j *Joiner) mergeSchemas(target, source map[string]*parser.Schema, strategy
 			}
 		} else {
 			target[effectiveName] = schema
+			result.recordOrigin(effectiveName, ctx)
 		}
 	}
 	return nil

--- a/joiner/oas3.go
+++ b/joiner/oas3.go
@@ -395,6 +395,7 @@ func (j *Joiner) mergeSchemas(target, source map[string]*parser.Schema, strategy
 					// See #482.
 					newName = j.generateRenamedSchemaName(effectiveName, leftOrigin.filePath, leftOrigin.docIndex, nil)
 				}
+				newName = uniqueSchemaName(target, newName)
 
 				// Move existing schema to new name
 				target[newName] = target[effectiveName]
@@ -423,6 +424,7 @@ func (j *Joiner) mergeSchemas(target, source map[string]*parser.Schema, strategy
 					// Pass sourceGraph for operation-aware renaming of the right/new schema
 					newName = j.generateRenamedSchemaName(effectiveName, ctx.filePath, ctx.docIndex, sourceGraph)
 				}
+				newName = uniqueSchemaName(target, newName)
 
 				// Add new schema under renamed name
 				target[newName] = schema

--- a/joiner/rename_scope.go
+++ b/joiner/rename_scope.go
@@ -172,6 +172,10 @@ func (s *renameScope) rewrite(joined any, owner map[any]int) error {
 func (s *renameScope) rewriteUnowned(joined any, owner map[any]int) error {
 	merged := make(map[string]string)
 	for _, renames := range s.byDoc {
+		// Documents are visited in merge order, so when two of them renamed the
+		// same name to different targets the later one wins. The name is genuinely
+		// ambiguous for a value that belongs to no document, and merge order is the
+		// only ordering the join has to break the tie with.
 		maps.Copy(merged, renames)
 	}
 	rewriter := NewSchemaRewriter()
@@ -182,6 +186,20 @@ func (s *renameScope) rewriteUnowned(joined any, owner map[any]int) error {
 		_, known := owner[entry]
 		return !known
 	})
+	return rewriter.RewriteDocument(joined)
+}
+
+// rewriteDedupeAliases repoints every reference to a deduplicated name at the
+// canonical name that replaced it.
+//
+// Unlike a collision rename, this is document-wide: deduplication only
+// consolidates schemas it found equivalent, so a reference to an alias means the
+// canonical schema no matter which document wrote it.
+func rewriteDedupeAliases(joined any, aliases map[string]string, version parser.OASVersion) error {
+	rewriter := NewSchemaRewriter()
+	for alias, canonical := range aliases {
+		rewriter.RegisterRename(alias, canonical, version)
+	}
 	return rewriter.RewriteDocument(joined)
 }
 

--- a/joiner/rename_scope.go
+++ b/joiner/rename_scope.go
@@ -1,0 +1,178 @@
+package joiner
+
+import (
+	"github.com/erraggy/oastools/parser"
+)
+
+// renameScope records schema renames per source document.
+//
+// A rename resolves a collision between two documents, so it only speaks for
+// the documents that were written against the renamed name. Renaming an
+// incoming schema (rename-right, or a namespace prefix) concerns that document
+// alone; renaming a schema already in the joined document (rename-left)
+// concerns the documents merged before it. Applying every rename to the whole
+// merged document repoints references that were already correct: see #478.
+type renameScope struct {
+	// version selects the $ref spelling: "#/definitions/" or "#/components/schemas/".
+	version parser.OASVersion
+	// byDoc is indexed by source document position and maps a name as spelled
+	// in that document to the name it ends up under in the joined document.
+	// Entries stay nil until that document has a rename, which is the common
+	// case: most joins resolve no collision by renaming.
+	byDoc []map[string]string
+}
+
+// newRenameScope returns a scope sized for docCount source documents.
+func newRenameScope(docCount int, version parser.OASVersion) *renameScope {
+	return &renameScope{version: version, byDoc: make([]map[string]string, docCount)}
+}
+
+// renamesFor returns the rename map for a document, creating it on first use.
+func (s *renameScope) renamesFor(docIndex int) map[string]string {
+	if s.byDoc[docIndex] == nil {
+		s.byDoc[docIndex] = make(map[string]string)
+	}
+	return s.byDoc[docIndex]
+}
+
+// registerRight records that a schema arriving with document docIndex was stored
+// under newName.
+//
+// sourceName is the name the schema carries in its own document, which is what
+// that document's references spell. Keying on it means a schema renamed twice
+// (a namespace prefix, then a collision) resolves to its final name in one step
+// instead of leaving a reference stranded at the intermediate name.
+func (s *renameScope) registerRight(docIndex int, sourceName, newName string) {
+	if s == nil || docIndex < 0 || docIndex >= len(s.byDoc) {
+		return
+	}
+	s.renamesFor(docIndex)[sourceName] = newName
+}
+
+// registerLeft records that the schema already stored under oldName was moved to
+// newName to make room for a schema from document docIndex.
+//
+// Every document merged before docIndex spelled oldName meaning the schema being
+// moved, so each of them follows it. A document that already maps some name onto
+// oldName is redirected rather than given a second entry, and one that already
+// maps oldName somewhere else is not talking about the schema being moved and is
+// left alone.
+func (s *renameScope) registerLeft(docIndex int, oldName, newName string) {
+	if s == nil {
+		return
+	}
+	for e := 0; e < docIndex && e < len(s.byDoc); e++ {
+		for src, dst := range s.byDoc[e] {
+			if dst == oldName {
+				s.byDoc[e][src] = newName
+			}
+		}
+		if _, taken := s.byDoc[e][oldName]; taken {
+			continue
+		}
+		s.renamesFor(e)[oldName] = newName
+	}
+}
+
+// empty reports whether no document has a rename recorded.
+func (s *renameScope) empty() bool {
+	if s == nil {
+		return true
+	}
+	for _, m := range s.byDoc {
+		if len(m) > 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// applyOAS2 rewrites the joined document's references, one source document's
+// renames at a time. sources are the documents that were merged, in order.
+//
+// The entries claimed here must cover everything SchemaRewriter traverses at the
+// top level, otherwise an unclaimed entry belongs to no document and is never
+// rewritten: keep this in step with rewriteOAS2Document.
+func (s *renameScope) applyOAS2(joined *parser.OAS2Document, sources []*parser.OAS2Document) error {
+	if s.empty() {
+		return nil
+	}
+	owner := make(map[any]int)
+	for docIndex, src := range sources {
+		claimEntries(owner, docIndex, src.Definitions)
+		claimEntries(owner, docIndex, src.Parameters)
+		claimEntries(owner, docIndex, src.Responses)
+		claimEntries(owner, docIndex, src.Paths)
+	}
+	return s.rewrite(joined, owner)
+}
+
+// applyOAS3 rewrites the joined document's references, one source document's
+// renames at a time. sources are the documents that were merged, in order.
+//
+// The entries claimed here must cover everything SchemaRewriter traverses at the
+// top level, otherwise an unclaimed entry belongs to no document and is never
+// rewritten: keep this in step with rewriteOAS3Document.
+func (s *renameScope) applyOAS3(joined *parser.OAS3Document, sources []*parser.OAS3Document) error {
+	if s.empty() {
+		return nil
+	}
+	owner := make(map[any]int)
+	for docIndex, src := range sources {
+		if src.Components != nil {
+			claimEntries(owner, docIndex, src.Components.Schemas)
+			claimEntries(owner, docIndex, src.Components.Parameters)
+			claimEntries(owner, docIndex, src.Components.Responses)
+			claimEntries(owner, docIndex, src.Components.RequestBodies)
+			claimEntries(owner, docIndex, src.Components.Headers)
+			claimEntries(owner, docIndex, src.Components.Callbacks)
+			claimEntries(owner, docIndex, src.Components.PathItems)
+		}
+		claimEntries(owner, docIndex, src.Paths)
+		claimEntries(owner, docIndex, src.Webhooks)
+	}
+	return s.rewrite(joined, owner)
+}
+
+// rewrite runs one restricted pass over the joined document per source document
+// that had a rename recorded. Each pass skips the top-level entries another
+// document contributed, so it descends into a subtree only when that subtree's
+// own document is being rewritten.
+func (s *renameScope) rewrite(joined any, owner map[any]int) error {
+	for docIndex, renames := range s.byDoc {
+		if len(renames) == 0 {
+			continue
+		}
+		rewriter := NewSchemaRewriter()
+		for oldName, newName := range renames {
+			rewriter.RegisterRename(oldName, newName, s.version)
+		}
+		rewriter.restrictTo(func(entry any) bool {
+			contributor, known := owner[entry]
+			return known && contributor == docIndex
+		})
+		if err := rewriter.RewriteDocument(joined); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// claimEntries records the source document that contributed each entry of a
+// top-level container. The joiner merges by pointer, so the joined document
+// holds these very values and pointer identity is what links them back.
+//
+// The first document to contribute a value keeps it. That only matters when the
+// caller passes the same parsed document twice, in which case the two positions
+// share every pointer and there is no contribution to tell apart.
+func claimEntries[T comparable](owner map[any]int, docIndex int, entries map[string]T) {
+	var zero T
+	for _, entry := range entries {
+		if entry == zero {
+			continue
+		}
+		if _, claimed := owner[entry]; !claimed {
+			owner[entry] = docIndex
+		}
+	}
+}

--- a/joiner/rename_scope.go
+++ b/joiner/rename_scope.go
@@ -6,21 +6,13 @@ import (
 	"github.com/erraggy/oastools/parser"
 )
 
-// renameScope records schema renames per source document.
-//
-// A rename resolves a collision between two documents, so it only speaks for
-// the documents that were written against the renamed name. Renaming an
-// incoming schema (rename-right, or a namespace prefix) concerns that document
-// alone; renaming a schema already in the joined document (rename-left)
-// concerns the documents merged before it. Applying every rename to the whole
-// merged document repoints references that were already correct: see #478.
+// renameScope records schema renames per source document, so a rename rewrites
+// only the references that arrived with the documents it concerns (#478).
 type renameScope struct {
 	// version selects the $ref spelling: "#/definitions/" or "#/components/schemas/".
 	version parser.OASVersion
-	// byDoc is indexed by source document position and maps a name as spelled
-	// in that document to the name it ends up under in the joined document.
-	// Entries stay nil until that document has a rename, which is the common
-	// case: most joins resolve no collision by renaming.
+	// byDoc maps, per source document position, a name as spelled in that
+	// document to the name it ends up under. Entries are nil until first use.
 	byDoc []map[string]string
 }
 
@@ -37,13 +29,10 @@ func (s *renameScope) renamesFor(docIndex int) map[string]string {
 	return s.byDoc[docIndex]
 }
 
-// registerRight records that a schema arriving with document docIndex was stored
-// under newName.
-//
-// sourceName is the name the schema carries in its own document, which is what
-// that document's references spell. Keying on it means a schema renamed twice
-// (a namespace prefix, then a collision) resolves to its final name in one step
-// instead of leaving a reference stranded at the intermediate name.
+// registerRight records that a schema from document docIndex was stored under
+// newName. sourceName is its name in that document, which is what that
+// document's references spell, so a prefix followed by a collision still
+// resolves in one step.
 func (s *renameScope) registerRight(docIndex int, sourceName, newName string) {
 	if s == nil || docIndex < 0 || docIndex >= len(s.byDoc) {
 		return
@@ -51,14 +40,10 @@ func (s *renameScope) registerRight(docIndex int, sourceName, newName string) {
 	s.renamesFor(docIndex)[sourceName] = newName
 }
 
-// registerLeft records that the schema already stored under oldName was moved to
-// newName to make room for a schema from document docIndex.
-//
-// Every document merged before docIndex spelled oldName meaning the schema being
-// moved, so each of them follows it. A document that already maps some name onto
-// oldName is redirected rather than given a second entry, and one that already
-// maps oldName somewhere else is not talking about the schema being moved and is
-// left alone.
+// registerLeft records that the schema under oldName moved to newName to make
+// room for one from document docIndex. Only earlier documents referenced it, so
+// only they follow: one already mapping a name onto oldName is redirected, and
+// one already mapping oldName elsewhere means a different schema.
 func (s *renameScope) registerLeft(docIndex int, oldName, newName string) {
 	if s == nil {
 		return
@@ -90,11 +75,10 @@ func (s *renameScope) empty() bool {
 }
 
 // applyOAS2 rewrites the joined document's references, one source document's
-// renames at a time. sources are the documents that were merged, in order.
+// renames at a time. sources are the merged documents, in order.
 //
-// The entries claimed here must cover everything SchemaRewriter traverses at the
-// top level, otherwise an unclaimed entry belongs to no document and is never
-// rewritten: keep this in step with rewriteOAS2Document.
+// Keep the claimed containers in step with rewriteOAS2Document: an unclaimed
+// entry counts as belonging to no document.
 func (s *renameScope) applyOAS2(joined *parser.OAS2Document, sources []*parser.OAS2Document) error {
 	if s.empty() {
 		return nil
@@ -110,11 +94,10 @@ func (s *renameScope) applyOAS2(joined *parser.OAS2Document, sources []*parser.O
 }
 
 // applyOAS3 rewrites the joined document's references, one source document's
-// renames at a time. sources are the documents that were merged, in order.
+// renames at a time. sources are the merged documents, in order.
 //
-// The entries claimed here must cover everything SchemaRewriter traverses at the
-// top level, otherwise an unclaimed entry belongs to no document and is never
-// rewritten: keep this in step with rewriteOAS3Document.
+// Keep the claimed containers in step with rewriteOAS3Document: an unclaimed
+// entry counts as belonging to no document.
 func (s *renameScope) applyOAS3(joined *parser.OAS3Document, sources []*parser.OAS3Document) error {
 	if s.empty() {
 		return nil
@@ -136,10 +119,8 @@ func (s *renameScope) applyOAS3(joined *parser.OAS3Document, sources []*parser.O
 	return s.rewrite(joined, owner)
 }
 
-// rewrite runs one restricted pass over the joined document per source document
-// that had a rename recorded. Each pass skips the top-level entries another
-// document contributed, so it descends into a subtree only when that subtree's
-// own document is being rewritten.
+// rewrite runs one pass per source document that recorded a rename, each
+// restricted to the entries that document contributed, then one for the rest.
 func (s *renameScope) rewrite(joined any, owner map[any]int) error {
 	for docIndex, renames := range s.byDoc {
 		if len(renames) == 0 {
@@ -160,22 +141,13 @@ func (s *renameScope) rewrite(joined any, owner map[any]int) error {
 	return s.rewriteUnowned(joined, owner)
 }
 
-// rewriteUnowned rewrites the top-level entries that came from no source document.
-//
-// A collision handler returning ResolutionCustom supplies a value the joiner
-// never received from a document (see applySchemaResolution and
-// applyPathResolution). It belongs to no document's namespace, so there is
-// nothing to scope its references to and every rename applies, which is the
-// document-wide treatment every entry had before renames became scoped. Skipping
-// these would leave a handler's references pointing at names the join no longer
-// has.
+// rewriteUnowned rewrites entries that came from no source document, which a
+// collision handler produces with ResolutionCustom. There is no document whose
+// namespace to read them in, so every rename applies.
 func (s *renameScope) rewriteUnowned(joined any, owner map[any]int) error {
 	merged := make(map[string]string)
 	for _, renames := range s.byDoc {
-		// Documents are visited in merge order, so when two of them renamed the
-		// same name to different targets the later one wins. The name is genuinely
-		// ambiguous for a value that belongs to no document, and merge order is the
-		// only ordering the join has to break the tie with.
+		// Merge order breaks the tie when two documents renamed the same name.
 		maps.Copy(merged, renames)
 	}
 	rewriter := NewSchemaRewriter()
@@ -189,12 +161,9 @@ func (s *renameScope) rewriteUnowned(joined any, owner map[any]int) error {
 	return rewriter.RewriteDocument(joined)
 }
 
-// rewriteDedupeAliases repoints every reference to a deduplicated name at the
-// canonical name that replaced it.
-//
-// Unlike a collision rename, this is document-wide: deduplication only
-// consolidates schemas it found equivalent, so a reference to an alias means the
-// canonical schema no matter which document wrote it.
+// rewriteDedupeAliases repoints references from deduplicated names to canonical
+// ones. Document-wide, unlike a collision rename: the schemas were found
+// equivalent, so the reference means the same thing whoever wrote it.
 func rewriteDedupeAliases(joined any, aliases map[string]string, version parser.OASVersion) error {
 	rewriter := NewSchemaRewriter()
 	for alias, canonical := range aliases {
@@ -203,17 +172,10 @@ func rewriteDedupeAliases(joined any, aliases map[string]string, version parser.
 	return rewriter.RewriteDocument(joined)
 }
 
-// claimEntries records the source document that contributed each entry of a
-// top-level container. The joiner merges by pointer, so the joined document
-// holds these very values and pointer identity is what links them back.
-//
-// The first document to contribute a value keeps it. That only matters when the
-// caller passes the same parsed document twice, in which case the two positions
-// share every pointer and there is no contribution to tell apart.
-// The map value type is *T rather than a comparable T so that only pointer
-// entries can be attributed: ownership is pointer identity, and a container of
-// values would key the map on content and attribute two equal values to one
-// document.
+// claimEntries records which document contributed each entry of a top-level
+// container. The joiner merges by pointer, so pointer identity links a joined
+// entry back to its document. First contributor wins. The *T value type keeps
+// non-pointer entries out, which would be matched on content instead.
 func claimEntries[T any](owner map[any]int, docIndex int, entries map[string]*T) {
 	for _, entry := range entries {
 		if entry == nil {

--- a/joiner/rename_scope.go
+++ b/joiner/rename_scope.go
@@ -1,6 +1,8 @@
 package joiner
 
 import (
+	"maps"
+
 	"github.com/erraggy/oastools/parser"
 )
 
@@ -155,7 +157,32 @@ func (s *renameScope) rewrite(joined any, owner map[any]int) error {
 			return err
 		}
 	}
-	return nil
+	return s.rewriteUnowned(joined, owner)
+}
+
+// rewriteUnowned rewrites the top-level entries that came from no source document.
+//
+// A collision handler returning ResolutionCustom supplies a value the joiner
+// never received from a document (see applySchemaResolution and
+// applyPathResolution). It belongs to no document's namespace, so there is
+// nothing to scope its references to and every rename applies, which is the
+// document-wide treatment every entry had before renames became scoped. Skipping
+// these would leave a handler's references pointing at names the join no longer
+// has.
+func (s *renameScope) rewriteUnowned(joined any, owner map[any]int) error {
+	merged := make(map[string]string)
+	for _, renames := range s.byDoc {
+		maps.Copy(merged, renames)
+	}
+	rewriter := NewSchemaRewriter()
+	for oldName, newName := range merged {
+		rewriter.RegisterRename(oldName, newName, s.version)
+	}
+	rewriter.restrictTo(func(entry any) bool {
+		_, known := owner[entry]
+		return !known
+	})
+	return rewriter.RewriteDocument(joined)
 }
 
 // claimEntries records the source document that contributed each entry of a

--- a/joiner/rename_scope.go
+++ b/joiner/rename_scope.go
@@ -210,10 +210,13 @@ func rewriteDedupeAliases(joined any, aliases map[string]string, version parser.
 // The first document to contribute a value keeps it. That only matters when the
 // caller passes the same parsed document twice, in which case the two positions
 // share every pointer and there is no contribution to tell apart.
-func claimEntries[T comparable](owner map[any]int, docIndex int, entries map[string]T) {
-	var zero T
+// The map value type is *T rather than a comparable T so that only pointer
+// entries can be attributed: ownership is pointer identity, and a container of
+// values would key the map on content and attribute two equal values to one
+// document.
+func claimEntries[T any](owner map[any]int, docIndex int, entries map[string]*T) {
 	for _, entry := range entries {
-		if entry == zero {
+		if entry == nil {
 			continue
 		}
 		if _, claimed := owner[entry]; !claimed {

--- a/joiner/rename_scope_test.go
+++ b/joiner/rename_scope_test.go
@@ -9,10 +9,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// petstoreFamily builds an OAS 2.0 document from the Petstore family: a Pet whose
-// category property is a $ref to Category, reached through one path. When
-// withDescription is set, Category gains a description property, which is a real
-// difference between two otherwise identical documents.
+// petstoreFamily builds an OAS 2.0 document with a Pet whose category property
+// refs Category, reached through one path. withDescription makes Category
+// genuinely differ between two documents.
 func petstoreFamily(name string, withDescription bool) parser.ParseResult {
 	category := &parser.Schema{
 		Type: "object",
@@ -79,8 +78,8 @@ func petResponseRef(t *testing.T, doc *parser.OAS2Document, path string) string 
 	return resp.Schema.Ref
 }
 
-// definitionRefs collects every $ref reachable from the fixture documents:
-// definition properties and path response schemas.
+// definitionRefs collects every $ref in the fixtures: definition properties and
+// path response schemas.
 func definitionRefs(doc *parser.OAS2Document) []string {
 	var refs []string
 	for _, schema := range doc.Definitions {
@@ -157,9 +156,8 @@ func TestRenameScopeRenameLeft(t *testing.T) {
 }
 
 // TestRenameScopeIncrementalJoin covers the first follow-on observation in #478:
-// a caller accumulating combined = join(combined, next) feeds the joined document
-// back in, so a reference left pointing at another document's alias would stop
-// the next byte-identical schema from comparing equal, and aliases would pile up.
+// a caller accumulating combined = join(combined, next) feeds the output back in,
+// where a reference left pointing at an alias made aliases pile up.
 func TestRenameScopeIncrementalJoin(t *testing.T) {
 	first, err := JoinWithOptions(
 		WithParsed(petstoreFamily("store", false), petstoreFamily("clinic", true)),
@@ -190,9 +188,8 @@ func TestRenameScopeIncrementalJoin(t *testing.T) {
 }
 
 // TestRenameScopeSemanticDeduplication covers the second follow-on observation in
-// #478: the collision pass and the deduplication pass used to share one rewriter
-// and could register opposing directions for the same name, sending a reference
-// back to an alias that deduplication had just removed.
+// #478: the collision and deduplication passes shared one rewriter and could
+// register opposing directions for the same name.
 func TestRenameScopeSemanticDeduplication(t *testing.T) {
 	res, err := JoinWithOptions(
 		WithParsed(petstoreFamily("store", false), petstoreFamily("clinic", false)),
@@ -216,8 +213,8 @@ func TestRenameScopeSemanticDeduplication(t *testing.T) {
 }
 
 // TestRenameScopeNamespacePrefixThenCollision checks that a schema renamed twice,
-// first by a namespace prefix and then by a collision, resolves in one step.
-// References in the source document spell the original name, not the prefixed one.
+// by a prefix then a collision, resolves in one step: its references spell the
+// original name, not the prefixed one.
 func TestRenameScopeNamespacePrefixThenCollision(t *testing.T) {
 	res, err := JoinWithOptions(
 		WithParsed(petstoreFamily("store", false), petstoreFamily("clinic", true)),
@@ -331,12 +328,10 @@ func oas3ResponseRef(t *testing.T, doc *parser.OAS3Document, path string) string
 }
 
 // TestRenameScopeCoversEveryContainer exercises every top-level container the
-// rewriter traverses. A container that renameScope forgets to attribute to a
-// source document belongs to no document, so its references are never rewritten
-// and the join emits a dangling reference. This fails loudly if the two lists
-// drift apart.
+// rewriter traverses, so a container renameScope forgets to attribute fails here
+// rather than silently taking every document's renames.
 func TestRenameScopeCoversEveryContainer(t *testing.T) {
-	// containerRef builds an operation whose 200 response references Target.
+	// containerRef builds an operation whose 200 response refs Target.
 	containerRef := func() *parser.Operation {
 		return &parser.Operation{
 			Responses: &parser.Responses{Codes: map[string]*parser.Response{
@@ -350,7 +345,7 @@ func TestRenameScopeCoversEveryContainer(t *testing.T) {
 		}
 	}
 
-	// doc names every component after its source so that only Target collides.
+	// Components are named after their source so only Target collides.
 	doc := func(name string, extra bool) parser.ParseResult {
 		target := &parser.Schema{
 			Type:       "object",
@@ -424,7 +419,7 @@ func TestRenameScopeCoversEveryContainer(t *testing.T) {
 	c := d.Components
 	require.Contains(t, c.Schemas, "Target.b", "b's Target should have been renamed")
 
-	// Every reference from each document, keyed by the container it lives in.
+	// Each document's references, keyed by the container they live in.
 	refs := func(source string) map[string]string {
 		callback := *c.Callbacks[source+"CB"]
 		return map[string]string{
@@ -450,9 +445,8 @@ func TestRenameScopeCoversEveryContainer(t *testing.T) {
 	}
 }
 
-// TestRenameScopeCoversEveryContainerOAS2 is the OAS 2 counterpart: definitions,
-// top-level parameters, top-level responses and paths are the four containers
-// renameScope.applyOAS2 attributes and rewriteOAS2Document traverses.
+// TestRenameScopeCoversEveryContainerOAS2 is the OAS 2 counterpart, covering the
+// four containers applyOAS2 attributes and rewriteOAS2Document traverses.
 func TestRenameScopeCoversEveryContainerOAS2(t *testing.T) {
 	targetRef := func() *parser.Schema { return &parser.Schema{Ref: "#/definitions/Target"} }
 
@@ -540,14 +534,12 @@ func oas3ResponseRefIn(t *testing.T, op *parser.Operation) string {
 	return media.Schema.Ref
 }
 
-// TestRenameScopeRewritesHandlerCustomValues covers the one kind of entry that
-// belongs to no source document: a collision handler returning ResolutionCustom
-// supplies a value the joiner never received from a document. Scoping renames by
-// contributing document must not skip it, or the handler's references keep
-// naming schemas the join no longer has.
+// TestRenameScopeRewritesHandlerCustomValues covers the one entry belonging to no
+// source document: a value from ResolutionCustom. Scoping must not skip it, or
+// its references keep naming schemas the join no longer has.
 func TestRenameScopeRewritesHandlerCustomValues(t *testing.T) {
-	// A namespace prefix on both documents means every reference written in a
-	// source document needs rewriting, so a value that is skipped dangles.
+	// Prefixing both documents means every reference needs rewriting, so a value
+	// that is skipped dangles.
 	handler := func(c CollisionContext) (CollisionResolution, error) {
 		if c.Type == CollisionTypeSchema && c.Name == "Api_Pet" {
 			return UseCustomValue(&parser.Schema{
@@ -575,8 +567,7 @@ func TestRenameScopeRewritesHandlerCustomValues(t *testing.T) {
 	d := res.Document.(*parser.OAS2Document)
 	require.Contains(t, d.Definitions, "Api_Pet")
 
-	// Both documents renamed Category, so the name is ambiguous for a value that
-	// belongs to neither: merge order breaks the tie and the later document wins.
+	// Both documents renamed Category, so merge order breaks the tie.
 	assert.Equal(t, "#/definitions/Api_Category.b",
 		d.Definitions["Api_Pet"].Properties["category"].Ref,
 		"the handler's value was skipped by every pass, so its reference was never rewritten")
@@ -633,8 +624,8 @@ func TestRenameScopeRewritesHandlerCustomPathItem(t *testing.T) {
 	assert.Contains(t, d.Definitions, extractSchemaName(ref), "dangling reference %s", ref)
 }
 
-// petVariant is a minimal document whose single definition carries one property
-// named after the document, so a schema can be traced back to its source.
+// petVariant is a minimal document whose one definition carries a property named
+// after the document, so a schema can be traced to its source.
 func petVariant(name string) parser.ParseResult {
 	return parser.ParseResult{
 		Document: &parser.OAS2Document{
@@ -662,8 +653,8 @@ func petVariant(name string) parser.ParseResult {
 }
 
 // TestRenameLeftNamesEachContributor covers #479: rename-left named the moved
-// schema after the first document every time, so the second rename in a three
-// document join generated a name that was already taken and overwrote it.
+// schema after the first document every time, so a three document join
+// generated the same name twice and lost a schema.
 func TestRenameLeftNamesEachContributor(t *testing.T) {
 	res, err := JoinWithOptions(
 		WithParsed(petVariant("a"), petVariant("b"), petVariant("c")),
@@ -712,8 +703,8 @@ func TestRenameLeftReportsContributingSource(t *testing.T) {
 	assert.Contains(t, res.Warnings, "definition 'Pet' from b renamed to 'Pet.b' (incoming document takes the original name)")
 }
 
-// TestJoinSameDocumentTwice covers #481: the two positions used to share every
-// pointer, so keeping both sides stored one schema under two names.
+// TestJoinSameDocumentTwice covers #481: the two positions shared every pointer,
+// so keeping both sides stored one schema under two names.
 func TestJoinSameDocumentTwice(t *testing.T) {
 	doc := petVariant("a")
 
@@ -768,7 +759,7 @@ func TestRenameTargetAlreadyTaken(t *testing.T) {
 }
 
 // TestRenameTemplateWithoutName covers the other way into #483: a template that
-// discards the schema name generates one name for every schema of a document.
+// discards the schema name generates one name for every schema.
 func TestRenameTemplateWithoutName(t *testing.T) {
 	res, err := JoinWithOptions(
 		WithParsed(petstoreFamily("store", false), petstoreFamily("clinic", true)),
@@ -847,9 +838,8 @@ func TestRenameScopeRegisterLeft(t *testing.T) {
 
 		s.registerLeft(1, "Api_Pet", "Api_Pet.store")
 
-		// Pet follows the schema to its new name. The direct Api_Pet entry is inert
-		// for this document, which spells Pet, but is recorded because a document
-		// that did reference Api_Pet would need it.
+		// Pet follows the schema. The Api_Pet entry is inert for this document,
+		// which spells Pet, but a document referencing Api_Pet would need it.
 		assert.Equal(t, map[string]string{
 			"Pet":     "Api_Pet.store",
 			"Api_Pet": "Api_Pet.store",

--- a/joiner/rename_scope_test.go
+++ b/joiner/rename_scope_test.go
@@ -462,6 +462,97 @@ func oas3ResponseRefIn(t *testing.T, op *parser.Operation) string {
 	return media.Schema.Ref
 }
 
+// TestRenameScopeRewritesHandlerCustomValues covers the one kind of entry that
+// belongs to no source document: a collision handler returning ResolutionCustom
+// supplies a value the joiner never received from a document. Scoping renames by
+// contributing document must not skip it, or the handler's references keep
+// naming schemas the join no longer has.
+func TestRenameScopeRewritesHandlerCustomValues(t *testing.T) {
+	// A namespace prefix on both documents means every reference written in a
+	// source document needs rewriting, so a value that is skipped dangles.
+	handler := func(c CollisionContext) (CollisionResolution, error) {
+		if c.Type == CollisionTypeSchema && c.Name == "Api_Pet" {
+			return UseCustomValue(&parser.Schema{
+				Type: "object",
+				Properties: map[string]*parser.Schema{
+					"category": {Ref: "#/definitions/Category"},
+				},
+			}), nil
+		}
+		return ContinueWithStrategy(), nil
+	}
+
+	res, err := JoinWithOptions(
+		WithParsed(petstoreFamily("a", false), petstoreFamily("b", true)),
+		WithSchemaStrategy(StrategyRenameRight),
+		WithEquivalenceMode("deep"),
+		WithNamespacePrefix("a", "Api"),
+		WithNamespacePrefix("b", "Api"),
+		WithAlwaysApplyPrefix(true),
+		WithRenameTemplate(`{{.Name}}.{{.Source}}`),
+		WithCollisionHandler(handler),
+	)
+	require.NoError(t, err)
+
+	d := res.Document.(*parser.OAS2Document)
+	require.Contains(t, d.Definitions, "Api_Pet")
+
+	custom := d.Definitions["Api_Pet"].Properties["category"].Ref
+	assert.NotEqual(t, "#/definitions/Category", custom,
+		"the handler's value was skipped by every pass, so its reference was never rewritten")
+	for _, ref := range definitionRefs(d) {
+		assert.Contains(t, d.Definitions, extractSchemaName(ref), "dangling reference %s", ref)
+	}
+}
+
+// TestRenameScopeRewritesHandlerCustomPathItem is the same case for paths, the
+// other resolution that accepts a custom value.
+func TestRenameScopeRewritesHandlerCustomPathItem(t *testing.T) {
+	// Both documents publish the same path, so the handler can replace it.
+	const shared = "/shared/pet"
+	withSharedPath := func(name string, withDescription bool) parser.ParseResult {
+		res := petstoreFamily(name, withDescription)
+		doc := res.Document.(*parser.OAS2Document)
+		doc.Paths[shared] = &parser.PathItem{Get: &parser.Operation{
+			OperationID: "shared" + name,
+			Responses: &parser.Responses{Codes: map[string]*parser.Response{
+				"200": {Description: "ok", Schema: &parser.Schema{Ref: "#/definitions/Pet"}},
+			}},
+		}}
+		return res
+	}
+
+	handler := func(c CollisionContext) (CollisionResolution, error) {
+		if c.Type == CollisionTypePath && c.Name == shared {
+			return UseCustomValue(&parser.PathItem{Get: &parser.Operation{
+				OperationID: "sharedMerged",
+				Responses: &parser.Responses{Codes: map[string]*parser.Response{
+					"200": {Description: "ok", Schema: &parser.Schema{Ref: "#/definitions/Pet"}},
+				}},
+			}}), nil
+		}
+		return ContinueWithStrategy(), nil
+	}
+
+	res, err := JoinWithOptions(
+		WithParsed(withSharedPath("a", false), withSharedPath("b", true)),
+		WithSchemaStrategy(StrategyRenameRight),
+		WithEquivalenceMode("deep"),
+		WithNamespacePrefix("a", "Api"),
+		WithNamespacePrefix("b", "Api"),
+		WithAlwaysApplyPrefix(true),
+		WithRenameTemplate(`{{.Name}}.{{.Source}}`),
+		WithCollisionHandler(handler),
+	)
+	require.NoError(t, err)
+
+	d := res.Document.(*parser.OAS2Document)
+	ref := petResponseRef(t, d, shared)
+	assert.NotEqual(t, "#/definitions/Pet", ref,
+		"the handler's path item was skipped by every pass, so its reference was never rewritten")
+	assert.Contains(t, d.Definitions, extractSchemaName(ref), "dangling reference %s", ref)
+}
+
 // petVariant is a minimal document whose single definition carries one property
 // named after the document, so a schema can be traced back to its source.
 func petVariant(name string) parser.ParseResult {

--- a/joiner/rename_scope_test.go
+++ b/joiner/rename_scope_test.go
@@ -450,6 +450,84 @@ func TestRenameScopeCoversEveryContainer(t *testing.T) {
 	}
 }
 
+// TestRenameScopeCoversEveryContainerOAS2 is the OAS 2 counterpart: definitions,
+// top-level parameters, top-level responses and paths are the four containers
+// renameScope.applyOAS2 attributes and rewriteOAS2Document traverses.
+func TestRenameScopeCoversEveryContainerOAS2(t *testing.T) {
+	targetRef := func() *parser.Schema { return &parser.Schema{Ref: "#/definitions/Target"} }
+
+	doc := func(name string, extra bool) parser.ParseResult {
+		target := &parser.Schema{
+			Type:       "object",
+			Properties: map[string]*parser.Schema{"id": {Type: "string"}},
+		}
+		if extra {
+			target.Properties["note"] = &parser.Schema{Type: "string"}
+		}
+
+		return parser.ParseResult{
+			Document: &parser.OAS2Document{
+				Swagger: "2.0",
+				Info:    &parser.Info{Title: name, Version: "1.0.0"},
+				Paths: parser.Paths{
+					"/" + name: &parser.PathItem{Get: &parser.Operation{
+						Responses: &parser.Responses{Codes: map[string]*parser.Response{
+							"200": {Description: "ok", Schema: targetRef()},
+						}},
+					}},
+				},
+				Definitions: map[string]*parser.Schema{
+					"Target": target,
+					name + "Holder": {
+						Type:       "object",
+						Properties: map[string]*parser.Schema{"target": targetRef()},
+					},
+				},
+				Parameters: map[string]*parser.Parameter{
+					name + "Param": {Name: "body", In: "body", Schema: targetRef()},
+				},
+				Responses: map[string]*parser.Response{
+					name + "Resp": {Description: "ok", Schema: targetRef()},
+				},
+				OASVersion: parser.OASVersion20,
+			},
+			Version:      "2.0",
+			OASVersion:   parser.OASVersion20,
+			SourcePath:   name,
+			SourceFormat: "json",
+		}
+	}
+
+	res, err := JoinWithOptions(
+		WithParsed(doc("a", false), doc("b", true)),
+		WithSchemaStrategy(StrategyRenameRight),
+		WithEquivalenceMode("deep"),
+		WithRenameTemplate(`{{.Name}}.{{.Source}}`),
+	)
+	require.NoError(t, err)
+
+	d := res.Document.(*parser.OAS2Document)
+	require.Contains(t, d.Definitions, "Target.b", "b's Target should have been renamed")
+
+	refs := func(source string) map[string]string {
+		return map[string]string{
+			"definitions": d.Definitions[source+"Holder"].Properties["target"].Ref,
+			"parameters":  d.Parameters[source+"Param"].Schema.Ref,
+			"responses":   d.Responses[source+"Resp"].Schema.Ref,
+			"paths":       petResponseRef(t, d, "/"+source),
+		}
+	}
+
+	for container, ref := range refs("b") {
+		assert.Equal(t, "#/definitions/Target.b", ref,
+			"%s: b's reference was not rewritten, so renameScope does not attribute this container", container)
+	}
+	for container, ref := range refs("a") {
+		assert.Equal(t, "#/definitions/Target", ref,
+			"%s: a's reference was repointed at b's definition", container)
+	}
+}
+
 func oas3ResponseRefIn(t *testing.T, op *parser.Operation) string {
 	t.Helper()
 	require.NotNil(t, op)
@@ -497,8 +575,10 @@ func TestRenameScopeRewritesHandlerCustomValues(t *testing.T) {
 	d := res.Document.(*parser.OAS2Document)
 	require.Contains(t, d.Definitions, "Api_Pet")
 
-	custom := d.Definitions["Api_Pet"].Properties["category"].Ref
-	assert.NotEqual(t, "#/definitions/Category", custom,
+	// Both documents renamed Category, so the name is ambiguous for a value that
+	// belongs to neither: merge order breaks the tie and the later document wins.
+	assert.Equal(t, "#/definitions/Api_Category.b",
+		d.Definitions["Api_Pet"].Properties["category"].Ref,
 		"the handler's value was skipped by every pass, so its reference was never rewritten")
 	for _, ref := range definitionRefs(d) {
 		assert.Contains(t, d.Definitions, extractSchemaName(ref), "dangling reference %s", ref)
@@ -548,7 +628,7 @@ func TestRenameScopeRewritesHandlerCustomPathItem(t *testing.T) {
 
 	d := res.Document.(*parser.OAS2Document)
 	ref := petResponseRef(t, d, shared)
-	assert.NotEqual(t, "#/definitions/Pet", ref,
+	assert.Equal(t, "#/definitions/Api_Pet.b", ref,
 		"the handler's path item was skipped by every pass, so its reference was never rewritten")
 	assert.Contains(t, d.Definitions, extractSchemaName(ref), "dangling reference %s", ref)
 }
@@ -701,7 +781,13 @@ func TestRenameScopeRegisterLeft(t *testing.T) {
 
 		s.registerLeft(1, "Api_Pet", "Api_Pet.store")
 
-		assert.Equal(t, "Api_Pet.store", s.byDoc[0]["Pet"])
+		// Pet follows the schema to its new name. The direct Api_Pet entry is inert
+		// for this document, which spells Pet, but is recorded because a document
+		// that did reference Api_Pet would need it.
+		assert.Equal(t, map[string]string{
+			"Pet":     "Api_Pet.store",
+			"Api_Pet": "Api_Pet.store",
+		}, s.byDoc[0])
 	})
 
 	t.Run("leaves a document whose name already resolves elsewhere", func(t *testing.T) {

--- a/joiner/rename_scope_test.go
+++ b/joiner/rename_scope_test.go
@@ -736,6 +736,72 @@ func TestJoinSameDocumentTwice(t *testing.T) {
 	assert.Empty(t, d.Definitions["Pet"].Description)
 }
 
+// TestRenameTargetAlreadyTaken covers #483: a generated name that the documents
+// already use must not overwrite the schema stored under it.
+func TestRenameTargetAlreadyTaken(t *testing.T) {
+	docA := petVariant("a")
+	// a already has a schema under the name the template will generate for b's Pet.
+	docA.Document.(*parser.OAS2Document).Definitions["Pet.b"] = &parser.Schema{
+		Type:       "object",
+		Properties: map[string]*parser.Schema{"preexisting": {Type: "string"}},
+	}
+
+	res, err := JoinWithOptions(
+		WithParsed(docA, petVariant("b")),
+		WithSchemaStrategy(StrategyRenameRight),
+		WithPathStrategy(StrategyAcceptLeft),
+		WithRenameTemplate(`{{.Name}}.{{.Source}}`),
+	)
+	require.NoError(t, err)
+
+	d := res.Document.(*parser.OAS2Document)
+
+	// Three definitions in, three out: a's Pet, a's own Pet.b, and b's renamed Pet.
+	assert.ElementsMatch(t, []string{"Pet", "Pet.b", "Pet.b_2"}, definitionNames(d))
+	assert.Contains(t, d.Definitions["Pet.b"].Properties, "preexisting",
+		"a's own Pet.b was overwritten by b's renamed Pet")
+	assert.Contains(t, d.Definitions["Pet.b_2"].Properties, "fromb")
+
+	// b's path names the schema under the name it actually ended up with.
+	assert.Equal(t, "#/definitions/Pet.b_2", petResponseRef(t, d, "/b"))
+	assert.Contains(t, res.Warnings, "definition 'Pet' from b renamed to 'Pet.b_2'")
+}
+
+// TestRenameTemplateWithoutName covers the other way into #483: a template that
+// discards the schema name generates one name for every schema of a document.
+func TestRenameTemplateWithoutName(t *testing.T) {
+	res, err := JoinWithOptions(
+		WithParsed(petstoreFamily("store", false), petstoreFamily("clinic", true)),
+		WithSchemaStrategy(StrategyRenameRight),
+		WithEquivalenceMode("deep"),
+		WithRenameTemplate(`{{.Source}}`),
+	)
+	require.NoError(t, err)
+
+	d := res.Document.(*parser.OAS2Document)
+
+	// clinic's two schemas both generated the name "clinic", so one is suffixed
+	// rather than dropped.
+	assert.ElementsMatch(t, []string{"Pet", "Category", "clinic", "clinic_2"}, definitionNames(d))
+	for _, ref := range definitionRefs(d) {
+		assert.Contains(t, d.Definitions, extractSchemaName(ref), "dangling reference %s", ref)
+	}
+}
+
+func TestUniqueSchemaName(t *testing.T) {
+	taken := map[string]*parser.Schema{
+		"Pet":     {},
+		"Pet_2":   {},
+		"Pet_3":   {},
+		"Unrelat": {},
+	}
+
+	assert.Equal(t, "Cat", uniqueSchemaName(taken, "Cat"), "a free name is returned unchanged")
+	assert.Equal(t, "Pet_4", uniqueSchemaName(taken, "Pet"), "the first free suffix is used")
+	assert.Equal(t, "Pet_2_2", uniqueSchemaName(taken, "Pet_2"), "suffixing is applied to the candidate as given")
+	assert.Equal(t, "Cat", uniqueSchemaName(map[string]*parser.Schema{}, "Cat"))
+}
+
 func definitionNames(doc *parser.OAS2Document) []string {
 	names := make([]string, 0, len(doc.Definitions))
 	for name := range doc.Definitions {

--- a/joiner/rename_scope_test.go
+++ b/joiner/rename_scope_test.go
@@ -1,0 +1,638 @@
+package joiner
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/erraggy/oastools/parser"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// petstoreFamily builds an OAS 2.0 document from the Petstore family: a Pet whose
+// category property is a $ref to Category, reached through one path. When
+// withDescription is set, Category gains a description property, which is a real
+// difference between two otherwise identical documents.
+func petstoreFamily(name string, withDescription bool) parser.ParseResult {
+	category := &parser.Schema{
+		Type: "object",
+		Properties: map[string]*parser.Schema{
+			"id":   {Type: "integer", Format: "int64"},
+			"name": {Type: "string"},
+		},
+	}
+	if withDescription {
+		category.Properties["description"] = &parser.Schema{Type: "string"}
+	}
+
+	return parser.ParseResult{
+		Document: &parser.OAS2Document{
+			Swagger: "2.0",
+			Info:    &parser.Info{Title: name, Version: "1.0.0"},
+			Paths: parser.Paths{
+				"/" + name + "/pet/{petId}": &parser.PathItem{Get: &parser.Operation{
+					OperationID: "getPetById" + name,
+					Responses: &parser.Responses{Codes: map[string]*parser.Response{
+						"200": {
+							Description: "successful operation",
+							Schema:      &parser.Schema{Ref: "#/definitions/Pet"},
+						},
+					}},
+				}},
+			},
+			Definitions: map[string]*parser.Schema{
+				"Pet": {
+					Type:     "object",
+					Required: []string{"name", "photoUrls"},
+					Properties: map[string]*parser.Schema{
+						"id":        {Type: "integer", Format: "int64"},
+						"category":  {Ref: "#/definitions/Category"},
+						"name":      {Type: "string"},
+						"photoUrls": {Type: "array", Items: &parser.Schema{Type: "string"}},
+						"status": {
+							Type: "string",
+							Enum: []any{"available", "pending", "sold"},
+						},
+					},
+				},
+				"Category": category,
+			},
+			OASVersion: parser.OASVersion20,
+		},
+		Version:      "2.0",
+		OASVersion:   parser.OASVersion20,
+		SourcePath:   name,
+		SourceFormat: "json",
+	}
+}
+
+// petResponseRef returns the $ref of the 200 response schema for a path.
+func petResponseRef(t *testing.T, doc *parser.OAS2Document, path string) string {
+	t.Helper()
+	item, ok := doc.Paths[path]
+	require.True(t, ok, "path %s missing", path)
+	require.NotNil(t, item.Get)
+	require.NotNil(t, item.Get.Responses)
+	resp, ok := item.Get.Responses.Codes["200"]
+	require.True(t, ok, "200 response missing on %s", path)
+	require.NotNil(t, resp.Schema)
+	return resp.Schema.Ref
+}
+
+// definitionRefs collects every $ref reachable from the fixture documents:
+// definition properties and path response schemas.
+func definitionRefs(doc *parser.OAS2Document) []string {
+	var refs []string
+	for _, schema := range doc.Definitions {
+		for _, prop := range schema.Properties {
+			if prop.Ref != "" {
+				refs = append(refs, prop.Ref)
+			}
+		}
+	}
+	for _, item := range doc.Paths {
+		if item.Get == nil || item.Get.Responses == nil {
+			continue
+		}
+		for _, resp := range item.Get.Responses.Codes {
+			if resp.Schema != nil && resp.Schema.Ref != "" {
+				refs = append(refs, resp.Schema.Ref)
+			}
+		}
+	}
+	sort.Strings(refs)
+	return refs
+}
+
+// TestRenameScopeRenameRight covers #478: renaming an incoming schema must not
+// repoint references that arrived with an earlier document.
+func TestRenameScopeRenameRight(t *testing.T) {
+	res, err := JoinWithOptions(
+		WithParsed(petstoreFamily("store", false), petstoreFamily("clinic", true)),
+		WithSchemaStrategy(StrategyRenameRight),
+		WithEquivalenceMode("deep"),
+		WithRenameTemplate(`{{.Name}}.{{.Source}}`),
+	)
+	require.NoError(t, err)
+
+	d := res.Document.(*parser.OAS2Document)
+
+	// store's Pet was not renamed, and store's Category kept its name, so this ref
+	// should still name it.
+	assert.Equal(t, "#/definitions/Category", d.Definitions["Pet"].Properties["category"].Ref)
+	assert.Equal(t, "#/definitions/Pet", petResponseRef(t, d, "/store/pet/{petId}"))
+
+	// clinic's Pet was renamed, and so was the Category it was written against.
+	assert.Equal(t, "#/definitions/Category.clinic", d.Definitions["Pet.clinic"].Properties["category"].Ref)
+	assert.Equal(t, "#/definitions/Pet.clinic", petResponseRef(t, d, "/clinic/pet/{petId}"))
+
+	// The two Categories stay distinct, which is why the rename happened at all.
+	assert.NotContains(t, d.Definitions["Category"].Properties, "description")
+	assert.Contains(t, d.Definitions["Category.clinic"].Properties, "description")
+}
+
+// TestRenameScopeRenameLeft is the mirror case: renaming a schema already in the
+// joined document moves the earlier documents' references, and only those.
+func TestRenameScopeRenameLeft(t *testing.T) {
+	res, err := JoinWithOptions(
+		WithParsed(petstoreFamily("store", false), petstoreFamily("clinic", true)),
+		WithSchemaStrategy(StrategyRenameLeft),
+		WithEquivalenceMode("deep"),
+		WithRenameTemplate(`{{.Name}}.{{.Source}}`),
+	)
+	require.NoError(t, err)
+
+	d := res.Document.(*parser.OAS2Document)
+
+	// store's schemas were moved aside, so store's references follow them.
+	assert.Equal(t, "#/definitions/Category.store", d.Definitions["Pet.store"].Properties["category"].Ref)
+	assert.Equal(t, "#/definitions/Pet.store", petResponseRef(t, d, "/store/pet/{petId}"))
+
+	// clinic's schemas took the original names, so clinic's references stand.
+	assert.Equal(t, "#/definitions/Category", d.Definitions["Pet"].Properties["category"].Ref)
+	assert.Equal(t, "#/definitions/Pet", petResponseRef(t, d, "/clinic/pet/{petId}"))
+
+	assert.NotContains(t, d.Definitions["Category.store"].Properties, "description")
+	assert.Contains(t, d.Definitions["Category"].Properties, "description")
+}
+
+// TestRenameScopeIncrementalJoin covers the first follow-on observation in #478:
+// a caller accumulating combined = join(combined, next) feeds the joined document
+// back in, so a reference left pointing at another document's alias would stop
+// the next byte-identical schema from comparing equal, and aliases would pile up.
+func TestRenameScopeIncrementalJoin(t *testing.T) {
+	first, err := JoinWithOptions(
+		WithParsed(petstoreFamily("store", false), petstoreFamily("clinic", true)),
+		WithSchemaStrategy(StrategyRenameRight),
+		WithEquivalenceMode("deep"),
+		WithRenameTemplate(`{{.Name}}.{{.Source}}`),
+	)
+	require.NoError(t, err)
+
+	// store2 is byte-identical to store, so deduplicating it against the
+	// accumulator must succeed rather than report a $ref target mismatch.
+	second, err := JoinWithOptions(
+		WithParsed(*first.ToParseResult(), petstoreFamily("store2", false)),
+		WithSchemaStrategy(StrategyDeduplicateEquivalent),
+		WithEquivalenceMode("deep"),
+		WithRenameTemplate(`{{.Name}}.{{.Source}}`),
+	)
+	require.NoError(t, err)
+
+	d := second.Document.(*parser.OAS2Document)
+
+	// No new alias: the four definitions from the first join are all there is.
+	assert.ElementsMatch(t,
+		[]string{"Pet", "Category", "Pet.clinic", "Category.clinic"},
+		definitionNames(d))
+	assert.Equal(t, "#/definitions/Category", d.Definitions["Pet"].Properties["category"].Ref)
+	assert.Equal(t, "#/definitions/Pet", petResponseRef(t, d, "/store2/pet/{petId}"))
+}
+
+// TestRenameScopeSemanticDeduplication covers the second follow-on observation in
+// #478: the collision pass and the deduplication pass used to share one rewriter
+// and could register opposing directions for the same name, sending a reference
+// back to an alias that deduplication had just removed.
+func TestRenameScopeSemanticDeduplication(t *testing.T) {
+	res, err := JoinWithOptions(
+		WithParsed(petstoreFamily("store", false), petstoreFamily("clinic", false)),
+		WithSchemaStrategy(StrategyRenameRight),
+		WithEquivalenceMode("deep"),
+		WithSemanticDeduplication(true),
+		WithRenameTemplate(`{{.Name}}.{{.Source}}`),
+	)
+	require.NoError(t, err)
+
+	d := res.Document.(*parser.OAS2Document)
+
+	// The two Categories were identical, so deduplication kept one.
+	assert.NotContains(t, d.Definitions, "Category.clinic")
+
+	// Every reference names a definition that is still in the document.
+	for _, ref := range definitionRefs(d) {
+		name := extractSchemaName(ref)
+		assert.Contains(t, d.Definitions, name, "dangling reference %s", ref)
+	}
+}
+
+// TestRenameScopeNamespacePrefixThenCollision checks that a schema renamed twice,
+// first by a namespace prefix and then by a collision, resolves in one step.
+// References in the source document spell the original name, not the prefixed one.
+func TestRenameScopeNamespacePrefixThenCollision(t *testing.T) {
+	res, err := JoinWithOptions(
+		WithParsed(petstoreFamily("store", false), petstoreFamily("clinic", true)),
+		WithSchemaStrategy(StrategyRenameRight),
+		WithEquivalenceMode("deep"),
+		WithNamespacePrefix("store", "Api"),
+		WithNamespacePrefix("clinic", "Api"),
+		WithAlwaysApplyPrefix(true),
+		WithRenameTemplate(`{{.Name}}.{{.Source}}`),
+	)
+	require.NoError(t, err)
+
+	d := res.Document.(*parser.OAS2Document)
+
+	assert.Equal(t, "#/definitions/Api_Category", d.Definitions["Api_Pet"].Properties["category"].Ref)
+	assert.Equal(t, "#/definitions/Api_Category.clinic", d.Definitions["Api_Pet.clinic"].Properties["category"].Ref)
+
+	for _, ref := range definitionRefs(d) {
+		name := extractSchemaName(ref)
+		assert.Contains(t, d.Definitions, name, "dangling reference %s", ref)
+	}
+}
+
+// petstoreFamilyOAS3 is the OAS 3.0 counterpart of petstoreFamily.
+func petstoreFamilyOAS3(name string, withDescription bool) parser.ParseResult {
+	category := &parser.Schema{
+		Type: "object",
+		Properties: map[string]*parser.Schema{
+			"id":   {Type: "integer", Format: "int64"},
+			"name": {Type: "string"},
+		},
+	}
+	if withDescription {
+		category.Properties["description"] = &parser.Schema{Type: "string"}
+	}
+
+	return parser.ParseResult{
+		Document: &parser.OAS3Document{
+			OpenAPI: "3.0.3",
+			Info:    &parser.Info{Title: name, Version: "1.0.0"},
+			Paths: parser.Paths{
+				"/" + name + "/pet/{petId}": &parser.PathItem{Get: &parser.Operation{
+					OperationID: "getPetById" + name,
+					Responses: &parser.Responses{Codes: map[string]*parser.Response{
+						"200": {
+							Description: "successful operation",
+							Content: map[string]*parser.MediaType{
+								"application/json": {Schema: &parser.Schema{Ref: "#/components/schemas/Pet"}},
+							},
+						},
+					}},
+				}},
+			},
+			Components: &parser.Components{
+				Schemas: map[string]*parser.Schema{
+					"Pet": {
+						Type: "object",
+						Properties: map[string]*parser.Schema{
+							"id":       {Type: "integer", Format: "int64"},
+							"category": {Ref: "#/components/schemas/Category"},
+							"name":     {Type: "string"},
+						},
+					},
+					"Category": category,
+				},
+			},
+			OASVersion: parser.OASVersion303,
+		},
+		Version:      "3.0.3",
+		OASVersion:   parser.OASVersion303,
+		SourcePath:   name,
+		SourceFormat: "json",
+	}
+}
+
+// TestRenameScopeOAS3 confirms the OAS 3 path scopes renames the same way. #478
+// reproduced on OAS 2.0 but noted the same rewrite-then-traverse structure here.
+func TestRenameScopeOAS3(t *testing.T) {
+	res, err := JoinWithOptions(
+		WithParsed(petstoreFamilyOAS3("store", false), petstoreFamilyOAS3("clinic", true)),
+		WithSchemaStrategy(StrategyRenameRight),
+		WithEquivalenceMode("deep"),
+		WithRenameTemplate(`{{.Name}}.{{.Source}}`),
+	)
+	require.NoError(t, err)
+
+	d := res.Document.(*parser.OAS3Document)
+	schemas := d.Components.Schemas
+
+	assert.Equal(t, "#/components/schemas/Category", schemas["Pet"].Properties["category"].Ref)
+	assert.Equal(t, "#/components/schemas/Category.clinic", schemas["Pet.clinic"].Properties["category"].Ref)
+
+	assert.Equal(t, "#/components/schemas/Pet",
+		oas3ResponseRef(t, d, "/store/pet/{petId}"))
+	assert.Equal(t, "#/components/schemas/Pet.clinic",
+		oas3ResponseRef(t, d, "/clinic/pet/{petId}"))
+}
+
+func oas3ResponseRef(t *testing.T, doc *parser.OAS3Document, path string) string {
+	t.Helper()
+	item, ok := doc.Paths[path]
+	require.True(t, ok, "path %s missing", path)
+	require.NotNil(t, item.Get)
+	require.NotNil(t, item.Get.Responses)
+	resp, ok := item.Get.Responses.Codes["200"]
+	require.True(t, ok, "200 response missing on %s", path)
+	media, ok := resp.Content["application/json"]
+	require.True(t, ok, "json content missing on %s", path)
+	require.NotNil(t, media.Schema)
+	return media.Schema.Ref
+}
+
+// TestRenameScopeCoversEveryContainer exercises every top-level container the
+// rewriter traverses. A container that renameScope forgets to attribute to a
+// source document belongs to no document, so its references are never rewritten
+// and the join emits a dangling reference. This fails loudly if the two lists
+// drift apart.
+func TestRenameScopeCoversEveryContainer(t *testing.T) {
+	// containerRef builds an operation whose 200 response references Target.
+	containerRef := func() *parser.Operation {
+		return &parser.Operation{
+			Responses: &parser.Responses{Codes: map[string]*parser.Response{
+				"200": {
+					Description: "ok",
+					Content: map[string]*parser.MediaType{
+						"application/json": {Schema: &parser.Schema{Ref: "#/components/schemas/Target"}},
+					},
+				},
+			}},
+		}
+	}
+
+	// doc names every component after its source so that only Target collides.
+	doc := func(name string, extra bool) parser.ParseResult {
+		target := &parser.Schema{
+			Type:       "object",
+			Properties: map[string]*parser.Schema{"id": {Type: "string"}},
+		}
+		if extra {
+			target.Properties["note"] = &parser.Schema{Type: "string"}
+		}
+		targetRef := func() *parser.Schema { return &parser.Schema{Ref: "#/components/schemas/Target"} }
+		jsonContent := func() map[string]*parser.MediaType {
+			return map[string]*parser.MediaType{"application/json": {Schema: targetRef()}}
+		}
+
+		callback := parser.Callback{"{$request.body#/url}": &parser.PathItem{Post: containerRef()}}
+
+		return parser.ParseResult{
+			Document: &parser.OAS3Document{
+				OpenAPI: "3.1.0",
+				Info:    &parser.Info{Title: name, Version: "1.0.0"},
+				Paths: parser.Paths{
+					"/" + name: &parser.PathItem{Get: containerRef()},
+				},
+				Webhooks: map[string]*parser.PathItem{
+					name + "Hook": {Post: containerRef()},
+				},
+				Components: &parser.Components{
+					Schemas: map[string]*parser.Schema{
+						"Target": target,
+						name + "Holder": {
+							Type:       "object",
+							Properties: map[string]*parser.Schema{"target": targetRef()},
+						},
+					},
+					Parameters: map[string]*parser.Parameter{
+						name + "Param": {Name: "q", In: "query", Schema: targetRef()},
+					},
+					Responses: map[string]*parser.Response{
+						name + "Resp": {Description: "ok", Content: jsonContent()},
+					},
+					RequestBodies: map[string]*parser.RequestBody{
+						name + "Body": {Content: jsonContent()},
+					},
+					Headers: map[string]*parser.Header{
+						name + "Header": {Schema: targetRef()},
+					},
+					Callbacks: map[string]*parser.Callback{
+						name + "CB": &callback,
+					},
+					PathItems: map[string]*parser.PathItem{
+						name + "PI": {Get: containerRef()},
+					},
+				},
+				OASVersion: parser.OASVersion310,
+			},
+			Version:      "3.1.0",
+			OASVersion:   parser.OASVersion310,
+			SourcePath:   name,
+			SourceFormat: "json",
+		}
+	}
+
+	res, err := JoinWithOptions(
+		WithParsed(doc("a", false), doc("b", true)),
+		WithSchemaStrategy(StrategyRenameRight),
+		WithEquivalenceMode("deep"),
+		WithRenameTemplate(`{{.Name}}.{{.Source}}`),
+	)
+	require.NoError(t, err)
+
+	d := res.Document.(*parser.OAS3Document)
+	c := d.Components
+	require.Contains(t, c.Schemas, "Target.b", "b's Target should have been renamed")
+
+	// Every reference from each document, keyed by the container it lives in.
+	refs := func(source string) map[string]string {
+		callback := *c.Callbacks[source+"CB"]
+		return map[string]string{
+			"components.schemas":       c.Schemas[source+"Holder"].Properties["target"].Ref,
+			"components.parameters":    c.Parameters[source+"Param"].Schema.Ref,
+			"components.responses":     c.Responses[source+"Resp"].Content["application/json"].Schema.Ref,
+			"components.requestBodies": c.RequestBodies[source+"Body"].Content["application/json"].Schema.Ref,
+			"components.headers":       c.Headers[source+"Header"].Schema.Ref,
+			"components.callbacks":     oas3ResponseRefIn(t, callback["{$request.body#/url}"].Post),
+			"components.pathItems":     oas3ResponseRefIn(t, c.PathItems[source+"PI"].Get),
+			"paths":                    oas3ResponseRefIn(t, d.Paths["/"+source].Get),
+			"webhooks":                 oas3ResponseRefIn(t, d.Webhooks[source+"Hook"].Post),
+		}
+	}
+
+	for container, ref := range refs("b") {
+		assert.Equal(t, "#/components/schemas/Target.b", ref,
+			"%s: b's reference was not rewritten, so renameScope does not attribute this container", container)
+	}
+	for container, ref := range refs("a") {
+		assert.Equal(t, "#/components/schemas/Target", ref,
+			"%s: a's reference was repointed at b's schema", container)
+	}
+}
+
+func oas3ResponseRefIn(t *testing.T, op *parser.Operation) string {
+	t.Helper()
+	require.NotNil(t, op)
+	require.NotNil(t, op.Responses)
+	resp, ok := op.Responses.Codes["200"]
+	require.True(t, ok, "200 response missing")
+	media, ok := resp.Content["application/json"]
+	require.True(t, ok, "json content missing")
+	require.NotNil(t, media.Schema)
+	return media.Schema.Ref
+}
+
+// petVariant is a minimal document whose single definition carries one property
+// named after the document, so a schema can be traced back to its source.
+func petVariant(name string) parser.ParseResult {
+	return parser.ParseResult{
+		Document: &parser.OAS2Document{
+			Swagger: "2.0",
+			Info:    &parser.Info{Title: name, Version: "1.0.0"},
+			Paths: parser.Paths{
+				"/" + name: &parser.PathItem{Get: &parser.Operation{
+					Responses: &parser.Responses{Codes: map[string]*parser.Response{
+						"200": {Description: "ok", Schema: &parser.Schema{Ref: "#/definitions/Pet"}},
+					}},
+				}},
+			},
+			Definitions: map[string]*parser.Schema{
+				"Pet": {Type: "object", Properties: map[string]*parser.Schema{
+					"from" + name: {Type: "string"},
+				}},
+			},
+			OASVersion: parser.OASVersion20,
+		},
+		Version:      "2.0",
+		OASVersion:   parser.OASVersion20,
+		SourcePath:   name,
+		SourceFormat: "json",
+	}
+}
+
+// TestRenameLeftNamesEachContributor covers #479: rename-left named the moved
+// schema after the first document every time, so the second rename in a three
+// document join generated a name that was already taken and overwrote it.
+func TestRenameLeftNamesEachContributor(t *testing.T) {
+	res, err := JoinWithOptions(
+		WithParsed(petVariant("a"), petVariant("b"), petVariant("c")),
+		WithSchemaStrategy(StrategyRenameLeft),
+		WithPathStrategy(StrategyAcceptLeft),
+		WithRenameTemplate(`{{.Name}}.{{.Source}}`),
+	)
+	require.NoError(t, err)
+
+	d := res.Document.(*parser.OAS2Document)
+
+	// Every document keeps a schema, each named after the document it came from
+	// except the last, which holds the original name.
+	assert.ElementsMatch(t, []string{"Pet.a", "Pet.b", "Pet"}, definitionNames(d))
+	assert.Contains(t, d.Definitions["Pet.a"].Properties, "froma")
+	assert.Contains(t, d.Definitions["Pet.b"].Properties, "fromb")
+	assert.Contains(t, d.Definitions["Pet"].Properties, "fromc")
+
+	// And each document's path names its own schema.
+	assert.Equal(t, "#/definitions/Pet.a", petResponseRef(t, d, "/a"))
+	assert.Equal(t, "#/definitions/Pet.b", petResponseRef(t, d, "/b"))
+	assert.Equal(t, "#/definitions/Pet", petResponseRef(t, d, "/c"))
+}
+
+// TestRenameLeftReportsContributingSource checks that the collision report and
+// the rename name agree on which document the left schema came from.
+func TestRenameLeftReportsContributingSource(t *testing.T) {
+	res, err := JoinWithOptions(
+		WithParsed(petVariant("a"), petVariant("b"), petVariant("c")),
+		WithSchemaStrategy(StrategyRenameLeft),
+		WithPathStrategy(StrategyAcceptLeft),
+		WithRenameTemplate(`{{.Name}}.{{.Source}}`),
+		WithCollisionReport(true),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, res.CollisionDetails)
+
+	byNewName := make(map[string]string)
+	for _, event := range res.CollisionDetails.Events {
+		byNewName[event.NewName] = event.LeftSource
+	}
+	assert.Equal(t, "a", byNewName["Pet.a"])
+	assert.Equal(t, "b", byNewName["Pet.b"], "the second rename moved b's schema, not a's")
+
+	assert.Contains(t, res.Warnings, "definition 'Pet' from a renamed to 'Pet.a' (incoming document takes the original name)")
+	assert.Contains(t, res.Warnings, "definition 'Pet' from b renamed to 'Pet.b' (incoming document takes the original name)")
+}
+
+// TestJoinSameDocumentTwice covers #481: the two positions used to share every
+// pointer, so keeping both sides stored one schema under two names.
+func TestJoinSameDocumentTwice(t *testing.T) {
+	doc := petVariant("a")
+
+	res, err := JoinWithOptions(
+		WithParsed(doc, doc),
+		WithSchemaStrategy(StrategyRenameRight),
+		WithPathStrategy(StrategyAcceptLeft),
+		WithRenameTemplate(`{{.Name}}.{{.Source}}`),
+	)
+	require.NoError(t, err)
+
+	d := res.Document.(*parser.OAS2Document)
+	require.Contains(t, d.Definitions, "Pet")
+	require.Contains(t, d.Definitions, "Pet.a")
+	assert.NotSame(t, d.Definitions["Pet"], d.Definitions["Pet.a"],
+		"the two positions must not share one schema")
+
+	// Editing one must not be visible through the other.
+	d.Definitions["Pet.a"].Description = "the second position"
+	assert.Empty(t, d.Definitions["Pet"].Description)
+}
+
+func definitionNames(doc *parser.OAS2Document) []string {
+	names := make([]string, 0, len(doc.Definitions))
+	for name := range doc.Definitions {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func TestRenameScopeRegisterRight(t *testing.T) {
+	s := newRenameScope(2, parser.OASVersion20)
+
+	s.registerRight(1, "Pet", "Api_Pet")
+	assert.Equal(t, map[string]string{"Pet": "Api_Pet"}, s.byDoc[1])
+
+	// A second rename of the same schema (a prefix, then a collision) replaces the
+	// mapping rather than stranding references at the intermediate name.
+	s.registerRight(1, "Pet", "Api_Pet.clinic")
+	assert.Equal(t, map[string]string{"Pet": "Api_Pet.clinic"}, s.byDoc[1])
+
+	// Documents that did not contribute the schema are untouched.
+	assert.Empty(t, s.byDoc[0])
+
+	// Out-of-range indices are ignored rather than panicking.
+	s.registerRight(-1, "Pet", "Pet_x")
+	s.registerRight(9, "Pet", "Pet_x")
+}
+
+func TestRenameScopeRegisterLeft(t *testing.T) {
+	t.Run("applies to earlier documents only", func(t *testing.T) {
+		s := newRenameScope(3, parser.OASVersion20)
+
+		s.registerLeft(2, "Pet", "Pet.store")
+
+		assert.Equal(t, map[string]string{"Pet": "Pet.store"}, s.byDoc[0])
+		assert.Equal(t, map[string]string{"Pet": "Pet.store"}, s.byDoc[1])
+		assert.Empty(t, s.byDoc[2])
+	})
+
+	t.Run("redirects an existing mapping instead of adding a second", func(t *testing.T) {
+		s := newRenameScope(2, parser.OASVersion20)
+		s.registerRight(0, "Pet", "Api_Pet")
+
+		s.registerLeft(1, "Api_Pet", "Api_Pet.store")
+
+		assert.Equal(t, "Api_Pet.store", s.byDoc[0]["Pet"])
+	})
+
+	t.Run("leaves a document whose name already resolves elsewhere", func(t *testing.T) {
+		s := newRenameScope(3, parser.OASVersion20)
+		s.registerRight(1, "Pet", "Pet.clinic")
+
+		// Document 1's Pet is already Pet.clinic, so moving the schema currently
+		// under "Pet" is not about document 1.
+		s.registerLeft(2, "Pet", "Pet.store")
+
+		assert.Equal(t, map[string]string{"Pet": "Pet.store"}, s.byDoc[0])
+		assert.Equal(t, map[string]string{"Pet": "Pet.clinic"}, s.byDoc[1])
+	})
+}
+
+func TestRenameScopeApplyWithoutRenames(t *testing.T) {
+	var nilScope *renameScope
+	assert.NoError(t, nilScope.applyOAS2(&parser.OAS2Document{}, nil))
+	assert.NoError(t, nilScope.applyOAS3(&parser.OAS3Document{}, nil))
+
+	// A scope that recorded nothing skips the rewrite entirely.
+	empty := newRenameScope(2, parser.OASVersion20)
+	assert.True(t, empty.empty())
+	assert.NoError(t, empty.applyOAS2(&parser.OAS2Document{}, nil))
+}

--- a/joiner/rename_scope_test.go
+++ b/joiner/rename_scope_test.go
@@ -61,7 +61,7 @@ func petstoreFamily(name string, withDescription bool) parser.ParseResult {
 		Version:      "2.0",
 		OASVersion:   parser.OASVersion20,
 		SourcePath:   name,
-		SourceFormat: "json",
+		SourceFormat: parser.SourceFormatJSON,
 	}
 }
 
@@ -286,7 +286,7 @@ func petstoreFamilyOAS3(name string, withDescription bool) parser.ParseResult {
 		Version:      "3.0.3",
 		OASVersion:   parser.OASVersion303,
 		SourcePath:   name,
-		SourceFormat: "json",
+		SourceFormat: parser.SourceFormatJSON,
 	}
 }
 
@@ -403,7 +403,7 @@ func TestRenameScopeCoversEveryContainer(t *testing.T) {
 			Version:      "3.1.0",
 			OASVersion:   parser.OASVersion310,
 			SourcePath:   name,
-			SourceFormat: "json",
+			SourceFormat: parser.SourceFormatJSON,
 		}
 	}
 
@@ -488,7 +488,7 @@ func TestRenameScopeCoversEveryContainerOAS2(t *testing.T) {
 			Version:      "2.0",
 			OASVersion:   parser.OASVersion20,
 			SourcePath:   name,
-			SourceFormat: "json",
+			SourceFormat: parser.SourceFormatJSON,
 		}
 	}
 
@@ -648,7 +648,7 @@ func petVariant(name string) parser.ParseResult {
 		Version:      "2.0",
 		OASVersion:   parser.OASVersion20,
 		SourcePath:   name,
-		SourceFormat: "json",
+		SourceFormat: parser.SourceFormatJSON,
 	}
 }
 

--- a/joiner/rewriter.go
+++ b/joiner/rewriter.go
@@ -47,6 +47,18 @@ func (r *SchemaRewriter) skipEntry(entry any) bool {
 	return r.owns != nil && !r.owns(entry)
 }
 
+// rewriteEntries applies fn to each in-scope entry of a top-level container.
+// Every such container goes through here, so a new one cannot miss the scope
+// check.
+func rewriteEntries[T any](r *SchemaRewriter, entries map[string]*T, fn func(*T)) {
+	for _, entry := range entries {
+		if r.skipEntry(entry) {
+			continue
+		}
+		fn(entry)
+	}
+}
+
 // RewriteDocument traverses and rewrites all references in the document
 func (r *SchemaRewriter) RewriteDocument(doc any) error {
 	// Reset visited tracking for new traversal
@@ -74,110 +86,31 @@ func schemaRefPath(name string, version parser.OASVersion) string {
 func (r *SchemaRewriter) rewriteOAS3Document(doc *parser.OAS3Document) error {
 	// Rewrite references in components
 	if doc.Components != nil {
-		// Schemas
-		for _, schema := range doc.Components.Schemas {
-			if r.skipEntry(schema) {
-				continue
-			}
-			r.rewriteSchema(schema)
-		}
-		// Parameters
-		for _, param := range doc.Components.Parameters {
-			if r.skipEntry(param) {
-				continue
-			}
-			r.rewriteParameter(param)
-		}
-		// Responses
-		for _, resp := range doc.Components.Responses {
-			if r.skipEntry(resp) {
-				continue
-			}
-			r.rewriteResponse(resp)
-		}
-		// Request bodies
-		for _, reqBody := range doc.Components.RequestBodies {
-			if r.skipEntry(reqBody) {
-				continue
-			}
-			r.rewriteRequestBody(reqBody)
-		}
-		// Headers
-		for _, header := range doc.Components.Headers {
-			if r.skipEntry(header) {
-				continue
-			}
-			r.rewriteHeader(header)
-		}
-		// Callbacks
-		for _, callback := range doc.Components.Callbacks {
-			if r.skipEntry(callback) {
-				continue
-			}
-			r.rewriteCallback(callback)
-		}
+		rewriteEntries(r, doc.Components.Schemas, r.rewriteSchema)
+		rewriteEntries(r, doc.Components.Parameters, r.rewriteParameter)
+		rewriteEntries(r, doc.Components.Responses, r.rewriteResponse)
+		rewriteEntries(r, doc.Components.RequestBodies, r.rewriteRequestBody)
+		rewriteEntries(r, doc.Components.Headers, r.rewriteHeader)
+		rewriteEntries(r, doc.Components.Callbacks, r.rewriteCallback)
 		// Links - intentionally not rewritten (don't contain schema references)
-		// Path items
-		for _, pathItem := range doc.Components.PathItems {
-			if r.skipEntry(pathItem) {
-				continue
-			}
-			r.rewritePathItem(pathItem)
-		}
+		rewriteEntries(r, doc.Components.PathItems, r.rewritePathItem)
 	}
 
 	// Rewrite references in paths
-	for _, pathItem := range doc.Paths {
-		if r.skipEntry(pathItem) {
-			continue
-		}
-		r.rewritePathItem(pathItem)
-	}
+	rewriteEntries(r, doc.Paths, r.rewritePathItem)
 
 	// Rewrite references in webhooks (OAS 3.1+)
-	for _, webhook := range doc.Webhooks {
-		if r.skipEntry(webhook) {
-			continue
-		}
-		r.rewritePathItem(webhook)
-	}
+	rewriteEntries(r, doc.Webhooks, r.rewritePathItem)
 
 	return nil
 }
 
 // rewriteOAS2Document rewrites all references in an OAS 2.0 document
 func (r *SchemaRewriter) rewriteOAS2Document(doc *parser.OAS2Document) error {
-	// Rewrite references in definitions
-	for _, schema := range doc.Definitions {
-		if r.skipEntry(schema) {
-			continue
-		}
-		r.rewriteSchema(schema)
-	}
-
-	// Rewrite references in parameters
-	for _, param := range doc.Parameters {
-		if r.skipEntry(param) {
-			continue
-		}
-		r.rewriteParameter(param)
-	}
-
-	// Rewrite references in responses
-	for _, resp := range doc.Responses {
-		if r.skipEntry(resp) {
-			continue
-		}
-		r.rewriteResponse(resp)
-	}
-
-	// Rewrite references in paths
-	for _, pathItem := range doc.Paths {
-		if r.skipEntry(pathItem) {
-			continue
-		}
-		r.rewritePathItem(pathItem)
-	}
+	rewriteEntries(r, doc.Definitions, r.rewriteSchema)
+	rewriteEntries(r, doc.Parameters, r.rewriteParameter)
+	rewriteEntries(r, doc.Responses, r.rewriteResponse)
+	rewriteEntries(r, doc.Paths, r.rewritePathItem)
 
 	return nil
 }

--- a/joiner/rewriter.go
+++ b/joiner/rewriter.go
@@ -34,20 +34,15 @@ func (r *SchemaRewriter) RegisterRename(oldName, newName string, version parser.
 	r.bareNameMap[oldName] = newName
 }
 
-// restrictTo limits the rewrite to the top-level entries the predicate accepts,
-// leaving the rest of the document alone. A nil predicate rewrites everything.
-//
-// The joiner uses this to apply one source document's renames to the entries
-// that document contributed: a rename resolves a collision between two
-// documents and does not speak for the references that arrived with the others
-// (see renameScope and #478).
+// restrictTo limits the rewrite to the top-level entries the predicate accepts.
+// A nil predicate rewrites everything. Used to scope renames to the entries one
+// source document contributed (#478).
 func (r *SchemaRewriter) restrictTo(owns func(entry any) bool) {
 	r.owns = owns
 }
 
-// skipEntry reports whether a top-level entry falls outside the rewrite's scope.
-// It is consulted once per entry, so a subtree is descended into at most once
-// even when the same document is rewritten under several restrictions.
+// skipEntry reports whether a top-level entry is out of scope. Checked once per
+// entry, so a skipped subtree is never descended into.
 func (r *SchemaRewriter) skipEntry(entry any) bool {
 	return r.owns != nil && !r.owns(entry)
 }

--- a/joiner/rewriter.go
+++ b/joiner/rewriter.go
@@ -14,6 +14,7 @@ type SchemaRewriter struct {
 	refMap      map[string]string // Full ref path: "#/components/schemas/Old" → "#/components/schemas/New"
 	bareNameMap map[string]string // Bare name: "Old" → "New" (for discriminator shorthand)
 	visited     map[uintptr]bool  // Tracks visited nodes to prevent infinite loops
+	owns        func(entry any) bool
 }
 
 // NewSchemaRewriter creates a new rewriter instance
@@ -31,6 +32,24 @@ func (r *SchemaRewriter) RegisterRename(oldName, newName string, version parser.
 	newRef := schemaRefPath(newName, version)
 	r.refMap[oldRef] = newRef
 	r.bareNameMap[oldName] = newName
+}
+
+// restrictTo limits the rewrite to the top-level entries the predicate accepts,
+// leaving the rest of the document alone. A nil predicate rewrites everything.
+//
+// The joiner uses this to apply one source document's renames to the entries
+// that document contributed: a rename resolves a collision between two
+// documents and does not speak for the references that arrived with the others
+// (see renameScope and #478).
+func (r *SchemaRewriter) restrictTo(owns func(entry any) bool) {
+	r.owns = owns
+}
+
+// skipEntry reports whether a top-level entry falls outside the rewrite's scope.
+// It is consulted once per entry, so a subtree is descended into at most once
+// even when the same document is rewritten under several restrictions.
+func (r *SchemaRewriter) skipEntry(entry any) bool {
+	return r.owns != nil && !r.owns(entry)
 }
 
 // RewriteDocument traverses and rewrites all references in the document
@@ -62,42 +81,69 @@ func (r *SchemaRewriter) rewriteOAS3Document(doc *parser.OAS3Document) error {
 	if doc.Components != nil {
 		// Schemas
 		for _, schema := range doc.Components.Schemas {
+			if r.skipEntry(schema) {
+				continue
+			}
 			r.rewriteSchema(schema)
 		}
 		// Parameters
 		for _, param := range doc.Components.Parameters {
+			if r.skipEntry(param) {
+				continue
+			}
 			r.rewriteParameter(param)
 		}
 		// Responses
 		for _, resp := range doc.Components.Responses {
+			if r.skipEntry(resp) {
+				continue
+			}
 			r.rewriteResponse(resp)
 		}
 		// Request bodies
 		for _, reqBody := range doc.Components.RequestBodies {
+			if r.skipEntry(reqBody) {
+				continue
+			}
 			r.rewriteRequestBody(reqBody)
 		}
 		// Headers
 		for _, header := range doc.Components.Headers {
+			if r.skipEntry(header) {
+				continue
+			}
 			r.rewriteHeader(header)
 		}
 		// Callbacks
 		for _, callback := range doc.Components.Callbacks {
+			if r.skipEntry(callback) {
+				continue
+			}
 			r.rewriteCallback(callback)
 		}
 		// Links - intentionally not rewritten (don't contain schema references)
 		// Path items
 		for _, pathItem := range doc.Components.PathItems {
+			if r.skipEntry(pathItem) {
+				continue
+			}
 			r.rewritePathItem(pathItem)
 		}
 	}
 
 	// Rewrite references in paths
 	for _, pathItem := range doc.Paths {
+		if r.skipEntry(pathItem) {
+			continue
+		}
 		r.rewritePathItem(pathItem)
 	}
 
 	// Rewrite references in webhooks (OAS 3.1+)
 	for _, webhook := range doc.Webhooks {
+		if r.skipEntry(webhook) {
+			continue
+		}
 		r.rewritePathItem(webhook)
 	}
 
@@ -108,21 +154,33 @@ func (r *SchemaRewriter) rewriteOAS3Document(doc *parser.OAS3Document) error {
 func (r *SchemaRewriter) rewriteOAS2Document(doc *parser.OAS2Document) error {
 	// Rewrite references in definitions
 	for _, schema := range doc.Definitions {
+		if r.skipEntry(schema) {
+			continue
+		}
 		r.rewriteSchema(schema)
 	}
 
 	// Rewrite references in parameters
 	for _, param := range doc.Parameters {
+		if r.skipEntry(param) {
+			continue
+		}
 		r.rewriteParameter(param)
 	}
 
 	// Rewrite references in responses
 	for _, resp := range doc.Responses {
+		if r.skipEntry(resp) {
+			continue
+		}
 		r.rewriteResponse(resp)
 	}
 
 	// Rewrite references in paths
 	for _, pathItem := range doc.Paths {
+		if r.skipEntry(pathItem) {
+			continue
+		}
 		r.rewritePathItem(pathItem)
 	}
 

--- a/joiner/warnings.go
+++ b/joiner/warnings.go
@@ -148,10 +148,8 @@ func NewSchemaCollisionWarning(schemaName, resolution, section, firstFile, secon
 
 // NewSchemaRenamedWarning creates a warning when a schema is renamed.
 //
-// sourceFile names the document the renamed schema came from, which for
-// keptOriginal (rename-left) is the document already in the join rather than the
-// incoming one. Naming it matters once three or more documents are joined, where
-// each rename moves a different document's schema aside (#479).
+// sourceFile names the document the renamed schema came from. For keptOriginal
+// (rename-left) that is the document already in the join, not the incoming one.
 func NewSchemaRenamedWarning(originalName, newName, section, sourceFile string, line, col int, keptOriginal bool) *JoinWarning {
 	msg := fmt.Sprintf("%s '%s' from %s renamed to '%s'", section, originalName, sourceFile, newName)
 	if keptOriginal {

--- a/joiner/warnings.go
+++ b/joiner/warnings.go
@@ -147,12 +147,15 @@ func NewSchemaCollisionWarning(schemaName, resolution, section, firstFile, secon
 }
 
 // NewSchemaRenamedWarning creates a warning when a schema is renamed.
+//
+// sourceFile names the document the renamed schema came from, which for
+// keptOriginal (rename-left) is the document already in the join rather than the
+// incoming one. Naming it matters once three or more documents are joined, where
+// each rename moves a different document's schema aside (#479).
 func NewSchemaRenamedWarning(originalName, newName, section, sourceFile string, line, col int, keptOriginal bool) *JoinWarning {
-	var msg string
+	msg := fmt.Sprintf("%s '%s' from %s renamed to '%s'", section, originalName, sourceFile, newName)
 	if keptOriginal {
-		msg = fmt.Sprintf("%s '%s' renamed to '%s' (kept from first document)", section, originalName, newName)
-	} else {
-		msg = fmt.Sprintf("%s '%s' from %s renamed to '%s'", section, originalName, sourceFile, newName)
+		msg += " (incoming document takes the original name)"
 	}
 	return &JoinWarning{
 		Category:   WarnSchemaRenamed,

--- a/joiner/warnings_test.go
+++ b/joiner/warnings_test.go
@@ -150,6 +150,7 @@ func TestNewSchemaRenamedWarning(t *testing.T) {
 			assert.Equal(t, WarnSchemaRenamed, w.Category)
 			assert.Equal(t, severity.SeverityInfo, w.Severity)
 			assert.Equal(t, tt.keptOriginal, w.Context["kept_original"])
+			assert.Contains(t, w.Message, tt.wantContains)
 		})
 	}
 }

--- a/joiner/warnings_test.go
+++ b/joiner/warnings_test.go
@@ -134,7 +134,7 @@ func TestNewSchemaRenamedWarning(t *testing.T) {
 		{
 			name:         "kept original",
 			keptOriginal: true,
-			wantContains: "kept from first document",
+			wantContains: "incoming document takes the original name",
 		},
 		{
 			name:         "renamed source",


### PR DESCRIPTION
## Summary 🎯

The joiner merges by pointer, so the merged document is a graph stitched from several source subgraphs with nothing recording which source each node came from. `SchemaRewriter` keyed renames by ref string alone and ran **once over the whole merged document**, so a reference that was already correct got repointed along with the ones that needed it.

The join succeeded, every ref resolved, and the output validated. Only the meaning changed.

Fixes #478, #479, #481, #483.

## What changed

`renameScope` (new, `joiner/rename_scope.go`) keeps one rename map **per source document**:

| Rename | Rewrites | Why |
|---|---|---|
| rename-right, namespace prefix, handler `Rename` | that document alone | earlier documents' schema is still there under its original name |
| rename-left | every document merged **before** it | they all spelled the name that was just vacated |
| semantic deduplication | the whole document | the schemas were found equivalent, so the reference means the same thing whoever wrote it |
| handler `ResolutionCustom` | the whole document | the value came from no document, so there is no namespace to read it in |

Ownership is derived after the merge from each source document's top-level containers, keyed by pointer identity, so **no merge call site changed**. `SchemaRewriter.restrictTo` gates the existing traversal, keeping one traversal function for the scoped and document-wide cases.

Two more defects fell out of the same change: renames now key on the schema's name **in its own document**, so a namespace prefix followed by a collision no longer strands a reference at the intermediate name; and deduplication gets its own rewriter applied after the scoped ones, so the two passes can no longer register opposing directions into one map. Deduplication also now compares references in their final form, which is what made incremental joins accumulate aliases.

## The other three issues

**#479** rename-left named the moved schema after the first document every time, so the second rename in a three document join generated a name that was already taken and silently overwrote it:

```
before: Pet{fromC}  Pet.a{fromB}                 <- document a's schema gone
after:  Pet{fromC}  Pet.a{fromA}  Pet.b{fromB}
```

`JoinResult.origins` records the contributing document, and the rename, the collision event and the warning all use it. The map is only allocated when rename-left or a collision handler can read it.

**#481** a document handed in at two positions shared every schema with itself, so a strategy keeping both sides stored one schema under two names. Repeat positions are deep copied. Detection is a linear scan over the already-collected sources, so it costs no allocation.

**#483** a generated rename target that was already taken overwrote the schema under it. Reachable when a document already uses the generated name, when a template discards `{{.Name}}`, and when a template is just `{{.Name}}`. `uniqueSchemaName` suffixes with `_2`, `_3` at all five sites that store under a generated name. Suffixing rather than failing keeps joins that used to succeed succeeding, and the rename warning already reports the name that was used.

## Performance ⚡

`benchstat`, n=6, Apple M4, against main:

```
JoinParsed/TwoDocs                       +6.21%   (+2 allocs)
JoinParsed/ThreeDocs                          ~   (p=0.372)
JoinParsed/FiveDocs                      +3.90%   (+3 allocs)

github-api.json   11 MB, rename-right   -36.60% time, -13.78% memory
stripe-spec3      7 MB,  rename-right   -31.99% time, -10.30% memory
discord            1 MB, rename-right   -10.02% time
```

Joins that rename are **faster than main**: a document with no renames is no longer traversed at all. Joins that rename nothing pay one slice and a lazily created map.

A first attempt deep copied every input so the rewrite could drive off the source documents. It measured at +167% time and +729% memory on github-api.json and was replaced by the ownership approach, which needs no copy.

## Behavior changes ⚠️

- `JoinResult.Warnings` strings changed for rename-left: `"definition 'Pet' renamed to 'Pet.a' (kept from first document)"` becomes `"definition 'Pet' from a renamed to 'Pet.a' (incoming document takes the original name)"`. The old text named no document and was wrong for every rename past the first. No in-repo consumer matches on these strings.
- A generated rename target that is already taken now gets a `_2` suffix instead of replacing the schema under it.
- Passing the same parsed document at two positions now yields two independent schemas.

## Tests 🧪

- Every integration test in `rename_scope_test.go` fails against the pre-fix code, verified by reverting.
- `TestRenameScopeCoversEveryContainer` and its OAS 2 counterpart exercise all 13 top-level containers the rewriter traverses. Verified by removing each `claimEntries` call in turn: every one fails the guard.
- `BenchmarkJoinRenames` covers the rename path, which nothing did. The testdata join fixtures define disjoint schema names (User, Post, Comment) and never collide, so the existing benchmarks never reach it.
- `BenchmarkJoinParsed/FiveDocs` reused two of its parsed documents, which after #481 measured the deep copy rather than a five document join, so it now parses five distinct documents.

`make check` clean, 10784 tests, no gopls diagnostics.

## Review notes 📝

Three rounds of CodeRabbit ran locally before opening. It caught a regression this PR introduced: a handler's `ResolutionCustom` value belongs to no document, so the ownership gate skipped it in every pass and left its references dangling. Fixed in 1a3b1bb with a final pass over unowned entries.

The commits are separable by concern, though they interleave in `oas2.go` and `oas3.go`.

## Follow-ups

- #480 the joined document shares schema pointers with its inputs, so joining rewrites the caller's documents. Pre-existing. Needs a targeted copy plus its own benchmark, which is why it is not here. Next PR, same release.
- #482 operation-aware rename templates do not reach the left side of a rename-left collision.