### PR TITLE
fix(joiner): stop rewriting the documents the caller handed in

### DIFF
--- a/joiner/deep_dive.md
+++ b/joiner/deep_dive.md
@@ -79,6 +79,8 @@ A rename only rewrites the references of documents that used the renamed name:
 
 Semantic deduplication rewrites every reference to a removed name, because the schemas were equivalent.
 
+Joining does not modify the documents it was given. The merged document holds the schemas and path items its inputs contributed, so anything whose references change is copied first. Entries that are not rewritten are still shared with the input they came from, which means the result is safe to read but should not be edited in place if the inputs are still in use.
+
 [↑ Back to top](#top)
 
 ## API Styles

--- a/joiner/input_mutation_test.go
+++ b/joiner/input_mutation_test.go
@@ -1,0 +1,194 @@
+package joiner
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/erraggy/oastools/parser"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// snapshot renders a parsed document so it can be compared before and after a join.
+func snapshot(t *testing.T, res parser.ParseResult) string {
+	t.Helper()
+	data, err := json.MarshalIndent(res.Document, "", "  ")
+	require.NoError(t, err)
+	return string(data)
+}
+
+// discriminatedOAS3 builds a document whose Pet schema selects a variant through
+// a discriminator, covering the mapping and defaultMapping rewrites as well as
+// the plain $ref one.
+func discriminatedOAS3(name string, extra bool) parser.ParseResult {
+	cat := &parser.Schema{Type: "object", Properties: map[string]*parser.Schema{"meow": {Type: "string"}}}
+	if extra {
+		cat.Properties["lives"] = &parser.Schema{Type: "integer"}
+	}
+	return parser.ParseResult{
+		Document: &parser.OAS3Document{
+			OpenAPI: "3.2.0",
+			Info:    &parser.Info{Title: name, Version: "1.0.0"},
+			Paths: parser.Paths{
+				"/" + name: &parser.PathItem{Get: &parser.Operation{
+					Responses: &parser.Responses{Codes: map[string]*parser.Response{
+						"200": {Description: "ok", Content: map[string]*parser.MediaType{
+							"application/json": {Schema: &parser.Schema{Ref: "#/components/schemas/Pet"}},
+						}},
+					}},
+				}},
+			},
+			Components: &parser.Components{
+				Schemas: map[string]*parser.Schema{
+					"Pet": {
+						Type:  "object",
+						OneOf: []*parser.Schema{{Ref: "#/components/schemas/Cat"}},
+						Discriminator: &parser.Discriminator{
+							PropertyName:   "kind",
+							Mapping:        map[string]string{"cat": "#/components/schemas/Cat"},
+							DefaultMapping: "#/components/schemas/Cat",
+						},
+					},
+					"Cat": cat,
+				},
+			},
+			OASVersion: parser.OASVersion320,
+		},
+		Version: "3.2.0", OASVersion: parser.OASVersion320,
+		SourcePath: name, SourceFormat: parser.SourceFormatJSON,
+	}
+}
+
+// TestJoinLeavesInputsUnchanged covers #480. The joined document holds the very
+// schemas and path items its inputs contributed, and the reference rewriting
+// used to edit them in place, so joining rewrote the caller's documents.
+func TestJoinLeavesInputsUnchanged(t *testing.T) {
+	customHandler := func(c CollisionContext) (CollisionResolution, error) {
+		if c.Type == CollisionTypeSchema && c.Name == "Pet" {
+			return UseCustomValue(&parser.Schema{
+				Type:       "object",
+				Properties: map[string]*parser.Schema{"category": {Ref: "#/definitions/Category"}},
+			}), nil
+		}
+		return ContinueWithStrategy(), nil
+	}
+
+	tests := []struct {
+		name string
+		docs func() []parser.ParseResult
+		opts []Option
+	}{
+		{
+			name: "oas2 rename-right",
+			docs: func() []parser.ParseResult {
+				return []parser.ParseResult{petstoreFamily("store", false), petstoreFamily("clinic", true)}
+			},
+			opts: []Option{WithSchemaStrategy(StrategyRenameRight), WithRenameTemplate(`{{.Name}}.{{.Source}}`)},
+		},
+		{
+			name: "oas2 rename-left",
+			docs: func() []parser.ParseResult {
+				return []parser.ParseResult{petstoreFamily("store", false), petstoreFamily("clinic", true)}
+			},
+			opts: []Option{WithSchemaStrategy(StrategyRenameLeft), WithRenameTemplate(`{{.Name}}.{{.Source}}`)},
+		},
+		{
+			name: "oas2 namespace prefix",
+			docs: func() []parser.ParseResult {
+				return []parser.ParseResult{petstoreFamily("store", false), petstoreFamily("clinic", true)}
+			},
+			opts: []Option{
+				WithSchemaStrategy(StrategyRenameRight),
+				WithNamespacePrefix("store", "Api"), WithNamespacePrefix("clinic", "Api"),
+				WithAlwaysApplyPrefix(true), WithRenameTemplate(`{{.Name}}.{{.Source}}`),
+			},
+		},
+		{
+			name: "oas2 semantic deduplication",
+			docs: func() []parser.ParseResult {
+				return []parser.ParseResult{petstoreFamily("store", false), petstoreFamily("clinic", false)}
+			},
+			opts: []Option{
+				WithSchemaStrategy(StrategyRenameRight), WithSemanticDeduplication(true),
+				WithEquivalenceMode("deep"), WithRenameTemplate(`{{.Name}}.{{.Source}}`),
+			},
+		},
+		{
+			name: "oas2 handler custom value",
+			docs: func() []parser.ParseResult {
+				return []parser.ParseResult{petstoreFamily("store", false), petstoreFamily("clinic", true)}
+			},
+			opts: []Option{
+				WithSchemaStrategy(StrategyRenameRight), WithRenameTemplate(`{{.Name}}.{{.Source}}`),
+				WithCollisionHandler(customHandler),
+			},
+		},
+		{
+			name: "oas2 accept-left renames nothing",
+			docs: func() []parser.ParseResult {
+				return []parser.ParseResult{petstoreFamily("store", false), petstoreFamily("clinic", true)}
+			},
+			opts: []Option{WithSchemaStrategy(StrategyAcceptLeft)},
+		},
+		{
+			name: "oas3 rename-right",
+			docs: func() []parser.ParseResult {
+				return []parser.ParseResult{petstoreFamilyOAS3("store", false), petstoreFamilyOAS3("clinic", true)}
+			},
+			opts: []Option{WithSchemaStrategy(StrategyRenameRight), WithRenameTemplate(`{{.Name}}.{{.Source}}`)},
+		},
+		{
+			name: "oas3 discriminator mapping",
+			docs: func() []parser.ParseResult {
+				return []parser.ParseResult{discriminatedOAS3("a", false), discriminatedOAS3("b", true)}
+			},
+			opts: []Option{WithSchemaStrategy(StrategyRenameRight), WithRenameTemplate(`{{.Name}}.{{.Source}}`)},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			docs := tt.docs()
+			before := make([]string, len(docs))
+			for i := range docs {
+				before[i] = snapshot(t, docs[i])
+			}
+
+			opts := append([]Option{WithParsed(docs...), WithPathStrategy(StrategyAcceptLeft)}, tt.opts...)
+			_, err := JoinWithOptions(opts...)
+			require.NoError(t, err)
+
+			for i := range docs {
+				assert.Equal(t, before[i], snapshot(t, docs[i]),
+					"joining modified input %d (%s)", i, docs[i].SourcePath)
+			}
+		})
+	}
+}
+
+// TestJoinDiscriminatorRewriteStillApplies guards the other half: the copy is
+// only worth anything if the joined document still gets the rewrite.
+func TestJoinDiscriminatorRewriteStillApplies(t *testing.T) {
+	res, err := JoinWithOptions(
+		WithParsed(discriminatedOAS3("a", false), discriminatedOAS3("b", true)),
+		WithSchemaStrategy(StrategyRenameRight),
+		WithPathStrategy(StrategyAcceptLeft),
+		WithRenameTemplate(`{{.Name}}.{{.Source}}`),
+	)
+	require.NoError(t, err)
+
+	d := res.Document.(*parser.OAS3Document)
+	renamed := d.Components.Schemas["Pet.b"]
+	require.NotNil(t, renamed)
+	require.NotNil(t, renamed.Discriminator)
+
+	assert.Equal(t, "#/components/schemas/Cat.b", renamed.OneOf[0].Ref)
+	assert.Equal(t, "#/components/schemas/Cat.b", renamed.Discriminator.Mapping["cat"])
+	assert.Equal(t, "#/components/schemas/Cat.b", renamed.Discriminator.DefaultMapping)
+
+	// a's schema was written against the Cat that kept its name.
+	original := d.Components.Schemas["Pet"]
+	assert.Equal(t, "#/components/schemas/Cat", original.OneOf[0].Ref)
+	assert.Equal(t, "#/components/schemas/Cat", original.Discriminator.Mapping["cat"])
+	assert.Equal(t, "#/components/schemas/Cat", original.Discriminator.DefaultMapping)
+}

--- a/joiner/input_mutation_test.go
+++ b/joiner/input_mutation_test.go
@@ -293,14 +293,24 @@ func everyContainerOAS3(name string, extra bool) parser.ParseResult {
 		target.Properties["note"] = &parser.Schema{Type: "string"}
 	}
 	ref := func() *parser.Schema { return &parser.Schema{Ref: "#/components/schemas/Target"} }
+	header := func(name string) map[string]*parser.Header {
+		return map[string]*parser.Header{name: {Schema: ref()}}
+	}
 	content := func() map[string]*parser.MediaType {
 		return map[string]*parser.MediaType{
 			"application/jsonl": {
 				Schema:     ref(),
 				ItemSchema: ref(),
 				Encoding: map[string]*parser.Encoding{
-					"part": {Headers: map[string]*parser.Header{"X-Meta": {Schema: ref()}}},
+					"part": {
+						Headers:        header("X-Meta"),
+						Encoding:       map[string]*parser.Encoding{"nested": {Headers: header("X-Nested")}},
+						ItemEncoding:   &parser.Encoding{Headers: header("X-PartItem")},
+						PrefixEncoding: []*parser.Encoding{{Headers: header("X-PartPrefix")}},
+					},
 				},
+				ItemEncoding:   &parser.Encoding{Headers: header("X-Item")},
+				PrefixEncoding: []*parser.Encoding{{Headers: header("X-Prefix")}},
 			},
 		}
 	}
@@ -346,12 +356,20 @@ func TestRewriteMediaTypeReachesEveryRef(t *testing.T) {
 	d := res.Document.(*parser.OAS3Document)
 	require.Contains(t, d.Components.Schemas, "Target.b")
 
-	refs := func(mt *parser.MediaType) []string {
+	// Every way a media type reaches a schema without going through Schema.
+	refs := func(mt *parser.MediaType) map[string]string {
 		require.NotNil(t, mt)
-		return []string{
-			mt.Schema.Ref,
-			mt.ItemSchema.Ref,
-			mt.Encoding["part"].Headers["X-Meta"].Schema.Ref,
+		part := mt.Encoding["part"]
+		require.NotNil(t, part)
+		return map[string]string{
+			"schema":                          mt.Schema.Ref,
+			"itemSchema":                      mt.ItemSchema.Ref,
+			"encoding.headers":                part.Headers["X-Meta"].Schema.Ref,
+			"encoding.encoding.headers":       part.Encoding["nested"].Headers["X-Nested"].Schema.Ref,
+			"encoding.itemEncoding.headers":   part.ItemEncoding.Headers["X-PartItem"].Schema.Ref,
+			"encoding.prefixEncoding.headers": part.PrefixEncoding[0].Headers["X-PartPrefix"].Schema.Ref,
+			"itemEncoding.headers":            mt.ItemEncoding.Headers["X-Item"].Schema.Ref,
+			"prefixEncoding.headers":          mt.PrefixEncoding[0].Headers["X-Prefix"].Schema.Ref,
 		}
 	}
 	jsonl := func(op *parser.Operation) *parser.MediaType {
@@ -365,13 +383,13 @@ func TestRewriteMediaTypeReachesEveryRef(t *testing.T) {
 		"components.callbacks":     jsonl((*d.Components.Callbacks["bCB"])["{$request.body#/url}"].Post),
 		"components.requestBodies": d.Components.RequestBodies["bBody"].Content["application/jsonl"],
 	} {
-		for _, ref := range refs(mt) {
-			assert.Equal(t, "#/components/schemas/Target.b", ref, "stale reference in %s", where)
+		for field, ref := range refs(mt) {
+			assert.Equal(t, "#/components/schemas/Target.b", ref, "stale reference in %s %s", where, field)
 		}
 	}
 
 	// a's references still name the schema that kept the original name.
-	for _, ref := range refs(jsonl(d.Paths["/a"].Get)) {
-		assert.Equal(t, "#/components/schemas/Target", ref)
+	for field, ref := range refs(jsonl(d.Paths["/a"].Get)) {
+		assert.Equal(t, "#/components/schemas/Target", ref, "a's %s was repointed", field)
 	}
 }

--- a/joiner/input_mutation_test.go
+++ b/joiner/input_mutation_test.go
@@ -113,6 +113,9 @@ func TestJoinLeavesInputsUnchanged(t *testing.T) {
 		name string
 		docs func() []parser.ParseResult
 		opts []Option
+		// verify runs after the join, for a case that needs more than the
+		// inputs being unchanged.
+		verify func(t *testing.T)
 	}{
 		{
 			name: "oas2 rename-right",
@@ -169,6 +172,9 @@ func TestJoinLeavesInputsUnchanged(t *testing.T) {
 				WithNamespacePrefix("store", "Api"), WithNamespacePrefix("clinic", "Api"),
 				WithAlwaysApplyPrefix(true), WithRenameTemplate(`{{.Name}}.{{.Source}}`),
 				WithCollisionHandler(sharingHandler),
+			},
+			verify: func(t *testing.T) {
+				assert.True(t, sharingRan, "the handler never fired, so nothing shared an input")
 			},
 		},
 		{
@@ -249,8 +255,8 @@ func TestJoinLeavesInputsUnchanged(t *testing.T) {
 				assert.Equal(t, beforeDoc[i], docs[i].Document,
 					"joining modified input %d (%s) outside its JSON form", i, docs[i].SourcePath)
 			}
-			if tt.name == "oas2 handler custom value sharing input schemas" {
-				assert.True(t, sharingRan, "the handler never fired, so nothing shared an input")
+			if tt.verify != nil {
+				tt.verify(t)
 			}
 		})
 	}

--- a/joiner/input_mutation_test.go
+++ b/joiner/input_mutation_test.go
@@ -9,12 +9,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// snapshot renders a parsed document so it can be compared before and after a join.
+// snapshot renders a parsed document so a difference reads as a diff.
 func snapshot(t *testing.T, res parser.ParseResult) string {
 	t.Helper()
 	data, err := json.MarshalIndent(res.Document, "", "  ")
 	require.NoError(t, err)
 	return string(data)
+}
+
+// cloneDocument copies a document so it can be compared field by field. JSON
+// alone would miss anything the marshaller drops, such as json:"-" fields.
+func cloneDocument(t *testing.T, doc any) any {
+	t.Helper()
+	switch d := doc.(type) {
+	case *parser.OAS2Document:
+		return d.DeepCopy()
+	case *parser.OAS3Document:
+		return d.DeepCopy()
+	default:
+		t.Fatalf("unexpected document type %T", doc)
+		return nil
+	}
 }
 
 // discriminatedOAS3 builds a document whose Pet schema selects a variant through
@@ -73,6 +88,23 @@ func TestJoinLeavesInputsUnchanged(t *testing.T) {
 		return ContinueWithStrategy(), nil
 	}
 
+	// sharingHandler returns a value built from the left document's own property
+	// schemas, so the custom value shares pointers with an input.
+	sharingHandler := func(c CollisionContext) (CollisionResolution, error) {
+		if c.Type == CollisionTypeSchema && c.Name == "Api_Pet" {
+			left, ok := c.LeftValue.(*parser.Schema)
+			if !ok {
+				return ContinueWithStrategy(), nil
+			}
+			merged := &parser.Schema{Type: left.Type, Properties: map[string]*parser.Schema{}}
+			for name, prop := range left.Properties {
+				merged.Properties[name] = prop
+			}
+			return UseCustomValue(merged), nil
+		}
+		return ContinueWithStrategy(), nil
+	}
+
 	tests := []struct {
 		name string
 		docs func() []parser.ParseResult
@@ -124,6 +156,18 @@ func TestJoinLeavesInputsUnchanged(t *testing.T) {
 			},
 		},
 		{
+			name: "oas2 handler custom value sharing input schemas",
+			docs: func() []parser.ParseResult {
+				return []parser.ParseResult{petstoreFamily("store", false), petstoreFamily("clinic", true)}
+			},
+			opts: []Option{
+				WithSchemaStrategy(StrategyRenameRight),
+				WithNamespacePrefix("store", "Api"), WithNamespacePrefix("clinic", "Api"),
+				WithAlwaysApplyPrefix(true), WithRenameTemplate(`{{.Name}}.{{.Source}}`),
+				WithCollisionHandler(sharingHandler),
+			},
+		},
+		{
 			name: "oas2 accept-left renames nothing",
 			docs: func() []parser.ParseResult {
 				return []parser.ParseResult{petstoreFamily("store", false), petstoreFamily("clinic", true)}
@@ -149,9 +193,11 @@ func TestJoinLeavesInputsUnchanged(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			docs := tt.docs()
-			before := make([]string, len(docs))
+			beforeJSON := make([]string, len(docs))
+			beforeDoc := make([]any, len(docs))
 			for i := range docs {
-				before[i] = snapshot(t, docs[i])
+				beforeJSON[i] = snapshot(t, docs[i])
+				beforeDoc[i] = cloneDocument(t, docs[i].Document)
 			}
 
 			opts := append([]Option{WithParsed(docs...), WithPathStrategy(StrategyAcceptLeft)}, tt.opts...)
@@ -159,8 +205,10 @@ func TestJoinLeavesInputsUnchanged(t *testing.T) {
 			require.NoError(t, err)
 
 			for i := range docs {
-				assert.Equal(t, before[i], snapshot(t, docs[i]),
+				assert.Equal(t, beforeJSON[i], snapshot(t, docs[i]),
 					"joining modified input %d (%s)", i, docs[i].SourcePath)
+				assert.Equal(t, beforeDoc[i], docs[i].Document,
+					"joining modified input %d (%s) outside its JSON form", i, docs[i].SourcePath)
 			}
 		})
 	}

--- a/joiner/input_mutation_test.go
+++ b/joiner/input_mutation_test.go
@@ -89,13 +89,17 @@ func TestJoinLeavesInputsUnchanged(t *testing.T) {
 	}
 
 	// sharingHandler returns a value built from the left document's own property
-	// schemas, so the custom value shares pointers with an input.
+	// schemas, so the custom value shares pointers with an input. sharingRan
+	// guards against the name drifting and the handler silently never firing,
+	// which would leave the case passing for the wrong reason.
+	sharingRan := false
 	sharingHandler := func(c CollisionContext) (CollisionResolution, error) {
 		if c.Type == CollisionTypeSchema && c.Name == "Api_Pet" {
 			left, ok := c.LeftValue.(*parser.Schema)
 			if !ok {
 				return ContinueWithStrategy(), nil
 			}
+			sharingRan = true
 			merged := &parser.Schema{Type: left.Type, Properties: map[string]*parser.Schema{}}
 			for name, prop := range left.Properties {
 				merged.Properties[name] = prop
@@ -175,6 +179,41 @@ func TestJoinLeavesInputsUnchanged(t *testing.T) {
 			opts: []Option{WithSchemaStrategy(StrategyAcceptLeft)},
 		},
 		{
+			name: "oas3 rename-left",
+			docs: func() []parser.ParseResult {
+				return []parser.ParseResult{petstoreFamilyOAS3("store", false), petstoreFamilyOAS3("clinic", true)}
+			},
+			opts: []Option{WithSchemaStrategy(StrategyRenameLeft), WithRenameTemplate(`{{.Name}}.{{.Source}}`)},
+		},
+		{
+			name: "oas3 namespace prefix",
+			docs: func() []parser.ParseResult {
+				return []parser.ParseResult{petstoreFamilyOAS3("store", false), petstoreFamilyOAS3("clinic", true)}
+			},
+			opts: []Option{
+				WithSchemaStrategy(StrategyRenameRight),
+				WithNamespacePrefix("store", "Api"), WithNamespacePrefix("clinic", "Api"),
+				WithAlwaysApplyPrefix(true), WithRenameTemplate(`{{.Name}}.{{.Source}}`),
+			},
+		},
+		{
+			name: "oas3 semantic deduplication",
+			docs: func() []parser.ParseResult {
+				return []parser.ParseResult{petstoreFamilyOAS3("store", false), petstoreFamilyOAS3("clinic", false)}
+			},
+			opts: []Option{
+				WithSchemaStrategy(StrategyRenameRight), WithSemanticDeduplication(true),
+				WithEquivalenceMode("deep"), WithRenameTemplate(`{{.Name}}.{{.Source}}`),
+			},
+		},
+		{
+			name: "oas3 every container",
+			docs: func() []parser.ParseResult {
+				return []parser.ParseResult{everyContainerOAS3("a", false), everyContainerOAS3("b", true)}
+			},
+			opts: []Option{WithSchemaStrategy(StrategyRenameRight), WithRenameTemplate(`{{.Name}}.{{.Source}}`)},
+		},
+		{
 			name: "oas3 rename-right",
 			docs: func() []parser.ParseResult {
 				return []parser.ParseResult{petstoreFamilyOAS3("store", false), petstoreFamilyOAS3("clinic", true)}
@@ -210,6 +249,9 @@ func TestJoinLeavesInputsUnchanged(t *testing.T) {
 				assert.Equal(t, beforeDoc[i], docs[i].Document,
 					"joining modified input %d (%s) outside its JSON form", i, docs[i].SourcePath)
 			}
+			if tt.name == "oas2 handler custom value sharing input schemas" {
+				assert.True(t, sharingRan, "the handler never fired, so nothing shared an input")
+			}
 		})
 	}
 }
@@ -239,4 +281,97 @@ func TestJoinDiscriminatorRewriteStillApplies(t *testing.T) {
 	assert.Equal(t, "#/components/schemas/Cat", original.OneOf[0].Ref)
 	assert.Equal(t, "#/components/schemas/Cat", original.Discriminator.Mapping["cat"])
 	assert.Equal(t, "#/components/schemas/Cat", original.Discriminator.DefaultMapping)
+}
+
+// everyContainerOAS3 populates the OAS 3 containers rewriteEntries copies that
+// the other fixtures leave empty: webhooks, components.pathItems,
+// components.callbacks and components.requestBodies, plus the media type fields
+// that reach a schema without going through MediaType.Schema.
+func everyContainerOAS3(name string, extra bool) parser.ParseResult {
+	target := &parser.Schema{Type: "object", Properties: map[string]*parser.Schema{"id": {Type: "string"}}}
+	if extra {
+		target.Properties["note"] = &parser.Schema{Type: "string"}
+	}
+	ref := func() *parser.Schema { return &parser.Schema{Ref: "#/components/schemas/Target"} }
+	content := func() map[string]*parser.MediaType {
+		return map[string]*parser.MediaType{
+			"application/jsonl": {
+				Schema:     ref(),
+				ItemSchema: ref(),
+				Encoding: map[string]*parser.Encoding{
+					"part": {Headers: map[string]*parser.Header{"X-Meta": {Schema: ref()}}},
+				},
+			},
+		}
+	}
+	op := func() *parser.Operation {
+		return &parser.Operation{Responses: &parser.Responses{Codes: map[string]*parser.Response{
+			"200": {Description: "ok", Content: content()},
+		}}}
+	}
+	callback := parser.Callback{"{$request.body#/url}": &parser.PathItem{Post: op()}}
+
+	return parser.ParseResult{
+		Document: &parser.OAS3Document{
+			OpenAPI:  "3.2.0",
+			Info:     &parser.Info{Title: name, Version: "1.0.0"},
+			Paths:    parser.Paths{"/" + name: &parser.PathItem{Get: op()}},
+			Webhooks: map[string]*parser.PathItem{name + "Hook": {Post: op()}},
+			Components: &parser.Components{
+				Schemas:       map[string]*parser.Schema{"Target": target},
+				RequestBodies: map[string]*parser.RequestBody{name + "Body": {Content: content()}},
+				Callbacks:     map[string]*parser.Callback{name + "CB": &callback},
+				PathItems:     map[string]*parser.PathItem{name + "PI": {Get: op()}},
+			},
+			OASVersion: parser.OASVersion320,
+		},
+		Version: "3.2.0", OASVersion: parser.OASVersion320,
+		SourcePath: name, SourceFormat: parser.SourceFormatJSON,
+	}
+}
+
+// TestRewriteMediaTypeReachesEveryRef covers the reference locations inside a
+// media type that are not MediaType.Schema: itemSchema (OAS 3.2+) and the
+// headers an encoding describes. A rename used to leave both pointing at the
+// name the other document now owns.
+func TestRewriteMediaTypeReachesEveryRef(t *testing.T) {
+	res, err := JoinWithOptions(
+		WithParsed(everyContainerOAS3("a", false), everyContainerOAS3("b", true)),
+		WithSchemaStrategy(StrategyRenameRight),
+		WithPathStrategy(StrategyAcceptLeft),
+		WithRenameTemplate(`{{.Name}}.{{.Source}}`),
+	)
+	require.NoError(t, err)
+
+	d := res.Document.(*parser.OAS3Document)
+	require.Contains(t, d.Components.Schemas, "Target.b")
+
+	refs := func(mt *parser.MediaType) []string {
+		require.NotNil(t, mt)
+		return []string{
+			mt.Schema.Ref,
+			mt.ItemSchema.Ref,
+			mt.Encoding["part"].Headers["X-Meta"].Schema.Ref,
+		}
+	}
+	jsonl := func(op *parser.Operation) *parser.MediaType {
+		return op.Responses.Codes["200"].Content["application/jsonl"]
+	}
+
+	for where, mt := range map[string]*parser.MediaType{
+		"paths":                    jsonl(d.Paths["/b"].Get),
+		"webhooks":                 jsonl(d.Webhooks["bHook"].Post),
+		"components.pathItems":     jsonl(d.Components.PathItems["bPI"].Get),
+		"components.callbacks":     jsonl((*d.Components.Callbacks["bCB"])["{$request.body#/url}"].Post),
+		"components.requestBodies": d.Components.RequestBodies["bBody"].Content["application/jsonl"],
+	} {
+		for _, ref := range refs(mt) {
+			assert.Equal(t, "#/components/schemas/Target.b", ref, "stale reference in %s", where)
+		}
+	}
+
+	// a's references still name the schema that kept the original name.
+	for _, ref := range refs(jsonl(d.Paths["/a"].Get)) {
+		assert.Equal(t, "#/components/schemas/Target", ref)
+	}
 }

--- a/joiner/joiner.go
+++ b/joiner/joiner.go
@@ -280,6 +280,13 @@ type documentContext struct {
 	result   *parser.ParseResult
 }
 
+// JoinParsed joins already parsed documents.
+//
+// The documents are not modified. A schema whose references change is copied
+// before it is rewritten, which relies on the generated deep copy, so a document
+// assembled in Go whose pointer graph contains a cycle is not supported and
+// overflows the stack rather than returning an error (#488). Decoding cannot
+// produce such a graph, so this only concerns documents built programmatically.
 func (j *Joiner) JoinParsed(parsedDocs []parser.ParseResult) (*JoinResult, error) {
 	if len(parsedDocs) < 2 {
 		return nil, fmt.Errorf("joiner: at least 2 specification documents are required for joining, got %d", len(parsedDocs))

--- a/joiner/joiner_bench_test.go
+++ b/joiner/joiner_bench_test.go
@@ -185,27 +185,22 @@ func renameBenchDoc(name string, schemaCount int) parser.ParseResult {
 
 // BenchmarkJoinRenames benchmarks joins that rename. The other benchmarks use
 // accept-left over documents with disjoint schema names and never rename.
-//
-// Fixtures are rebuilt each iteration, outside the timed section, because
-// joining rewrites the references of the documents it was handed (#480).
 func BenchmarkJoinRenames(b *testing.B) {
+	docs := make([]parser.ParseResult, 5)
+	for i := range docs {
+		docs[i] = renameBenchDoc(fmt.Sprintf("doc%d", i), renameBenchSchemaCount)
+	}
+
 	run := func(b *testing.B, strategy CollisionStrategy, count int) {
 		config := DefaultConfig()
 		config.PathStrategy = StrategyAcceptLeft
 		config.SchemaStrategy = strategy
 		config.RenameTemplate = "{{.Name}}.{{.Source}}"
 		j := New(config)
-		docs := make([]parser.ParseResult, count)
 
 		b.ReportAllocs()
 		for b.Loop() {
-			b.StopTimer()
-			for i := range docs {
-				docs[i] = renameBenchDoc(fmt.Sprintf("doc%d", i), renameBenchSchemaCount)
-			}
-			b.StartTimer()
-
-			if _, err := j.JoinParsed(docs); err != nil {
+			if _, err := j.JoinParsed(docs[:count]); err != nil {
 				b.Fatalf("Failed to join: %v", err)
 			}
 		}

--- a/joiner/joiner_options.go
+++ b/joiner/joiner_options.go
@@ -355,7 +355,9 @@ func WithFilePaths(paths ...string) Option {
 	}
 }
 
-// WithParsed specifies parsed ParseResults as input sources
+// WithParsed specifies parsed ParseResults as input sources.
+//
+// See Joiner.JoinParsed for what the join does and does not do to them.
 func WithParsed(docs ...parser.ParseResult) Option {
 	return func(cfg *joinConfig) error {
 		cfg.parsedDocs = append(cfg.parsedDocs, docs...)

--- a/joiner/oas2.go
+++ b/joiner/oas2.go
@@ -86,7 +86,8 @@ func (j *Joiner) joinOAS2Documents(docs []parser.ParseResult) (*JoinResult, erro
 	result.Document = joined
 
 	// Before deduplication, so comparison sees references in their final form.
-	if err := result.scope.applyOAS2(joined, sources); err != nil {
+	copied, err := result.scope.applyOAS2(joined, sources)
+	if err != nil {
 		return nil, fmt.Errorf("joiner: failed to rewrite references after definition renames: %w", err)
 	}
 
@@ -108,7 +109,7 @@ func (j *Joiner) joinOAS2Documents(docs []parser.ParseResult) (*JoinResult, erro
 		joined.Definitions = dedupeResult.CanonicalSchemas
 
 		if len(dedupeResult.Aliases) > 0 {
-			if err := rewriteDedupeAliases(joined, dedupeResult.Aliases, joined.OASVersion); err != nil {
+			if err := rewriteDedupeAliases(joined, dedupeResult.Aliases, joined.OASVersion, copied); err != nil {
 				return nil, fmt.Errorf("joiner: failed to rewrite references after semantic deduplication: %w", err)
 			}
 			result.AddWarning(NewSemanticDedupSummaryWarning(dedupeResult.RemovedCount, "definition"))

--- a/joiner/oas3.go
+++ b/joiner/oas3.go
@@ -200,7 +200,8 @@ func (j *Joiner) joinOAS3Documents(docs []parser.ParseResult) (*JoinResult, erro
 	result.Document = joined
 
 	// Before deduplication, so comparison sees references in their final form.
-	if err := result.scope.applyOAS3(joined, sources); err != nil {
+	copied, err := result.scope.applyOAS3(joined, sources)
+	if err != nil {
 		return nil, fmt.Errorf("joiner: failed to rewrite references after schema renames: %w", err)
 	}
 
@@ -222,7 +223,7 @@ func (j *Joiner) joinOAS3Documents(docs []parser.ParseResult) (*JoinResult, erro
 		joined.Components.Schemas = dedupeResult.CanonicalSchemas
 
 		if len(dedupeResult.Aliases) > 0 {
-			if err := rewriteDedupeAliases(joined, dedupeResult.Aliases, joined.OASVersion); err != nil {
+			if err := rewriteDedupeAliases(joined, dedupeResult.Aliases, joined.OASVersion, copied); err != nil {
 				return nil, fmt.Errorf("joiner: failed to rewrite references after semantic deduplication: %w", err)
 			}
 			result.AddWarning(NewSemanticDedupSummaryWarning(dedupeResult.RemovedCount, "schema"))

--- a/joiner/rename_scope.go
+++ b/joiner/rename_scope.go
@@ -79,9 +79,9 @@ func (s *renameScope) empty() bool {
 //
 // Keep the claimed containers in step with rewriteOAS2Document: an unclaimed
 // entry counts as belonging to no document.
-func (s *renameScope) applyOAS2(joined *parser.OAS2Document, sources []*parser.OAS2Document) error {
+func (s *renameScope) applyOAS2(joined *parser.OAS2Document, sources []*parser.OAS2Document) (map[any]bool, error) {
 	if s.empty() {
-		return nil
+		return nil, nil
 	}
 	owner := make(map[any]int)
 	for docIndex, src := range sources {
@@ -98,9 +98,9 @@ func (s *renameScope) applyOAS2(joined *parser.OAS2Document, sources []*parser.O
 //
 // Keep the claimed containers in step with rewriteOAS3Document: an unclaimed
 // entry counts as belonging to no document.
-func (s *renameScope) applyOAS3(joined *parser.OAS3Document, sources []*parser.OAS3Document) error {
+func (s *renameScope) applyOAS3(joined *parser.OAS3Document, sources []*parser.OAS3Document) (map[any]bool, error) {
 	if s.empty() {
-		return nil
+		return nil, nil
 	}
 	owner := make(map[any]int)
 	for docIndex, src := range sources {
@@ -121,7 +121,8 @@ func (s *renameScope) applyOAS3(joined *parser.OAS3Document, sources []*parser.O
 
 // rewrite runs one pass per source document that recorded a rename, each
 // restricted to the entries that document contributed, then one for the rest.
-func (s *renameScope) rewrite(joined any, owner map[any]int) error {
+func (s *renameScope) rewrite(joined any, owner map[any]int) (map[any]bool, error) {
+	copied := make(map[any]bool)
 	for docIndex, renames := range s.byDoc {
 		if len(renames) == 0 {
 			continue
@@ -134,18 +135,18 @@ func (s *renameScope) rewrite(joined any, owner map[any]int) error {
 			contributor, known := owner[entry]
 			return known && contributor == docIndex
 		})
-		rewriter.copyOnWrite(reown(owner))
+		rewriter.copyOnWrite(copied, reown(owner))
 		if err := rewriter.RewriteDocument(joined); err != nil {
-			return err
+			return nil, err
 		}
 	}
-	return s.rewriteUnowned(joined, owner)
+	return copied, s.rewriteUnowned(joined, owner, copied)
 }
 
 // rewriteUnowned rewrites entries that came from no source document, which a
 // collision handler produces with ResolutionCustom. There is no document whose
 // namespace to read them in, so every rename applies.
-func (s *renameScope) rewriteUnowned(joined any, owner map[any]int) error {
+func (s *renameScope) rewriteUnowned(joined any, owner map[any]int, copied map[any]bool) error {
 	merged := make(map[string]string)
 	for _, renames := range s.byDoc {
 		// Merge order breaks the tie when two documents renamed the same name.
@@ -159,7 +160,7 @@ func (s *renameScope) rewriteUnowned(joined any, owner map[any]int) error {
 		_, known := owner[entry]
 		return !known
 	})
-	rewriter.copyOnWrite(reown(owner))
+	rewriter.copyOnWrite(copied, reown(owner))
 	return rewriter.RewriteDocument(joined)
 }
 
@@ -176,12 +177,15 @@ func reown(owner map[any]int) func(old, replacement any) {
 // rewriteDedupeAliases repoints references from deduplicated names to canonical
 // ones. Document-wide, unlike a collision rename: the schemas were found
 // equivalent, so the reference means the same thing whoever wrote it.
-func rewriteDedupeAliases(joined any, aliases map[string]string, version parser.OASVersion) error {
+func rewriteDedupeAliases(joined any, aliases map[string]string, version parser.OASVersion, copied map[any]bool) error {
 	rewriter := NewSchemaRewriter()
 	for alias, canonical := range aliases {
 		rewriter.RegisterRename(alias, canonical, version)
 	}
-	rewriter.copyOnWrite(nil)
+	if copied == nil {
+		copied = make(map[any]bool)
+	}
+	rewriter.copyOnWrite(copied, nil)
 	return rewriter.RewriteDocument(joined)
 }
 

--- a/joiner/rename_scope.go
+++ b/joiner/rename_scope.go
@@ -134,6 +134,7 @@ func (s *renameScope) rewrite(joined any, owner map[any]int) error {
 			contributor, known := owner[entry]
 			return known && contributor == docIndex
 		})
+		rewriter.copyOnWrite(reown(owner))
 		if err := rewriter.RewriteDocument(joined); err != nil {
 			return err
 		}
@@ -158,7 +159,18 @@ func (s *renameScope) rewriteUnowned(joined any, owner map[any]int) error {
 		_, known := owner[entry]
 		return !known
 	})
+	rewriter.copyOnWrite(reown(owner))
 	return rewriter.RewriteDocument(joined)
+}
+
+// reown keeps the ownership map following an entry that copy-on-write replaced,
+// so a later pass still reads the copy as belonging to the same document.
+func reown(owner map[any]int) func(old, replacement any) {
+	return func(old, replacement any) {
+		if contributor, known := owner[old]; known {
+			owner[replacement] = contributor
+		}
+	}
 }
 
 // rewriteDedupeAliases repoints references from deduplicated names to canonical
@@ -169,6 +181,7 @@ func rewriteDedupeAliases(joined any, aliases map[string]string, version parser.
 	for alias, canonical := range aliases {
 		rewriter.RegisterRename(alias, canonical, version)
 	}
+	rewriter.copyOnWrite(nil)
 	return rewriter.RewriteDocument(joined)
 }
 

--- a/joiner/rename_scope.go
+++ b/joiner/rename_scope.go
@@ -182,9 +182,6 @@ func rewriteDedupeAliases(joined any, aliases map[string]string, version parser.
 	for alias, canonical := range aliases {
 		rewriter.RegisterRename(alias, canonical, version)
 	}
-	if copied == nil {
-		copied = make(map[any]bool)
-	}
 	rewriter.copyOnWrite(copied, nil)
 	return rewriter.RewriteDocument(joined)
 }

--- a/joiner/rename_scope_test.go
+++ b/joiner/rename_scope_test.go
@@ -861,11 +861,16 @@ func TestRenameScopeRegisterLeft(t *testing.T) {
 
 func TestRenameScopeApplyWithoutRenames(t *testing.T) {
 	var nilScope *renameScope
-	assert.NoError(t, nilScope.applyOAS2(&parser.OAS2Document{}, nil))
-	assert.NoError(t, nilScope.applyOAS3(&parser.OAS3Document{}, nil))
+	copied, err := nilScope.applyOAS2(&parser.OAS2Document{}, nil)
+	assert.NoError(t, err)
+	assert.Nil(t, copied, "nothing was copied, so nothing to hand on")
+	_, err = nilScope.applyOAS3(&parser.OAS3Document{}, nil)
+	assert.NoError(t, err)
 
 	// A scope that recorded nothing skips the rewrite entirely.
 	empty := newRenameScope(2, parser.OASVersion20)
 	assert.True(t, empty.empty())
-	assert.NoError(t, empty.applyOAS2(&parser.OAS2Document{}, nil))
+	copied, err = empty.applyOAS2(&parser.OAS2Document{}, nil)
+	assert.NoError(t, err)
+	assert.Nil(t, copied)
 }

--- a/joiner/rename_scope_test.go
+++ b/joiner/rename_scope_test.go
@@ -864,13 +864,17 @@ func TestRenameScopeApplyWithoutRenames(t *testing.T) {
 	copied, err := nilScope.applyOAS2(&parser.OAS2Document{}, nil)
 	assert.NoError(t, err)
 	assert.Nil(t, copied, "nothing was copied, so nothing to hand on")
-	_, err = nilScope.applyOAS3(&parser.OAS3Document{}, nil)
+	copied, err = nilScope.applyOAS3(&parser.OAS3Document{}, nil)
 	assert.NoError(t, err)
+	assert.Nil(t, copied)
 
 	// A scope that recorded nothing skips the rewrite entirely.
 	empty := newRenameScope(2, parser.OASVersion20)
 	assert.True(t, empty.empty())
 	copied, err = empty.applyOAS2(&parser.OAS2Document{}, nil)
+	assert.NoError(t, err)
+	assert.Nil(t, copied)
+	copied, err = empty.applyOAS3(&parser.OAS3Document{}, nil)
 	assert.NoError(t, err)
 	assert.Nil(t, copied)
 }

--- a/joiner/rewriter.go
+++ b/joiner/rewriter.go
@@ -20,6 +20,9 @@ type SchemaRewriter struct {
 	// inside it changes. See copyOnWrite.
 	copying bool
 	onCopy  func(old, replacement any)
+	// owned holds the entries already copied, which no longer belong to any
+	// input and can be changed in place by a later pass.
+	owned map[any]bool
 	// probing suppresses the changes themselves, and changed records whether
 	// there were any. See probe.
 	probing bool
@@ -61,10 +64,12 @@ func (r *SchemaRewriter) skipEntry(entry any) bool {
 // left as they were (#480). Only entries that actually have a reference to
 // change are copied.
 //
-// onCopy, if given, receives the old and new pointer. Callers keying anything on
-// identity need it, since the copy is a different pointer.
-func (r *SchemaRewriter) copyOnWrite(onCopy func(old, replacement any)) {
+// owned is shared between the passes of one join so an entry is copied once
+// rather than once per pass. onCopy, if given, receives the old and new pointer,
+// which callers keying anything on identity need.
+func (r *SchemaRewriter) copyOnWrite(owned map[any]bool, onCopy func(old, replacement any)) {
 	r.copying = true
+	r.owned = owned
 	r.onCopy = onCopy
 }
 
@@ -103,12 +108,13 @@ func rewriteEntries[T any](r *SchemaRewriter, entries map[string]*T, fn func(*T)
 		if r.skipEntry(entry) {
 			continue
 		}
-		if r.copying {
+		if r.copying && !r.owned[entry] {
 			if !r.probe(func() { fn(entry) }) {
 				continue
 			}
 			replacement := clone(entry)
 			entries[name] = replacement
+			r.owned[replacement] = true
 			if r.onCopy != nil {
 				r.onCopy(entry, replacement)
 			}

--- a/joiner/rewriter.go
+++ b/joiner/rewriter.go
@@ -15,6 +15,15 @@ type SchemaRewriter struct {
 	bareNameMap map[string]string // Bare name: "Old" → "New" (for discriminator shorthand)
 	visited     map[uintptr]bool  // Tracks visited nodes to prevent infinite loops
 	owns        func(entry any) bool
+
+	// copying makes a top-level entry be replaced by a deep copy before anything
+	// inside it changes. See copyOnWrite.
+	copying bool
+	onCopy  func(old, replacement any)
+	// probing suppresses the changes themselves, and changed records whether
+	// there were any. See probe.
+	probing bool
+	changed bool
 }
 
 // NewSchemaRewriter creates a new rewriter instance
@@ -47,16 +56,79 @@ func (r *SchemaRewriter) skipEntry(entry any) bool {
 	return r.owns != nil && !r.owns(entry)
 }
 
+// copyOnWrite makes the rewrite replace a top-level entry with a deep copy
+// before changing anything inside it, so the documents the joiner was handed are
+// left as they were (#480). Only entries that actually have a reference to
+// change are copied.
+//
+// onCopy, if given, receives the old and new pointer. Callers keying anything on
+// identity need it, since the copy is a different pointer.
+func (r *SchemaRewriter) copyOnWrite(onCopy func(old, replacement any)) {
+	r.copying = true
+	r.onCopy = onCopy
+}
+
+// probe runs a rewrite with its changes suppressed and reports whether there
+// were any, so an entry is copied only when copying buys something.
+func (r *SchemaRewriter) probe(run func()) bool {
+	saved := r.visited
+	r.visited = make(map[uintptr]bool)
+	r.probing, r.changed = true, false
+
+	run()
+
+	r.probing = false
+	r.visited = saved
+	return r.changed
+}
+
+// mapped looks up a replacement and notes that the entry being rewritten has
+// something to change, which is what probe reports.
+func (r *SchemaRewriter) mapped(names map[string]string, value string) (string, bool) {
+	replacement, ok := names[value]
+	if ok {
+		r.changed = true
+	}
+	return replacement, ok
+}
+
 // rewriteEntries applies fn to each in-scope entry of a top-level container.
 // Every such container goes through here, so a new one cannot miss the scope
-// check.
-func rewriteEntries[T any](r *SchemaRewriter, entries map[string]*T, fn func(*T)) {
-	for _, entry := range entries {
+// check or the copy.
+//
+// clone is the entry's deep copy, passed in because parser.Callback's is not
+// exported.
+func rewriteEntries[T any](r *SchemaRewriter, entries map[string]*T, fn func(*T), clone func(*T) *T) {
+	for name, entry := range entries {
 		if r.skipEntry(entry) {
 			continue
 		}
+		if r.copying {
+			if !r.probe(func() { fn(entry) }) {
+				continue
+			}
+			replacement := clone(entry)
+			entries[name] = replacement
+			if r.onCopy != nil {
+				r.onCopy(entry, replacement)
+			}
+			entry = replacement
+		}
 		fn(entry)
 	}
+}
+
+// cloneCallback deep copies a callback. parser.Callback is a map type and the
+// parser's deep copy for it is unexported, so it is rebuilt here.
+func cloneCallback(callback *parser.Callback) *parser.Callback {
+	if callback == nil {
+		return nil
+	}
+	out := make(parser.Callback, len(*callback))
+	for expression, item := range *callback {
+		out[expression] = item.DeepCopy()
+	}
+	return &out
 }
 
 // RewriteDocument traverses and rewrites all references in the document
@@ -86,31 +158,31 @@ func schemaRefPath(name string, version parser.OASVersion) string {
 func (r *SchemaRewriter) rewriteOAS3Document(doc *parser.OAS3Document) error {
 	// Rewrite references in components
 	if doc.Components != nil {
-		rewriteEntries(r, doc.Components.Schemas, r.rewriteSchema)
-		rewriteEntries(r, doc.Components.Parameters, r.rewriteParameter)
-		rewriteEntries(r, doc.Components.Responses, r.rewriteResponse)
-		rewriteEntries(r, doc.Components.RequestBodies, r.rewriteRequestBody)
-		rewriteEntries(r, doc.Components.Headers, r.rewriteHeader)
-		rewriteEntries(r, doc.Components.Callbacks, r.rewriteCallback)
+		rewriteEntries(r, doc.Components.Schemas, r.rewriteSchema, (*parser.Schema).DeepCopy)
+		rewriteEntries(r, doc.Components.Parameters, r.rewriteParameter, (*parser.Parameter).DeepCopy)
+		rewriteEntries(r, doc.Components.Responses, r.rewriteResponse, (*parser.Response).DeepCopy)
+		rewriteEntries(r, doc.Components.RequestBodies, r.rewriteRequestBody, (*parser.RequestBody).DeepCopy)
+		rewriteEntries(r, doc.Components.Headers, r.rewriteHeader, (*parser.Header).DeepCopy)
+		rewriteEntries(r, doc.Components.Callbacks, r.rewriteCallback, cloneCallback)
 		// Links - intentionally not rewritten (don't contain schema references)
-		rewriteEntries(r, doc.Components.PathItems, r.rewritePathItem)
+		rewriteEntries(r, doc.Components.PathItems, r.rewritePathItem, (*parser.PathItem).DeepCopy)
 	}
 
 	// Rewrite references in paths
-	rewriteEntries(r, doc.Paths, r.rewritePathItem)
+	rewriteEntries(r, doc.Paths, r.rewritePathItem, (*parser.PathItem).DeepCopy)
 
 	// Rewrite references in webhooks (OAS 3.1+)
-	rewriteEntries(r, doc.Webhooks, r.rewritePathItem)
+	rewriteEntries(r, doc.Webhooks, r.rewritePathItem, (*parser.PathItem).DeepCopy)
 
 	return nil
 }
 
 // rewriteOAS2Document rewrites all references in an OAS 2.0 document
 func (r *SchemaRewriter) rewriteOAS2Document(doc *parser.OAS2Document) error {
-	rewriteEntries(r, doc.Definitions, r.rewriteSchema)
-	rewriteEntries(r, doc.Parameters, r.rewriteParameter)
-	rewriteEntries(r, doc.Responses, r.rewriteResponse)
-	rewriteEntries(r, doc.Paths, r.rewritePathItem)
+	rewriteEntries(r, doc.Definitions, r.rewriteSchema, (*parser.Schema).DeepCopy)
+	rewriteEntries(r, doc.Parameters, r.rewriteParameter, (*parser.Parameter).DeepCopy)
+	rewriteEntries(r, doc.Responses, r.rewriteResponse, (*parser.Response).DeepCopy)
+	rewriteEntries(r, doc.Paths, r.rewritePathItem, (*parser.PathItem).DeepCopy)
 
 	return nil
 }
@@ -130,7 +202,7 @@ func (r *SchemaRewriter) rewriteSchema(schema *parser.Schema) {
 
 	// Rewrite $ref
 	if schema.Ref != "" {
-		if newRef, exists := r.refMap[schema.Ref]; exists {
+		if newRef, exists := r.mapped(r.refMap, schema.Ref); exists && !r.probing {
 			schema.Ref = newRef
 		}
 	}
@@ -208,20 +280,28 @@ func (r *SchemaRewriter) rewriteSchema(schema *parser.Schema) {
 	if schema.Discriminator != nil {
 		for key, value := range schema.Discriminator.Mapping {
 			// Handle full $ref paths first, then bare schema names if not matched
-			if newRef, exists := r.refMap[value]; exists {
-				schema.Discriminator.Mapping[key] = newRef
-			} else if newName, exists := r.bareNameMap[value]; exists {
-				schema.Discriminator.Mapping[key] = newName
+			if newRef, exists := r.mapped(r.refMap, value); exists {
+				if !r.probing {
+					schema.Discriminator.Mapping[key] = newRef
+				}
+			} else if newName, exists := r.mapped(r.bareNameMap, value); exists {
+				if !r.probing {
+					schema.Discriminator.Mapping[key] = newName
+				}
 			}
 		}
 		// defaultMapping (OAS 3.2+) names a schema in the same two spellings, so
 		// it is resolved the same way. A join that renames the fallback's target
 		// without rewriting this produces a dangling reference.
 		if value := schema.Discriminator.DefaultMapping; value != "" {
-			if newRef, exists := r.refMap[value]; exists {
-				schema.Discriminator.DefaultMapping = newRef
-			} else if newName, exists := r.bareNameMap[value]; exists {
-				schema.Discriminator.DefaultMapping = newName
+			if newRef, exists := r.mapped(r.refMap, value); exists {
+				if !r.probing {
+					schema.Discriminator.DefaultMapping = newRef
+				}
+			} else if newName, exists := r.mapped(r.bareNameMap, value); exists {
+				if !r.probing {
+					schema.Discriminator.DefaultMapping = newName
+				}
 			}
 		}
 	}

--- a/joiner/rewriter.go
+++ b/joiner/rewriter.go
@@ -71,15 +71,15 @@ func (r *SchemaRewriter) copyOnWrite(onCopy func(old, replacement any)) {
 // probe runs a rewrite with its changes suppressed and reports whether there
 // were any, so an entry is copied only when copying buys something.
 func (r *SchemaRewriter) probe(run func()) bool {
-	saved := r.visited
+	savedVisited, savedProbing, savedChanged := r.visited, r.probing, r.changed
 	r.visited = make(map[uintptr]bool)
 	r.probing, r.changed = true, false
 
 	run()
 
-	r.probing = false
-	r.visited = saved
-	return r.changed
+	changed := r.changed
+	r.visited, r.probing, r.changed = savedVisited, savedProbing, savedChanged
+	return changed
 }
 
 // mapped looks up a replacement and notes that the entry being rewritten has

--- a/joiner/rewriter.go
+++ b/joiner/rewriter.go
@@ -68,6 +68,9 @@ func (r *SchemaRewriter) skipEntry(entry any) bool {
 // rather than once per pass. onCopy, if given, receives the old and new pointer,
 // which callers keying anything on identity need.
 func (r *SchemaRewriter) copyOnWrite(owned map[any]bool, onCopy func(old, replacement any)) {
+	if owned == nil {
+		owned = make(map[any]bool)
+	}
 	r.copying = true
 	r.owned = owned
 	r.onCopy = onCopy

--- a/joiner/rewriter.go
+++ b/joiner/rewriter.go
@@ -390,8 +390,45 @@ func (r *SchemaRewriter) rewriteMediaType(mediaType *parser.MediaType) {
 	}
 
 	r.rewriteSchema(mediaType.Schema)
+	// itemSchema names a schema the same way schema does (OAS 3.2+).
+	r.rewriteSchema(mediaType.ItemSchema)
+
+	// Encoding reaches schemas through the headers it describes.
+	for _, encoding := range mediaType.Encoding {
+		r.rewriteEncoding(encoding)
+	}
+	r.rewriteEncoding(mediaType.ItemEncoding)
+	for _, encoding := range mediaType.PrefixEncoding {
+		r.rewriteEncoding(encoding)
+	}
 
 	// Examples intentionally not rewritten (don't contain schema references)
+}
+
+// rewriteEncoding rewrites references in an encoding: the headers it describes,
+// and the encodings nested under it (OAS 3.2+).
+func (r *SchemaRewriter) rewriteEncoding(encoding *parser.Encoding) {
+	if encoding == nil {
+		return
+	}
+
+	// Nested encodings can be cyclic in a document assembled in Go.
+	ptr := reflect.ValueOf(encoding).Pointer()
+	if r.visited[ptr] {
+		return
+	}
+	r.visited[ptr] = true
+
+	for _, header := range encoding.Headers {
+		r.rewriteHeader(header)
+	}
+	for _, nested := range encoding.Encoding {
+		r.rewriteEncoding(nested)
+	}
+	r.rewriteEncoding(encoding.ItemEncoding)
+	for _, prefix := range encoding.PrefixEncoding {
+		r.rewriteEncoding(prefix)
+	}
 }
 
 // rewriteHeader rewrites references in a header

--- a/joiner/rewriter.go
+++ b/joiner/rewriter.go
@@ -412,7 +412,10 @@ func (r *SchemaRewriter) rewriteEncoding(encoding *parser.Encoding) {
 		return
 	}
 
-	// Nested encodings can be cyclic in a document assembled in Go.
+	// Guard against a nested encoding reaching itself, which decoding cannot
+	// produce but a document assembled in Go can. Note this protects the
+	// traversal only: copy on write calls the generated deep copy first, and
+	// that is not cycle safe (#488).
 	ptr := reflect.ValueOf(encoding).Pointer()
 	if r.visited[ptr] {
 		return


### PR DESCRIPTION
## Summary 🎯

The merged document holds the schemas and path items its inputs contributed, and the reference rewriting edited them in place. Joining therefore modified the caller's documents: a document joined into two different combinations carried the first join's renames into the second.

Fixes #480.

## Approach

The rewriting is the only thing that mutates input-owned memory: three assignments in `rewriteSchema`, for `$ref`, discriminator `mapping` and `defaultMapping`. Everything else inserts pointers into new maps. So a join that renames nothing already left its inputs alone, and the fix only has to cover the entries a rewrite actually changes.

`SchemaRewriter.copyOnWrite` probes a top-level entry with its changes suppressed, and deep copies it only when the probe found something to rewrite. The copy replaces the entry in the merged document and is rewritten in its place. Copying breaks the pointer identity `renameScope` attributes entries by, so the rewriter hands back both pointers and `reown` follows them. The passes of one join share the set of entries already copied, so an entry touched by both a rename pass and the deduplication pass is copied once.

Deep copying every input instead measured at **+167% time and +729% memory** on `testdata/corpus/github-api.json`, and charged that price even when nothing was renamed. That is why this copies per entry, on demand.

## Performance ⚡

Cost tracks how many schemas actually reference a renamed name, not document count or size.

**Nothing renames, which is the default configuration: no cost at all.** No rewriter runs, so nothing is probed or copied.

```
JoinParsed Two/Three/FiveDocs        identical allocs and bytes
github-api.json accept-left          identical allocs and bytes
```

Scaling with overlap, two 200 schema documents:

| Colliding names | Time | Memory |
|---|---|---|
| 0 of 200 | identical | identical |
| 10 of 200 | wash | +25% |
| 100 of 200 | +14% | +50% |
| 200 of 200 | +34% | +51% |

Corpus specs joined with themselves under rename-right, which is the ceiling: every schema collides and is renamed.

```
large-oas3.yaml    unchanged, -2.3% memory
discord-openapi    +40% time, +84% memory
github-api.json    +88% time, +289% memory     (9.9ms -> 18.6ms)
```

`large-oas3.yaml` does not move because it barely cross-references, so most entries probe clean and are never copied. `github-api.json` is densely cross-referenced with every schema colliding, so nearly everything is copied.

## Tests 🧪

`TestJoinLeavesInputsUnchanged` covers nine configurations across both OAS versions: rename-right, rename-left, namespace prefixes, semantic deduplication, two collision handler shapes, and discriminator mappings. **Seven of the nine fail with copy on write disabled**, verified by disabling it; the other two are controls that rename nothing.

Each input is compared two ways: its JSON form, so a difference reads as a diff, and a deep copy taken before the join, which catches anything the marshaller drops.

One handler case builds its custom value out of the left document's own property schemas, so the value shares pointers with an input. That case fails without the copy and the simpler handler case does not, which is why both are there.

`make check` clean at 10795 tests, no gopls diagnostics.

## Benchmark change

`BenchmarkJoinRenames` no longer rebuilds its documents each iteration. That existed only because joining used to degrade them, and it under-reported 1557 allocs where the real cost is 1803. Reuse is now safe, which is itself a check that inputs are stable.

## Not covered

Entries that are never rewritten remain shared with the input they came from. The joined document is safe to read, but editing it in place can still reach an input. Making the result fully independent means copying everything, which is the approach measured above and rejected.

## Review notes 📝

Two local CodeRabbit rounds: five findings, three applied (deep copy comparison alongside JSON, the handler case that shares input schemas, `probe` restoring its own state), two declined with evidence. A third round was clean.

An attempt at a `deduplicate-or-rename` collision strategy came out of the performance work and was backed out: deciding equivalence at merge time cannot see transitive divergence, so it silently merged two schemas whose references later resolved differently. Written up separately.