### PR TITLE
fix(joiner): merge components.mediaTypes, and name a rename-left schema from its own document

### DIFF
--- a/joiner/collision_handler.go
+++ b/joiner/collision_handler.go
@@ -79,6 +79,8 @@ const (
 	// form where the other document holds the other is not reported here at all:
 	// see Joiner.mergeAllCallbacks.
 	CollisionTypeCallback CollisionType = "callback"
+	// CollisionTypeMediaType indicates a media type collision in components.mediaTypes (OAS 3.2+).
+	CollisionTypeMediaType CollisionType = "mediaType"
 )
 
 // ResolutionAction specifies what the joiner should do after a collision.

--- a/joiner/deep_dive.md
+++ b/joiner/deep_dive.md
@@ -79,6 +79,8 @@ A rename only rewrites the references of documents that used the renamed name:
 
 Semantic deduplication rewrites every reference to a removed name, because the schemas were equivalent.
 
+`components.mediaTypes` (OAS 3.2) is merged and rewritten like any other component map, and its entries reach a schema through `schema`, `itemSchema` and the headers an `encoding` describes.
+
 Joining does not modify the documents it was given. The merged document holds the schemas and path items its inputs contributed, so anything whose references change is copied first. Entries that are not rewritten are still shared with the input they came from, which means the result is safe to read but should not be edited in place if the inputs are still in use.
 
 [↑ Back to top](#top)

--- a/joiner/input_mutation_test.go
+++ b/joiner/input_mutation_test.go
@@ -338,6 +338,7 @@ func everyContainerOAS3(name string, extra bool) parser.ParseResult {
 				RequestBodies: map[string]*parser.RequestBody{name + "Body": {Content: content()}},
 				Callbacks:     map[string]*parser.Callback{name + "CB": &callback},
 				PathItems:     map[string]*parser.PathItem{name + "PI": {Get: op()}},
+				MediaTypes:    map[string]*parser.MediaType{name + "MT": content()["application/jsonl"]},
 			},
 			OASVersion: parser.OASVersion320,
 		},
@@ -388,6 +389,7 @@ func TestRewriteMediaTypeReachesEveryRef(t *testing.T) {
 		"components.pathItems":     jsonl(d.Components.PathItems["bPI"].Get),
 		"components.callbacks":     jsonl((*d.Components.Callbacks["bCB"])["{$request.body#/url}"].Post),
 		"components.requestBodies": d.Components.RequestBodies["bBody"].Content["application/jsonl"],
+		"components.mediaTypes":    d.Components.MediaTypes["bMT"],
 	} {
 		for field, ref := range refs(mt) {
 			assert.Equal(t, "#/components/schemas/Target.b", ref, "stale reference in %s %s", where, field)
@@ -395,7 +397,12 @@ func TestRewriteMediaTypeReachesEveryRef(t *testing.T) {
 	}
 
 	// a's references still name the schema that kept the original name.
-	for field, ref := range refs(jsonl(d.Paths["/a"].Get)) {
-		assert.Equal(t, "#/components/schemas/Target", ref, "a's %s was repointed", field)
+	for where, mt := range map[string]*parser.MediaType{
+		"paths":                 jsonl(d.Paths["/a"].Get),
+		"components.mediaTypes": d.Components.MediaTypes["aMT"],
+	} {
+		for field, ref := range refs(mt) {
+			assert.Equal(t, "#/components/schemas/Target", ref, "a's %s %s was repointed", where, field)
+		}
 	}
 }

--- a/joiner/media_types_test.go
+++ b/joiner/media_types_test.go
@@ -33,8 +33,9 @@ func mediaTypeComponentDoc(name string, extra bool) parser.ParseResult {
 							"part": {Headers: map[string]*parser.Header{"X-Meta": {Schema: ref()}}},
 						},
 					},
-					// Named the same in both, so it collides.
-					"Shared": {Schema: ref()},
+					// Named the same in both, so it collides. Example carries the
+					// source name so a collision resolution is distinguishable.
+					"Shared": {Schema: ref(), Example: name},
 				},
 			},
 			OASVersion: parser.OASVersion320,
@@ -60,11 +61,44 @@ func TestMediaTypeComponentsAreMerged(t *testing.T) {
 	d := res.Document.(*parser.OAS3Document)
 	require.NotNil(t, d.Components)
 
-	// Both documents' own entries survive, and the colliding one is resolved by
-	// the component strategy rather than vanishing.
+	// Both documents' own entries survive.
 	assert.Contains(t, d.Components.MediaTypes, "aMedia")
 	assert.Contains(t, d.Components.MediaTypes, "bMedia")
-	assert.Contains(t, d.Components.MediaTypes, "Shared")
+
+	// The colliding one is resolved by the component strategy rather than
+	// vanishing, and accept-left keeps the left value.
+	require.Contains(t, d.Components.MediaTypes, "Shared")
+	assert.Equal(t, "a", d.Components.MediaTypes["Shared"].Example)
+}
+
+// TestMediaTypeCollisionIsReported checks that a media type collision reaches a
+// handler under its own type, the way every other component's does.
+func TestMediaTypeCollisionIsReported(t *testing.T) {
+	var seen []CollisionContext
+	_, err := JoinWithOptions(
+		WithParsed(mediaTypeComponentDoc("a", false), mediaTypeComponentDoc("b", true)),
+		WithSchemaStrategy(StrategyRenameRight),
+		WithPathStrategy(StrategyAcceptLeft),
+		WithComponentStrategy(StrategyAcceptLeft),
+		WithRenameTemplate(`{{.Name}}.{{.Source}}`),
+		WithCollisionHandler(func(c CollisionContext) (CollisionResolution, error) {
+			if c.Type == CollisionTypeMediaType {
+				seen = append(seen, c)
+			}
+			return ContinueWithStrategy(), nil
+		}),
+	)
+	require.NoError(t, err)
+
+	require.Len(t, seen, 1, "the colliding media type should be reported once")
+	assert.Equal(t, "Shared", seen[0].Name)
+	assert.Equal(t, "$.components.mediaTypes.Shared", seen[0].JSONPath)
+	left, ok := seen[0].LeftValue.(*parser.MediaType)
+	require.True(t, ok, "LeftValue is %T", seen[0].LeftValue)
+	assert.Equal(t, "a", left.Example)
+	right, ok := seen[0].RightValue.(*parser.MediaType)
+	require.True(t, ok, "RightValue is %T", seen[0].RightValue)
+	assert.Equal(t, "b", right.Example)
 }
 
 // TestMediaTypeComponentsAreRewritten checks the other half: a merged media type

--- a/joiner/media_types_test.go
+++ b/joiner/media_types_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// mediaTypeComponentDoc builds an OAS 3.2 document with a components.mediaTypes
-// entry that references a schema, which is the shape #485 dropped.
+// mediaTypeComponentDoc builds an OAS 3.2 document whose components.mediaTypes
+// entries reference a schema, one named after its source and one shared.
 func mediaTypeComponentDoc(name string, extra bool) parser.ParseResult {
 	target := &parser.Schema{Type: "object", Properties: map[string]*parser.Schema{"id": {Type: "string"}}}
 	if extra {
@@ -25,7 +25,7 @@ func mediaTypeComponentDoc(name string, extra bool) parser.ParseResult {
 			Components: &parser.Components{
 				Schemas: map[string]*parser.Schema{"Target": target},
 				MediaTypes: map[string]*parser.MediaType{
-					// Named after its source so both survive the join.
+					// Named after its source, so both survive the join.
 					name + "Media": {
 						Schema:     ref(),
 						ItemSchema: ref(),
@@ -45,9 +45,8 @@ func mediaTypeComponentDoc(name string, extra bool) parser.ParseResult {
 	}
 }
 
-// TestMediaTypeComponentsAreMerged covers #485. mergeOAS3Components handled every
-// Components field except MediaTypes, so both documents' entries were discarded
-// with nothing reported.
+// TestMediaTypeComponentsAreMerged covers #485: components.mediaTypes reaches the
+// joined document, and a colliding entry goes through the component strategy.
 func TestMediaTypeComponentsAreMerged(t *testing.T) {
 	res, err := JoinWithOptions(
 		WithParsed(mediaTypeComponentDoc("a", false), mediaTypeComponentDoc("b", true)),
@@ -65,8 +64,8 @@ func TestMediaTypeComponentsAreMerged(t *testing.T) {
 	assert.Contains(t, d.Components.MediaTypes, "aMedia")
 	assert.Contains(t, d.Components.MediaTypes, "bMedia")
 
-	// The colliding one is resolved by the component strategy rather than
-	// vanishing, and accept-left keeps the left value.
+	// The colliding one is resolved by the component strategy, and accept-left
+	// keeps the left value.
 	require.Contains(t, d.Components.MediaTypes, "Shared")
 	assert.Equal(t, "a", d.Components.MediaTypes["Shared"].Example)
 }

--- a/joiner/media_types_test.go
+++ b/joiner/media_types_test.go
@@ -1,0 +1,125 @@
+package joiner
+
+import (
+	"testing"
+
+	"github.com/erraggy/oastools/parser"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mediaTypeComponentDoc builds an OAS 3.2 document with a components.mediaTypes
+// entry that references a schema, which is the shape #485 dropped.
+func mediaTypeComponentDoc(name string, extra bool) parser.ParseResult {
+	target := &parser.Schema{Type: "object", Properties: map[string]*parser.Schema{"id": {Type: "string"}}}
+	if extra {
+		target.Properties["note"] = &parser.Schema{Type: "string"}
+	}
+	ref := func() *parser.Schema { return &parser.Schema{Ref: "#/components/schemas/Target"} }
+
+	return parser.ParseResult{
+		Document: &parser.OAS3Document{
+			OpenAPI: "3.2.0",
+			Info:    &parser.Info{Title: name, Version: "1.0.0"},
+			Paths:   parser.Paths{"/" + name: &parser.PathItem{Get: &parser.Operation{}}},
+			Components: &parser.Components{
+				Schemas: map[string]*parser.Schema{"Target": target},
+				MediaTypes: map[string]*parser.MediaType{
+					// Named after its source so both survive the join.
+					name + "Media": {
+						Schema:     ref(),
+						ItemSchema: ref(),
+						Encoding: map[string]*parser.Encoding{
+							"part": {Headers: map[string]*parser.Header{"X-Meta": {Schema: ref()}}},
+						},
+					},
+					// Named the same in both, so it collides.
+					"Shared": {Schema: ref()},
+				},
+			},
+			OASVersion: parser.OASVersion320,
+		},
+		Version: "3.2.0", OASVersion: parser.OASVersion320,
+		SourcePath: name, SourceFormat: parser.SourceFormatJSON,
+	}
+}
+
+// TestMediaTypeComponentsAreMerged covers #485. mergeOAS3Components handled every
+// Components field except MediaTypes, so both documents' entries were discarded
+// with nothing reported.
+func TestMediaTypeComponentsAreMerged(t *testing.T) {
+	res, err := JoinWithOptions(
+		WithParsed(mediaTypeComponentDoc("a", false), mediaTypeComponentDoc("b", true)),
+		WithSchemaStrategy(StrategyRenameRight),
+		WithPathStrategy(StrategyAcceptLeft),
+		WithComponentStrategy(StrategyAcceptLeft),
+		WithRenameTemplate(`{{.Name}}.{{.Source}}`),
+	)
+	require.NoError(t, err)
+
+	d := res.Document.(*parser.OAS3Document)
+	require.NotNil(t, d.Components)
+
+	// Both documents' own entries survive, and the colliding one is resolved by
+	// the component strategy rather than vanishing.
+	assert.Contains(t, d.Components.MediaTypes, "aMedia")
+	assert.Contains(t, d.Components.MediaTypes, "bMedia")
+	assert.Contains(t, d.Components.MediaTypes, "Shared")
+}
+
+// TestMediaTypeComponentsAreRewritten checks the other half: a merged media type
+// carries schema references, so a rename has to reach them and must reach only
+// the document that wrote them.
+func TestMediaTypeComponentsAreRewritten(t *testing.T) {
+	res, err := JoinWithOptions(
+		WithParsed(mediaTypeComponentDoc("a", false), mediaTypeComponentDoc("b", true)),
+		WithSchemaStrategy(StrategyRenameRight),
+		WithPathStrategy(StrategyAcceptLeft),
+		WithComponentStrategy(StrategyAcceptLeft),
+		WithRenameTemplate(`{{.Name}}.{{.Source}}`),
+	)
+	require.NoError(t, err)
+
+	d := res.Document.(*parser.OAS3Document)
+	require.Contains(t, d.Components.Schemas, "Target.b", "b's Target should have been renamed")
+
+	refs := func(mt *parser.MediaType) map[string]string {
+		require.NotNil(t, mt)
+		return map[string]string{
+			"schema":           mt.Schema.Ref,
+			"itemSchema":       mt.ItemSchema.Ref,
+			"encoding.headers": mt.Encoding["part"].Headers["X-Meta"].Schema.Ref,
+		}
+	}
+
+	for field, ref := range refs(d.Components.MediaTypes["bMedia"]) {
+		assert.Equal(t, "#/components/schemas/Target.b", ref, "b's %s was not rewritten", field)
+	}
+	for field, ref := range refs(d.Components.MediaTypes["aMedia"]) {
+		assert.Equal(t, "#/components/schemas/Target", ref, "a's %s was repointed", field)
+	}
+}
+
+// TestMediaTypeComponentsLeaveInputsUnchanged extends the #480 guarantee to the
+// container: a merged media type is copied before its references change.
+func TestMediaTypeComponentsLeaveInputsUnchanged(t *testing.T) {
+	docs := []parser.ParseResult{mediaTypeComponentDoc("a", false), mediaTypeComponentDoc("b", true)}
+	before := make([]any, len(docs))
+	for i := range docs {
+		before[i] = cloneDocument(t, docs[i].Document)
+	}
+
+	_, err := JoinWithOptions(
+		WithParsed(docs...),
+		WithSchemaStrategy(StrategyRenameRight),
+		WithPathStrategy(StrategyAcceptLeft),
+		WithComponentStrategy(StrategyAcceptLeft),
+		WithRenameTemplate(`{{.Name}}.{{.Source}}`),
+	)
+	require.NoError(t, err)
+
+	for i := range docs {
+		assert.Equal(t, before[i], docs[i].Document,
+			"joining modified input %d (%s)", i, docs[i].SourcePath)
+	}
+}

--- a/joiner/oas2.go
+++ b/joiner/oas2.go
@@ -70,6 +70,10 @@ func (j *Joiner) joinOAS2Documents(docs []parser.ParseResult) (*JoinResult, erro
 		OASVersion:          baseDoc.OASVersion,
 	}
 
+	graphs := newRefGraphs(j.config.OperationContext, func(docIndex int) *RefGraph {
+		return buildRefGraphOAS2(sources[docIndex])
+	})
+
 	// Merge all documents
 	for i, doc := range docs {
 		ctx := documentContext{
@@ -78,7 +82,7 @@ func (j *Joiner) joinOAS2Documents(docs []parser.ParseResult) (*JoinResult, erro
 			result:   &doc,
 		}
 
-		if err := j.mergeOAS2Document(joined, sources[i], ctx, result); err != nil {
+		if err := j.mergeOAS2Document(joined, sources[i], ctx, result, graphs); err != nil {
 			return nil, err
 		}
 	}
@@ -122,20 +126,14 @@ func (j *Joiner) joinOAS2Documents(docs []parser.ParseResult) (*JoinResult, erro
 }
 
 // mergeOAS2Document merges a single OAS2 document into the joined document
-func (j *Joiner) mergeOAS2Document(joined *parser.OAS2Document, oas2Doc *parser.OAS2Document, ctx documentContext, result *JoinResult) error {
+func (j *Joiner) mergeOAS2Document(joined *parser.OAS2Document, oas2Doc *parser.OAS2Document, ctx documentContext, result *JoinResult, graphs *refGraphs) error {
 	// Merge paths
 	if err := j.mergeOAS2Paths(joined, oas2Doc, ctx, result); err != nil {
 		return err
 	}
 
-	// Build reference graph if operation context is enabled
-	var sourceGraph *RefGraph
-	if j.config.OperationContext {
-		sourceGraph = buildRefGraphOAS2(oas2Doc)
-	}
-
 	// Merge definitions (schemas)
-	if err := j.mergeOAS2Definitions(joined, oas2Doc, ctx, result, sourceGraph); err != nil {
+	if err := j.mergeOAS2Definitions(joined, oas2Doc, ctx, result, graphs); err != nil {
 		return err
 	}
 
@@ -157,8 +155,9 @@ func (j *Joiner) mergeOAS2Paths(joined, source *parser.OAS2Document, ctx documen
 }
 
 // mergeOAS2Definitions merges definitions (schemas) from source document
-func (j *Joiner) mergeOAS2Definitions(joined, source *parser.OAS2Document, ctx documentContext, result *JoinResult, sourceGraph *RefGraph) error {
+func (j *Joiner) mergeOAS2Definitions(joined, source *parser.OAS2Document, ctx documentContext, result *JoinResult, graphs *refGraphs) error {
 	schemaStrategy := j.getEffectiveStrategy(j.config.SchemaStrategy)
+	sourceGraph := graphs.forDoc(ctx.docIndex)
 
 	// Get namespace prefix for this source (if configured)
 	sourcePrefix := j.getNamespacePrefix(ctx.filePath)
@@ -266,7 +265,7 @@ func (j *Joiner) mergeOAS2Definitions(joined, source *parser.OAS2Document, ctx d
 				if leftPrefix != "" {
 					newName = j.generatePrefixedSchemaName(effectiveName, leftPrefix)
 				} else {
-					newName = j.generateRenamedSchemaName(effectiveName, leftOrigin.filePath, leftOrigin.docIndex, nil)
+					newName = j.generateRenamedSchemaName(effectiveName, leftOrigin.filePath, leftOrigin.docIndex, graphs.forDoc(leftOrigin.docIndex))
 				}
 				newName = uniqueSchemaName(joined.Definitions, newName)
 

--- a/joiner/oas3.go
+++ b/joiner/oas3.go
@@ -81,6 +81,11 @@ func (j *Joiner) joinOAS3Documents(docs []parser.ParseResult) (*JoinResult, erro
 	joined.Components.PathItems = make(map[string]*parser.PathItem)
 	joined.Components.MediaTypes = make(map[string]*parser.MediaType)
 
+	graphs := newRefGraphs(j.config.OperationContext, func(docIndex int) *RefGraph {
+		src := sources[docIndex]
+		return buildRefGraphOAS3(src, src.OASVersion)
+	})
+
 	// Merge all documents
 	for i, doc := range docs {
 		oas3Doc := sources[i]
@@ -168,13 +173,7 @@ func (j *Joiner) joinOAS3Documents(docs []parser.ParseResult) (*JoinResult, erro
 
 		// Merge components
 		if oas3Doc.Components != nil {
-			// Build reference graph if operation context is enabled
-			var sourceGraph *RefGraph
-			if j.config.OperationContext {
-				sourceGraph = buildRefGraphOAS3(oas3Doc, oas3Doc.OASVersion)
-			}
-
-			if err := j.mergeOAS3Components(joined.Components, oas3Doc.Components, ctx, result, sourceGraph); err != nil {
+			if err := j.mergeOAS3Components(joined.Components, oas3Doc.Components, ctx, result, graphs); err != nil {
 				return nil, err
 			}
 		}
@@ -237,12 +236,12 @@ func (j *Joiner) joinOAS3Documents(docs []parser.ParseResult) (*JoinResult, erro
 }
 
 // mergeOAS3Components merges components from source into target
-func (j *Joiner) mergeOAS3Components(target, source *parser.Components, ctx documentContext, result *JoinResult, sourceGraph *RefGraph) error {
+func (j *Joiner) mergeOAS3Components(target, source *parser.Components, ctx documentContext, result *JoinResult, graphs *refGraphs) error {
 	schemaStrategy := j.getEffectiveStrategy(j.config.SchemaStrategy)
 	componentStrategy := j.getEffectiveStrategy(j.config.ComponentStrategy)
 
 	// Merge schemas with detailed warnings
-	if err := j.mergeSchemas(target.Schemas, source.Schemas, schemaStrategy, ctx, result, sourceGraph); err != nil {
+	if err := j.mergeSchemas(target.Schemas, source.Schemas, schemaStrategy, ctx, result, graphs); err != nil {
 		return err
 	}
 
@@ -282,7 +281,9 @@ func (j *Joiner) mergeOAS3Components(target, source *parser.Components, ctx docu
 }
 
 // mergeSchemas is a specialized merger for schemas with detailed warnings
-func (j *Joiner) mergeSchemas(target, source map[string]*parser.Schema, strategy CollisionStrategy, ctx documentContext, result *JoinResult, sourceGraph *RefGraph) error {
+func (j *Joiner) mergeSchemas(target, source map[string]*parser.Schema, strategy CollisionStrategy, ctx documentContext, result *JoinResult, graphs *refGraphs) error {
+	sourceGraph := graphs.forDoc(ctx.docIndex)
+
 	// Get namespace prefix for this source (if configured)
 	sourcePrefix := j.getNamespacePrefix(ctx.filePath)
 
@@ -389,8 +390,7 @@ func (j *Joiner) mergeSchemas(target, source map[string]*parser.Schema, strategy
 				if leftPrefix != "" {
 					newName = j.generatePrefixedSchemaName(effectiveName, leftPrefix)
 				} else {
-					// No graph: operation-aware templates are not wired up here (#482).
-					newName = j.generateRenamedSchemaName(effectiveName, leftOrigin.filePath, leftOrigin.docIndex, nil)
+					newName = j.generateRenamedSchemaName(effectiveName, leftOrigin.filePath, leftOrigin.docIndex, graphs.forDoc(leftOrigin.docIndex))
 				}
 				newName = uniqueSchemaName(target, newName)
 

--- a/joiner/oas3.go
+++ b/joiner/oas3.go
@@ -79,6 +79,7 @@ func (j *Joiner) joinOAS3Documents(docs []parser.ParseResult) (*JoinResult, erro
 	joined.Components.Callbacks = make(map[string]*parser.Callback)
 	joined.Components.CallbackRefs = make(map[string]*parser.Reference)
 	joined.Components.PathItems = make(map[string]*parser.PathItem)
+	joined.Components.MediaTypes = make(map[string]*parser.MediaType)
 
 	// Merge all documents
 	for i, doc := range docs {
@@ -273,6 +274,9 @@ func (j *Joiner) mergeOAS3Components(target, source *parser.Components, ctx docu
 	if err := j.mergePathItems(target.PathItems, source.PathItems, componentStrategy, ctx, result); err != nil {
 		return err
 	}
+	if err := j.mergeMediaTypes(target.MediaTypes, source.MediaTypes, componentStrategy, ctx, result); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -463,6 +467,13 @@ func (j *Joiner) mergeResponses(target, source map[string]*parser.Response, stra
 
 func (j *Joiner) mergeParameters(target, source map[string]*parser.Parameter, strategy CollisionStrategy, ctx documentContext, result *JoinResult) error {
 	return mergeMap(j, target, source, "components.parameters", CollisionTypeParameter, strategy, ctx, result)
+}
+
+// mergeMediaTypes merges components.mediaTypes (OAS 3.2+). Its entries carry
+// schema references, so renameScope attributes them and the rewriter traverses
+// them alongside the other component maps.
+func (j *Joiner) mergeMediaTypes(target, source map[string]*parser.MediaType, strategy CollisionStrategy, ctx documentContext, result *JoinResult) error {
+	return mergeMap(j, target, source, "components.mediaTypes", CollisionTypeMediaType, strategy, ctx, result)
 }
 
 func (j *Joiner) mergeExamples(target, source map[string]*parser.Example, strategy CollisionStrategy, ctx documentContext, result *JoinResult) error {

--- a/joiner/refgraph_cache.go
+++ b/joiner/refgraph_cache.go
@@ -1,0 +1,37 @@
+package joiner
+
+// refGraphs hands out a source document's reference graph by position, building
+// each at most once.
+//
+// A join can rename many schemas, and every rename that wants operation context
+// needs the graph of the document the schema came from. Building one per rename
+// would walk the same document repeatedly.
+//
+// A nil *refGraphs yields nil graphs, which is what the rename context falls
+// back to when WithOperationContext is off.
+type refGraphs struct {
+	build func(docIndex int) *RefGraph
+	cache map[int]*RefGraph
+}
+
+// newRefGraphs returns a cache over build, or nil when enabled is false so the
+// graphs are never built.
+func newRefGraphs(enabled bool, build func(docIndex int) *RefGraph) *refGraphs {
+	if !enabled {
+		return nil
+	}
+	return &refGraphs{build: build, cache: make(map[int]*RefGraph)}
+}
+
+// forDoc returns the graph of the document at docIndex.
+func (g *refGraphs) forDoc(docIndex int) *RefGraph {
+	if g == nil || docIndex < 0 {
+		return nil
+	}
+	if cached, ok := g.cache[docIndex]; ok {
+		return cached
+	}
+	graph := g.build(docIndex)
+	g.cache[docIndex] = graph
+	return graph
+}

--- a/joiner/refgraph_cache.go
+++ b/joiner/refgraph_cache.go
@@ -3,12 +3,8 @@ package joiner
 // refGraphs hands out a source document's reference graph by position, building
 // each at most once.
 //
-// A join can rename many schemas, and every rename that wants operation context
-// needs the graph of the document the schema came from. Building one per rename
-// would walk the same document repeatedly.
-//
-// A nil *refGraphs yields nil graphs, which is what the rename context falls
-// back to when WithOperationContext is off.
+// A nil *refGraphs yields nil graphs, which is what the rename context reads
+// when WithOperationContext is off.
 type refGraphs struct {
 	build func(docIndex int) *RefGraph
 	cache map[int]*RefGraph

--- a/joiner/rename_left_context_test.go
+++ b/joiner/rename_left_context_test.go
@@ -1,0 +1,137 @@
+package joiner
+
+import (
+	"testing"
+
+	"github.com/erraggy/oastools/parser"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// operationContextDoc gives its Response schema one operation, whose operationId
+// is what an operation-aware rename template reads.
+func operationContextDoc(name, operationID string, extra bool) parser.ParseResult {
+	response := &parser.Schema{Type: "object", Properties: map[string]*parser.Schema{"id": {Type: "string"}}}
+	if extra {
+		response.Properties["note"] = &parser.Schema{Type: "string"}
+	}
+	return parser.ParseResult{
+		Document: &parser.OAS3Document{
+			OpenAPI: "3.0.3",
+			Info:    &parser.Info{Title: name, Version: "1.0.0"},
+			Paths: parser.Paths{
+				"/" + name: &parser.PathItem{Get: &parser.Operation{
+					OperationID: operationID,
+					Responses: &parser.Responses{Codes: map[string]*parser.Response{
+						"200": {Description: "ok", Content: map[string]*parser.MediaType{
+							"application/json": {Schema: &parser.Schema{Ref: "#/components/schemas/Response"}},
+						}},
+					}},
+				}},
+			},
+			Components: &parser.Components{Schemas: map[string]*parser.Schema{"Response": response}},
+			OASVersion: parser.OASVersion303,
+		},
+		Version: "3.0.3", OASVersion: parser.OASVersion303,
+		SourcePath: name, SourceFormat: parser.SourceFormatJSON,
+	}
+}
+
+// TestRenameLeftUsesOperationContext covers #482. The left side of a rename-left
+// collision was named with a nil reference graph, so an operation-aware template
+// fell back to its empty-field output while the right side got a full name.
+func TestRenameLeftUsesOperationContext(t *testing.T) {
+	res, err := JoinWithOptions(
+		WithParsed(
+			operationContextDoc("orders", "listOrders", false),
+			operationContextDoc("users", "listUsers", true),
+		),
+		WithSchemaStrategy(StrategyRenameLeft),
+		WithPathStrategy(StrategyAcceptLeft),
+		WithOperationContext(true),
+		WithRenameTemplate(`{{pascalCase .OperationID}}{{.Name}}`),
+	)
+	require.NoError(t, err)
+
+	d := res.Document.(*parser.OAS3Document)
+
+	// orders was moved aside, and its name comes from its own operation rather
+	// than from an empty context.
+	assert.Contains(t, d.Components.Schemas, "ListOrdersResponse")
+	assert.NotContains(t, d.Components.Schemas, "Response_orders",
+		"the template fell back, so the left side had no operation context")
+
+	// users took the original name.
+	assert.Contains(t, d.Components.Schemas, "Response")
+	assert.Contains(t, d.Components.Schemas["Response"].Properties, "note")
+
+	// Each document still reads its own schema.
+	ref := func(path string) string {
+		return d.Paths[path].Get.Responses.Codes["200"].Content["application/json"].Schema.Ref
+	}
+	assert.Equal(t, "#/components/schemas/ListOrdersResponse", ref("/orders"))
+	assert.Equal(t, "#/components/schemas/Response", ref("/users"))
+}
+
+// TestRenameLeftOperationContextOAS2 is the OAS 2 counterpart.
+func TestRenameLeftOperationContextOAS2(t *testing.T) {
+	doc := func(name, operationID string, extra bool) parser.ParseResult {
+		response := &parser.Schema{Type: "object", Properties: map[string]*parser.Schema{"id": {Type: "string"}}}
+		if extra {
+			response.Properties["note"] = &parser.Schema{Type: "string"}
+		}
+		return parser.ParseResult{
+			Document: &parser.OAS2Document{
+				Swagger: "2.0",
+				Info:    &parser.Info{Title: name, Version: "1.0.0"},
+				Paths: parser.Paths{
+					"/" + name: &parser.PathItem{Get: &parser.Operation{
+						OperationID: operationID,
+						Responses: &parser.Responses{Codes: map[string]*parser.Response{
+							"200": {Description: "ok", Schema: &parser.Schema{Ref: "#/definitions/Response"}},
+						}},
+					}},
+				},
+				Definitions: map[string]*parser.Schema{"Response": response},
+				OASVersion:  parser.OASVersion20,
+			},
+			Version: "2.0", OASVersion: parser.OASVersion20,
+			SourcePath: name, SourceFormat: parser.SourceFormatJSON,
+		}
+	}
+
+	res, err := JoinWithOptions(
+		WithParsed(doc("orders", "listOrders", false), doc("users", "listUsers", true)),
+		WithSchemaStrategy(StrategyRenameLeft),
+		WithPathStrategy(StrategyAcceptLeft),
+		WithOperationContext(true),
+		WithRenameTemplate(`{{pascalCase .OperationID}}{{.Name}}`),
+	)
+	require.NoError(t, err)
+
+	d := res.Document.(*parser.OAS2Document)
+	assert.Contains(t, d.Definitions, "ListOrdersResponse")
+	assert.Contains(t, d.Definitions, "Response")
+	assert.Equal(t, "#/definitions/ListOrdersResponse", petResponseRef(t, d, "/orders"))
+	assert.Equal(t, "#/definitions/Response", petResponseRef(t, d, "/users"))
+}
+
+func TestRefGraphsCachesPerDocument(t *testing.T) {
+	built := map[int]int{}
+	graphs := newRefGraphs(true, func(docIndex int) *RefGraph {
+		built[docIndex]++
+		return &RefGraph{}
+	})
+
+	for range 3 {
+		graphs.forDoc(0)
+		graphs.forDoc(1)
+	}
+	assert.Equal(t, map[int]int{0: 1, 1: 1}, built, "each document's graph is built once")
+
+	// Disabled and nil caches never build, which is the operation context off path.
+	assert.Nil(t, newRefGraphs(false, func(int) *RefGraph { t.Fatal("built while disabled"); return nil }))
+	var absent *refGraphs
+	assert.Nil(t, absent.forDoc(0))
+	assert.Nil(t, graphs.forDoc(-1))
+}

--- a/joiner/rename_left_context_test.go
+++ b/joiner/rename_left_context_test.go
@@ -37,9 +37,9 @@ func operationContextDoc(name, operationID string, extra bool) parser.ParseResul
 	}
 }
 
-// TestRenameLeftUsesOperationContext covers #482. The left side of a rename-left
-// collision was named with a nil reference graph, so an operation-aware template
-// fell back to its empty-field output while the right side got a full name.
+// TestRenameLeftUsesOperationContext covers #482: the schema moved aside by
+// rename-left is named from its own document's operation context, the same as
+// the schema renamed by rename-right.
 func TestRenameLeftUsesOperationContext(t *testing.T) {
 	res, err := JoinWithOptions(
 		WithParsed(
@@ -55,8 +55,7 @@ func TestRenameLeftUsesOperationContext(t *testing.T) {
 
 	d := res.Document.(*parser.OAS3Document)
 
-	// orders was moved aside, and its name comes from its own operation rather
-	// than from an empty context.
+	// orders was moved aside, and its name comes from its own operation.
 	assert.Contains(t, d.Components.Schemas, "ListOrdersResponse")
 	assert.NotContains(t, d.Components.Schemas, "Response_orders",
 		"the template fell back, so the left side had no operation context")

--- a/joiner/rename_scope.go
+++ b/joiner/rename_scope.go
@@ -112,6 +112,7 @@ func (s *renameScope) applyOAS3(joined *parser.OAS3Document, sources []*parser.O
 			claimEntries(owner, docIndex, src.Components.Headers)
 			claimEntries(owner, docIndex, src.Components.Callbacks)
 			claimEntries(owner, docIndex, src.Components.PathItems)
+			claimEntries(owner, docIndex, src.Components.MediaTypes)
 		}
 		claimEntries(owner, docIndex, src.Paths)
 		claimEntries(owner, docIndex, src.Webhooks)

--- a/joiner/rename_scope_test.go
+++ b/joiner/rename_scope_test.go
@@ -397,6 +397,9 @@ func TestRenameScopeCoversEveryContainer(t *testing.T) {
 					PathItems: map[string]*parser.PathItem{
 						name + "PI": {Get: containerRef()},
 					},
+					MediaTypes: map[string]*parser.MediaType{
+						name + "MT": {Schema: targetRef()},
+					},
 				},
 				OASVersion: parser.OASVersion310,
 			},
@@ -430,6 +433,7 @@ func TestRenameScopeCoversEveryContainer(t *testing.T) {
 			"components.headers":       c.Headers[source+"Header"].Schema.Ref,
 			"components.callbacks":     oas3ResponseRefIn(t, callback["{$request.body#/url}"].Post),
 			"components.pathItems":     oas3ResponseRefIn(t, c.PathItems[source+"PI"].Get),
+			"components.mediaTypes":    c.MediaTypes[source+"MT"].Schema.Ref,
 			"paths":                    oas3ResponseRefIn(t, d.Paths["/"+source].Get),
 			"webhooks":                 oas3ResponseRefIn(t, d.Webhooks[source+"Hook"].Post),
 		}

--- a/joiner/rename_scope_test.go
+++ b/joiner/rename_scope_test.go
@@ -363,7 +363,7 @@ func TestRenameScopeCoversEveryContainer(t *testing.T) {
 
 		return parser.ParseResult{
 			Document: &parser.OAS3Document{
-				OpenAPI: "3.1.0",
+				OpenAPI: "3.2.0",
 				Info:    &parser.Info{Title: name, Version: "1.0.0"},
 				Paths: parser.Paths{
 					"/" + name: &parser.PathItem{Get: containerRef()},
@@ -401,10 +401,10 @@ func TestRenameScopeCoversEveryContainer(t *testing.T) {
 						name + "MT": {Schema: targetRef()},
 					},
 				},
-				OASVersion: parser.OASVersion310,
+				OASVersion: parser.OASVersion320,
 			},
-			Version:      "3.1.0",
-			OASVersion:   parser.OASVersion310,
+			Version:      "3.2.0",
+			OASVersion:   parser.OASVersion320,
 			SourcePath:   name,
 			SourceFormat: parser.SourceFormatJSON,
 		}

--- a/joiner/rewriter.go
+++ b/joiner/rewriter.go
@@ -175,6 +175,9 @@ func (r *SchemaRewriter) rewriteOAS3Document(doc *parser.OAS3Document) error {
 		rewriteEntries(r, doc.Components.Callbacks, r.rewriteCallback, cloneCallback)
 		// Links - intentionally not rewritten (don't contain schema references)
 		rewriteEntries(r, doc.Components.PathItems, r.rewritePathItem, (*parser.PathItem).DeepCopy)
+		// mediaTypes is OAS 3.2+, and its entries reach schemas the same way any
+		// other media type does.
+		rewriteEntries(r, doc.Components.MediaTypes, r.rewriteMediaType, (*parser.MediaType).DeepCopy)
 	}
 
 	// Rewrite references in paths


### PR DESCRIPTION
## Summary 🎯

Two joiner follow-ups from the #478 and #480 work, both found while fixing something else.

Fixes #485, #482.

## components.mediaTypes was dropped (#485)

`mergeOAS3Components` handled every field of `parser.Components` except `MediaTypes`, and `joinOAS3Documents` never initialized the map, so every entry of every input was discarded and nothing was reported. Two documents holding one entry each produced none.

The section carries schema references, so three parts are needed together and each fails on its own:

| part | where | fails alone |
|---|---|---|
| merge it | `mergeMediaTypes`, through `mergeMap` like the other component maps | 3 assertions |
| attribute it | `renameScope.applyOAS3` claims its entries | 4 assertions |
| traverse it | `rewriteOAS3Document`, with `rewriteMediaType` | 4 assertions |

Missing the attribution is the subtle one: an unattributed entry is not left unrewritten, it becomes unowned, and the unowned pass applies every document's renames. That is right by accident for the last document and silently repoints the earlier ones, which is the #478 failure mode arriving through a new door. It is why the tests assert both directions.

`CollisionTypeMediaType` is the collision type for the section, so a handler is told what collided the way it is for every other component.

## rename-left had no operation context (#482)

`WithOperationContext` populates `Path`, `OperationID`, `Tags` and friends for a rename template. The left side of a `rename-left` collision was named with a nil reference graph, so it got the fallback while the right side got a full name. With `{{pascalCase .OperationID}}{{.Name}}`:

```
before:  ListUsersResponse   and   Response_orders
after:   ListUsersResponse   and   ListOrdersResponse
```

`refGraphs` hands out a source document's graph by position and builds each at most once. It replaces the `sourceGraph` parameter rather than adding another: the incoming document's graph is `forDoc(ctx.docIndex)` and the moved schema's is `forDoc(leftOrigin.docIndex)`, using the origin tracking #479 added. Nothing is built when the option is off, which is the same nil the rename context already handled.

## Tests 🧪

Every part above was verified by disabling it and counting the failures, listed in the table.

`TestRewriteMediaTypeReachesEveryRef` gains `components.mediaTypes` as a sixth location, so the new container is checked across all eight of a media type's reference paths (`schema`, `itemSchema`, and the headers reachable through `encoding`, its nesting, `itemEncoding` and `prefixEncoding`) rather than the three a new fixture would have covered. Dropping the traversal fails 8 of them.

`TestJoinLeavesInputsUnchanged` covers the new container too, so the #480 guarantee extends to it.

`make check` clean at 10807 tests, no gopls diagnostics.

## Not included

**#418** was in the original plan and came out, because its stated shape does not build. `internal/equalutil` cannot host the parser typed helpers, since `parser` imports it and the reverse edge is a cycle, and the ordering divergence covers three fields rather than one while the same parser helper also serves `enum`, `schemes`, `consumes`, `produces` and `tags`. That makes it a `parser` semantics change with its own blast radius rather than a joiner cleanup. Written up on the issue.

**#487** and **#488** are open and out of scope: #487 is blocked on deciding which name survives a deduplication, and #488 is a change to the deep copy generator.

## Review notes 📝

Two local CodeRabbit rounds before opening. Three findings applied, two declined with evidence: there is no HTTP status constant to key response maps with (`internal/httputil` carries methods only, the 28 response keys already in this package's tests are literals, and `net/http`'s `StatusOK` is an `int` where these are map keys that also take `default` and `2XX`), and duplicating the encoding recursion into a second fixture would have covered code the existing test already guards.