### PR TITLE
chore(mcp): drop the project level context7 server

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -7,14 +7,6 @@
         "mcp"
       ],
       "env": {}
-    },
-    "context7": {
-      "type": "stdio",
-      "command": "npx",
-      "args": [
-        "-y",
-        "@upstash/context7-mcp@1.0.17"
-      ]
     }
   }
 }


### PR DESCRIPTION
Removes the project-level `context7` MCP server from `.mcp.json`. It collided with the user-level one, registering the same server twice in every session started from this repo. The user-level config is the one to keep.

`gopls-mcp` is unchanged.