### PR TITLE
fix(converter): convert OAS 2.0 tuples instead of copying them across

### DIFF
--- a/converter/helpers_test.go
+++ b/converter/helpers_test.go
@@ -341,7 +341,7 @@ func TestConvertOAS3SchemaToOAS2_AdditionalFeatures(t *testing.T) {
 		assert.Equal(t, 1, elseCount, "Expected exactly 1 issue for 'else'")
 	})
 
-	t.Run("prefixItems detected", func(t *testing.T) {
+	t.Run("prefixItems converts to the OAS 2.0 tuple and reports nothing", func(t *testing.T) {
 		c := New()
 		result := &ConversionResult{Issues: []ConversionIssue{}}
 		schema := &parser.Schema{
@@ -350,12 +350,26 @@ func TestConvertOAS3SchemaToOAS2_AdditionalFeatures(t *testing.T) {
 				{Type: "string"},
 				{Type: "integer"},
 			},
+			Items: &parser.Schema{Type: "boolean"},
 		}
 
-		c.convertOAS3SchemaToOAS2(schema, result, "test.prefixItems")
+		converted := c.convertOAS3SchemaToOAS2(schema, result, "test.prefixItems")
 
-		require.NotEmpty(t, result.Issues, "Expected issue for prefixItems")
-		assertHasIssueContaining(t, result.Issues, "prefixItems")
+		// OAS 2.0 takes items from JSON Schema draft 4, whose array form says
+		// what prefixItems says, so this is a conversion and not a loss.
+		assert.Empty(t, result.Issues, "a tuple OAS 2.0 can express is not a conversion issue")
+
+		tuple, ok := converted.Items.([]*parser.Schema)
+		require.True(t, ok, "expected the tuple form, got %T", converted.Items)
+		require.Len(t, tuple, 2)
+		assert.Equal(t, "string", tuple[0].Type)
+		assert.Equal(t, "integer", tuple[1].Type)
+		assert.Empty(t, converted.PrefixItems, "prefixItems has no meaning in OAS 2.0")
+
+		rest, ok := converted.AdditionalItems.(*parser.Schema)
+		require.True(t, ok, "expected items to become additionalItems, got %T", converted.AdditionalItems)
+		assert.Equal(t, "boolean", rest.Type,
+			"2020-12 items constrains what follows the tuple, which draft 4 calls additionalItems")
 	})
 
 	t.Run("contains detected", func(t *testing.T) {

--- a/converter/oas3_to_oas2_test.go
+++ b/converter/oas3_to_oas2_test.go
@@ -640,14 +640,6 @@ func TestConvertOAS3ToOAS2_SchemaFeatureDetection(t *testing.T) {
 			expectedKeyword: "if",
 		},
 		{
-			name: "prefixItems in component schema",
-			schema: &parser.Schema{
-				Type:        "array",
-				PrefixItems: []*parser.Schema{{Type: "string"}, {Type: "integer"}},
-			},
-			expectedKeyword: "prefixItems",
-		},
-		{
 			name: "contains in component schema",
 			schema: &parser.Schema{
 				Type:     "array",

--- a/converter/schema_convert.go
+++ b/converter/schema_convert.go
@@ -30,9 +30,111 @@ func (c *Converter) convertOAS2SchemaToOAS3(schema *parser.Schema, targetVersion
 	// For OAS 3.1+, convert boolean exclusiveMaximum/exclusiveMinimum to numeric form
 	if c.isOAS31OrLater(targetVersion) {
 		fixSchemaExclusiveMinMaxForOAS31(c, converted, result, path, make(map[*parser.Schema]bool))
+		tupleToPrefixItems(converted)
+	} else {
+		tupleForOAS30(c, converted, result, path)
 	}
 
 	return converted
+}
+
+// tupleToPrefixItems rewrites the OAS 2.0 tuple spelling of `items` into the one
+// OAS 3.1 and later use. Both versions can express a tuple, so nothing is lost
+// and nothing is reported: 2.0 takes `items` from JSON Schema draft 4, where an
+// array of schemas constrains each position, and 3.1 inherits 2020-12, where
+// `prefixItems` holds those positions and `items` constrains whatever follows
+// them.
+//
+// draft 4 gives that trailing role to `additionalItems`, so it moves to `items`.
+// Absent stays absent, which in both dialects means anything may follow.
+func tupleToPrefixItems(schema *parser.Schema) {
+	walkSchemas(schema, func(s *parser.Schema) {
+		tuple, ok := s.Items.([]*parser.Schema)
+		if !ok {
+			return
+		}
+		s.PrefixItems = tuple
+		s.Items = s.AdditionalItems
+		s.AdditionalItems = nil
+	})
+}
+
+// tupleForOAS30 removes tuple-form `items`, which OAS 3.0 forbids: "Value MUST
+// be an object and not an array". 3.0 has no positional array validation at all,
+// so unless the tuple collapses (see uniformTupleElement) the positions cannot
+// come across and the loss is reported.
+//
+// What is left behind is weaker than the source rather than different from it:
+// an array whose elements are unconstrained accepts everything the tuple
+// accepted. minItems and maxItems are untouched, so the length constraints
+// survive even when the positions do not.
+func tupleForOAS30(c *Converter, schema *parser.Schema, result *ConversionResult, path string) {
+	walkSchemas(schema, func(s *parser.Schema) {
+		tuple, ok := s.Items.([]*parser.Schema)
+		if !ok {
+			return
+		}
+
+		if uniform, ok := uniformTupleElement(s, tuple); ok {
+			s.Items = uniform
+			s.AdditionalItems = nil
+			return
+		}
+
+		s.Items = nil
+		s.AdditionalItems = nil
+		c.addIssueWithContext(result, path,
+			fmt.Sprintf("Schema uses a %d element tuple in 'items', which OAS 3.0 forbids; positional element schemas dropped", len(tuple)),
+			"OAS 3.0 requires 'items' to be a single schema, so it cannot say what belongs at each position. Convert to OAS 3.1 or later to keep the tuple as 'prefixItems', or describe the array with one schema that admits every position")
+	})
+}
+
+// uniformTupleElement reports the single schema a tuple is equivalent to, when
+// it has one. A tuple whose positions all carry the same schema says no more
+// than that schema applied to every element, PROVIDED nothing longer than the
+// tuple can slip past with a different shape.
+//
+// Three ways that is guaranteed: maxItems stops the array at or before the last
+// tuple position, additionalItems forbids anything after it, or additionalItems
+// repeats the same schema.
+//
+// A bare-boolean element is refused even when uniform, because OAS 3.0 has no
+// boolean schema form and collapsing to one would trade an invalid tuple for an
+// invalid `items`.
+func uniformTupleElement(s *parser.Schema, tuple []*parser.Schema) (*parser.Schema, bool) {
+	if len(tuple) == 0 {
+		return nil, false
+	}
+
+	first := tuple[0]
+	if first == nil {
+		return nil, false
+	}
+	if _, isBool := first.IsBool(); isBool {
+		return nil, false
+	}
+	for _, elem := range tuple[1:] {
+		if !first.Equals(elem) {
+			return nil, false
+		}
+	}
+
+	switch {
+	case s.MaxItems != nil && *s.MaxItems <= len(tuple):
+		return first, true
+	case s.AdditionalItems == nil:
+		// draft 4 lets anything follow the tuple, so a single schema would say
+		// more than the source did.
+		return nil, false
+	default:
+		if b, ok := s.AdditionalItems.(bool); ok && !b {
+			return first, true
+		}
+		if rest, ok := s.AdditionalItems.(*parser.Schema); ok && first.Equals(rest) {
+			return first, true
+		}
+		return nil, false
+	}
 }
 
 // discriminatorToObjectForm clears StringForm on every discriminator in the
@@ -193,7 +295,26 @@ func (c *Converter) convertOAS3SchemaToOAS2(schema *parser.Schema, result *Conve
 	// Demote the OAS 3.x discriminator object to the OAS 2.0 bare-string form
 	discriminatorToStringForm(c, converted, result, path)
 
+	// Demote prefixItems to the OAS 2.0 tuple spelling of items
+	prefixItemsToTuple(converted)
+
 	return converted
+}
+
+// prefixItemsToTuple rewrites the 2020-12 tuple spelling into the draft 4 one
+// OAS 2.0 uses. It is the inverse of tupleToPrefixItems and loses nothing:
+// `prefixItems` becomes the array form of `items`, and `items`, which in
+// 2020-12 constrains whatever follows the listed positions, becomes
+// `additionalItems`, which is draft 4's name for that role.
+func prefixItemsToTuple(schema *parser.Schema) {
+	walkSchemas(schema, func(s *parser.Schema) {
+		if len(s.PrefixItems) == 0 {
+			return
+		}
+		s.AdditionalItems = s.Items
+		s.Items = s.PrefixItems
+		s.PrefixItems = nil
+	})
 }
 
 // detectOAS3SchemaFeatures checks a single schema for OAS 3.x-only features
@@ -231,11 +352,9 @@ func detectOAS3SchemaFeatures(c *Converter, schema *parser.Schema, result *Conve
 			"Conditional schema composition has no OAS 2.0 equivalent")
 	}
 
-	// Check for prefixItems (JSON Schema 2020-12, OAS 3.1+)
-	if len(schema.PrefixItems) > 0 {
-		c.addIssueWithContext(result, path, "Schema uses 'prefixItems' which is OAS 3.1+ (JSON Schema 2020-12)",
-			"Tuple validation via 'prefixItems' has no OAS 2.0 equivalent")
-	}
+	// prefixItems is deliberately absent from this list. OAS 2.0 takes items from
+	// JSON Schema draft 4, whose array form says the same thing, so the tuple
+	// converts rather than being lost: see prefixItemsToTuple.
 
 	// Check for contains (JSON Schema 2020-12, OAS 3.1+)
 	if schema.Contains != nil {

--- a/converter/schema_convert.go
+++ b/converter/schema_convert.go
@@ -30,7 +30,7 @@ func (c *Converter) convertOAS2SchemaToOAS3(schema *parser.Schema, targetVersion
 	// For OAS 3.1+, convert boolean exclusiveMaximum/exclusiveMinimum to numeric form
 	if c.isOAS31OrLater(targetVersion) {
 		fixSchemaExclusiveMinMaxForOAS31(c, converted, result, path, make(map[*parser.Schema]bool))
-		tupleToPrefixItems(converted)
+		tupleToPrefixItems(c, converted, result, path)
 	} else {
 		tupleForOAS30(c, converted, result, path)
 	}
@@ -47,7 +47,7 @@ func (c *Converter) convertOAS2SchemaToOAS3(schema *parser.Schema, targetVersion
 //
 // draft 4 gives that trailing role to `additionalItems`, so it moves to `items`.
 // Absent stays absent, which in both dialects means anything may follow.
-func tupleToPrefixItems(schema *parser.Schema) {
+func tupleToPrefixItems(c *Converter, schema *parser.Schema, result *ConversionResult, path string) {
 	walkSchemas(schema, func(s *parser.Schema) {
 		tuple, ok := s.Items.([]*parser.Schema)
 		if !ok {
@@ -58,7 +58,19 @@ func tupleToPrefixItems(schema *parser.Schema) {
 			return
 		}
 		s.PrefixItems = tuple
-		s.Items = s.AdditionalItems
+
+		// additionalItems takes a schema or a bool in draft 4, never an array,
+		// so a source holding one is malformed. It cannot move to `items`, which
+		// 2020-12 also requires to be a schema, and carrying it across would put
+		// an array back in the field this conversion exists to clear.
+		if rest, isTuple := s.AdditionalItems.([]*parser.Schema); isTuple {
+			c.addIssueWithContext(result, path,
+				fmt.Sprintf("Schema holds a %d element array in 'additionalItems', which no version accepts there; dropped", len(rest)),
+				"JSON Schema draft 4 takes a schema or a boolean in 'additionalItems', and 2020-12 requires 'items' to be a schema, so there is nothing to convert this into. Describe what follows the tuple with a single schema")
+			s.Items = nil
+		} else {
+			s.Items = s.AdditionalItems
+		}
 		s.AdditionalItems = nil
 	})
 }
@@ -342,7 +354,16 @@ func prefixItemsToTuple(c *Converter, schema *parser.Schema, result *ConversionR
 			}
 		}
 
-		s.AdditionalItems = s.Items
+		// 2020-12 requires items to be a schema, so an array there is malformed,
+		// and draft 4 would not accept one in additionalItems either.
+		if rest, isTuple := s.Items.([]*parser.Schema); isTuple {
+			c.addIssueWithContext(result, path,
+				fmt.Sprintf("Schema holds a %d element array in 'items' beside 'prefixItems', which no version accepts there; dropped", len(rest)),
+				"JSON Schema 2020-12 uses 'items' for what follows the listed positions and requires it to be a schema. Describe the trailing elements with a single schema, or list them in 'prefixItems'")
+			s.AdditionalItems = nil
+		} else {
+			s.AdditionalItems = s.Items
+		}
 		s.Items = s.PrefixItems
 		s.PrefixItems = nil
 	})

--- a/converter/schema_convert.go
+++ b/converter/schema_convert.go
@@ -81,7 +81,11 @@ func tupleForOAS30(c *Converter, schema *parser.Schema, result *ConversionResult
 			return
 		}
 
-		s.Items = nil
+		// The empty schema, not a missing one: OAS 3.0 says "items MUST be
+		// present if type is 'array'", so removing the keyword would trade a
+		// forbidden tuple for a missing required field. An empty schema accepts
+		// everything, which is what is left once the positions are gone.
+		s.Items = &parser.Schema{}
 		s.AdditionalItems = nil
 		c.addIssueWithContext(result, path,
 			fmt.Sprintf("Schema uses a %d element tuple in 'items', which OAS 3.0 forbids; positional element schemas dropped", len(tuple)),
@@ -296,21 +300,41 @@ func (c *Converter) convertOAS3SchemaToOAS2(schema *parser.Schema, result *Conve
 	discriminatorToStringForm(c, converted, result, path)
 
 	// Demote prefixItems to the OAS 2.0 tuple spelling of items
-	prefixItemsToTuple(converted)
+	prefixItemsToTuple(c, converted, result, path)
 
 	return converted
 }
 
 // prefixItemsToTuple rewrites the 2020-12 tuple spelling into the draft 4 one
-// OAS 2.0 uses. It is the inverse of tupleToPrefixItems and loses nothing:
-// `prefixItems` becomes the array form of `items`, and `items`, which in
-// 2020-12 constrains whatever follows the listed positions, becomes
-// `additionalItems`, which is draft 4's name for that role.
-func prefixItemsToTuple(schema *parser.Schema) {
+// OAS 2.0 uses: `prefixItems` becomes the array form of `items`, and `items`,
+// which in 2020-12 constrains whatever follows the listed positions, becomes
+// `additionalItems`, which is draft 4's name for that role. A bool is left
+// alone there, since draft 4 accepts one in `additionalItems`.
+//
+// A bool in a POSITION is another matter, because draft 4 has no boolean schema
+// form: every member of the items array must be an object. `true` accepts
+// anything, which the empty schema also does, so it converts. `false` accepts
+// nothing, and draft 4 cannot say that without `not`, which OAS 2.0 does not
+// have, so the position becomes the empty schema and the loss is reported.
+func prefixItemsToTuple(c *Converter, schema *parser.Schema, result *ConversionResult, path string) {
 	walkSchemas(schema, func(s *parser.Schema) {
 		if len(s.PrefixItems) == 0 {
 			return
 		}
+
+		for i, elem := range s.PrefixItems {
+			b, isBool := elem.IsBool()
+			if !isBool {
+				continue
+			}
+			s.PrefixItems[i] = &parser.Schema{}
+			if !b {
+				c.addIssueWithContext(result, fmt.Sprintf("%s.prefixItems[%d]", path, i),
+					"Schema uses the boolean schema 'false' at a tuple position, which OAS 2.0 cannot express; position now accepts any value",
+					"OAS 2.0 follows JSON Schema draft 4, which has no boolean schema form and no 'not' keyword to build one from. Constrain the position with an explicit schema, or keep the document at OAS 3.1 or later")
+			}
+		}
+
 		s.AdditionalItems = s.Items
 		s.Items = s.PrefixItems
 		s.PrefixItems = nil

--- a/converter/schema_convert.go
+++ b/converter/schema_convert.go
@@ -51,6 +51,10 @@ func tupleToPrefixItems(schema *parser.Schema) {
 	walkSchemas(schema, func(s *parser.Schema) {
 		tuple, ok := s.Items.([]*parser.Schema)
 		if !ok {
+			// draft 4 ignores additionalItems unless items is an array, so
+			// dropping it here says exactly what the source said, and no OAS 3.x
+			// version has the keyword to carry it anyway.
+			s.AdditionalItems = nil
 			return
 		}
 		s.PrefixItems = tuple
@@ -72,6 +76,9 @@ func tupleForOAS30(c *Converter, schema *parser.Schema, result *ConversionResult
 	walkSchemas(schema, func(s *parser.Schema) {
 		tuple, ok := s.Items.([]*parser.Schema)
 		if !ok {
+			// Ignored by draft 4 without an array items, and not a field OAS 3.0
+			// has: see tupleToPrefixItems.
+			s.AdditionalItems = nil
 			return
 		}
 

--- a/converter/schema_convert.go
+++ b/converter/schema_convert.go
@@ -54,6 +54,11 @@ func tupleToPrefixItems(c *Converter, schema *parser.Schema, result *ConversionR
 			// draft 4 ignores additionalItems unless items is an array, so
 			// dropping it here says exactly what the source said, and no OAS 3.x
 			// version has the keyword to carry it anyway.
+			//
+			// Silent even when it holds an array, which is reported below in the
+			// tuple case. The difference is not the value but whether the field
+			// was doing anything: beside a single-schema items it constrains
+			// nothing, so there is no loss to announce.
 			s.AdditionalItems = nil
 			return
 		}
@@ -338,6 +343,10 @@ func (c *Converter) convertOAS3SchemaToOAS2(schema *parser.Schema, result *Conve
 func prefixItemsToTuple(c *Converter, schema *parser.Schema, result *ConversionResult, path string) {
 	walkSchemas(schema, func(s *parser.Schema) {
 		if len(s.PrefixItems) == 0 {
+			// An array left in items is not touched here. OAS 2.0 spells a tuple
+			// exactly that way, so it needs no conversion and loses nothing. The
+			// array is only unconvertible when prefixItems already holds the
+			// positions, which is the case handled below.
 			return
 		}
 

--- a/converter/tuple_items_test.go
+++ b/converter/tuple_items_test.go
@@ -508,3 +508,49 @@ components:
 	assert.Equal(t, 1, reported,
 		"only `false` loses meaning, so only `false` is reported")
 }
+
+// TestAdditionalItemsDoesNotSurviveConversion covers the branch the tuple cases
+// do not reach: a schema whose items is a single schema rather than a tuple.
+// draft 4 ignores additionalItems unless items is an array, so the field says
+// nothing there, and no OAS 3.x version has the keyword to carry it: it appears
+// nowhere in the 3.0.4 or 3.1.1 specifications.
+func TestAdditionalItemsDoesNotSurviveConversion(t *testing.T) {
+	const spec = `swagger: "2.0"
+info:
+  title: t
+  version: "1.0.0"
+paths: {}
+definitions:
+  ObjectItems:
+    type: array
+    items:
+      type: string
+    additionalItems: false
+  NoItems:
+    type: object
+    additionalItems:
+      type: string
+`
+	for _, target := range []string{"3.0.3", "3.1.0", "3.2.0"} {
+		t.Run(target, func(t *testing.T) {
+			parsed, err := parser.New().ParseBytes([]byte(spec))
+			require.NoError(t, err)
+
+			result, err := ConvertWithOptions(WithParsed(*parsed), WithTargetVersion(target))
+			require.NoError(t, err)
+
+			doc, ok := result.Document.(*parser.OAS3Document)
+			require.True(t, ok)
+
+			objectItems := doc.Components.Schemas["ObjectItems"]
+			assert.Nil(t, objectItems.AdditionalItems,
+				"additionalItems has no meaning beside a single-schema items and no spelling in OAS 3.x")
+			single, ok := objectItems.Items.(*parser.Schema)
+			require.True(t, ok, "the single-schema items is untouched, got %T", objectItems.Items)
+			assert.Equal(t, "string", single.Type)
+
+			assert.Nil(t, doc.Components.Schemas["NoItems"].AdditionalItems,
+				"a schema with no items at all cannot carry additionalItems either")
+		})
+	}
+}

--- a/converter/tuple_items_test.go
+++ b/converter/tuple_items_test.go
@@ -43,16 +43,17 @@ definitions:
 // "#/components/schemas", and a $ref the rewrite never visits keeps the old
 // prefix and points at nothing in the converted document.
 //
-// It asserts the $ref only. That the tuple reaches OAS 3 output at all is a
-// separate defect, since OAS 3.0 says of items "Value MUST be an object and not
-// an array".
+// The target is 3.1, which is where a tuple survives conversion and so where a
+// $ref inside one still has to resolve. OAS 3.0 forbids tuples outright and
+// drops the positions, leaving no reference to check: see
+// TestTupleConversionByTargetVersion.
 func TestTupleItemsRefIsRewrittenOnUpconversion(t *testing.T) {
 	parseResult, err := parser.New().ParseBytes([]byte(tupleItemsOAS2Spec))
 	require.NoError(t, err)
 
 	result, err := ConvertWithOptions(
 		WithParsed(*parseResult),
-		WithTargetVersion("3.0.3"),
+		WithTargetVersion("3.1.0"),
 	)
 	require.NoError(t, err)
 
@@ -75,17 +76,14 @@ func collectRefsUnderItems(t *testing.T, schema *parser.Schema) []string {
 	t.Helper()
 
 	var refs []string
-	found := false
 	for _, s := range schemautil.SchemaOrBoolSchemas(schema.Items) {
-		found = true
 		refs = append(refs, s.Ref)
 	}
-	if !found {
-		t.Fatalf("items held no schema to check, got %T", schema.Items)
-	}
-
 	for _, s := range schema.PrefixItems {
 		refs = append(refs, s.Ref)
+	}
+	if len(refs) == 0 {
+		t.Fatalf("neither items nor prefixItems held a schema to check, items was %T", schema.Items)
 	}
 
 	return refs
@@ -155,11 +153,17 @@ definitions:
 		assert.Nil(t, s.Minimum, "%s should have moved minimum into exclusiveMinimum", name)
 	}
 
+	// The two array fields are checked under their OAS 3.1 names: the tuple is
+	// spelled prefixItems there, and items takes over the trailing-element role
+	// draft 4 gave additionalItems.
+	check("prefixItems", converted.PrefixItems)
 	check("items", converted.Items)
-	check("additionalItems", converted.AdditionalItems)
 	check("additionalProperties", converted.AdditionalProperties)
 	check("unevaluatedItems", converted.UnevaluatedItems)
 	check("unevaluatedProperties", converted.UnevaluatedProperties)
+
+	assert.Nil(t, converted.AdditionalItems,
+		"additionalItems is the draft 4 spelling and has no role in an OAS 3.1 document")
 }
 
 // TestSchemaOrBoolFieldsAreWalkedOnDowngrade covers the fields the feature walk
@@ -233,4 +237,201 @@ components:
 	}
 	assert.Contains(t, strings.Join(paths, "\n"), "additionalProperties[0]",
 		"the nullable schema in a tuple additionalProperties element was not reached")
+}
+
+// TestTupleConversionByTargetVersion pins what happens to an OAS 2.0 tuple at
+// each target, which differs because the three versions disagree about tuples.
+// OAS 2.0 takes items from JSON Schema draft 4, where an array of schemas
+// constrains each position. OAS 3.0 forbids that outright: "Value MUST be an
+// object and not an array". OAS 3.1 and later inherit 2020-12, which moves the
+// positions to prefixItems. So the tuple converts at 3.1+, and at 3.0 it either
+// collapses or is dropped and reported (#508).
+func TestTupleConversionByTargetVersion(t *testing.T) {
+	const heterogeneous = `swagger: "2.0"
+info:
+  title: t
+  version: "1.0.0"
+paths: {}
+definitions:
+  Row:
+    type: array
+    items:
+      - type: string
+      - type: integer
+`
+	const uniformBounded = `swagger: "2.0"
+info:
+  title: t
+  version: "1.0.0"
+paths: {}
+definitions:
+  Row:
+    type: array
+    items:
+      - type: number
+      - type: number
+    maxItems: 2
+`
+	const uniformOpen = `swagger: "2.0"
+info:
+  title: t
+  version: "1.0.0"
+paths: {}
+definitions:
+  Row:
+    type: array
+    items:
+      - type: number
+      - type: number
+`
+	const uniformBools = `swagger: "2.0"
+info:
+  title: t
+  version: "1.0.0"
+paths: {}
+definitions:
+  Row:
+    type: array
+    items:
+      - true
+      - true
+    maxItems: 2
+`
+
+	tests := []struct {
+		name        string
+		spec        string
+		target      string
+		wantWarning bool
+		assert      func(t *testing.T, s *parser.Schema)
+	}{
+		{
+			name:   "3.1 keeps the positions as prefixItems",
+			spec:   heterogeneous,
+			target: "3.1.0",
+			assert: func(t *testing.T, s *parser.Schema) {
+				require.Len(t, s.PrefixItems, 2)
+				assert.Equal(t, "string", s.PrefixItems[0].Type)
+				assert.Equal(t, "integer", s.PrefixItems[1].Type)
+				assert.Nil(t, s.Items, "nothing constrains what follows, as in the source")
+			},
+		},
+		{
+			name:   "3.2 keeps the positions as prefixItems",
+			spec:   heterogeneous,
+			target: "3.2.0",
+			assert: func(t *testing.T, s *parser.Schema) {
+				require.Len(t, s.PrefixItems, 2)
+				assert.Equal(t, "string", s.PrefixItems[0].Type)
+			},
+		},
+		{
+			name:        "3.0 drops positions it cannot express, and says so",
+			spec:        heterogeneous,
+			target:      "3.0.3",
+			wantWarning: true,
+			assert: func(t *testing.T, s *parser.Schema) {
+				assert.Nil(t, s.Items, "an unconstrained array accepts everything the tuple accepted")
+				assert.Empty(t, s.PrefixItems, "prefixItems is not valid in OAS 3.0 either")
+			},
+		},
+		{
+			name:   "3.0 collapses a uniform tuple that cannot grow",
+			spec:   uniformBounded,
+			target: "3.0.3",
+			assert: func(t *testing.T, s *parser.Schema) {
+				single, ok := s.Items.(*parser.Schema)
+				require.True(t, ok, "expected a single schema, got %T", s.Items)
+				assert.Equal(t, "number", single.Type)
+			},
+		},
+		{
+			name:        "3.0 will not collapse a uniform tuple that can grow",
+			spec:        uniformOpen,
+			target:      "3.0.3",
+			wantWarning: true,
+			assert: func(t *testing.T, s *parser.Schema) {
+				// draft 4 lets anything follow a tuple when additionalItems is
+				// absent, so `items: {type: number}` would forbid arrays the
+				// source allows.
+				assert.Nil(t, s.Items)
+			},
+		},
+		{
+			name:        "3.0 will not collapse to a boolean schema",
+			spec:        uniformBools,
+			target:      "3.0.3",
+			wantWarning: true,
+			assert: func(t *testing.T, s *parser.Schema) {
+				// OAS 3.0 has no bare-boolean schema form, so collapsing here
+				// would trade an invalid tuple for an invalid items.
+				assert.Nil(t, s.Items)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parsed, err := parser.New().ParseBytes([]byte(tt.spec))
+			require.NoError(t, err)
+
+			result, err := ConvertWithOptions(WithParsed(*parsed), WithTargetVersion(tt.target))
+			require.NoError(t, err)
+
+			doc, ok := result.Document.(*parser.OAS3Document)
+			require.True(t, ok)
+			tt.assert(t, doc.Components.Schemas["Row"])
+
+			var tupleWarnings int
+			for _, issue := range result.Issues {
+				if issue.Severity == SeverityWarning && strings.Contains(issue.Message, "tuple") {
+					tupleWarnings++
+				}
+			}
+			if tt.wantWarning {
+				assert.Equal(t, 1, tupleWarnings, "expected exactly one warning naming the tuple")
+			} else {
+				assert.Zero(t, tupleWarnings, "a tuple that came across is not a conversion issue")
+			}
+		})
+	}
+}
+
+// TestTupleSurvivesRoundTrip is the counterpart to the per-target assertions.
+// Each direction can look right on its own while losing something the other
+// direction would reveal, and 2.0 and 3.1 can both express a tuple, so a round
+// trip through 3.1 has to come back unchanged.
+func TestTupleSurvivesRoundTrip(t *testing.T) {
+	const spec = `swagger: "2.0"
+info:
+  title: t
+  version: "1.0.0"
+paths: {}
+definitions:
+  Row:
+    type: array
+    items:
+      - type: string
+      - type: integer
+    additionalItems: false
+`
+	parsed, err := parser.New().ParseBytes([]byte(spec))
+	require.NoError(t, err)
+	original := parsed.Document.(*parser.OAS2Document).Definitions["Row"]
+
+	up, err := ConvertWithOptions(WithParsed(*parsed), WithTargetVersion("3.1.0"))
+	require.NoError(t, err)
+
+	upDoc := up.Document.(*parser.OAS3Document)
+	require.Len(t, upDoc.Components.Schemas["Row"].PrefixItems, 2)
+	assert.Equal(t, false, upDoc.Components.Schemas["Row"].Items,
+		"additionalItems: false becomes items: false in 2020-12")
+
+	upParsed := parser.ParseResult{Document: up.Document, OASVersion: parser.OASVersion310, Version: "3.1.0"}
+	down, err := ConvertWithOptions(WithParsed(upParsed), WithTargetVersion("2.0"))
+	require.NoError(t, err)
+
+	returned := down.Document.(*parser.OAS2Document).Definitions["Row"]
+	assert.True(t, original.Equals(returned),
+		"a tuple both versions can express must survive 2.0 to 3.1 and back")
 }

--- a/converter/tuple_items_test.go
+++ b/converter/tuple_items_test.go
@@ -637,3 +637,79 @@ func assertReports(t *testing.T, result *ConversionResult, field string) {
 	}
 	assert.Equal(t, 1, matched, "expected exactly one warning naming %q; issues: %+v", field, result.Issues)
 }
+
+// TestEarlyReturnShapesAreDeliberate pins the two shapes that reach a
+// conversion's early return, because both look like oversights and neither is.
+// The rule they follow is the one the reporting cases follow: put each thing
+// where the target can hold it, and report only what has nowhere to go.
+func TestEarlyReturnShapesAreDeliberate(t *testing.T) {
+	t.Run("an inert additionalItems is dropped without a report", func(t *testing.T) {
+		// draft 4 ignores additionalItems unless items is an array, so beside a
+		// single-schema items it constrains nothing. Dropping it loses nothing,
+		// even when it holds an array, so there is no loss to announce. Contrast
+		// TestArrayValuedSchemaOrBoolIsNotCarriedAcross, where the same value is
+		// reported because a tuple beside it makes the field live.
+		const spec = `swagger: "2.0"
+info:
+  title: t
+  version: "1.0.0"
+paths: {}
+definitions:
+  A:
+    type: array
+    items:
+      type: string
+    additionalItems:
+      - type: integer
+      - type: boolean
+`
+		parsed, err := parser.New().ParseBytes([]byte(spec))
+		require.NoError(t, err)
+
+		result, err := ConvertWithOptions(WithParsed(*parsed), WithTargetVersion("3.1.0"))
+		require.NoError(t, err)
+
+		schema := result.Document.(*parser.OAS3Document).Components.Schemas["A"]
+		assert.Nil(t, schema.AdditionalItems)
+		single, ok := schema.Items.(*parser.Schema)
+		require.True(t, ok, "the single-schema items is untouched, got %T", schema.Items)
+		assert.Equal(t, "string", single.Type)
+
+		for _, issue := range result.Issues {
+			assert.NotContains(t, issue.Message, "additionalItems",
+				"dropping a field that constrained nothing is not a conversion issue")
+		}
+	})
+
+	t.Run("an array items with no prefixItems converts rather than dropping", func(t *testing.T) {
+		// OAS 2.0 spells a tuple exactly this way, so the array has somewhere to
+		// go and the conversion keeps it. Dropping it would discard the only
+		// thing the source said.
+		const spec = `openapi: 3.1.0
+info:
+  title: t
+  version: "1.0.0"
+paths: {}
+components:
+  schemas:
+    B:
+      type: array
+      items:
+        - type: integer
+        - type: boolean
+`
+		parsed, err := parser.New().ParseBytes([]byte(spec))
+		require.NoError(t, err)
+
+		result, err := ConvertWithOptions(WithParsed(*parsed), WithTargetVersion("2.0"))
+		require.NoError(t, err)
+
+		schema := result.Document.(*parser.OAS2Document).Definitions["B"]
+		tuple, ok := schema.Items.([]*parser.Schema)
+		require.True(t, ok, "expected the tuple to survive, got %T", schema.Items)
+		require.Len(t, tuple, 2)
+		assert.Equal(t, "integer", tuple[0].Type)
+		assert.Equal(t, "boolean", tuple[1].Type)
+		assert.Nil(t, schema.AdditionalItems)
+	})
+}

--- a/converter/tuple_items_test.go
+++ b/converter/tuple_items_test.go
@@ -331,7 +331,9 @@ definitions:
 			target:      "3.0.3",
 			wantWarning: true,
 			assert: func(t *testing.T, s *parser.Schema) {
-				assert.Nil(t, s.Items, "an unconstrained array accepts everything the tuple accepted")
+				empty, ok := s.Items.(*parser.Schema)
+				require.True(t, ok, "OAS 3.0 requires items when type is array, got %T", s.Items)
+				assert.Equal(t, &parser.Schema{}, empty, "the empty schema accepts everything the tuple accepted")
 				assert.Empty(t, s.PrefixItems, "prefixItems is not valid in OAS 3.0 either")
 			},
 		},
@@ -354,7 +356,9 @@ definitions:
 				// draft 4 lets anything follow a tuple when additionalItems is
 				// absent, so `items: {type: number}` would forbid arrays the
 				// source allows.
-				assert.Nil(t, s.Items)
+				empty, ok := s.Items.(*parser.Schema)
+				require.True(t, ok)
+				assert.Equal(t, &parser.Schema{}, empty)
 			},
 		},
 		{
@@ -365,7 +369,9 @@ definitions:
 			assert: func(t *testing.T, s *parser.Schema) {
 				// OAS 3.0 has no bare-boolean schema form, so collapsing here
 				// would trade an invalid tuple for an invalid items.
-				assert.Nil(t, s.Items)
+				empty, ok := s.Items.(*parser.Schema)
+				require.True(t, ok)
+				assert.Equal(t, &parser.Schema{}, empty)
 			},
 		},
 	}
@@ -417,7 +423,7 @@ definitions:
 `
 	parsed, err := parser.New().ParseBytes([]byte(spec))
 	require.NoError(t, err)
-	original := parsed.Document.(*parser.OAS2Document).Definitions["Row"]
+	original := parsed.Document.(*parser.OAS2Document).Definitions["Row"].DeepCopy()
 
 	up, err := ConvertWithOptions(WithParsed(*parsed), WithTargetVersion("3.1.0"))
 	require.NoError(t, err)
@@ -434,4 +440,71 @@ definitions:
 	returned := down.Document.(*parser.OAS2Document).Definitions["Row"]
 	assert.True(t, original.Equals(returned),
 		"a tuple both versions can express must survive 2.0 to 3.1 and back")
+}
+
+// TestBoolTuplePositionDownconversion covers a bool at a tuple POSITION going to
+// OAS 2.0. Draft 4 has no boolean schema form, so a bool cannot stay where it
+// is: `true` and the empty schema both accept anything, so that one converts,
+// while `false` accepts nothing and draft 4 cannot say so without `not`, which
+// OAS 2.0 does not have.
+//
+// A bool in `items` is a different matter and stays a bool, because it lands in
+// `additionalItems`, where draft 4 does accept one.
+func TestBoolTuplePositionDownconversion(t *testing.T) {
+	const spec = `openapi: 3.1.0
+info:
+  title: t
+  version: "1.0.0"
+paths: {}
+components:
+  schemas:
+    Permissive:
+      type: array
+      prefixItems:
+        - true
+        - type: string
+      items: false
+    Restrictive:
+      type: array
+      prefixItems:
+        - false
+        - type: string
+`
+	parsed, err := parser.New().ParseBytes([]byte(spec))
+	require.NoError(t, err)
+
+	result, err := ConvertWithOptions(WithParsed(*parsed), WithTargetVersion("2.0"))
+	require.NoError(t, err)
+
+	doc, ok := result.Document.(*parser.OAS2Document)
+	require.True(t, ok)
+
+	tupleOf := func(name string) []*parser.Schema {
+		t.Helper()
+		tuple, ok := doc.Definitions[name].Items.([]*parser.Schema)
+		require.True(t, ok, "%s: expected the tuple form, got %T", name, doc.Definitions[name].Items)
+		return tuple
+	}
+
+	permissive := tupleOf("Permissive")
+	require.Len(t, permissive, 2)
+	assert.Equal(t, &parser.Schema{}, permissive[0], "`true` says what the empty schema says")
+	_, isBool := permissive[0].IsBool()
+	assert.False(t, isBool, "a boolean schema is not valid in an OAS 2.0 document")
+	assert.Equal(t, false, doc.Definitions["Permissive"].AdditionalItems,
+		"a bool is legal in draft 4 additionalItems, so items keeps its value there")
+
+	restrictive := tupleOf("Restrictive")
+	require.Len(t, restrictive, 2)
+	assert.Equal(t, &parser.Schema{}, restrictive[0])
+
+	var reported int
+	for _, issue := range result.Issues {
+		if strings.Contains(issue.Message, "boolean schema 'false' at a tuple position") {
+			reported++
+			assert.Equal(t, SeverityWarning, issue.Severity)
+		}
+	}
+	assert.Equal(t, 1, reported,
+		"only `false` loses meaning, so only `false` is reported")
 }

--- a/converter/tuple_items_test.go
+++ b/converter/tuple_items_test.go
@@ -554,3 +554,86 @@ definitions:
 		})
 	}
 }
+
+// TestArrayValuedSchemaOrBoolIsNotCarriedAcross covers a source that is
+// malformed but parseable: an array in a field that takes a schema or a bool.
+// draft 4 takes neither an array in `additionalItems`, nor does 2020-12 take
+// one in `items`, so neither can be moved into the other's slot. Carrying one
+// across would put an array back into exactly the field this conversion exists
+// to clear.
+func TestArrayValuedSchemaOrBoolIsNotCarriedAcross(t *testing.T) {
+	t.Run("2.0 additionalItems array does not become 3.1 items", func(t *testing.T) {
+		const spec = `swagger: "2.0"
+info:
+  title: t
+  version: "1.0.0"
+paths: {}
+definitions:
+  Weird:
+    type: array
+    items:
+      - type: string
+    additionalItems:
+      - type: integer
+      - type: boolean
+`
+		parsed, err := parser.New().ParseBytes([]byte(spec))
+		require.NoError(t, err)
+
+		result, err := ConvertWithOptions(WithParsed(*parsed), WithTargetVersion("3.1.0"))
+		require.NoError(t, err)
+
+		schema := result.Document.(*parser.OAS3Document).Components.Schemas["Weird"]
+		require.Len(t, schema.PrefixItems, 1, "the legal tuple still converts")
+		assert.Nil(t, schema.Items, "an array cannot be 2020-12 items")
+		assert.Nil(t, schema.AdditionalItems, "and the keyword does not survive into OAS 3.x")
+
+		assertReports(t, result, "additionalItems")
+	})
+
+	t.Run("3.1 items array does not become 2.0 additionalItems", func(t *testing.T) {
+		const spec = `openapi: 3.1.0
+info:
+  title: t
+  version: "1.0.0"
+paths: {}
+components:
+  schemas:
+    Weird:
+      type: array
+      prefixItems:
+        - type: string
+      items:
+        - type: integer
+        - type: boolean
+`
+		parsed, err := parser.New().ParseBytes([]byte(spec))
+		require.NoError(t, err)
+
+		result, err := ConvertWithOptions(WithParsed(*parsed), WithTargetVersion("2.0"))
+		require.NoError(t, err)
+
+		schema := result.Document.(*parser.OAS2Document).Definitions["Weird"]
+		tuple, ok := schema.Items.([]*parser.Schema)
+		require.True(t, ok, "the legal tuple still converts, got %T", schema.Items)
+		require.Len(t, tuple, 1)
+		assert.Nil(t, schema.AdditionalItems, "an array cannot be draft 4 additionalItems")
+
+		assertReports(t, result, "items")
+	})
+}
+
+// assertReports fails unless exactly one warning names the field, so a silent
+// drop and a doubled report are both caught.
+func assertReports(t *testing.T, result *ConversionResult, field string) {
+	t.Helper()
+
+	var matched int
+	for _, issue := range result.Issues {
+		if issue.Severity == SeverityWarning && strings.Contains(issue.Message, "which no version accepts there") &&
+			strings.Contains(issue.Message, field) {
+			matched++
+		}
+	}
+	assert.Equal(t, 1, matched, "expected exactly one warning naming %q; issues: %+v", field, result.Issues)
+}


### PR DESCRIPTION
## Summary

- An OAS 2.0 tuple-form `items` was copied unchanged into every 3.x target, so `convert` emitted a document OAS 3.0 forbids and reported success.
- Going the other way, `prefixItems` was reported as having no OAS 2.0 equivalent. It has one, so a tuple could not survive a round trip.
- The three versions disagree about tuples, and the conversion now says so in each direction.

## What each version actually says

Verified against the published HTML rather than recalled:

| Version | Tuple | Evidence |
|---|---|---|
| 2.0 | legal, `items: [...]` | Schema Object is "based on JSON Schema Draft 4"; `items` is "taken from the JSON Schema definition". The phrase "MUST be an object and not an array" is **absent** |
| 3.0.x | **illegal** | "items - Value MUST be an object and not an array" |
| 3.1 / 3.2 | legal, `prefixItems` | 3.1.1 "inherits the parsing requirements of JSON Schema Specification Draft 2020-12"; 3.2.0 uses `prefixItems` in worked examples |

## Changes

**2.0 to 3.1 or 3.2** — `items: [A, B]` becomes `prefixItems: [A, B]`, and `additionalItems` becomes `items`, which is the role 2020-12 gives it. Nothing is lost, so nothing is reported.

**2.0 to 3.0** — no representation exists, so the positions are dropped and a **warning** names the schema. `minItems` and `maxItems` are untouched, so what remains is weaker than the source rather than different from it: it accepts everything the tuple accepted.

`items` is set to the empty schema rather than removed, because OAS 3.0 also says "items MUST be present if type is 'array'".

**2.0 to 3.0, uniform tuple** — a tuple whose positions all carry the same schema collapses to that schema and reports nothing, because it is equivalent. Two cases refuse the collapse:

- a tuple that can still grow (`additionalItems` absent), since draft 4 lets anything follow, so a single `items` would forbid arrays the source allowed;
- a tuple of bare booleans, since OAS 3.0 has no boolean schema form.

**3.1 or 3.2 to 2.0** — `prefixItems` becomes the tuple form of `items` and `items` becomes `additionalItems`. A bool at a *position* cannot stay, because draft 4 has no boolean schema form: `true` becomes the empty schema silently, since both accept anything, and `false` becomes the empty schema **with a warning**, since draft 4 cannot express "accepts nothing" without `not`, which OAS 2.0 does not have. A bool in `items` is untouched, because it lands in `additionalItems`, where draft 4 accepts one.

## Tests

Four existing tests recorded the old behavior and were moved deliberately:

- two asserted the false `prefixItems` report: one deleted, one rewritten to assert the conversion and an empty issue list;
- `collectRefsUnderItems` already read `prefixItems` but guarded on `items` alone;
- the `$ref` rewrite test targeted 3.0.3, where there is now no tuple left to hold a reference, so it targets 3.1.

New: a six-case table across all three targets covering both collapse refusals, a bool-position downconversion test asserting exactly one warning, and a 2.0 to 3.1 to 2.0 round trip asserting `original.Equals(returned)` against a deep copy.

## Testing

- `make check` green: **11002 tests**, against 10994 on `main`.
- Corpus verdicts diffed per spec against a binary built from `main`: identical across all ten.
- All 187 vendored conformance fixtures: no verdict moved.
- Serialization: 115 vendored pass fixtures marshaled through both binaries, **0 differing hashes**.
- [x] All tests pass (`make check`)
- [x] Coverage reviewed
- [x] Security scan (`govulncheck`): clean on go1.25.13

## Reviewed

Two CodeRabbit CLI passes. The first found that dropping `items` produced invalid OAS 3.0 output, which was a real defect in the fix and is corrected here: the fix for a command emitting forbidden documents was emitting one of its own. It also found the bool-position case and a round-trip test that held a pointer into the document it converted. All three taken.

One finding **skipped with a reason**: conversion issues report the enclosing component path (`components.schemas.Report`) rather than the nested field (`...Report.properties.rows`). `walkSchemas` has no path parameter and around 25 recursion sites, the converter already has a second path-carrying walk in `walkSchemaFeatures`, and the pre-existing `discriminatorToStringForm` reports at the same granularity. Threading a path properly means deciding whether those two walks should be one, which is a refactor rather than a message fix.

## Notes

The invalid 3.0 output passed `validate`, because the validator does not enforce "items MUST be present" either. That validator gap is recorded on #505, along with a correction to its field list.

## Related Issues

Closes #508
