### PR TITLE
fix(joiner): rank names the same way in both deduplication passes

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -823,7 +823,8 @@ if err != nil {
 
 // Semantic deduplication consolidates identical schemas:
 // - Schemas with identical structure are detected via FNV-1a hashing
-// - The alphabetically-first name becomes the canonical schema
+// - A name a document declared beats one a collision rename generated
+// - Among equally declared names, the alphabetically-first one is canonical
 // - All $ref references are automatically rewritten
 // - Warnings indicate how many duplicates were consolidated
 ```

--- a/internal/schemautil/dedupe.go
+++ b/internal/schemautil/dedupe.go
@@ -2,11 +2,21 @@ package schemautil
 
 import "github.com/erraggy/oastools/parser"
 
+// OutranksFunc reports whether name should be the canonical name of an
+// equivalence group in place of candidate. It breaks ties the caller knows more
+// about than the deduplicator does: the deduplicator sees only names and
+// schemas, so a caller that synthesized some of those names has to say so.
+type OutranksFunc func(name, candidate string) bool
+
 // DeduplicationConfig configures semantic schema deduplication behavior.
 type DeduplicationConfig struct {
 	// EquivalenceMode controls comparison depth ("deep" recommended).
 	// Uses joiner.EquivalenceMode values: "none", "shallow", "deep".
 	EquivalenceMode string
+
+	// Outranks chooses the canonical name of an equivalence group. When nil,
+	// the alphabetically first name wins.
+	Outranks OutranksFunc
 }
 
 // DefaultDeduplicationConfig returns a DeduplicationConfig with sensible defaults.

--- a/internal/schemautil/deduplicator.go
+++ b/internal/schemautil/deduplicator.go
@@ -36,7 +36,8 @@ func NewSchemaDeduplicator(config DeduplicationConfig, compare CompareFunc) *Sch
 // The algorithm:
 //  1. Group schemas by structural hash (O(N))
 //  2. Verify equivalence within each group using deep comparison
-//  3. Select canonical name (alphabetically first) for each equivalence group
+//  3. Select canonical name for each equivalence group, by
+//     DeduplicationConfig.Outranks or alphabetically when it is nil
 //  4. Build alias mapping and return only canonical schemas
 func (d *SchemaDeduplicator) Deduplicate(schemas map[string]*parser.Schema) (*DeduplicationResult, error) {
 	if len(schemas) < 2 {
@@ -139,23 +140,55 @@ func (d *SchemaDeduplicator) buildResult(
 	}
 
 	for _, group := range equivalenceGroups {
-		// Sort names alphabetically to select canonical name deterministically
+		// Sort names alphabetically so the canonical name does not depend on the
+		// order the schemas were hashed in
 		sort.Strings(group)
-		canonical := group[0]
+		canonical := d.canonicalName(group)
 
 		// Store canonical schema
 		result.CanonicalSchemas[canonical] = schemas[canonical]
-		result.EquivalenceGroups[canonical] = group
+		result.EquivalenceGroups[canonical] = canonicalFirst(group, canonical)
 
 		// Record aliases (all names except canonical)
-		for i := 1; i < len(group); i++ {
-			alias := group[i]
+		for _, alias := range group {
+			if alias == canonical {
+				continue
+			}
 			result.Aliases[alias] = canonical
 			result.RemovedCount++
 		}
 	}
 
 	return result
+}
+
+// canonicalName picks the name an equivalence group keeps. group must be
+// sorted, so the alphabetically first name is what an absent Outranks yields.
+func (d *SchemaDeduplicator) canonicalName(group []string) string {
+	canonical := group[0]
+	if d.config.Outranks == nil {
+		return canonical
+	}
+	for _, name := range group[1:] {
+		if d.config.Outranks(name, canonical) {
+			canonical = name
+		}
+	}
+	return canonical
+}
+
+// canonicalFirst returns group with canonical moved to the front, which is
+// where DeduplicationResult.EquivalenceGroups reports it. The rest stay in
+// order, so the result is the sorted group whenever canonical is already first.
+func canonicalFirst(group []string, canonical string) []string {
+	ordered := make([]string, 0, len(group))
+	ordered = append(ordered, canonical)
+	for _, name := range group {
+		if name != canonical {
+			ordered = append(ordered, name)
+		}
+	}
+	return ordered
 }
 
 // CanonicalName returns the canonical name for a schema name.

--- a/internal/schemautil/deduplicator_test.go
+++ b/internal/schemautil/deduplicator_test.go
@@ -267,3 +267,71 @@ func TestDeduplicationResult_EquivalenceGroups(t *testing.T) {
 	// First should be canonical (Address, alphabetically first)
 	assert.Equal(t, "Address", group[0])
 }
+
+func TestSchemaDeduplicator_Outranks(t *testing.T) {
+	schemas := map[string]*parser.Schema{
+		"Address":  {Type: "object"},
+		"Location": {Type: "object"},
+		"Place":    {Type: "object"},
+	}
+
+	tests := []struct {
+		name      string
+		outranks  OutranksFunc
+		canonical string
+		aliases   []string
+	}{
+		{
+			name:      "nil keeps the alphabetical tiebreak",
+			outranks:  nil,
+			canonical: "Address",
+			aliases:   []string{"Location", "Place"},
+		},
+		{
+			// The joiner's case: a name a rename generated loses to one a
+			// document wrote, whatever the two sort like.
+			name: "generated name loses to a declared one",
+			outranks: func(name, candidate string) bool {
+				generated := map[string]bool{"Address": true}
+				if generated[name] != generated[candidate] {
+					return !generated[name]
+				}
+				return name < candidate
+			},
+			canonical: "Location",
+			aliases:   []string{"Address", "Place"},
+		},
+		{
+			name: "every name outranking the last still settles on one",
+			outranks: func(name, candidate string) bool {
+				return name > candidate
+			},
+			canonical: "Place",
+			aliases:   []string{"Address", "Location"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := DefaultDeduplicationConfig()
+			config.Outranks = tt.outranks
+			deduper := NewSchemaDeduplicator(config, alwaysEqual)
+
+			result, err := deduper.Deduplicate(schemas)
+			require.NoError(t, err)
+
+			require.Len(t, result.CanonicalSchemas, 1)
+			assert.Contains(t, result.CanonicalSchemas, tt.canonical)
+			assert.Equal(t, len(tt.aliases), result.RemovedCount)
+			for _, alias := range tt.aliases {
+				assert.Equal(t, tt.canonical, result.CanonicalName(alias))
+			}
+
+			// The canonical name leads its group whether or not it sorts first.
+			group := result.EquivalenceGroups[tt.canonical]
+			require.Len(t, group, len(schemas))
+			assert.Equal(t, tt.canonical, group[0])
+			assert.Equal(t, tt.aliases, group[1:], "the rest stay sorted")
+		})
+	}
+}

--- a/joiner/collapse.go
+++ b/joiner/collapse.go
@@ -34,7 +34,7 @@ func (j *Joiner) collapseEquivalent(schemas map[string]*parser.Schema, owner map
 	// owner is the map the rewrite reads entries through, so every schema is
 	// compared under the renames that will actually be applied to it.
 	views := newViewIndex(result.scope, owner, schemas)
-	generated := result.scope.generatedNames()
+	generated := result.generated
 	// Always deep, whatever EquivalenceMode says. A shallow comparison reads
 	// neither $ref nor nested properties, so it cannot decide whether two
 	// schemas are interchangeable. EquivalenceDocs still applies.
@@ -265,6 +265,19 @@ func canonicalName(class []string, generated map[string]bool) string {
 		}
 	}
 	return canonical
+}
+
+// outranksGenerated adapts outranks for schemautil.SchemaDeduplicator, so
+// semantic deduplication settles a group of equivalent names the way a collapse
+// would rather than by sorting alone (#498). It returns nil when no name was
+// generated, leaving the deduplicator's own alphabetical tiebreak in place.
+func outranksGenerated(generated map[string]bool) schemautil.OutranksFunc {
+	if len(generated) == 0 {
+		return nil
+	}
+	return func(name, candidate string) bool {
+		return outranks(name, candidate, generated)
+	}
 }
 
 // outranks reports whether name should survive a collapse in place of canonical.

--- a/joiner/dedupe_canonical_test.go
+++ b/joiner/dedupe_canonical_test.go
@@ -1,0 +1,305 @@
+package joiner
+
+import (
+	"maps"
+	"slices"
+	"testing"
+
+	"github.com/erraggy/oastools/parser"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The rename template from outranks's own doc comment, which puts every alias
+// ahead of the name it was generated from alphabetically. That ordering is what
+// made semantic deduplication consolidate into the alias (#498).
+const aliasFirstTemplate = `Api_{{.Name}}`
+
+// storefrontOAS2 is one of several documents that all declare the same Pet and
+// Category, so every join after the first collides on both.
+func storefrontOAS2(name string) parser.ParseResult {
+	return parser.ParseResult{
+		Document: &parser.OAS2Document{
+			Swagger: "2.0",
+			Info:    &parser.Info{Title: name, Version: "1.0.0"},
+			Paths: parser.Paths{
+				"/" + name + "/pet": &parser.PathItem{Get: &parser.Operation{
+					OperationID: "getPet" + name,
+					Responses: &parser.Responses{Codes: map[string]*parser.Response{
+						"200": {
+							Description: "ok",
+							Schema:      &parser.Schema{Ref: "#/definitions/Pet"},
+						},
+					}},
+				}},
+			},
+			Definitions: map[string]*parser.Schema{
+				"Pet": {
+					Type:     "object",
+					Required: []string{"name"},
+					Properties: map[string]*parser.Schema{
+						"category": {Ref: "#/definitions/Category"},
+						"name":     {Type: "string"},
+					},
+				},
+				"Category": {
+					Type: "object",
+					Properties: map[string]*parser.Schema{
+						"id":   {Type: "integer", Format: "int64"},
+						"name": {Type: "string"},
+					},
+				},
+			},
+			OASVersion: parser.OASVersion20,
+		},
+		Version:      "2.0",
+		OASVersion:   parser.OASVersion20,
+		SourcePath:   name,
+		SourceFormat: "json",
+	}
+}
+
+// storefrontOAS3 is storefrontOAS2's OAS 3 counterpart. The semantic pass runs
+// through the same schemautil deduplicator in both, so both reach the bug.
+func storefrontOAS3(name string) parser.ParseResult {
+	doc := &parser.OAS3Document{
+		OpenAPI: "3.0.3",
+		Info:    &parser.Info{Title: name, Version: "1.0.0"},
+		Paths: parser.Paths{
+			"/" + name + "/pet": &parser.PathItem{Get: &parser.Operation{
+				OperationID: "getPet" + name,
+				Responses: &parser.Responses{Codes: map[string]*parser.Response{
+					"200": {
+						Description: "ok",
+						Content: map[string]*parser.MediaType{
+							"application/json": {Schema: &parser.Schema{Ref: "#/components/schemas/Pet"}},
+						},
+					},
+				}},
+			}},
+		},
+		Components: &parser.Components{
+			Schemas: map[string]*parser.Schema{
+				"Pet": {
+					Type:     "object",
+					Required: []string{"name"},
+					Properties: map[string]*parser.Schema{
+						"category": {Ref: "#/components/schemas/Category"},
+						"name":     {Type: "string"},
+					},
+				},
+				"Category": {
+					Type: "object",
+					Properties: map[string]*parser.Schema{
+						"id":   {Type: "integer", Format: "int64"},
+						"name": {Type: "string"},
+					},
+				},
+			},
+		},
+		OASVersion: parser.OASVersion303,
+	}
+	return parser.ParseResult{
+		Document:     doc,
+		Version:      "3.0.3",
+		OASVersion:   parser.OASVersion303,
+		SourcePath:   name,
+		SourceFormat: "json",
+	}
+}
+
+// emptyCombined is the accumulator a caller folding documents one at a time
+// starts from.
+func emptyCombined(version parser.OASVersion) parser.ParseResult {
+	if version == parser.OASVersion20 {
+		return parser.ParseResult{
+			Document: &parser.OAS2Document{
+				Swagger:     "2.0",
+				Info:        &parser.Info{Title: "combined", Version: "1.0.0"},
+				Paths:       make(parser.Paths),
+				Definitions: map[string]*parser.Schema{},
+				OASVersion:  parser.OASVersion20,
+			},
+			Version:      "2.0",
+			OASVersion:   parser.OASVersion20,
+			SourcePath:   "combined",
+			SourceFormat: "json",
+		}
+	}
+	return parser.ParseResult{
+		Document: &parser.OAS3Document{
+			OpenAPI:    "3.0.3",
+			Info:       &parser.Info{Title: "combined", Version: "1.0.0"},
+			Paths:      make(parser.Paths),
+			Components: &parser.Components{Schemas: map[string]*parser.Schema{}},
+			OASVersion: parser.OASVersion303,
+		},
+		Version:      "3.0.3",
+		OASVersion:   parser.OASVersion303,
+		SourcePath:   "combined",
+		SourceFormat: "json",
+	}
+}
+
+// foldStorefronts joins the documents one at a time the way a caller that
+// accumulates does, and returns the last result.
+func foldStorefronts(t *testing.T, combined parser.ParseResult, storefront func(string) parser.ParseResult, names ...string) parser.ParseResult {
+	t.Helper()
+	for _, name := range names {
+		res, err := JoinWithOptions(
+			WithParsed(combined, storefront(name)),
+			WithSchemaStrategy(StrategyDeduplicateOrRename),
+			WithEquivalenceMode("deep"),
+			WithSemanticDeduplication(true),
+			WithRenameTemplate(aliasFirstTemplate),
+		)
+		require.NoError(t, err)
+		parsed := res.ToParseResult()
+		parsed.SourcePath = "combined"
+		combined = *parsed
+		t.Logf("after %s -> %v", name, sortedSchemaNames(t, combined.Document))
+	}
+	return combined
+}
+
+// sortedSchemaNames returns the top-level schema names, sorted.
+func sortedSchemaNames(t *testing.T, document any) []string {
+	t.Helper()
+	names := schemaNamesOf(t, document)
+	slices.Sort(names)
+	return names
+}
+
+// refsOf returns every $ref the storefront documents place: one per path
+// response, plus Pet's category property.
+func refsOf(t *testing.T, document any) (responses, category []string) {
+	t.Helper()
+	switch doc := document.(type) {
+	case *parser.OAS2Document:
+		for _, item := range doc.Paths {
+			responses = append(responses, item.Get.Responses.Codes["200"].Schema.Ref)
+		}
+		for _, schema := range doc.Definitions {
+			if property, ok := schema.Properties["category"]; ok {
+				category = append(category, property.Ref)
+			}
+		}
+	case *parser.OAS3Document:
+		for _, item := range doc.Paths {
+			responses = append(responses,
+				item.Get.Responses.Codes["200"].Content["application/json"].Schema.Ref)
+		}
+		for _, schema := range doc.Components.Schemas {
+			if property, ok := schema.Properties["category"]; ok {
+				category = append(category, property.Ref)
+			}
+		}
+	default:
+		t.Fatalf("unexpected document type %T", document)
+	}
+	return responses, category
+}
+
+// assertRefsPointAt checks that the surviving names are what references spell,
+// so nothing still points at a name the deduplication removed.
+func assertRefsPointAt(t *testing.T, document any, pet, category string) {
+	t.Helper()
+	responses, categories := refsOf(t, document)
+	require.NotEmpty(t, responses)
+	require.NotEmpty(t, categories)
+	for _, ref := range responses {
+		assert.Equal(t, pet, ref, "a response still references a removed name")
+	}
+	for _, ref := range categories {
+		assert.Equal(t, category, ref, "Pet still references a removed name")
+	}
+}
+
+// schemaNamesOf returns the top-level schema names of either document version.
+func schemaNamesOf(t *testing.T, document any) []string {
+	t.Helper()
+	switch doc := document.(type) {
+	case *parser.OAS2Document:
+		return slices.Collect(maps.Keys(doc.Definitions))
+	case *parser.OAS3Document:
+		return slices.Collect(maps.Keys(doc.Components.Schemas))
+	default:
+		t.Fatalf("unexpected document type %T", document)
+		return nil
+	}
+}
+
+func TestJoiner_SemanticDeduplication_KeepsDeclaredNameOverAlias_OAS2(t *testing.T) {
+	combined := foldStorefronts(t, emptyCombined(parser.OASVersion20), storefrontOAS2,
+		"downtown", "airport", "harbor")
+
+	// Every storefront declared Pet and Category and they are all equivalent, so
+	// there is nothing to consolidate into a name the joiner synthesized.
+	assert.Equal(t, []string{"Category", "Pet"}, sortedSchemaNames(t, combined.Document))
+
+	doc := combined.Document.(*parser.OAS2Document)
+	assertRefsPointAt(t, combined.Document, "#/definitions/Pet", "#/definitions/Category")
+	assert.Len(t, doc.Paths, 3, "one path per storefront, so every response ref is checked")
+}
+
+func TestJoiner_SemanticDeduplication_KeepsDeclaredNameOverAlias_OAS3(t *testing.T) {
+	combined := foldStorefronts(t, emptyCombined(parser.OASVersion303), storefrontOAS3,
+		"downtown", "airport", "harbor")
+
+	assert.Equal(t, []string{"Category", "Pet"}, sortedSchemaNames(t, combined.Document))
+
+	doc := combined.Document.(*parser.OAS3Document)
+	assertRefsPointAt(t, combined.Document,
+		"#/components/schemas/Pet", "#/components/schemas/Category")
+	assert.Len(t, doc.Paths, 3, "one path per storefront, so every response ref is checked")
+}
+
+// The collapse in StrategyDeduplicateOrRename is not what makes the declared
+// name win: StrategyRenameRight generates the same aliases and never collapses,
+// so only the semantic pass is left to choose between a name and its alias.
+func TestJoiner_SemanticDeduplication_KeepsDeclaredNameUnderRename(t *testing.T) {
+	res, err := JoinWithOptions(
+		WithParsed(storefrontOAS3("downtown"), storefrontOAS3("airport")),
+		WithSchemaStrategy(StrategyRenameRight),
+		WithEquivalenceMode("deep"),
+		WithSemanticDeduplication(true),
+		WithRenameTemplate(aliasFirstTemplate),
+	)
+	require.NoError(t, err)
+
+	schemas := schemaNamesOf(t, res.Document)
+	slices.Sort(schemas)
+	// Api_Category is gone and Category survived. Api_Pet remains because
+	// deduplication is a single pass: it compares the two Pets while their
+	// $refs still read Category and Api_Category, so it does not yet see them as
+	// equivalent. That is separate from which name a settled group keeps.
+	assert.Equal(t, []string{"Api_Pet", "Category", "Pet"}, schemas)
+}
+
+// A name no rename generated is preferred, but among names that documents wrote
+// the tiebreak is still alphabetical, matching what the deduplicator does on its
+// own. Neither of these two names is an alias.
+func TestJoiner_SemanticDeduplication_TiesStillGoAlphabetically(t *testing.T) {
+	left := storefrontOAS3("downtown")
+	right := storefrontOAS3("airport")
+	// Rename the right document's Pet before joining, so the two names are
+	// equivalent, differ, and neither is generated.
+	rightDoc := right.Document.(*parser.OAS3Document)
+	rightDoc.Components.Schemas["Zebra"] = rightDoc.Components.Schemas["Pet"]
+	delete(rightDoc.Components.Schemas, "Pet")
+	rightDoc.Paths["/airport/pet"].Get.Responses.Codes["200"].
+		Content["application/json"].Schema.Ref = "#/components/schemas/Zebra"
+
+	res, err := JoinWithOptions(
+		WithParsed(left, right),
+		WithSchemaStrategy(StrategyDeduplicateOrRename),
+		WithEquivalenceMode("deep"),
+		WithSemanticDeduplication(true),
+		WithRenameTemplate(aliasFirstTemplate),
+	)
+	require.NoError(t, err)
+
+	schemas := schemaNamesOf(t, res.Document)
+	slices.Sort(schemas)
+	assert.Equal(t, []string{"Category", "Pet"}, schemas, "Pet sorts before Zebra")
+}

--- a/joiner/deep_dive.md
+++ b/joiner/deep_dive.md
@@ -96,7 +96,7 @@ The two `Pet` schemas compare equal: both literally say `#/components/schemas/Ca
 
 So the decision runs later, at the one point where every document's renames are known and none of them has been applied yet. Each side of a comparison is read through its own document's pending renames, so two schemas are equivalent exactly when they would still be equivalent in the rewritten document. `Category` and `Category_clinic` differ, so the two `Pet` schemas differ too, and both survive.
 
-**Which name survives.** A name no rename generated beats one that a rename produced, so `Common` survives rather than an alias like `Api_Common` that happens to sort first. Names that are equally original are ordered alphabetically.
+**Which name survives.** A name no rename generated beats one that a rename produced, so `Common` survives rather than an alias like `Api_Common` that happens to sort first. Names that are equally original are ordered alphabetically. Semantic deduplication ranks names the same way, so a group it settles keeps the name the documents wrote rather than one the join synthesized, whatever the rename template makes those two sort like (#498).
 
 **One decision, not a fixed point.** A schema is compared once. When a group of schemas collapses, the schemas that *reference* them were already compared, while their references still pointed apart:
 
@@ -1303,7 +1303,8 @@ func main() {
     }
     
     // If Address, ShippingAddress, and BillingAddress are structurally identical,
-    // they'll be consolidated to "Address" (alphabetically first)
+    // they'll be consolidated to "Address": no rename generated any of the three,
+    // so the alphabetically first one wins
     // All references are rewritten automatically
     
     fmt.Printf("Schema count after deduplication: %d\n", result.Stats.SchemaCount)

--- a/joiner/joiner.go
+++ b/joiner/joiner.go
@@ -228,6 +228,11 @@ type JoinResult struct {
 	// deferred holds the collisions StrategyDeduplicateOrRename resolved by
 	// renaming, until the collapse decides which of those renames survive.
 	deferred []deferredRename
+	// generated is the set of names that exist only because a rename produced
+	// them, taken before the collapse runs. Both the collapse and semantic
+	// deduplication rank names by it, so the two cannot disagree about which
+	// name a document actually wrote (#498).
+	generated map[string]bool
 }
 
 // deferredRename is one collision StrategyDeduplicateOrRename renamed its way

--- a/joiner/oas2.go
+++ b/joiner/oas2.go
@@ -86,6 +86,10 @@ func (j *Joiner) joinOAS2Documents(docs []parser.ParseResult) (*JoinResult, erro
 
 	result.Document = joined
 
+	// Taken before the collapse, which redirects a rename onto the name it kept:
+	// a set taken afterwards would report that name as generated (#498).
+	result.generated = result.scope.generatedNames()
+
 	// The renames are all known and none is applied yet, which is the one point
 	// at which a definition headed for a collapse can be dropped rather than
 	// rewritten and copied (#487).
@@ -109,6 +113,7 @@ func (j *Joiner) joinOAS2Documents(docs []parser.ParseResult) (*JoinResult, erro
 			return res.Equivalent
 		}
 		config := schemautil.DefaultDeduplicationConfig()
+		config.Outranks = outranksGenerated(result.generated)
 		deduper := schemautil.NewSchemaDeduplicator(config, compare)
 		dedupeResult, err := deduper.Deduplicate(joined.Definitions)
 		if err != nil {

--- a/joiner/oas3.go
+++ b/joiner/oas3.go
@@ -200,6 +200,10 @@ func (j *Joiner) joinOAS3Documents(docs []parser.ParseResult) (*JoinResult, erro
 
 	result.Document = joined
 
+	// Taken before the collapse, which redirects a rename onto the name it kept:
+	// a set taken afterwards would report that name as generated (#498).
+	result.generated = result.scope.generatedNames()
+
 	// The renames are all known and none is applied yet, which is the one point
 	// at which a schema headed for a collapse can be dropped rather than
 	// rewritten and copied (#487).
@@ -223,6 +227,7 @@ func (j *Joiner) joinOAS3Documents(docs []parser.ParseResult) (*JoinResult, erro
 			return res.Equivalent
 		}
 		config := schemautil.DefaultDeduplicationConfig()
+		config.Outranks = outranksGenerated(result.generated)
 		deduper := schemautil.NewSchemaDeduplicator(config, compare)
 		dedupeResult, err := deduper.Deduplicate(joined.Components.Schemas)
 		if err != nil {


### PR DESCRIPTION
Fixes #498

## The problem 🐛

Two passes answered the same question, and the one that answered last had less to answer it with.

| Pass | Tiebreak |
|---|---|
| `StrategyDeduplicateOrRename` collapse (`outranks`) | a name no rename generated beats one a rename produced; ties alphabetical |
| `SemanticDeduplication` (`schemautil.SchemaDeduplicator`) | `sort.Strings`, with no notion of which names were generated |

With both enabled, the second pass could consolidate into the generated alias and drop the name every document declared. Folding three Petstore storefronts with a rename template of `Api_{{.Name}}`:

```
after downtown  -> [Category Pet]
after airport   -> [Api_Pet Category]     <- Pet is gone
after harbor    -> [Api_Pet Category]
```

`Category`, which the collision pass deduplicated rather than renamed, kept its name. So within one join two identical situations resolved differently depending on which pass settled them.

## The fix ✨

Give `schemautil.SchemaDeduplicator` an optional `Outranks` tiebreak, the same dependency-injection shape as the `CompareFunc` it already takes, and have the joiner supply the one it uses for a collapse. There is now one ranking function reached from two places rather than two rules that happen to agree. A caller that passes nothing, such as `builder`, keeps the alphabetical behavior exactly.

The generated set is taken **before** the collapse runs. `renameScope.redirect` points a rename at the name a class kept, so a set taken afterwards would report that name as generated: `Pet` would rank itself below its own alias.

## Two things beyond the report 🔍

**OAS 3 is reachable.** The issue listed this as unconfirmed. Reverting the fix and running the same fold on OAS 3 gives `[Api_Pet Category]`, identical to OAS 2. Both versions are covered.

**`joiner/deep_dive.md` was already contradicted.** Its table promises that `rename-right` plus semantic deduplication yields `Category, Pet, Pet_v1..v3`. With an `Api_` template it actually yielded `Api_Category, Api_Pet, Pet`: the documented behavior held only because the default `_v1` template happens to sort *after* the original. The fix makes the table true for any template.

## Tests 🧪

`joiner/dedupe_canonical_test.go`:

- the issue's iterative fold, for OAS 2 and OAS 3
- a `StrategyRenameRight` case, showing the collapse is not what makes the declared name win: that strategy generates the same aliases and never collapses, so only the semantic pass is left to choose
- a tie case, showing alphabetical ordering still governs when neither name is generated

All of them assert **references**, not only names. Reverted, the OAS 2 case fails on `#/definitions/Api_Pet` in three responses as well as on the schema map.

`internal/schemautil/deduplicator_test.go` covers the hook directly: nil, the joiner's generated-name rule, and a ranking that reverses the sort, plus the canonical-first ordering of `EquivalenceGroups`.

## Related 🔗

Not addressed here, but #418 (joiner and parser reimplement the same equality helpers, and the copies have drifted) is the same class of defect: two implementations of one question, drifting apart. The `Outranks` injection is a small precedent for its "share what answers the question, keep separate what reports differences" proposal.

Also worth stating: the `StrategyRenameRight` test leaves `Api_Pet` in the output, because a single deduplication pass compares the two `Pet` schemas while their `$ref`s still read `Category` and `Api_Category`. That is the documented "One decision, not a fixed point" limit in `joiner/deep_dive.md`, not a regression, and it is separate from which name a settled group keeps.

## Verification ✅

- `make check` passes: 10883 tests, lint and markdownlint clean
- gopls reports no diagnostics on any changed file
- two CodeRabbit local review passes, the second with zero findings across all ten files
