### PR TITLE
fix(joiner): report the document that contributed the colliding value

### DIFF
--- a/joiner/collision_handler.go
+++ b/joiner/collision_handler.go
@@ -134,7 +134,8 @@ type CollisionContext struct {
 	// JSONPath is the full path (e.g., "$.components.schemas.User").
 	JSONPath string
 
-	// LeftSource is the source file/identifier for left document.
+	// LeftSource is the source file/identifier of the document that contributed
+	// LeftValue, which is the first document only until something replaces it.
 	LeftSource string
 	// LeftLocation is the line/column in left document (nil if unknown).
 	LeftLocation *SourceLocation
@@ -266,6 +267,7 @@ type schemaResolutionParams struct {
 	sourceName  string
 	sourceGraph *RefGraph
 	label       string // "schema" for OAS3, "definition" for OAS2
+	section     string // the JSON path section the target map lives at
 }
 
 // applySchemaResolution applies a CollisionResolution to a schema/definition collision.
@@ -296,7 +298,7 @@ func (j *Joiner) applySchemaResolution(p schemaResolutionParams) (bool, error) {
 	case ResolutionAcceptRight:
 		// Replace with incoming (right)
 		p.target[p.collision.Name] = schema
-		p.result.recordOrigin(p.collision.Name, p.ctx)
+		p.result.recordOrigin(p.section, p.collision.Name, p.ctx)
 		j.recordCollisionEvent(p.result, p.collision.Name, p.collision.LeftSource, p.collision.RightSource, p.collision.ConfiguredStrategy, resolutionKeptRight, "")
 		return true, nil
 
@@ -304,7 +306,7 @@ func (j *Joiner) applySchemaResolution(p schemaResolutionParams) (bool, error) {
 		// Rename right schema/definition
 		newName := uniqueSchemaName(p.target, j.generateRenamedSchemaName(p.collision.Name, p.ctx.filePath, p.ctx.docIndex, p.sourceGraph))
 		p.target[newName] = schema
-		p.result.recordOrigin(newName, p.ctx)
+		p.result.recordOrigin(p.section, newName, p.ctx)
 		// Only the incoming document referenced the renamed schema.
 		p.result.scope.registerRight(p.ctx.docIndex, p.sourceName, newName)
 		line, col := j.getLocation(p.ctx.filePath, p.collision.JSONPath)
@@ -336,7 +338,7 @@ func (j *Joiner) applySchemaResolution(p schemaResolutionParams) (bool, error) {
 			return true, fmt.Errorf("collision handler: CustomValue is %T, expected *parser.Schema for %s collisions", p.resolution.CustomValue, p.label)
 		}
 		p.target[p.collision.Name] = customSchema
-		p.result.recordOrigin(p.collision.Name, p.ctx)
+		p.result.recordOrigin(p.section, p.collision.Name, p.ctx)
 		j.recordCollisionEvent(p.result, p.collision.Name, p.collision.LeftSource, p.collision.RightSource, p.collision.ConfiguredStrategy, "custom", "")
 		return true, nil
 

--- a/joiner/collision_source_test.go
+++ b/joiner/collision_source_test.go
@@ -1,0 +1,180 @@
+package joiner
+
+import (
+	"testing"
+
+	"github.com/erraggy/oastools/parser"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// threeDocOAS3 builds a document that collides with its siblings on one entry in
+// every section a collision can be reported for. Each value carries the source
+// name, so the side a collision reports is identifiable.
+func threeDocOAS3(name string) parser.ParseResult {
+	return parser.ParseResult{
+		Document: &parser.OAS3Document{
+			OpenAPI: "3.1.0",
+			Info:    &parser.Info{Title: name, Version: "1.0.0"},
+			Paths: parser.Paths{
+				"/shared": &parser.PathItem{Description: name, Get: &parser.Operation{OperationID: name}},
+			},
+			Webhooks: map[string]*parser.PathItem{
+				"Shared": {Description: name},
+			},
+			Components: &parser.Components{
+				Schemas:    map[string]*parser.Schema{"Shared": {Type: "object", Description: name}},
+				Responses:  map[string]*parser.Response{"Shared": {Description: name}},
+				Parameters: map[string]*parser.Parameter{"Shared": {Name: "q", In: "query", Description: name}},
+			},
+			OASVersion: parser.OASVersion310,
+		},
+		Version: "3.1.0", OASVersion: parser.OASVersion310,
+		SourcePath: name, SourceFormat: parser.SourceFormatJSON,
+	}
+}
+
+// collisionSources joins a, b and c under accept-right, so each document
+// replaces the last, and returns what each collision reported as its left side
+// keyed by "section/incoming document".
+func collisionSources(t *testing.T, opts ...Option) map[string]string {
+	t.Helper()
+	seen := map[string]string{}
+	base := []Option{
+		WithParsed(threeDocOAS3("a"), threeDocOAS3("b"), threeDocOAS3("c")),
+		WithDefaultStrategy(StrategyAcceptRight),
+		WithPathStrategy(StrategyAcceptRight),
+		WithSchemaStrategy(StrategyAcceptRight),
+		WithComponentStrategy(StrategyAcceptRight),
+		WithCollisionHandler(func(c CollisionContext) (CollisionResolution, error) {
+			seen[string(c.Type)+"/"+c.RightSource] = c.LeftSource
+			return ContinueWithStrategy(), nil
+		}),
+	}
+	_, err := JoinWithOptions(append(base, opts...)...)
+	require.NoError(t, err)
+	return seen
+}
+
+// TestCollisionReportsContributingLeftSource covers #490. Every section took its
+// left source from the first document, so once a later document replaced a
+// value, the next collision named a document whose value was no longer there.
+func TestCollisionReportsContributingLeftSource(t *testing.T) {
+	seen := collisionSources(t)
+
+	for _, section := range []string{
+		string(CollisionTypePath),
+		string(CollisionTypeWebhook),
+		string(CollisionTypeSchema),
+		string(CollisionTypeResponse),
+		string(CollisionTypeParameter),
+	} {
+		// b collides with a, which is still the contributor.
+		assert.Equal(t, "a", seen[section+"/b"], "%s: b's collision", section)
+		// c collides with b, because accept-right put b's value there.
+		assert.Equal(t, "b", seen[section+"/c"], "%s: c's collision", section)
+	}
+}
+
+// TestCollisionLeftValueMatchesLeftSource is the property that matters: the
+// document named as the left side is the one whose value is being handed over.
+func TestCollisionLeftValueMatchesLeftSource(t *testing.T) {
+	var mismatches []string
+	_, err := JoinWithOptions(
+		WithParsed(threeDocOAS3("a"), threeDocOAS3("b"), threeDocOAS3("c")),
+		WithDefaultStrategy(StrategyAcceptRight),
+		WithPathStrategy(StrategyAcceptRight),
+		WithSchemaStrategy(StrategyAcceptRight),
+		WithComponentStrategy(StrategyAcceptRight),
+		WithCollisionHandler(func(c CollisionContext) (CollisionResolution, error) {
+			var describes string
+			switch v := c.LeftValue.(type) {
+			case *parser.Schema:
+				describes = v.Description
+			case *parser.Response:
+				describes = v.Description
+			case *parser.Parameter:
+				describes = v.Description
+			case *parser.PathItem:
+				describes = v.Description
+			default:
+				return ContinueWithStrategy(), nil
+			}
+			if describes != c.LeftSource {
+				mismatches = append(mismatches,
+					string(c.Type)+": LeftSource="+c.LeftSource+" but LeftValue is from "+describes)
+			}
+			return ContinueWithStrategy(), nil
+		}),
+	)
+	require.NoError(t, err)
+	assert.Empty(t, mismatches)
+}
+
+// TestCollisionReportRecordsContributingSource checks the collision report, which
+// reads the same source as the handler.
+func TestCollisionReportRecordsContributingSource(t *testing.T) {
+	res, err := JoinWithOptions(
+		WithParsed(threeDocOAS3("a"), threeDocOAS3("b"), threeDocOAS3("c")),
+		WithDefaultStrategy(StrategyAcceptRight),
+		WithPathStrategy(StrategyAcceptRight),
+		WithSchemaStrategy(StrategyAcceptRight),
+		WithComponentStrategy(StrategyAcceptRight),
+		WithCollisionReport(true),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, res.CollisionDetails)
+
+	lefts := map[string][]string{}
+	for _, e := range res.CollisionDetails.Events {
+		lefts[e.RightSource] = append(lefts[e.RightSource], e.LeftSource)
+	}
+	require.NotEmpty(t, lefts["c"], "c's collisions should be recorded")
+	for _, left := range lefts["c"] {
+		assert.Equal(t, "b", left, "c collided with b's value, not a's")
+	}
+}
+
+// TestCollisionSourceSectionsAreIndependent checks the section is part of the
+// key: two sections holding the same name track their contributors separately.
+func TestCollisionSourceSectionsAreIndependent(t *testing.T) {
+	// a contributes the schema, b contributes the response, and neither
+	// document has the other's entry, so nothing collides until c arrives.
+	doc := func(name string, schema, response bool) parser.ParseResult {
+		components := &parser.Components{}
+		if schema {
+			components.Schemas = map[string]*parser.Schema{"Shared": {Type: "object", Description: name}}
+		}
+		if response {
+			components.Responses = map[string]*parser.Response{"Shared": {Description: name}}
+		}
+		return parser.ParseResult{
+			Document: &parser.OAS3Document{
+				OpenAPI:    "3.1.0",
+				Info:       &parser.Info{Title: name, Version: "1.0.0"},
+				Paths:      parser.Paths{"/" + name: &parser.PathItem{Get: &parser.Operation{}}},
+				Components: components,
+				OASVersion: parser.OASVersion310,
+			},
+			Version: "3.1.0", OASVersion: parser.OASVersion310,
+			SourcePath: name, SourceFormat: parser.SourceFormatJSON,
+		}
+	}
+
+	seen := map[string]string{}
+	_, err := JoinWithOptions(
+		WithParsed(doc("a", true, false), doc("b", false, true), doc("c", true, true)),
+		WithDefaultStrategy(StrategyAcceptRight),
+		WithPathStrategy(StrategyAcceptLeft),
+		WithSchemaStrategy(StrategyAcceptRight),
+		WithComponentStrategy(StrategyAcceptRight),
+		WithCollisionHandler(func(c CollisionContext) (CollisionResolution, error) {
+			seen[string(c.Type)] = c.LeftSource
+			return ContinueWithStrategy(), nil
+		}),
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, "a", seen[string(CollisionTypeSchema)], "the schema came from a")
+	assert.Equal(t, "b", seen[string(CollisionTypeResponse)], "the response came from b")
+}

--- a/joiner/collision_source_test.go
+++ b/joiner/collision_source_test.go
@@ -178,3 +178,78 @@ func TestCollisionSourceSectionsAreIndependent(t *testing.T) {
 	assert.Equal(t, "a", seen[string(CollisionTypeSchema)], "the schema came from a")
 	assert.Equal(t, "b", seen[string(CollisionTypeResponse)], "the response came from b")
 }
+
+// threeDocOAS2 is the OAS 2 counterpart, covering the definitions path, which
+// merges separately from the component maps, and the three sections OAS 2 puts
+// at the document root.
+func threeDocOAS2(name string) parser.ParseResult {
+	return parser.ParseResult{
+		Document: &parser.OAS2Document{
+			Swagger: "2.0",
+			Info:    &parser.Info{Title: name, Version: "1.0.0"},
+			Paths: parser.Paths{
+				"/shared": &parser.PathItem{Description: name, Get: &parser.Operation{OperationID: name}},
+			},
+			Definitions: map[string]*parser.Schema{"Shared": {Type: "object", Description: name}},
+			Parameters:  map[string]*parser.Parameter{"Shared": {Name: "q", In: "query", Description: name}},
+			Responses:   map[string]*parser.Response{"Shared": {Description: name}},
+			SecurityDefinitions: map[string]*parser.SecurityScheme{
+				"Shared": {Type: "apiKey", Name: name, In: "header"},
+			},
+			OASVersion: parser.OASVersion20,
+		},
+		Version: "2.0", OASVersion: parser.OASVersion20,
+		SourcePath: name, SourceFormat: parser.SourceFormatJSON,
+	}
+}
+
+// TestCollisionReportsContributingLeftSourceOAS2 is the OAS 2 counterpart of
+// TestCollisionReportsContributingLeftSource. Definitions merge through
+// mergeOAS2Definitions rather than mergeMap, so the path is separate.
+func TestCollisionReportsContributingLeftSourceOAS2(t *testing.T) {
+	seen := map[string]string{}
+	values := map[string]string{}
+	_, err := JoinWithOptions(
+		WithParsed(threeDocOAS2("a"), threeDocOAS2("b"), threeDocOAS2("c")),
+		WithDefaultStrategy(StrategyAcceptRight),
+		WithPathStrategy(StrategyAcceptRight),
+		WithSchemaStrategy(StrategyAcceptRight),
+		WithComponentStrategy(StrategyAcceptRight),
+		WithCollisionHandler(func(c CollisionContext) (CollisionResolution, error) {
+			key := string(c.Type) + "/" + c.RightSource
+			seen[key] = c.LeftSource
+			switch v := c.LeftValue.(type) {
+			case *parser.Schema:
+				values[key] = v.Description
+			case *parser.Parameter:
+				values[key] = v.Description
+			case *parser.Response:
+				values[key] = v.Description
+			case *parser.SecurityScheme:
+				values[key] = v.Name
+			case *parser.PathItem:
+				values[key] = v.Description
+			}
+			return ContinueWithStrategy(), nil
+		}),
+	)
+	require.NoError(t, err)
+
+	for _, section := range []string{
+		string(CollisionTypeSchema),
+		string(CollisionTypeParameter),
+		string(CollisionTypeResponse),
+		string(CollisionTypeSecurityScheme),
+		string(CollisionTypePath),
+	} {
+		assert.Equal(t, "a", seen[section+"/b"], "%s: b's collision", section)
+		assert.Equal(t, "b", seen[section+"/c"], "%s: c's collision", section)
+	}
+
+	// And the named source is the one whose value is on the left.
+	for key, source := range seen {
+		if got, ok := values[key]; ok {
+			assert.Equal(t, source, got, "%s: LeftSource and LeftValue disagree", key)
+		}
+	}
+}

--- a/joiner/collision_source_test.go
+++ b/joiner/collision_source_test.go
@@ -1,6 +1,7 @@
 package joiner
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/erraggy/oastools/parser"
@@ -252,4 +253,105 @@ func TestCollisionReportsContributingLeftSourceOAS2(t *testing.T) {
 			assert.Equal(t, source, got, "%s: LeftSource and LeftValue disagree", key)
 		}
 	}
+}
+
+// parseWithSourceMap parses a document with locations recorded, so a collision's
+// LeftLocation can be traced back to the document it came from. Each document
+// pads its Shared schema to a different line.
+func parseWithSourceMap(t *testing.T, name string, pad int) parser.ParseResult {
+	t.Helper()
+	var filler string
+	for i := range pad {
+		filler += fmt.Sprintf("    Pad%d%s:\n      type: string\n", i, name)
+	}
+	spec := fmt.Sprintf(`openapi: 3.0.3
+info:
+  title: %s
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+%s    Shared:
+      type: object
+      description: %s
+`, name, filler, name)
+
+	res, err := parser.ParseWithOptions(
+		parser.WithBytes([]byte(spec)),
+		parser.WithSourceMap(true),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, res.SourceMap, "the parse should record locations")
+	res.SourcePath = name
+	return *res
+}
+
+// TestCollisionReportsContributingLeftLocation covers the other half of the
+// context: the location has to come from the same document as the source, or a
+// caller following it lands in a file that no longer holds the value.
+func TestCollisionReportsContributingLeftLocation(t *testing.T) {
+	docs := []parser.ParseResult{
+		parseWithSourceMap(t, "a", 0),
+		parseWithSourceMap(t, "b", 2),
+		parseWithSourceMap(t, "c", 4),
+	}
+	const schemaPath = "$.components.schemas.Shared"
+	lineOf := map[string]int{}
+	maps := map[string]*parser.SourceMap{}
+	for _, d := range docs {
+		lineOf[d.SourcePath] = d.SourceMap.Get(schemaPath).Line
+		maps[d.SourcePath] = d.SourceMap
+	}
+	require.NotEqual(t, lineOf["a"], lineOf["b"], "the fixtures must differ in position")
+
+	j := New(JoinerConfig{
+		DefaultStrategy:   StrategyAcceptRight,
+		PathStrategy:      StrategyAcceptRight,
+		SchemaStrategy:    StrategyAcceptRight,
+		ComponentStrategy: StrategyAcceptRight,
+	})
+	j.SourceMaps = maps
+
+	seenLine := map[string]int{}
+	seenSource := map[string]string{}
+	j.collisionHandler = func(c CollisionContext) (CollisionResolution, error) {
+		if c.Type == CollisionTypeSchema && c.LeftLocation != nil {
+			seenLine[c.RightSource] = c.LeftLocation.Line
+			seenSource[c.RightSource] = c.LeftSource
+		}
+		return ContinueWithStrategy(), nil
+	}
+
+	_, err := j.JoinParsed(docs)
+	require.NoError(t, err)
+
+	assert.Equal(t, lineOf["a"], seenLine["b"], "b collided with a's value")
+	assert.Equal(t, lineOf["b"], seenLine["c"], "c collided with b's value")
+
+	// The location and the source name the same document.
+	assert.Equal(t, "a", seenSource["b"])
+	assert.Equal(t, "b", seenSource["c"])
+}
+
+// TestWebhookHandlerOverwriteRecordsSource covers the webhook path a handler
+// takes: accepting the right value has to move the contributor with it, or the
+// next collision names the document that was replaced.
+func TestWebhookHandlerOverwriteRecordsSource(t *testing.T) {
+	seen := map[string]string{}
+	_, err := JoinWithOptions(
+		WithParsed(threeDocOAS3("a"), threeDocOAS3("b"), threeDocOAS3("c")),
+		WithDefaultStrategy(StrategyAcceptLeft),
+		WithPathStrategy(StrategyAcceptLeft),
+		WithSchemaStrategy(StrategyAcceptLeft),
+		WithComponentStrategy(StrategyAcceptLeft),
+		// The handler, not the strategy, is what accepts the incoming webhook.
+		WithCollisionHandlerFor(func(c CollisionContext) (CollisionResolution, error) {
+			seen[c.RightSource] = c.LeftSource
+			return AcceptRight(), nil
+		}, CollisionTypeWebhook),
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, "a", seen["b"], "b collided with a")
+	assert.Equal(t, "b", seen["c"], "the handler accepted b, so c collides with b")
 }

--- a/joiner/helpers.go
+++ b/joiner/helpers.go
@@ -210,7 +210,7 @@ func (j *Joiner) mergePathsMap(
 				result.AddWarning(NewPathCollisionWarning(path, "overwritten", leftSource, ctx.filePath, line, col))
 			} else {
 				line, col := j.getLocation(ctx.filePath, fmt.Sprintf("$.paths['%s']", path))
-				result.AddWarning(NewPathCollisionWarning(path, "kept from first document", leftSource, ctx.filePath, line, col))
+				result.AddWarning(NewPathCollisionWarning(path, "kept existing value", leftSource, ctx.filePath, line, col))
 			}
 		} else {
 			target[path] = pathItem
@@ -249,7 +249,7 @@ func (j *Joiner) applyPathResolution(
 		// Keep existing (left), discard incoming (right) - no action needed
 		j.recordCollisionEventWithPath(result, collision.Name, collision.JSONPath, collision.LeftSource, collision.RightSource, collision.ConfiguredStrategy, resolutionKeptLeft)
 		line, col := j.getLocation(ctx.filePath, collision.JSONPath)
-		result.AddWarning(NewPathCollisionWarning(collision.Name, "kept from first document", collision.LeftSource, ctx.filePath, line, col))
+		result.AddWarning(NewPathCollisionWarning(collision.Name, "kept existing value", collision.LeftSource, ctx.filePath, line, col))
 		return true, nil
 
 	case ResolutionAcceptRight:
@@ -269,7 +269,7 @@ func (j *Joiner) applyPathResolution(
 		// Keep left, discard right (treat as equivalent)
 		j.recordCollisionEventWithPath(result, collision.Name, collision.JSONPath, collision.LeftSource, collision.RightSource, collision.ConfiguredStrategy, resolutionDeduplicated)
 		line, col := j.getLocation(ctx.filePath, collision.JSONPath)
-		result.AddWarning(NewPathCollisionWarning(collision.Name, "deduplicated (kept from first document)", collision.LeftSource, ctx.filePath, line, col))
+		result.AddWarning(NewPathCollisionWarning(collision.Name, "deduplicated (kept existing value)", collision.LeftSource, ctx.filePath, line, col))
 		return true, nil
 
 	case ResolutionFail:

--- a/joiner/helpers.go
+++ b/joiner/helpers.go
@@ -156,6 +156,10 @@ func (j *Joiner) mergePathsMap(
 		if _, exists := target[path]; exists {
 			result.CollisionCount++
 
+			// The left side is whichever document contributed the path now under
+			// this name, which is the first only until something replaces it (#490).
+			leftSource := result.originOf(sectionPaths, path).filePath
+
 			// Invoke collision handler if configured for paths
 			if j.shouldInvokeHandler(CollisionTypePath) {
 				jsonPath := fmt.Sprintf("$.paths['%s']", path)
@@ -163,8 +167,8 @@ func (j *Joiner) mergePathsMap(
 					Type:               CollisionTypePath,
 					Name:               path,
 					JSONPath:           jsonPath,
-					LeftSource:         result.firstFilePath,
-					LeftLocation:       j.getLocationPtr(result.firstFilePath, jsonPath),
+					LeftSource:         leftSource,
+					LeftLocation:       j.getLocationPtr(leftSource, jsonPath),
 					LeftValue:          target[path],
 					RightSource:        ctx.filePath,
 					RightLocation:      j.getLocationPtr(ctx.filePath, jsonPath),
@@ -196,19 +200,21 @@ func (j *Joiner) mergePathsMap(
 			}
 
 			// Apply configured strategy
-			if err := j.handleCollision(path, "paths", strategy, result.firstFilePath, ctx.filePath); err != nil {
+			if err := j.handleCollision(path, "paths", strategy, leftSource, ctx.filePath); err != nil {
 				return err
 			}
 			if j.shouldOverwrite(strategy) {
 				target[path] = pathItem
+				result.recordOrigin(sectionPaths, path, ctx)
 				line, col := j.getLocation(ctx.filePath, fmt.Sprintf("$.paths['%s']", path))
-				result.AddWarning(NewPathCollisionWarning(path, "overwritten", result.firstFilePath, ctx.filePath, line, col))
+				result.AddWarning(NewPathCollisionWarning(path, "overwritten", leftSource, ctx.filePath, line, col))
 			} else {
 				line, col := j.getLocation(ctx.filePath, fmt.Sprintf("$.paths['%s']", path))
-				result.AddWarning(NewPathCollisionWarning(path, "kept from first document", result.firstFilePath, ctx.filePath, line, col))
+				result.AddWarning(NewPathCollisionWarning(path, "kept from first document", leftSource, ctx.filePath, line, col))
 			}
 		} else {
 			target[path] = pathItem
+			result.recordOrigin(sectionPaths, path, ctx)
 		}
 	}
 	return nil
@@ -249,6 +255,7 @@ func (j *Joiner) applyPathResolution(
 	case ResolutionAcceptRight:
 		// Replace with incoming (right)
 		target[collision.Name] = pathItem
+		result.recordOrigin(sectionPaths, collision.Name, ctx)
 		j.recordCollisionEventWithPath(result, collision.Name, collision.JSONPath, collision.LeftSource, collision.RightSource, collision.ConfiguredStrategy, resolutionKeptRight)
 		line, col := j.getLocation(ctx.filePath, collision.JSONPath)
 		result.AddWarning(NewPathCollisionWarning(collision.Name, "overwritten", collision.LeftSource, ctx.filePath, line, col))
@@ -283,6 +290,7 @@ func (j *Joiner) applyPathResolution(
 			return true, fmt.Errorf("collision handler: CustomValue is %T, expected *parser.PathItem for path collisions", resolution.CustomValue)
 		}
 		target[collision.Name] = customPathItem
+		result.recordOrigin(sectionPaths, collision.Name, ctx)
 		j.recordCollisionEventWithPath(result, collision.Name, collision.JSONPath, collision.LeftSource, collision.RightSource, collision.ConfiguredStrategy, "custom")
 		return true, nil
 

--- a/joiner/joiner.go
+++ b/joiner/joiner.go
@@ -192,46 +192,56 @@ type JoinResult struct {
 	firstFilePath string
 	// scope accumulates schema renames per source document for reference rewriting
 	scope *renameScope
-	// origins records which document contributed the schema under each name.
-	// Nil unless Joiner.tracksSchemaOrigins.
-	origins map[string]schemaOrigin
+	// origins records which document contributed the value under each name, per
+	// section.
+	origins map[originKey]schemaOrigin
 }
 
-// tracksSchemaOrigins reports whether the join needs to know which document
-// contributed each merged schema. Only rename-left and a collision handler read
-// it, so other strategies skip the bookkeeping.
-func (j *Joiner) tracksSchemaOrigins() bool {
-	return j.getEffectiveStrategy(j.config.SchemaStrategy) == StrategyRenameLeft ||
-		j.shouldInvokeHandler(CollisionTypeSchema)
+// The JSON path sections a merged value can live at, used as the origin key's
+// section and in the paths reported for a collision.
+const (
+	sectionDefinitions = "definitions"
+	sectionSchemas     = "components.schemas"
+	sectionPaths       = "paths"
+	sectionWebhooks    = "webhooks"
+)
+
+// originKey names a merged value. Sections share a namespace of names, so the
+// section is part of the key.
+type originKey struct {
+	section string
+	name    string
 }
 
-// schemaOrigin identifies the document that contributed a schema, so a rename
-// can name it after its own source (#479).
+// schemaOrigin identifies the document that contributed a merged value, so a
+// rename can name it after its own source (#479) and a collision can report it
+// (#490).
 type schemaOrigin struct {
 	filePath string
 	docIndex int
 }
 
-// recordOrigin notes which document contributed the schema now under name.
-// No-op when origins are not tracked.
-func (r *JoinResult) recordOrigin(name string, ctx documentContext) {
+// recordOrigin notes which document contributed the value now under name. The
+// map is created on demand, so a JoinResult built directly is usable.
+func (r *JoinResult) recordOrigin(section, name string, ctx documentContext) {
 	if r.origins == nil {
-		return
+		r.origins = make(map[originKey]schemaOrigin)
 	}
-	r.origins[name] = schemaOrigin{filePath: ctx.filePath, docIndex: ctx.docIndex}
+	r.origins[originKey{section, name}] = schemaOrigin{filePath: ctx.filePath, docIndex: ctx.docIndex}
 }
 
-// moveOrigin follows a schema's origin when the join stores it under a new name.
-func (r *JoinResult) moveOrigin(oldName, newName string) {
-	if origin, ok := r.origins[oldName]; ok {
-		r.origins[newName] = origin
+// moveOrigin follows a value's origin when the join stores it under a new name.
+func (r *JoinResult) moveOrigin(section, oldName, newName string) {
+	if origin, ok := r.origins[originKey{section, oldName}]; ok {
+		r.origins[originKey{section, newName}] = origin
 	}
 }
 
-// originOf returns the document that contributed the schema under name, falling
-// back to the first document.
-func (r *JoinResult) originOf(name string) schemaOrigin {
-	if origin, ok := r.origins[name]; ok {
+// originOf returns the document that contributed the value under name. It falls
+// back to the first document, which is the only contributor a two document join
+// can have on the left.
+func (r *JoinResult) originOf(section, name string) schemaOrigin {
+	if origin, ok := r.origins[originKey{section, name}]; ok {
 		return origin
 	}
 	return schemaOrigin{filePath: r.firstFilePath}

--- a/joiner/oas2.go
+++ b/joiner/oas2.go
@@ -321,7 +321,7 @@ func (j *Joiner) mergeOAS2Definitions(joined, source *parser.OAS2Document, ctx d
 					result.AddWarning(NewSchemaCollisionWarning(effectiveName, "overwritten", "definitions", leftSource, ctx.filePath, line, col))
 					j.recordCollisionEvent(result, effectiveName, leftSource, ctx.filePath, schemaStrategy, resolutionKeptRight, "")
 				} else {
-					result.AddWarning(NewSchemaCollisionWarning(effectiveName, "kept from first document", "definitions", leftSource, ctx.filePath, line, col))
+					result.AddWarning(NewSchemaCollisionWarning(effectiveName, "kept existing value", "definitions", leftSource, ctx.filePath, line, col))
 					j.recordCollisionEvent(result, effectiveName, leftSource, ctx.filePath, schemaStrategy, resolutionKeptLeft, "")
 				}
 			}

--- a/joiner/oas2.go
+++ b/joiner/oas2.go
@@ -41,9 +41,6 @@ func (j *Joiner) joinOAS2Documents(docs []parser.ParseResult) (*JoinResult, erro
 		firstFilePath: docs[0].SourcePath,
 		scope:         newRenameScope(len(docs), docs[0].OASVersion),
 	}
-	if j.tracksSchemaOrigins() {
-		result.origins = make(map[string]schemaOrigin)
-	}
 
 	// Initialize collision report if enabled
 	if j.config.CollisionReport {
@@ -181,10 +178,12 @@ func (j *Joiner) mergeOAS2Definitions(joined, source *parser.OAS2Document, ctx d
 			// Handle collision based on strategy
 			result.CollisionCount++
 
+			// The left side is whichever document contributed the definition now under
+			// this name, which is the first only until something replaces it.
+			leftSource := result.originOf(sectionDefinitions, effectiveName).filePath
+
 			// Invoke collision handler if configured for schemas
 			if j.shouldInvokeHandler(CollisionTypeSchema) {
-				// The left side is whichever document contributed this definition (#479).
-				leftSource := result.originOf(effectiveName).filePath
 				collision := CollisionContext{
 					Type:               CollisionTypeSchema,
 					Name:               effectiveName,
@@ -218,6 +217,7 @@ func (j *Joiner) mergeOAS2Definitions(joined, source *parser.OAS2Document, ctx d
 						result:      result,
 						ctx:         ctx,
 						sourceName:  name,
+						section:     sectionDefinitions,
 						sourceGraph: sourceGraph,
 						label:       "definition",
 					})
@@ -248,7 +248,7 @@ func (j *Joiner) mergeOAS2Definitions(joined, source *parser.OAS2Document, ctx d
 						// Schemas are equivalent, keep existing and skip
 						line, col := j.getLocation(ctx.filePath, fmt.Sprintf("$.definitions.%s", effectiveName))
 						result.AddWarning(NewSchemaDedupWarning(effectiveName, "definition", ctx.filePath, line, col))
-						j.recordCollisionEvent(result, effectiveName, result.firstFilePath, ctx.filePath, schemaStrategy, resolutionDeduplicated, "")
+						j.recordCollisionEvent(result, effectiveName, leftSource, ctx.filePath, schemaStrategy, resolutionDeduplicated, "")
 						continue
 					}
 					// Not equivalent, fall back to fail
@@ -259,7 +259,7 @@ func (j *Joiner) mergeOAS2Definitions(joined, source *parser.OAS2Document, ctx d
 			case StrategyRenameLeft:
 				// Rename the existing (left) definition and keep the new (right) definition under original name
 				// Name it after the contributing document, not always the first (#479).
-				leftOrigin := result.originOf(effectiveName)
+				leftOrigin := result.originOf(sectionDefinitions, effectiveName)
 				leftPrefix := j.getNamespacePrefix(leftOrigin.filePath)
 				var newName string
 				if leftPrefix != "" {
@@ -271,11 +271,11 @@ func (j *Joiner) mergeOAS2Definitions(joined, source *parser.OAS2Document, ctx d
 
 				// Move existing definition to new name
 				joined.Definitions[newName] = joined.Definitions[effectiveName]
-				result.moveOrigin(effectiveName, newName)
+				result.moveOrigin(sectionDefinitions, effectiveName, newName)
 
 				// Add new definition under original name
 				joined.Definitions[effectiveName] = schema
-				result.recordOrigin(effectiveName, ctx)
+				result.recordOrigin(sectionDefinitions, effectiveName, ctx)
 
 				// Only documents merged before this one referenced the moved definition.
 				result.scope.registerLeft(ctx.docIndex, effectiveName, newName)
@@ -298,7 +298,7 @@ func (j *Joiner) mergeOAS2Definitions(joined, source *parser.OAS2Document, ctx d
 
 				// Add new definition under renamed name
 				joined.Definitions[newName] = schema
-				result.recordOrigin(newName, ctx)
+				result.recordOrigin(sectionDefinitions, newName, ctx)
 
 				// Keep existing definition under original name (no change needed)
 
@@ -307,27 +307,27 @@ func (j *Joiner) mergeOAS2Definitions(joined, source *parser.OAS2Document, ctx d
 
 				line, col := j.getLocation(ctx.filePath, fmt.Sprintf("$.definitions.%s", effectiveName))
 				result.AddWarning(NewSchemaRenamedWarning(effectiveName, newName, "definition", ctx.filePath, line, col, false))
-				j.recordCollisionEvent(result, effectiveName, result.firstFilePath, ctx.filePath, schemaStrategy, resolutionRenamed, newName)
+				j.recordCollisionEvent(result, effectiveName, leftSource, ctx.filePath, schemaStrategy, resolutionRenamed, newName)
 
 			default:
 				// Handle existing strategies
-				if err := j.handleCollision(effectiveName, "definitions", schemaStrategy, result.firstFilePath, ctx.filePath); err != nil {
+				if err := j.handleCollision(effectiveName, "definitions", schemaStrategy, leftSource, ctx.filePath); err != nil {
 					return err
 				}
 				line, col := j.getLocation(ctx.filePath, fmt.Sprintf("$.definitions.%s", effectiveName))
 				if j.shouldOverwrite(schemaStrategy) {
 					joined.Definitions[effectiveName] = schema
-					result.recordOrigin(effectiveName, ctx)
-					result.AddWarning(NewSchemaCollisionWarning(effectiveName, "overwritten", "definitions", result.firstFilePath, ctx.filePath, line, col))
-					j.recordCollisionEvent(result, effectiveName, result.firstFilePath, ctx.filePath, schemaStrategy, resolutionKeptRight, "")
+					result.recordOrigin(sectionDefinitions, effectiveName, ctx)
+					result.AddWarning(NewSchemaCollisionWarning(effectiveName, "overwritten", "definitions", leftSource, ctx.filePath, line, col))
+					j.recordCollisionEvent(result, effectiveName, leftSource, ctx.filePath, schemaStrategy, resolutionKeptRight, "")
 				} else {
-					result.AddWarning(NewSchemaCollisionWarning(effectiveName, "kept from first document", "definitions", result.firstFilePath, ctx.filePath, line, col))
-					j.recordCollisionEvent(result, effectiveName, result.firstFilePath, ctx.filePath, schemaStrategy, resolutionKeptLeft, "")
+					result.AddWarning(NewSchemaCollisionWarning(effectiveName, "kept from first document", "definitions", leftSource, ctx.filePath, line, col))
+					j.recordCollisionEvent(result, effectiveName, leftSource, ctx.filePath, schemaStrategy, resolutionKeptLeft, "")
 				}
 			}
 		} else {
 			joined.Definitions[effectiveName] = schema
-			result.recordOrigin(effectiveName, ctx)
+			result.recordOrigin(sectionDefinitions, effectiveName, ctx)
 		}
 	}
 	return nil

--- a/joiner/oas3.go
+++ b/joiner/oas3.go
@@ -40,9 +40,6 @@ func (j *Joiner) joinOAS3Documents(docs []parser.ParseResult) (*JoinResult, erro
 		firstFilePath: docs[0].SourcePath,
 		scope:         newRenameScope(len(docs), docs[0].OASVersion),
 	}
-	if j.tracksSchemaOrigins() {
-		result.origins = make(map[string]schemaOrigin)
-	}
 
 	// Initialize collision report if enabled
 	if j.config.CollisionReport {
@@ -107,6 +104,7 @@ func (j *Joiner) joinOAS3Documents(docs []parser.ParseResult) (*JoinResult, erro
 			if exists {
 				jsonPath := fmt.Sprintf("$.webhooks.%s", name)
 				result.CollisionCount++
+				leftSource := result.originOf(sectionWebhooks, name).filePath
 
 				// Invoke collision handler if registered and applicable
 				if j.collisionHandler != nil && j.shouldInvokeHandler(CollisionTypeWebhook) {
@@ -114,8 +112,8 @@ func (j *Joiner) joinOAS3Documents(docs []parser.ParseResult) (*JoinResult, erro
 						Type:               CollisionTypeWebhook,
 						Name:               name,
 						JSONPath:           jsonPath,
-						LeftSource:         result.firstFilePath,
-						LeftLocation:       j.getLocationPtr(result.firstFilePath, jsonPath),
+						LeftSource:         leftSource,
+						LeftLocation:       j.getLocationPtr(leftSource, jsonPath),
 						LeftValue:          existingWebhook,
 						RightSource:        ctx.filePath,
 						RightLocation:      j.getLocationPtr(ctx.filePath, jsonPath),
@@ -155,19 +153,21 @@ func (j *Joiner) joinOAS3Documents(docs []parser.ParseResult) (*JoinResult, erro
 				}
 
 				// Default strategy handling (or fallback from handler)
-				if err := j.handleCollision(name, "webhooks", pathStrategy, result.firstFilePath, ctx.filePath); err != nil {
+				if err := j.handleCollision(name, "webhooks", pathStrategy, leftSource, ctx.filePath); err != nil {
 					return nil, err
 				}
 				if j.shouldOverwrite(pathStrategy) {
 					joined.Webhooks[name] = webhook
+					result.recordOrigin(sectionWebhooks, name, ctx)
 					line, col := j.getLocation(ctx.filePath, jsonPath)
-					result.AddWarning(NewWebhookCollisionWarning(name, "overwritten", result.firstFilePath, ctx.filePath, line, col))
+					result.AddWarning(NewWebhookCollisionWarning(name, "overwritten", leftSource, ctx.filePath, line, col))
 				} else {
 					line, col := j.getLocation(ctx.filePath, jsonPath)
-					result.AddWarning(NewWebhookCollisionWarning(name, "kept from first document", result.firstFilePath, ctx.filePath, line, col))
+					result.AddWarning(NewWebhookCollisionWarning(name, "kept from first document", leftSource, ctx.filePath, line, col))
 				}
 			} else {
 				joined.Webhooks[name] = webhook
+				result.recordOrigin(sectionWebhooks, name, ctx)
 			}
 		}
 
@@ -306,10 +306,12 @@ func (j *Joiner) mergeSchemas(target, source map[string]*parser.Schema, strategy
 			// Handle collision based on strategy
 			result.CollisionCount++
 
+			// The left side is whichever document contributed the schema now under
+			// this name, which is the first only until something replaces it.
+			leftSource := result.originOf(sectionSchemas, effectiveName).filePath
+
 			// Invoke collision handler if configured
 			if j.shouldInvokeHandler(CollisionTypeSchema) {
-				// The left side is whichever document contributed this schema (#479).
-				leftSource := result.originOf(effectiveName).filePath
 				collision := CollisionContext{
 					Type:               CollisionTypeSchema,
 					Name:               effectiveName,
@@ -343,6 +345,7 @@ func (j *Joiner) mergeSchemas(target, source map[string]*parser.Schema, strategy
 						result:      result,
 						ctx:         ctx,
 						sourceName:  name,
+						section:     sectionSchemas,
 						sourceGraph: sourceGraph,
 						label:       "schema",
 					})
@@ -373,7 +376,7 @@ func (j *Joiner) mergeSchemas(target, source map[string]*parser.Schema, strategy
 						// Schemas are equivalent, keep existing and skip
 						line, col := j.getLocation(ctx.filePath, fmt.Sprintf("$.components.schemas.%s", effectiveName))
 						result.AddWarning(NewSchemaDedupWarning(effectiveName, "schema", ctx.filePath, line, col))
-						j.recordCollisionEvent(result, effectiveName, result.firstFilePath, ctx.filePath, strategy, resolutionDeduplicated, "")
+						j.recordCollisionEvent(result, effectiveName, leftSource, ctx.filePath, strategy, resolutionDeduplicated, "")
 						continue
 					}
 					// Not equivalent, fall back to default strategy or fail
@@ -384,7 +387,7 @@ func (j *Joiner) mergeSchemas(target, source map[string]*parser.Schema, strategy
 			case StrategyRenameLeft:
 				// Rename the existing (left) schema and keep the new (right) schema under original name
 				// Name it after the contributing document, not always the first (#479).
-				leftOrigin := result.originOf(effectiveName)
+				leftOrigin := result.originOf(sectionSchemas, effectiveName)
 				leftPrefix := j.getNamespacePrefix(leftOrigin.filePath)
 				var newName string
 				if leftPrefix != "" {
@@ -396,11 +399,11 @@ func (j *Joiner) mergeSchemas(target, source map[string]*parser.Schema, strategy
 
 				// Move existing schema to new name
 				target[newName] = target[effectiveName]
-				result.moveOrigin(effectiveName, newName)
+				result.moveOrigin(sectionSchemas, effectiveName, newName)
 
 				// Add new schema under original name
 				target[effectiveName] = schema
-				result.recordOrigin(effectiveName, ctx)
+				result.recordOrigin(sectionSchemas, effectiveName, ctx)
 
 				// Only documents merged before this one referenced the moved schema.
 				result.scope.registerLeft(ctx.docIndex, effectiveName, newName)
@@ -424,7 +427,7 @@ func (j *Joiner) mergeSchemas(target, source map[string]*parser.Schema, strategy
 
 				// Add new schema under renamed name
 				target[newName] = schema
-				result.recordOrigin(newName, ctx)
+				result.recordOrigin(sectionSchemas, newName, ctx)
 
 				// Keep existing schema under original name (no change needed)
 
@@ -433,28 +436,28 @@ func (j *Joiner) mergeSchemas(target, source map[string]*parser.Schema, strategy
 
 				line, col := j.getLocation(ctx.filePath, fmt.Sprintf("$.components.schemas.%s", effectiveName))
 				result.AddWarning(NewSchemaRenamedWarning(effectiveName, newName, "schema", ctx.filePath, line, col, false))
-				j.recordCollisionEvent(result, effectiveName, result.firstFilePath, ctx.filePath, strategy, resolutionRenamed, newName)
+				j.recordCollisionEvent(result, effectiveName, leftSource, ctx.filePath, strategy, resolutionRenamed, newName)
 
 			default:
 				// Handle existing strategies (accept-left, accept-right, fail, fail-on-paths)
-				if err := j.handleCollision(effectiveName, "components.schemas", strategy, result.firstFilePath, ctx.filePath); err != nil {
+				if err := j.handleCollision(effectiveName, "components.schemas", strategy, leftSource, ctx.filePath); err != nil {
 					return err
 				}
 				if j.shouldOverwrite(strategy) {
 					target[effectiveName] = schema
-					result.recordOrigin(effectiveName, ctx)
+					result.recordOrigin(sectionSchemas, effectiveName, ctx)
 					line, col := j.getLocation(ctx.filePath, fmt.Sprintf("$.components.schemas.%s", effectiveName))
-					result.AddWarning(NewSchemaCollisionWarning(effectiveName, "overwritten", "components.schemas", result.firstFilePath, ctx.filePath, line, col))
-					j.recordCollisionEvent(result, effectiveName, result.firstFilePath, ctx.filePath, strategy, resolutionKeptRight, "")
+					result.AddWarning(NewSchemaCollisionWarning(effectiveName, "overwritten", "components.schemas", leftSource, ctx.filePath, line, col))
+					j.recordCollisionEvent(result, effectiveName, leftSource, ctx.filePath, strategy, resolutionKeptRight, "")
 				} else {
 					line, col := j.getLocation(ctx.filePath, fmt.Sprintf("$.components.schemas.%s", effectiveName))
-					result.AddWarning(NewSchemaCollisionWarning(effectiveName, "kept from first document", "components.schemas", result.firstFilePath, ctx.filePath, line, col))
-					j.recordCollisionEvent(result, effectiveName, result.firstFilePath, ctx.filePath, strategy, resolutionKeptLeft, "")
+					result.AddWarning(NewSchemaCollisionWarning(effectiveName, "kept from first document", "components.schemas", leftSource, ctx.filePath, line, col))
+					j.recordCollisionEvent(result, effectiveName, leftSource, ctx.filePath, strategy, resolutionKeptLeft, "")
 				}
 			}
 		} else {
 			target[effectiveName] = schema
-			result.recordOrigin(effectiveName, ctx)
+			result.recordOrigin(sectionSchemas, effectiveName, ctx)
 		}
 	}
 	return nil
@@ -559,14 +562,18 @@ func mergeMap[T any](j *Joiner, target, source map[string]T, section string, col
 			jsonPath := fmt.Sprintf("$.%s.%s", section, name)
 			result.CollisionCount++
 
+			// The left side is whichever document contributed the value now under
+			// this name, which is the first only until something replaces it (#490).
+			leftSource := result.originOf(section, name).filePath
+
 			// Invoke collision handler if registered and applicable
 			if j.collisionHandler != nil && j.shouldInvokeHandler(collisionType) {
 				collision := CollisionContext{
 					Type:               collisionType,
 					Name:               name,
 					JSONPath:           jsonPath,
-					LeftSource:         result.firstFilePath,
-					LeftLocation:       j.getLocationPtr(result.firstFilePath, jsonPath),
+					LeftSource:         leftSource,
+					LeftLocation:       j.getLocationPtr(leftSource, jsonPath),
 					LeftValue:          existing,
 					RightSource:        ctx.filePath,
 					RightLocation:      j.getLocationPtr(ctx.filePath, jsonPath),
@@ -598,6 +605,7 @@ func mergeMap[T any](j *Joiner, target, source map[string]T, section string, col
 					if handled {
 						if shouldOverwrite {
 							target[name] = item
+							result.recordOrigin(section, name, ctx)
 						}
 						continue // Resolution handled, skip strategy handling
 					}
@@ -606,14 +614,16 @@ func mergeMap[T any](j *Joiner, target, source map[string]T, section string, col
 			}
 
 			// Default strategy handling (or fallback from handler)
-			if err := j.handleCollision(name, section, strategy, result.firstFilePath, ctx.filePath); err != nil {
+			if err := j.handleCollision(name, section, strategy, leftSource, ctx.filePath); err != nil {
 				return err
 			}
 			if j.shouldOverwrite(strategy) {
 				target[name] = item
+				result.recordOrigin(section, name, ctx)
 			}
 		} else {
 			target[name] = item
+			result.recordOrigin(section, name, ctx)
 		}
 	}
 	return nil

--- a/joiner/oas3.go
+++ b/joiner/oas3.go
@@ -145,6 +145,7 @@ func (j *Joiner) joinOAS3Documents(docs []parser.ParseResult) (*JoinResult, erro
 						if handled {
 							if shouldOverwrite {
 								joined.Webhooks[name] = webhook
+								result.recordOrigin(sectionWebhooks, name, ctx)
 							}
 							continue // Resolution handled, skip strategy handling
 						}
@@ -163,7 +164,7 @@ func (j *Joiner) joinOAS3Documents(docs []parser.ParseResult) (*JoinResult, erro
 					result.AddWarning(NewWebhookCollisionWarning(name, "overwritten", leftSource, ctx.filePath, line, col))
 				} else {
 					line, col := j.getLocation(ctx.filePath, jsonPath)
-					result.AddWarning(NewWebhookCollisionWarning(name, "kept from first document", leftSource, ctx.filePath, line, col))
+					result.AddWarning(NewWebhookCollisionWarning(name, "kept existing value", leftSource, ctx.filePath, line, col))
 				}
 			} else {
 				joined.Webhooks[name] = webhook
@@ -451,7 +452,7 @@ func (j *Joiner) mergeSchemas(target, source map[string]*parser.Schema, strategy
 					j.recordCollisionEvent(result, effectiveName, leftSource, ctx.filePath, strategy, resolutionKeptRight, "")
 				} else {
 					line, col := j.getLocation(ctx.filePath, fmt.Sprintf("$.components.schemas.%s", effectiveName))
-					result.AddWarning(NewSchemaCollisionWarning(effectiveName, "kept from first document", "components.schemas", leftSource, ctx.filePath, line, col))
+					result.AddWarning(NewSchemaCollisionWarning(effectiveName, "kept existing value", "components.schemas", leftSource, ctx.filePath, line, col))
 					j.recordCollisionEvent(result, effectiveName, leftSource, ctx.filePath, strategy, resolutionKeptLeft, "")
 				}
 			}


### PR DESCRIPTION
## Summary 🎯

Every collision took its left source from `result.firstFilePath`. That is right until something replaces a value, and wrong afterwards: a handler was handed a `LeftValue` from one document and told a different one had provided it.

```
collision from b: LeftSource="a" but LeftValue is from "a"
collision from c: LeftSource="a" but LeftValue is from "b"
```

Fixes #490.

## What changed

#479 solved this for schemas with `JoinResult.origins`. This generalises it. The key gains the section, since the sections share a namespace of names, and every site that stores a merged value records the document it came from.

`mergeMap` and `mergePathsMap` are one place each, so the thirteen sections they serve are fixed together:

`components.responses`, `components.parameters`, `components.examples`, `components.requestBodies`, `components.headers`, `components.securitySchemes`, `components.links`, `components.callbacks`, `components.pathItems`, `components.mediaTypes`, and OAS 2's `parameters`, `responses` and `securityDefinitions`.

Webhooks and the two schema paths merge inline rather than through `mergeMap`, so they are fixed alongside.

## More readers than the issue named

Chasing `firstFilePath` through the package turned up four kinds of consumer, not one:

| Reader | Was |
|---|---|
| The handler's `CollisionContext` and its `LeftLocation` | first document |
| The collision report, at eight event sites | first document |
| `NewSchemaCollisionWarning`, `NewWebhookCollisionWarning`, `NewPathCollisionWarning` | first document |
| The error raised by the `fail` strategy | first document |

`CollisionContext.LeftSource` also documented itself as "the source file/identifier for left document", which was never quite what it held. It now says it names the document that contributed `LeftValue`.

## Origins are no longer gated ⚡

#479 only recorded origins when rename-left or a schema handler could read them. That gate cannot survive this change: the `fail` strategy raises a collision error naming the left file, and `fail` is the default, so the gate would be on for a default configuration anyway. Recording unconditionally is simpler and honest about when the data is needed.

Measured cost is one map plus an entry per merged component:

```
JoinParsed              +2 allocs, +516 bytes    (a 2.1KiB baseline, so the percentage reads large)
JoinRenames five docs   +0.16% allocations
```

## Tests 🧪

Four cases, all failing against the previous behaviour, verified by putting the left source back to `firstFilePath`:

- **8 assertions** across paths, webhooks, schemas, responses and parameters: b collides with a, c collides with b
- **`LeftValue` matches `LeftSource`**, the property that actually matters, checked by embedding the source name in every value
- The collision report reads the same source the handler does
- Sections are independent: a schema contributed by a and a response contributed by b, both named `Shared`, track separately, which is what puts the section in the key

Plus an OAS 2 counterpart worth **10 more assertions**. It is not redundant: definitions merge through `mergeOAS2Definitions` rather than `mergeMap`, so the OAS 3 cases never exercise that path.

`make check` clean at 10812 tests, no gopls diagnostics.

## Review notes 📝

One local CodeRabbit round before opening, with no findings. The OAS 2 gap above was found afterwards by checking the new tests against the code paths rather than the sections, which is the sort of thing a section-shaped test list hides.