### PR TITLE
fix(parser): read a tuple-form items the same way on every decode path

### DIFF
--- a/internal/schemautil/bool_schema_hash_test.go
+++ b/internal/schemautil/bool_schema_hash_test.go
@@ -101,3 +101,44 @@ func TestHashBoolSchemaValuesDiffer(t *testing.T) {
 		})
 	}
 }
+
+// TestHashAndEqualsAgreeOnBoolSpellings asserts the joint invariant rather than
+// either half of it: things that hash alike must compare alike. The hasher was
+// taught the two spellings first, which left the contract broken in the other
+// direction, with both spellings sharing a bucket that the comparison then
+// split (#504). A test on the hasher alone cannot see that.
+func TestHashAndEqualsAgreeOnBoolSpellings(t *testing.T) {
+	arr := func(items any) *parser.Schema {
+		return &parser.Schema{Type: "array", Items: items}
+	}
+
+	tests := []struct {
+		name  string
+		left  *parser.Schema
+		right *parser.Schema
+		same  bool
+	}{
+		{"bare true and BoolForm true", arr(true), arr(parser.NewBoolSchema(true)), true},
+		{"bare false and BoolForm false", arr(false), arr(parser.NewBoolSchema(false)), true},
+		{"bare true and BoolForm false", arr(true), arr(parser.NewBoolSchema(false)), false},
+		{"bare true and an object schema", arr(true), arr(&parser.Schema{Type: "string"}), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := NewSchemaHasher()
+			hashesAgree := h.Hash(tt.left) == h.Hash(tt.right)
+			equal := tt.left.Equals(tt.right)
+
+			assert.Equal(t, tt.same, equal, "Equals")
+			assert.Equal(t, tt.same, hashesAgree, "Hash")
+
+			// The contract itself, stated once: a shared bucket that the
+			// comparison rejects is the failure mode deduplication cannot see.
+			if hashesAgree {
+				assert.True(t, equal,
+					"hash equal implies compare equal, or deduplication buckets what it will not merge")
+			}
+		})
+	}
+}

--- a/internal/schemautil/bool_schema_hash_test.go
+++ b/internal/schemautil/bool_schema_hash_test.go
@@ -103,10 +103,10 @@ func TestHashBoolSchemaValuesDiffer(t *testing.T) {
 }
 
 // TestHashAndEqualsAgreeOnBoolSpellings asserts the joint invariant rather than
-// either half of it: things that hash alike must compare alike. The hasher was
-// taught the two spellings first, which left the contract broken in the other
-// direction, with both spellings sharing a bucket that the comparison then
-// split (#504). A test on the hasher alone cannot see that.
+// either half of it: things that hash alike must compare alike. Testing the
+// hasher alone cannot see a break, because the two spellings can share a bucket
+// that the comparison then splits, which is deduplication that never merges
+// (#504).
 func TestHashAndEqualsAgreeOnBoolSpellings(t *testing.T) {
 	arr := func(items any) *parser.Schema {
 		return &parser.Schema{Type: "array", Items: items}

--- a/parser/decode_helpers.go
+++ b/parser/decode_helpers.go
@@ -227,13 +227,21 @@ func decodeSchemaOrBool(v any) any {
 		s.decodeFromMap(val)
 		return s
 	case []any:
-		// OAS 2.0 tuple validation: items can be an array of schemas
-		schemas := make([]*Schema, 0, len(val))
-		for _, elem := range val {
-			if m, ok := elem.(map[string]any); ok {
+		// OAS 2.0 tuple validation: items can be an array of schemas. The form
+		// is positional, so every element holds its index: dropping one
+		// renumbers the rest and silently changes what the document says
+		// (#510). A bool becomes the *Schema spelling because []*Schema cannot
+		// hold a bare bool; an explicit null, and anything this path cannot
+		// represent, keeps its slot as a nil element.
+		schemas := make([]*Schema, len(val))
+		for i, elem := range val {
+			switch e := elem.(type) {
+			case map[string]any:
 				s := new(Schema)
-				s.decodeFromMap(m)
-				schemas = append(schemas, s)
+				s.decodeFromMap(e)
+				schemas[i] = s
+			case bool:
+				schemas[i] = NewBoolSchema(e)
 			}
 		}
 		return schemas

--- a/parser/decode_helpers.go
+++ b/parser/decode_helpers.go
@@ -227,12 +227,16 @@ func decodeSchemaOrBool(v any) any {
 		s.decodeFromMap(val)
 		return s
 	case []any:
-		// OAS 2.0 tuple validation: items can be an array of schemas. The form
-		// is positional, so every element holds its index: dropping one
-		// renumbers the rest and silently changes what the document says
-		// (#510). A bool becomes the *Schema spelling because []*Schema cannot
-		// hold a bare bool; an explicit null, and anything this path cannot
-		// represent, keeps its slot as a nil element.
+		// OAS 2.0 tuple validation: items can be an array of schemas.
+		//
+		// The slice is allocated at full length and written by index, not
+		// appended to, so an element this path cannot represent leaves a nil
+		// at its own index instead of shifting the rest down. The tuple form
+		// is positional: a shift renumbers every later element and silently
+		// changes what the document says (#510).
+		//
+		// A bool becomes the *Schema spelling because []*Schema cannot hold a
+		// bare bool.
 		schemas := make([]*Schema, len(val))
 		for i, elem := range val {
 			switch e := elem.(type) {

--- a/parser/decode_helpers_test.go
+++ b/parser/decode_helpers_test.go
@@ -322,7 +322,12 @@ func TestDecodeSchemaOrBool_ArrayOfSchemas(t *testing.T) {
 }
 
 func TestDecodeSchemaOrBool_ArrayWithNonMapElements(t *testing.T) {
-	// Non-map elements in the array should be skipped
+	// Elements this path cannot represent keep their slot as a nil element.
+	// This test asserted that they were skipped, which is the behavior #510
+	// reports: the tuple form is positional, so dropping element 1 moves
+	// element 3 to index 1 and the document means something else. The nil is
+	// not a good answer either, but it is the one that leaves every other
+	// element where the document put it.
 	input := []any{
 		map[string]any{"type": "string"},
 		"not-a-map",
@@ -332,9 +337,38 @@ func TestDecodeSchemaOrBool_ArrayWithNonMapElements(t *testing.T) {
 	result := decodeSchemaOrBool(input)
 	schemas, ok := result.([]*Schema)
 	require.True(t, ok, "Expected []*Schema, got %T", result)
-	require.Len(t, schemas, 2, "Non-map elements should be skipped")
+	require.Len(t, schemas, 4, "every element holds its index")
 	assert.Equal(t, "string", schemas[0].Type)
-	assert.Equal(t, "boolean", schemas[1].Type)
+	assert.Nil(t, schemas[1])
+	assert.Nil(t, schemas[2])
+	assert.Equal(t, "boolean", schemas[3].Type)
+}
+
+func TestDecodeSchemaOrBool_ArrayWithBoolAndNullElements(t *testing.T) {
+	// A bool element becomes the *Schema spelling, because []*Schema cannot
+	// hold a bare bool. An explicit null stays a nil element. Both match what
+	// the YAML path has always produced (#510).
+	input := []any{
+		map[string]any{"type": "string"},
+		true,
+		nil,
+		false,
+	}
+	result := decodeSchemaOrBool(input)
+	schemas, ok := result.([]*Schema)
+	require.True(t, ok, "Expected []*Schema, got %T", result)
+	require.Len(t, schemas, 4)
+	assert.Equal(t, "string", schemas[0].Type)
+
+	v, isBool := schemas[1].IsBool()
+	assert.True(t, isBool, "element 1 is the bare-boolean form")
+	assert.True(t, v)
+
+	assert.Nil(t, schemas[2], "an explicit null holds its slot")
+
+	v, isBool = schemas[3].IsBool()
+	assert.True(t, isBool, "element 3 is the bare-boolean form")
+	assert.False(t, v, "false is a schema that accepts nothing, not an absent element")
 }
 
 func TestDecodeSchemaOrBool_EmptyArray(t *testing.T) {

--- a/parser/decode_helpers_test.go
+++ b/parser/decode_helpers_test.go
@@ -322,12 +322,10 @@ func TestDecodeSchemaOrBool_ArrayOfSchemas(t *testing.T) {
 }
 
 func TestDecodeSchemaOrBool_ArrayWithNonMapElements(t *testing.T) {
-	// Elements this path cannot represent keep their slot as a nil element.
-	// This test asserted that they were skipped, which is the behavior #510
-	// reports: the tuple form is positional, so dropping element 1 moves
-	// element 3 to index 1 and the document means something else. The nil is
-	// not a good answer either, but it is the one that leaves every other
-	// element where the document put it.
+	// An element decodeSchemaOrBool cannot turn into a schema still occupies
+	// its index, so the string and the number below produce nil at 1 and 2
+	// rather than a shorter slice, and the last schema stays at index 3.
+	// See #510 for why a shorter slice would be the wrong answer.
 	input := []any{
 		map[string]any{"type": "string"},
 		"not-a-map",
@@ -345,9 +343,9 @@ func TestDecodeSchemaOrBool_ArrayWithNonMapElements(t *testing.T) {
 }
 
 func TestDecodeSchemaOrBool_ArrayWithBoolAndNullElements(t *testing.T) {
-	// A bool element becomes the *Schema spelling, because []*Schema cannot
-	// hold a bare bool. An explicit null stays a nil element. Both match what
-	// the YAML path has always produced (#510).
+	// The three legal element forms: a schema, a bool, and an explicit null.
+	// The bool arrives as a *Schema carrying BoolForm, since []*Schema cannot
+	// hold a bare bool, and the null arrives as a nil element.
 	input := []any{
 		map[string]any{"type": "string"},
 		true,

--- a/parser/equals.go
+++ b/parser/equals.go
@@ -97,13 +97,16 @@ func equalSchemaOrBool(a, b any) bool {
 		return false
 	}
 
+	// The bare-boolean form first, across both spellings: see boolSchemaValue.
+	if av, ok := boolSchemaValue(a); ok {
+		bv, ok := boolSchemaValue(b)
+		return ok && av == bv
+	}
+	if _, ok := boolSchemaValue(b); ok {
+		return false
+	}
+
 	switch ta := a.(type) {
-	case bool:
-		tb, ok := b.(bool)
-		if !ok {
-			return false
-		}
-		return ta == tb
 	case *Schema:
 		tb, ok := b.(*Schema)
 		if !ok {

--- a/parser/schema.go
+++ b/parser/schema.go
@@ -134,6 +134,25 @@ func NewBoolSchema(v bool) *Schema {
 	return &Schema{BoolForm: &v}
 }
 
+// boolSchemaValue reports the boolean a schema-or-bool field carries, in either
+// spelling: a bare `bool`, or a *Schema with BoolForm set.
+//
+// Both spellings occur in parsed documents and neither is a mistake. A scalar
+// `items: true` decodes to a bare bool, while the same value inside an OAS 2.0
+// tuple decodes to a *Schema, because []*Schema cannot hold a bool. They mean
+// the same schema, so the structural hasher in internal/schemautil writes one
+// encoding for both, and equality has to agree with it: a bucket whose members
+// hash alike but compare unlike never merges (#504).
+func boolSchemaValue(v any) (value bool, ok bool) {
+	switch t := v.(type) {
+	case bool:
+		return t, true
+	case *Schema:
+		return t.IsBool()
+	}
+	return false, false
+}
+
 // Discriminator represents a discriminator for polymorphism.
 //
 // The two OAS dialects spell this differently. In OAS 2.0 the Schema Object's

--- a/parser/schema_equals.go
+++ b/parser/schema_equals.go
@@ -421,13 +421,16 @@ func equalSchemaOrBoolWithVisited(a, b any, visited map[schemaPair]bool) bool {
 		return false
 	}
 
+	// The bare-boolean form first, across both spellings: see boolSchemaValue.
+	if av, ok := boolSchemaValue(a); ok {
+		bv, ok := boolSchemaValue(b)
+		return ok && av == bv
+	}
+	if _, ok := boolSchemaValue(b); ok {
+		return false
+	}
+
 	switch ta := a.(type) {
-	case bool:
-		tb, ok := b.(bool)
-		if !ok {
-			return false
-		}
-		return ta == tb
 	case *Schema:
 		tb, ok := b.(*Schema)
 		if !ok {

--- a/parser/schema_equals_tuple_test.go
+++ b/parser/schema_equals_tuple_test.go
@@ -98,3 +98,35 @@ func TestSchemaEquals_TupleItemsBoolForm(t *testing.T) {
 	assert.False(t, tuple(boolSchema(true)).Equals(tuple(&Schema{Type: "string"})),
 		"a boolean schema and a typed schema are not the same")
 }
+
+// TestSchemaEquals_BoolSpellingsAgree pins the two spellings of a boolean
+// schema to one meaning. A scalar `items: true` decodes to a bare bool while
+// the same value inside a tuple decodes to a *Schema, because []*Schema cannot
+// hold a bool, so both spellings occur in parsed documents. The structural
+// hasher in internal/schemautil writes one encoding for both; equality has to
+// match it or a hash bucket holds members its comparison rejects (#504).
+func TestSchemaEquals_BoolSpellingsAgree(t *testing.T) {
+	arr := func(items any) *Schema {
+		return &Schema{Type: "array", Items: items}
+	}
+
+	t.Run("the spellings compare equal, in both directions", func(t *testing.T) {
+		assert.True(t, arr(true).Equals(arr(NewBoolSchema(true))))
+		assert.True(t, arr(NewBoolSchema(true)).Equals(arr(true)))
+		assert.True(t, arr(false).Equals(arr(NewBoolSchema(false))))
+		assert.True(t, arr(NewBoolSchema(false)).Equals(arr(false)))
+	})
+
+	// The counterpart. Without it, this file would pass just as well if every
+	// schema-or-bool comparison returned true.
+	t.Run("and the value still decides", func(t *testing.T) {
+		assert.False(t, arr(true).Equals(arr(NewBoolSchema(false))),
+			"true and false accept opposite things")
+		assert.False(t, arr(NewBoolSchema(true)).Equals(arr(false)))
+		assert.False(t, arr(true).Equals(arr(&Schema{Type: "string"})),
+			"a boolean schema is not an object schema in either spelling")
+		assert.False(t, arr(&Schema{Type: "string"}).Equals(arr(true)))
+		assert.False(t, arr(true).Equals(arr(nil)),
+			"an absent field is not the schema `true`")
+	})
+}

--- a/parser/schema_json.go
+++ b/parser/schema_json.go
@@ -158,12 +158,16 @@ func promoteSchemaOrBool(v any) (any, error) {
 		}
 		return s, nil
 	case []any:
-		// OAS 2.0 tuple validation: items can be an array of schemas. The form
-		// is positional, so every element holds its index: dropping one
-		// renumbers the rest and silently changes what the document says
-		// (#510). A bool becomes the *Schema spelling because []*Schema cannot
-		// hold a bare bool; an explicit null, and anything this path cannot
-		// represent, keeps its slot as a nil element.
+		// OAS 2.0 tuple validation: items can be an array of schemas.
+		//
+		// The slice is allocated at full length and written by index, not
+		// appended to, so an element this path cannot represent leaves a nil
+		// at its own index instead of shifting the rest down. The tuple form
+		// is positional: a shift renumbers every later element and silently
+		// changes what the document says (#510).
+		//
+		// A bool becomes the *Schema spelling because []*Schema cannot hold a
+		// bare bool.
 		schemas := make([]*Schema, len(val))
 		for i, elem := range val {
 			promoted, err := promoteSchemaOrBool(elem)

--- a/parser/schema_json.go
+++ b/parser/schema_json.go
@@ -158,15 +158,23 @@ func promoteSchemaOrBool(v any) (any, error) {
 		}
 		return s, nil
 	case []any:
-		// OAS 2.0 tuple validation: items can be an array of schemas.
-		schemas := make([]*Schema, 0, len(val))
-		for _, elem := range val {
+		// OAS 2.0 tuple validation: items can be an array of schemas. The form
+		// is positional, so every element holds its index: dropping one
+		// renumbers the rest and silently changes what the document says
+		// (#510). A bool becomes the *Schema spelling because []*Schema cannot
+		// hold a bare bool; an explicit null, and anything this path cannot
+		// represent, keeps its slot as a nil element.
+		schemas := make([]*Schema, len(val))
+		for i, elem := range val {
 			promoted, err := promoteSchemaOrBool(elem)
 			if err != nil {
 				return nil, err
 			}
-			if s, ok := promoted.(*Schema); ok {
-				schemas = append(schemas, s)
+			switch p := promoted.(type) {
+			case *Schema:
+				schemas[i] = p
+			case bool:
+				schemas[i] = NewBoolSchema(p)
 			}
 		}
 		return schemas, nil

--- a/parser/tuple_decode_parity_test.go
+++ b/parser/tuple_decode_parity_test.go
@@ -1,0 +1,125 @@
+// tuple_decode_parity_test.go pins the three decode paths to the same reading of
+// an OAS 2.0 tuple-form items field: YAML through promoteYAMLSchemaOrBool, JSON
+// through promoteSchemaOrBool, and the map decode through decodeSchemaOrBool,
+// which is what ResolveRefs uses. The form is positional, so an element a path
+// declines to represent must still hold its index: dropping one renumbers every
+// element after it and the document means something else (#510).
+package parser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const tupleParityYAML = `swagger: "2.0"
+info:
+  title: T
+  version: "1.0.0"
+paths: {}
+definitions:
+  Tuple:
+    type: array
+    items:
+      - type: string
+      - true
+      - null
+      - type: integer
+`
+
+const tupleParityJSON = `{
+  "swagger": "2.0",
+  "info": {"title": "T", "version": "1.0.0"},
+  "paths": {},
+  "definitions": {
+    "Tuple": {
+      "type": "array",
+      "items": [{"type": "string"}, true, null, {"type": "integer"}]
+    }
+  }
+}`
+
+// assertParityTuple states the one reading all three paths must produce.
+func assertParityTuple(t *testing.T, items any) {
+	t.Helper()
+
+	schemas, ok := items.([]*Schema)
+	require.True(t, ok, "expected the tuple form []*Schema, got %T", items)
+	require.Len(t, schemas, 4, "every element holds its index")
+
+	assert.Equal(t, "string", schemas[0].Type)
+
+	v, isBool := schemas[1].IsBool()
+	assert.True(t, isBool, "element 1 is the bare-boolean form")
+	assert.True(t, v)
+
+	assert.Nil(t, schemas[2], "an explicit null holds its slot")
+
+	assert.Equal(t, "integer", schemas[3].Type,
+		"element 3 keeps index 3: this is what a dropped element would move")
+}
+
+func TestTupleDecodeParityAcrossPaths(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		opts []Option
+	}{
+		{name: "YAML", src: tupleParityYAML},
+		{name: "JSON", src: tupleParityJSON},
+		{name: "YAML with ResolveRefs, the map decode", src: tupleParityYAML,
+			opts: []Option{WithResolveRefs(true)}},
+		{name: "JSON with ResolveRefs, the map decode", src: tupleParityJSON,
+			opts: []Option{WithResolveRefs(true)}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := append([]Option{WithBytes([]byte(tt.src))}, tt.opts...)
+			result, err := ParseWithOptions(opts...)
+			require.NoError(t, err)
+
+			doc, ok := result.Document.(*OAS2Document)
+			require.True(t, ok, "expected an OAS 2.0 document, got %T", result.Document)
+
+			assertParityTuple(t, doc.Definitions["Tuple"].Items)
+		})
+	}
+}
+
+// TestTupleDecodeParityEqualsAcrossFormats is the counterpart the parity test
+// needs: the two formats agreeing element by element is only useful if the
+// documents they produce also compare equal, which is what `diff` asks.
+func TestTupleDecodeParityEqualsAcrossFormats(t *testing.T) {
+	fromYAML, err := ParseWithOptions(WithBytes([]byte(tupleParityYAML)))
+	require.NoError(t, err)
+	fromJSON, err := ParseWithOptions(WithBytes([]byte(tupleParityJSON)))
+	require.NoError(t, err)
+
+	yamlSchema := fromYAML.Document.(*OAS2Document).Definitions["Tuple"]
+	jsonSchema := fromJSON.Document.(*OAS2Document).Definitions["Tuple"]
+
+	assert.True(t, yamlSchema.Equals(jsonSchema), "same document, two formats")
+	assert.True(t, jsonSchema.Equals(yamlSchema), "and equality is symmetric")
+}
+
+// TestTupleDecodeLengthStillDistinguishes is the mutation counterpart: a test
+// that only asserts two tuples match would pass just as well if every tuple
+// decoded to the same thing.
+func TestTupleDecodeLengthStillDistinguishes(t *testing.T) {
+	shorter := `{"swagger":"2.0","info":{"title":"T","version":"1.0.0"},"paths":{},` +
+		`"definitions":{"Tuple":{"type":"array","items":[{"type":"string"},true,null]}}}`
+
+	full, err := ParseWithOptions(WithBytes([]byte(tupleParityJSON)))
+	require.NoError(t, err)
+	short, err := ParseWithOptions(WithBytes([]byte(shorter)))
+	require.NoError(t, err)
+
+	fullSchema := full.Document.(*OAS2Document).Definitions["Tuple"]
+	shortSchema := short.Document.(*OAS2Document).Definitions["Tuple"]
+
+	require.Len(t, shortSchema.Items, 3)
+	assert.False(t, fullSchema.Equals(shortSchema),
+		"a tuple missing its last element is a different schema")
+}


### PR DESCRIPTION
## Summary

- Three decode paths read an OAS 2.0 tuple-form `items` differently, and two of them dropped elements. Because the form is positional, they also renumbered the elements they kept.
- `Equals` treated the two spellings of a boolean schema as different meanings while the structural hasher treated them as one, so the same document in two formats compared unequal.
- Both are the same decision, which is why they ship together: see the note under Context.

## Changes

- `parser/schema_json.go` and `parser/decode_helpers.go`: the tuple arm allocates at full length and writes by index rather than appending, so an element the path cannot represent leaves a nil at its own index instead of shifting the rest down. A bool element becomes the `*Schema` spelling, since `[]*Schema` cannot hold a bare bool.
- `parser/schema.go`: new unexported `boolSchemaValue`, which reads a boolean schema in either spelling.
- `parser/equals.go` and `parser/schema_equals.go`: both schema-or-bool equality functions consult it before their type switch, so spelling stops standing in for meaning.
- `TestDecodeSchemaOrBool_ArrayWithNonMapElements` asserted that unrepresentable elements are skipped. That was the defect recorded as a verdict, so it is flipped deliberately.
- New tests: three-path decode parity, cross-format `Equals`, a tuple-length counterpart, bool-spelling equality with its discrimination counterpart, and a hash-versus-equality contract test in `internal/schemautil`.

## Context

Measured before the change, on `[{type: string}, true, null, {type: integer}]`:

| Path | Result |
|---|---|
| YAML, `promoteYAMLSchemaOrBool` | 4 elements |
| JSON, `promoteSchemaOrBool` | 2 elements |
| map decode, `decodeSchemaOrBool` (what `ResolveRefs` uses) | 2 elements |

User-visible, converting that document from JSON:

```
before:  items: [{type: string}, {type: integer}]              # two elements deleted, exit 0
after:   items: [{type: string}, true, null, {type: integer}]
```

**Why the two issues are one change.** Fixing the decoders means deciding how a bool element is represented, and that decision is exactly what #504 is about. There was no representation to choose: `[]*Schema` cannot hold a bare bool, so a tuple element must be `*Schema{BoolForm}`, while a scalar `items: true` stays a bare bool on all three paths. Both spellings are therefore correct in their own position, and the real defect was that equality read a difference in spelling as a difference in meaning. The hasher already read them as one, so the pair hashed alike and compared unlike: a bucket that deduplication will never merge.

`#402` is not in this PR. It rewrites `promoteYAMLSchemaOrBool`, which this change does not touch, because the YAML path was already correct.

## Testing

- `make check` green: **10994 tests**, against 10978 on `main`.
- Corpus verdicts diffed per spec against a binary built from `main`: **identical across all ten**, after stripping operationId attribution and sorting.
- All 187 vendored conformance fixtures: **no verdict moved**.
- `boolSchemaValue` mutation-tested in both directions. Forcing it to report no bool fails the new agreement tests; forcing it to report `true` for everything fails the pre-existing discrimination tests. Two different failures, so both behaviors are pinned.
- [x] All tests pass (`make check`)
- [x] Coverage reviewed
- [x] Security scan (`govulncheck`): 4 stdlib findings, all `go1.25.12` fixed in `go1.25.13`, none reachable from this diff and none introduced by it (no new module dependencies).

## Related Issues

Closes #510
Closes #504
