### PR TITLE
fix(converter): drop arrays from the schema-or-bool fields that forbid them

### DIFF
--- a/converter/array_valued_guard_test.go
+++ b/converter/array_valued_guard_test.go
@@ -1,0 +1,228 @@
+// array_valued_guard_test.go guards a defect this package hit three times in
+// one change: an array left in a schema-or-bool field that the target version
+// forbids. Each instance passed the unit tests, the corpus differential and
+// `validate`, because nothing asserted the property directly. This file asserts
+// it over whole converted documents rather than one field at a time.
+package converter
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/erraggy/oastools/parser"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// arrayValuedSourceOAS2 puts an array in every schema-or-bool field, nested and
+// top level. Only `items` is legal that way in OAS 2.0; the rest are malformed
+// but parseable, which is exactly the shape that produced the defects.
+const arrayValuedSourceOAS2 = `swagger: "2.0"
+info:
+  title: rakes
+  version: "1.0.0"
+paths:
+  /things:
+    get:
+      operationId: listThings
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: "#/definitions/Nested"
+definitions:
+  Tuple:
+    type: array
+    items:
+      - type: string
+      - type: integer
+  TupleWithTrailing:
+    type: array
+    items:
+      - type: string
+    additionalItems:
+      - type: integer
+      - type: boolean
+  ArrayInAdditionalProperties:
+    type: object
+    additionalProperties:
+      - type: string
+      - type: integer
+  ArrayInUnevaluated:
+    type: object
+    unevaluatedProperties:
+      - type: string
+    unevaluatedItems:
+      - type: integer
+  Nested:
+    type: object
+    properties:
+      inner:
+        type: array
+        items:
+          - type: string
+          - type: integer
+    allOf:
+      - type: object
+        additionalProperties:
+          - type: string
+`
+
+// schemaOrBoolFields is every field parser models as *Schema, []*Schema or bool.
+// Keep this list in step with the one CLAUDE.md names; a field missing here is a
+// field this guard does not watch.
+func schemaOrBoolFields(s *parser.Schema) map[string]any {
+	return map[string]any{
+		"items":                 s.Items,
+		"additionalItems":       s.AdditionalItems,
+		"additionalProperties":  s.AdditionalProperties,
+		"unevaluatedItems":      s.UnevaluatedItems,
+		"unevaluatedProperties": s.UnevaluatedProperties,
+	}
+}
+
+// assertNoIllegalArrays walks every schema reachable from one and fails for each
+// schema-or-bool field holding an array where the target version forbids one.
+// OAS 2.0 spells a tuple as an array in `items`, and that is the only position
+// any version allows: 3.0 forbids arrays there outright, and 3.1 and later put
+// the positions in prefixItems, which is a typed slice rather than one of these
+// fields.
+func assertNoIllegalArrays(t *testing.T, name string, s *parser.Schema, target parser.OASVersion, seen map[*parser.Schema]bool) {
+	t.Helper()
+	if s == nil || seen[s] {
+		return
+	}
+	seen[s] = true
+
+	for field, value := range schemaOrBoolFields(s) {
+		arr, isArray := value.([]*parser.Schema)
+		if !isArray {
+			continue
+		}
+		legal := field == "items" && target == parser.OASVersion20
+		assert.True(t, legal,
+			"%s: %s holds a %d element array, which OAS %s does not accept there",
+			name, field, len(arr), target)
+	}
+
+	if target < parser.OASVersion310 && len(s.PrefixItems) > 0 {
+		assert.Fail(t, "prefixItems before OAS 3.1",
+			"%s: prefixItems is a JSON Schema 2020-12 keyword and has no place in OAS %s", name, target)
+	}
+
+	for k, v := range s.Properties {
+		assertNoIllegalArrays(t, name+".properties."+k, v, target, seen)
+	}
+	for k, v := range s.PatternProperties {
+		assertNoIllegalArrays(t, name+".patternProperties."+k, v, target, seen)
+	}
+	for i, v := range s.AllOf {
+		assertNoIllegalArrays(t, fmt.Sprintf("%s.allOf[%d]", name, i), v, target, seen)
+	}
+	for i, v := range s.AnyOf {
+		assertNoIllegalArrays(t, fmt.Sprintf("%s.anyOf[%d]", name, i), v, target, seen)
+	}
+	for i, v := range s.OneOf {
+		assertNoIllegalArrays(t, fmt.Sprintf("%s.oneOf[%d]", name, i), v, target, seen)
+	}
+	for i, v := range s.PrefixItems {
+		assertNoIllegalArrays(t, fmt.Sprintf("%s.prefixItems[%d]", name, i), v, target, seen)
+	}
+	assertNoIllegalArrays(t, name+".not", s.Not, target, seen)
+
+	for field, value := range schemaOrBoolFields(s) {
+		switch v := value.(type) {
+		case *parser.Schema:
+			assertNoIllegalArrays(t, name+"."+field, v, target, seen)
+		case []*parser.Schema:
+			for i, elem := range v {
+				assertNoIllegalArrays(t, fmt.Sprintf("%s.%s[%d]", name, field, i), elem, target, seen)
+			}
+		}
+	}
+}
+
+func TestConvertedOutputHoldsNoIllegalArrays(t *testing.T) {
+	for _, target := range []struct {
+		spec string
+		enum parser.OASVersion
+	}{
+		{"3.0.3", parser.OASVersion303},
+		{"3.1.0", parser.OASVersion310},
+		{"3.2.0", parser.OASVersion320},
+	} {
+		t.Run(target.spec, func(t *testing.T) {
+			parsed, err := parser.New().ParseBytes([]byte(arrayValuedSourceOAS2))
+			require.NoError(t, err)
+
+			result, err := ConvertWithOptions(WithParsed(*parsed), WithTargetVersion(target.spec))
+			require.NoError(t, err)
+
+			doc, ok := result.Document.(*parser.OAS3Document)
+			require.True(t, ok)
+			require.NotNil(t, doc.Components)
+
+			seen := make(map[*parser.Schema]bool)
+			for name, schema := range doc.Components.Schemas {
+				assertNoIllegalArrays(t, "components.schemas."+name, schema, target.enum, seen)
+			}
+		})
+	}
+}
+
+// arrayValuedSourceOAS31 is the same shape from the other side. `items` holds an
+// array here too, which 2020-12 does not allow, and OAS 2.0 does: the guard
+// therefore expects it to survive as a tuple while the rest are dropped.
+const arrayValuedSourceOAS31 = `openapi: 3.1.0
+info:
+  title: rakes
+  version: "1.0.0"
+paths: {}
+components:
+  schemas:
+    Tuple:
+      type: array
+      prefixItems:
+        - type: string
+        - type: integer
+    ArrayInAdditionalProperties:
+      type: object
+      additionalProperties:
+        - type: string
+        - type: integer
+    ArrayInUnevaluated:
+      type: object
+      unevaluatedProperties:
+        - type: string
+      unevaluatedItems:
+        - type: integer
+    Nested:
+      type: object
+      properties:
+        inner:
+          type: object
+          additionalProperties:
+            - type: string
+`
+
+func TestDownconvertedOutputHoldsNoIllegalArrays(t *testing.T) {
+	parsed, err := parser.New().ParseBytes([]byte(arrayValuedSourceOAS31))
+	require.NoError(t, err)
+
+	result, err := ConvertWithOptions(WithParsed(*parsed), WithTargetVersion("2.0"))
+	require.NoError(t, err)
+
+	doc, ok := result.Document.(*parser.OAS2Document)
+	require.True(t, ok)
+
+	seen := make(map[*parser.Schema]bool)
+	for name, schema := range doc.Definitions {
+		assertNoIllegalArrays(t, "definitions."+name, schema, parser.OASVersion20, seen)
+	}
+
+	// The counterpart: the guard must not pass by dropping everything. The
+	// legal tuple has to arrive.
+	tuple, ok := doc.Definitions["Tuple"].Items.([]*parser.Schema)
+	require.True(t, ok, "the prefixItems tuple should convert, got %T", doc.Definitions["Tuple"].Items)
+	assert.Len(t, tuple, 2)
+}

--- a/converter/array_valued_guard_test.go
+++ b/converter/array_valued_guard_test.go
@@ -84,11 +84,11 @@ definitions:
 // field this guard does not watch.
 func schemaOrBoolFields(s *parser.Schema) map[string]any {
 	return map[string]any{
-		"items":                 s.Items,
-		"additionalItems":       s.AdditionalItems,
-		"additionalProperties":  s.AdditionalProperties,
-		"unevaluatedItems":      s.UnevaluatedItems,
-		"unevaluatedProperties": s.UnevaluatedProperties,
+		fieldItems:                 s.Items,
+		fieldAdditionalItems:       s.AdditionalItems,
+		fieldAdditionalProperties:  s.AdditionalProperties,
+		fieldUnevaluatedItems:      s.UnevaluatedItems,
+		fieldUnevaluatedProperties: s.UnevaluatedProperties,
 	}
 }
 
@@ -115,7 +115,7 @@ func assertNoIllegalArrays(t *testing.T, name string, root *parser.Schema, targe
 			if !isArray {
 				continue
 			}
-			legal := field == "items" && target == parser.OASVersion20
+			legal := field == fieldItems && target == parser.OASVersion20
 			assert.True(t, legal,
 				"%s: %s holds a %d element array, which OAS %s does not accept there",
 				name, field, len(arr), target)

--- a/converter/array_valued_guard_test.go
+++ b/converter/array_valued_guard_test.go
@@ -130,7 +130,16 @@ func assertNoIllegalArrays(t *testing.T, name string, root *parser.Schema, targe
 
 // clearedField names one place a fixture leaves a malformed value: the issue
 // path it is reported under, and the field within it.
-type clearedField struct{ path, field string }
+//
+// kind is a fragment of the message, because a field name alone does not say
+// which report fired. Two different diagnostics can name `additionalItems` at
+// one path, and matching only the name lets either stand in for the other, so a
+// branch can be removed with the guard still green.
+type clearedField struct{ path, field, kind string }
+
+// arrayKind is the fragment shared by every malformed-array diagnostic. It is
+// what separates them from the other reports that name the same fields.
+const arrayKind = "no OAS version accepts there"
 
 // assertClearedFieldsReported fails unless each named occurrence produced
 // exactly one warning. Asserting the output is clean is not enough on its own,
@@ -142,6 +151,16 @@ type clearedField struct{ path, field string }
 // counted field names would accept a conversion that reported the first and
 // dropped the second without a word. Exactly one, rather than at least one, so
 // a doubled report fails too.
+//
+// The path is matched exactly, or as a prefix ending at a dot, rather than as a
+// substring: `components.schemas.Nested` is a substring of
+// `components.schemas.NestedDeep`, so a loose match would count another
+// component's report as this one's.
+//
+// One limit worth knowing. Reports carry the path of the schema the walk
+// started from, so two cleared values under one component are indistinguishable
+// here and would read as a doubled report. Threading a path per subschema is
+// #521; until then, keep one cleared value per component in these fixtures.
 func assertClearedFieldsReported(t *testing.T, result *ConversionResult, want ...clearedField) {
 	t.Helper()
 
@@ -150,8 +169,9 @@ func assertClearedFieldsReported(t *testing.T, result *ConversionResult, want ..
 		var found int
 		for _, issue := range result.Issues {
 			if issue.Severity == SeverityWarning &&
-				strings.Contains(issue.Path, w.path) &&
-				strings.Contains(issue.Message, "'"+w.field+"'") {
+				(issue.Path == w.path || strings.HasPrefix(issue.Path, w.path+".")) &&
+				strings.Contains(issue.Message, "'"+w.field+"'") &&
+				strings.Contains(issue.Message, w.kind) {
 				found++
 			}
 		}
@@ -198,15 +218,15 @@ func TestConvertedOutputHoldsNoIllegalArrays(t *testing.T) {
 			// Every malformed field the fixture plants must be reported, not
 			// merely removed.
 			assertClearedFieldsReported(t, result,
-				clearedField{"components.schemas.ArrayInAdditionalProperties", "additionalProperties"},
-				clearedField{"components.schemas.ArrayInUnevaluated", "unevaluatedItems"},
-				clearedField{"components.schemas.ArrayInUnevaluated", "unevaluatedProperties"},
-				clearedField{"components.schemas.Nested", "additionalProperties"},
-				clearedField{"components.schemas.TupleWithTrailing", "additionalItems"},
+				clearedField{"components.schemas.ArrayInAdditionalProperties", "additionalProperties", arrayKind},
+				clearedField{"components.schemas.ArrayInUnevaluated", "unevaluatedItems", arrayKind},
+				clearedField{"components.schemas.ArrayInUnevaluated", "unevaluatedProperties", arrayKind},
+				clearedField{"components.schemas.Nested", "additionalProperties", arrayKind},
+				clearedField{"components.schemas.TupleWithTrailing", "additionalItems", arrayKind},
 				// the two inline schemas, which reach the conversion by their own
 				// call sites and report under paths of their own
-				clearedField{"requestBody", "additionalProperties"},
-				clearedField{"paths./things.post.responses.200.schema", "unevaluatedProperties"})
+				clearedField{"requestBody", "additionalProperties", arrayKind},
+				clearedField{"paths./things.post.responses.200.schema", "unevaluatedProperties", arrayKind})
 
 			// The counterpart: the guard must not pass by dropping everything.
 			// The legal tuple has to arrive, spelled the way the target spells it.
@@ -325,19 +345,19 @@ func TestDownconvertedOutputHoldsNoIllegalArrays(t *testing.T) {
 	// The counterpart: the guard must not pass by dropping everything. The
 	// legal tuple has to arrive.
 	assertClearedFieldsReported(t, result,
-		clearedField{"components.schemas.ArrayInAdditionalProperties", "additionalProperties"},
-		clearedField{"components.schemas.ArrayInUnevaluated", "unevaluatedItems"},
-		clearedField{"components.schemas.ArrayInUnevaluated", "unevaluatedProperties"},
-		clearedField{"components.schemas.Nested", "additionalProperties"},
-		clearedField{"paths./things.post.requestBody.content.application/json.schema", "additionalProperties"},
-		clearedField{"paths./things.post.responses.200.content.application/json.schema", "unevaluatedProperties"},
+		clearedField{"components.schemas.ArrayInAdditionalProperties", "additionalProperties", arrayKind},
+		clearedField{"components.schemas.ArrayInUnevaluated", "unevaluatedItems", arrayKind},
+		clearedField{"components.schemas.ArrayInUnevaluated", "unevaluatedProperties", arrayKind},
+		clearedField{"components.schemas.Nested", "additionalProperties", arrayKind},
+		clearedField{"paths./things.post.requestBody.content.application/json.schema", "additionalProperties", arrayKind},
+		clearedField{"paths./things.post.responses.200.content.application/json.schema", "unevaluatedProperties", arrayKind},
 		// no prefixItems, so the conversion takes its early return: the array in
 		// items becomes the OAS 2.0 tuple and the one in additionalItems, which
 		// draft 4 never accepts, is dropped and reported
-		clearedField{"components.schemas.BareAdditionalItems", "additionalItems"},
+		clearedField{"components.schemas.BareAdditionalItems", "additionalItems", arrayKind},
 		// prefixItems present, so items becomes additionalItems: the array
 		// already sitting there is discarded and must not go quietly
-		clearedField{"components.schemas.BothPresent", "additionalItems"})
+		clearedField{"components.schemas.BothPresent", "additionalItems", arrayKind})
 
 	tupleSchema := doc.Definitions["Tuple"]
 	require.NotNil(t, tupleSchema, "the Tuple definition should survive conversion")

--- a/converter/array_valued_guard_test.go
+++ b/converter/array_valued_guard_test.go
@@ -6,6 +6,7 @@
 package converter
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/erraggy/oastools/parser"
@@ -22,13 +23,23 @@ info:
   version: "1.0.0"
 paths:
   /things:
-    get:
-      operationId: listThings
+    post:
+      operationId: addThing
+      parameters:
+        - name: body
+          in: body
+          schema:
+            type: object
+            additionalProperties:
+              - type: string
+              - type: integer
       responses:
         "200":
           description: OK
           schema:
-            $ref: "#/definitions/Nested"
+            type: object
+            unevaluatedProperties:
+              - type: string
 definitions:
   Tuple:
     type: array
@@ -140,6 +151,12 @@ func TestConvertedOutputHoldsNoIllegalArrays(t *testing.T) {
 				assertNoIllegalArrays(t, "components.schemas."+name, schema, target.enum)
 			}
 
+			// Inline schemas reach the conversion through their own call sites,
+			// so component roots alone would not prove they were cleaned.
+			for name, schema := range inlineSchemasOAS3(t, doc) {
+				assertNoIllegalArrays(t, name, schema, target.enum)
+			}
+
 			// The counterpart: the guard must not pass by dropping everything.
 			// The legal tuple has to arrive, spelled the way the target spells it.
 			tuple := doc.Components.Schemas["Tuple"]
@@ -148,6 +165,18 @@ func TestConvertedOutputHoldsNoIllegalArrays(t *testing.T) {
 				assert.Len(t, tuple.PrefixItems, 2, "3.1 and later hold the positions in prefixItems")
 			} else {
 				assert.NotNil(t, tuple.Items, "OAS 3.0 keeps items present, even when the positions go")
+			}
+
+			// The interaction this change has to preserve: legal tuple positions
+			// beside a malformed additionalItems. Removing the one must not take
+			// the other with it.
+			trailing := doc.Components.Schemas["TupleWithTrailing"]
+			require.NotNil(t, trailing)
+			assert.Nil(t, trailing.AdditionalItems, "the malformed array goes")
+			if target.enum >= parser.OASVersion310 {
+				assert.Len(t, trailing.PrefixItems, 1, "and the tuple position stays")
+			} else {
+				assert.NotNil(t, trailing.Items, "and items stays present for OAS 3.0")
 			}
 		})
 	}
@@ -161,7 +190,27 @@ const arrayValuedSourceOAS31 = `openapi: 3.1.0
 info:
   title: rakes
   version: "1.0.0"
-paths: {}
+paths:
+  /things:
+    post:
+      operationId: addThing
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                - type: string
+                - type: integer
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                unevaluatedProperties:
+                  - type: string
 components:
   schemas:
     Tuple:
@@ -202,6 +251,9 @@ func TestDownconvertedOutputHoldsNoIllegalArrays(t *testing.T) {
 	for name, schema := range doc.Definitions {
 		assertNoIllegalArrays(t, "definitions."+name, schema, parser.OASVersion20)
 	}
+	for name, schema := range inlineSchemasOAS2(t, doc) {
+		assertNoIllegalArrays(t, name, schema, parser.OASVersion20)
+	}
 
 	// The counterpart: the guard must not pass by dropping everything. The
 	// legal tuple has to arrive.
@@ -210,4 +262,64 @@ func TestDownconvertedOutputHoldsNoIllegalArrays(t *testing.T) {
 	tuple, ok := tupleSchema.Items.([]*parser.Schema)
 	require.True(t, ok, "the prefixItems tuple should convert, got %T", tupleSchema.Items)
 	assert.Len(t, tuple, 2)
+}
+
+// inlineSchemasOAS3 gathers the schemas that live in operations rather than in
+// components, which reach the conversion through their own call sites.
+func inlineSchemasOAS3(t *testing.T, doc *parser.OAS3Document) map[string]*parser.Schema {
+	t.Helper()
+
+	found := make(map[string]*parser.Schema)
+	for path, item := range doc.Paths {
+		op := item.Post
+		if op == nil {
+			continue
+		}
+		if op.RequestBody != nil {
+			for mt, media := range op.RequestBody.Content {
+				if media.Schema != nil {
+					found[path+".post.requestBody."+mt] = media.Schema
+				}
+			}
+		}
+		if op.Responses != nil {
+			for code, resp := range op.Responses.Codes {
+				for mt, media := range resp.Content {
+					if media.Schema != nil {
+						found[path+".post.responses."+code+"."+mt] = media.Schema
+					}
+				}
+			}
+		}
+	}
+	require.NotEmpty(t, found, "the fixture should carry inline schemas; it does not, so this guard proves nothing")
+	return found
+}
+
+// inlineSchemasOAS2 is the same for an OAS 2.0 document, where a body parameter
+// and a response each carry a schema directly.
+func inlineSchemasOAS2(t *testing.T, doc *parser.OAS2Document) map[string]*parser.Schema {
+	t.Helper()
+
+	found := make(map[string]*parser.Schema)
+	for path, item := range doc.Paths {
+		op := item.Post
+		if op == nil {
+			continue
+		}
+		for i, param := range op.Parameters {
+			if param.Schema != nil {
+				found[fmt.Sprintf("%s.post.parameters[%d].schema", path, i)] = param.Schema
+			}
+		}
+		if op.Responses != nil {
+			for code, resp := range op.Responses.Codes {
+				if resp.Schema != nil {
+					found[path+".post.responses."+code+".schema"] = resp.Schema
+				}
+			}
+		}
+	}
+	require.NotEmpty(t, found, "the fixture should carry inline schemas; it does not, so this guard proves nothing")
+	return found
 }

--- a/converter/array_valued_guard_test.go
+++ b/converter/array_valued_guard_test.go
@@ -287,6 +287,15 @@ components:
       additionalItems:
         - type: integer
         - type: boolean
+    BothPresent:
+      type: array
+      prefixItems:
+        - type: string
+      items:
+        type: number
+      additionalItems:
+        - type: integer
+        - type: boolean
     Nested:
       type: object
       properties:
@@ -325,7 +334,10 @@ func TestDownconvertedOutputHoldsNoIllegalArrays(t *testing.T) {
 		// no prefixItems, so the conversion takes its early return: the array in
 		// items becomes the OAS 2.0 tuple and the one in additionalItems, which
 		// draft 4 never accepts, is dropped and reported
-		clearedField{"components.schemas.BareAdditionalItems", "additionalItems"})
+		clearedField{"components.schemas.BareAdditionalItems", "additionalItems"},
+		// prefixItems present, so items becomes additionalItems: the array
+		// already sitting there is discarded and must not go quietly
+		clearedField{"components.schemas.BothPresent", "additionalItems"})
 
 	tupleSchema := doc.Definitions["Tuple"]
 	require.NotNil(t, tupleSchema, "the Tuple definition should survive conversion")

--- a/converter/array_valued_guard_test.go
+++ b/converter/array_valued_guard_test.go
@@ -7,6 +7,7 @@ package converter
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/erraggy/oastools/parser"
@@ -127,6 +128,26 @@ func assertNoIllegalArrays(t *testing.T, name string, root *parser.Schema, targe
 	})
 }
 
+// assertClearedFieldsReported fails unless every field the fixture leaves
+// malformed produced a warning. Asserting the output is clean is not enough on
+// its own: a conversion that dropped the value and said nothing would satisfy
+// that, and silent loss is the failure this package keeps producing.
+func assertClearedFieldsReported(t *testing.T, result *ConversionResult, fields ...string) {
+	t.Helper()
+
+	for _, field := range fields {
+		var found bool
+		for _, issue := range result.Issues {
+			if issue.Severity == SeverityWarning && strings.Contains(issue.Message, "'"+field+"'") {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found,
+			"clearing %s was not reported; issues were %+v", field, result.Issues)
+	}
+}
+
 func TestConvertedOutputHoldsNoIllegalArrays(t *testing.T) {
 	for _, target := range []struct {
 		spec string
@@ -156,6 +177,11 @@ func TestConvertedOutputHoldsNoIllegalArrays(t *testing.T) {
 			for name, schema := range inlineSchemasOAS3(t, doc) {
 				assertNoIllegalArrays(t, name, schema, target.enum)
 			}
+
+			// Every malformed field the fixture plants must be reported, not
+			// merely removed.
+			assertClearedFieldsReported(t, result,
+				"additionalProperties", "unevaluatedItems", "unevaluatedProperties", "additionalItems")
 
 			// The counterpart: the guard must not pass by dropping everything.
 			// The legal tuple has to arrive, spelled the way the target spells it.
@@ -257,6 +283,9 @@ func TestDownconvertedOutputHoldsNoIllegalArrays(t *testing.T) {
 
 	// The counterpart: the guard must not pass by dropping everything. The
 	// legal tuple has to arrive.
+	assertClearedFieldsReported(t, result,
+		"additionalProperties", "unevaluatedItems", "unevaluatedProperties")
+
 	tupleSchema := doc.Definitions["Tuple"]
 	require.NotNil(t, tupleSchema, "the Tuple definition should survive conversion")
 	tuple, ok := tupleSchema.Items.([]*parser.Schema)

--- a/converter/array_valued_guard_test.go
+++ b/converter/array_valued_guard_test.go
@@ -145,6 +145,7 @@ type clearedField struct{ path, field string }
 func assertClearedFieldsReported(t *testing.T, result *ConversionResult, want ...clearedField) {
 	t.Helper()
 
+	var missed bool
 	for _, w := range want {
 		var found int
 		for _, issue := range result.Issues {
@@ -154,8 +155,13 @@ func assertClearedFieldsReported(t *testing.T, result *ConversionResult, want ..
 				found++
 			}
 		}
-		assert.Equal(t, 1, found,
-			"expected exactly one warning for %s at %s; issues were %+v", w.field, w.path, result.Issues)
+		if !assert.Equal(t, 1, found, "expected exactly one warning for %s at %s", w.field, w.path) {
+			missed = true
+		}
+	}
+	if missed {
+		// Once, rather than repeated into every failing assertion.
+		t.Logf("conversion issues were: %+v", result.Issues)
 	}
 }
 
@@ -274,6 +280,13 @@ components:
         - type: string
       unevaluatedItems:
         - type: integer
+    BareAdditionalItems:
+      type: array
+      items:
+        - type: string
+      additionalItems:
+        - type: integer
+        - type: boolean
     Nested:
       type: object
       properties:
@@ -308,7 +321,11 @@ func TestDownconvertedOutputHoldsNoIllegalArrays(t *testing.T) {
 		clearedField{"components.schemas.ArrayInUnevaluated", "unevaluatedProperties"},
 		clearedField{"components.schemas.Nested", "additionalProperties"},
 		clearedField{"paths./things.post.requestBody.content.application/json.schema", "additionalProperties"},
-		clearedField{"paths./things.post.responses.200.content.application/json.schema", "unevaluatedProperties"})
+		clearedField{"paths./things.post.responses.200.content.application/json.schema", "unevaluatedProperties"},
+		// no prefixItems, so the conversion takes its early return: the array in
+		// items becomes the OAS 2.0 tuple and the one in additionalItems, which
+		// draft 4 never accepts, is dropped and reported
+		clearedField{"components.schemas.BareAdditionalItems", "additionalItems"})
 
 	tupleSchema := doc.Definitions["Tuple"]
 	require.NotNil(t, tupleSchema, "the Tuple definition should survive conversion")

--- a/converter/array_valued_guard_test.go
+++ b/converter/array_valued_guard_test.go
@@ -6,7 +6,6 @@
 package converter
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/erraggy/oastools/parser"
@@ -81,65 +80,40 @@ func schemaOrBoolFields(s *parser.Schema) map[string]any {
 	}
 }
 
-// assertNoIllegalArrays walks every schema reachable from one and fails for each
-// schema-or-bool field holding an array where the target version forbids one.
-// OAS 2.0 spells a tuple as an array in `items`, and that is the only position
-// any version allows: 3.0 forbids arrays there outright, and 3.1 and later put
-// the positions in prefixItems, which is a typed slice rather than one of these
-// fields.
-func assertNoIllegalArrays(t *testing.T, name string, s *parser.Schema, target parser.OASVersion, seen map[*parser.Schema]bool) {
+// assertNoIllegalArrays fails for each schema-or-bool field holding an array
+// where the target version forbids one. OAS 2.0 spells a tuple as an array in
+// `items`, and that is the only position any version allows: 3.0 forbids arrays
+// there outright, and 3.1 and later put the positions in prefixItems, which is
+// a typed slice rather than one of these fields.
+//
+// It walks with walkSchemas, the same traversal the conversions use, rather
+// than a second one written for the test. A guard that visits fewer positions
+// than the code it guards is the defect it exists to catch, and the first
+// version of this function had exactly that gap: it never reached Contains,
+// PropertyNames, DependentSchemas, If, Then, Else, ContentSchema or Defs.
+//
+// The trade is that a report names the component rather than the field inside
+// it. Locating it is #521's subject; detecting it is this function's.
+func assertNoIllegalArrays(t *testing.T, name string, root *parser.Schema, target parser.OASVersion) {
 	t.Helper()
-	if s == nil || seen[s] {
-		return
-	}
-	seen[s] = true
 
-	for field, value := range schemaOrBoolFields(s) {
-		arr, isArray := value.([]*parser.Schema)
-		if !isArray {
-			continue
-		}
-		legal := field == "items" && target == parser.OASVersion20
-		assert.True(t, legal,
-			"%s: %s holds a %d element array, which OAS %s does not accept there",
-			name, field, len(arr), target)
-	}
-
-	if target < parser.OASVersion310 && len(s.PrefixItems) > 0 {
-		assert.Fail(t, "prefixItems before OAS 3.1",
-			"%s: prefixItems is a JSON Schema 2020-12 keyword and has no place in OAS %s", name, target)
-	}
-
-	for k, v := range s.Properties {
-		assertNoIllegalArrays(t, name+".properties."+k, v, target, seen)
-	}
-	for k, v := range s.PatternProperties {
-		assertNoIllegalArrays(t, name+".patternProperties."+k, v, target, seen)
-	}
-	for i, v := range s.AllOf {
-		assertNoIllegalArrays(t, fmt.Sprintf("%s.allOf[%d]", name, i), v, target, seen)
-	}
-	for i, v := range s.AnyOf {
-		assertNoIllegalArrays(t, fmt.Sprintf("%s.anyOf[%d]", name, i), v, target, seen)
-	}
-	for i, v := range s.OneOf {
-		assertNoIllegalArrays(t, fmt.Sprintf("%s.oneOf[%d]", name, i), v, target, seen)
-	}
-	for i, v := range s.PrefixItems {
-		assertNoIllegalArrays(t, fmt.Sprintf("%s.prefixItems[%d]", name, i), v, target, seen)
-	}
-	assertNoIllegalArrays(t, name+".not", s.Not, target, seen)
-
-	for field, value := range schemaOrBoolFields(s) {
-		switch v := value.(type) {
-		case *parser.Schema:
-			assertNoIllegalArrays(t, name+"."+field, v, target, seen)
-		case []*parser.Schema:
-			for i, elem := range v {
-				assertNoIllegalArrays(t, fmt.Sprintf("%s.%s[%d]", name, field, i), elem, target, seen)
+	walkSchemas(root, func(s *parser.Schema) {
+		for field, value := range schemaOrBoolFields(s) {
+			arr, isArray := value.([]*parser.Schema)
+			if !isArray {
+				continue
 			}
+			legal := field == "items" && target == parser.OASVersion20
+			assert.True(t, legal,
+				"%s: %s holds a %d element array, which OAS %s does not accept there",
+				name, field, len(arr), target)
 		}
-	}
+
+		if target < parser.OASVersion310 && len(s.PrefixItems) > 0 {
+			assert.Fail(t, "prefixItems before OAS 3.1",
+				"%s: prefixItems is a JSON Schema 2020-12 keyword and has no place in OAS %s", name, target)
+		}
+	})
 }
 
 func TestConvertedOutputHoldsNoIllegalArrays(t *testing.T) {
@@ -162,17 +136,27 @@ func TestConvertedOutputHoldsNoIllegalArrays(t *testing.T) {
 			require.True(t, ok)
 			require.NotNil(t, doc.Components)
 
-			seen := make(map[*parser.Schema]bool)
 			for name, schema := range doc.Components.Schemas {
-				assertNoIllegalArrays(t, "components.schemas."+name, schema, target.enum, seen)
+				assertNoIllegalArrays(t, "components.schemas."+name, schema, target.enum)
+			}
+
+			// The counterpart: the guard must not pass by dropping everything.
+			// The legal tuple has to arrive, spelled the way the target spells it.
+			tuple := doc.Components.Schemas["Tuple"]
+			require.NotNil(t, tuple, "the Tuple definition should survive conversion")
+			if target.enum >= parser.OASVersion310 {
+				assert.Len(t, tuple.PrefixItems, 2, "3.1 and later hold the positions in prefixItems")
+			} else {
+				assert.NotNil(t, tuple.Items, "OAS 3.0 keeps items present, even when the positions go")
 			}
 		})
 	}
 }
 
-// arrayValuedSourceOAS31 is the same shape from the other side. `items` holds an
-// array here too, which 2020-12 does not allow, and OAS 2.0 does: the guard
-// therefore expects it to survive as a tuple while the rest are dropped.
+// arrayValuedSourceOAS31 is the same shape from the other side. The positions
+// live in prefixItems, which is how 2020-12 spells a tuple, so the guard expects
+// them to arrive as an OAS 2.0 array-form items while the malformed arrays in
+// the other fields are dropped.
 const arrayValuedSourceOAS31 = `openapi: 3.1.0
 info:
   title: rakes
@@ -215,14 +199,15 @@ func TestDownconvertedOutputHoldsNoIllegalArrays(t *testing.T) {
 	doc, ok := result.Document.(*parser.OAS2Document)
 	require.True(t, ok)
 
-	seen := make(map[*parser.Schema]bool)
 	for name, schema := range doc.Definitions {
-		assertNoIllegalArrays(t, "definitions."+name, schema, parser.OASVersion20, seen)
+		assertNoIllegalArrays(t, "definitions."+name, schema, parser.OASVersion20)
 	}
 
 	// The counterpart: the guard must not pass by dropping everything. The
 	// legal tuple has to arrive.
-	tuple, ok := doc.Definitions["Tuple"].Items.([]*parser.Schema)
-	require.True(t, ok, "the prefixItems tuple should convert, got %T", doc.Definitions["Tuple"].Items)
+	tupleSchema := doc.Definitions["Tuple"]
+	require.NotNil(t, tupleSchema, "the Tuple definition should survive conversion")
+	tuple, ok := tupleSchema.Items.([]*parser.Schema)
+	require.True(t, ok, "the prefixItems tuple should convert, got %T", tupleSchema.Items)
 	assert.Len(t, tuple, 2)
 }

--- a/converter/array_valued_guard_test.go
+++ b/converter/array_valued_guard_test.go
@@ -128,23 +128,34 @@ func assertNoIllegalArrays(t *testing.T, name string, root *parser.Schema, targe
 	})
 }
 
-// assertClearedFieldsReported fails unless every field the fixture leaves
-// malformed produced a warning. Asserting the output is clean is not enough on
-// its own: a conversion that dropped the value and said nothing would satisfy
-// that, and silent loss is the failure this package keeps producing.
-func assertClearedFieldsReported(t *testing.T, result *ConversionResult, fields ...string) {
+// clearedField names one place a fixture leaves a malformed value: the issue
+// path it is reported under, and the field within it.
+type clearedField struct{ path, field string }
+
+// assertClearedFieldsReported fails unless each named occurrence produced
+// exactly one warning. Asserting the output is clean is not enough on its own,
+// because a conversion that dropped the value silently would satisfy that, and
+// silent loss is the failure this package keeps producing.
+//
+// Occurrences are matched by path as well as field. The fixtures plant the same
+// field in a component schema and in an inline one, so a check that only
+// counted field names would accept a conversion that reported the first and
+// dropped the second without a word. Exactly one, rather than at least one, so
+// a doubled report fails too.
+func assertClearedFieldsReported(t *testing.T, result *ConversionResult, want ...clearedField) {
 	t.Helper()
 
-	for _, field := range fields {
-		var found bool
+	for _, w := range want {
+		var found int
 		for _, issue := range result.Issues {
-			if issue.Severity == SeverityWarning && strings.Contains(issue.Message, "'"+field+"'") {
-				found = true
-				break
+			if issue.Severity == SeverityWarning &&
+				strings.Contains(issue.Path, w.path) &&
+				strings.Contains(issue.Message, "'"+w.field+"'") {
+				found++
 			}
 		}
-		assert.True(t, found,
-			"clearing %s was not reported; issues were %+v", field, result.Issues)
+		assert.Equal(t, 1, found,
+			"expected exactly one warning for %s at %s; issues were %+v", w.field, w.path, result.Issues)
 	}
 }
 
@@ -181,7 +192,15 @@ func TestConvertedOutputHoldsNoIllegalArrays(t *testing.T) {
 			// Every malformed field the fixture plants must be reported, not
 			// merely removed.
 			assertClearedFieldsReported(t, result,
-				"additionalProperties", "unevaluatedItems", "unevaluatedProperties", "additionalItems")
+				clearedField{"components.schemas.ArrayInAdditionalProperties", "additionalProperties"},
+				clearedField{"components.schemas.ArrayInUnevaluated", "unevaluatedItems"},
+				clearedField{"components.schemas.ArrayInUnevaluated", "unevaluatedProperties"},
+				clearedField{"components.schemas.Nested", "additionalProperties"},
+				clearedField{"components.schemas.TupleWithTrailing", "additionalItems"},
+				// the two inline schemas, which reach the conversion by their own
+				// call sites and report under paths of their own
+				clearedField{"requestBody", "additionalProperties"},
+				clearedField{"paths./things.post.responses.200.schema", "unevaluatedProperties"})
 
 			// The counterpart: the guard must not pass by dropping everything.
 			// The legal tuple has to arrive, spelled the way the target spells it.
@@ -284,7 +303,12 @@ func TestDownconvertedOutputHoldsNoIllegalArrays(t *testing.T) {
 	// The counterpart: the guard must not pass by dropping everything. The
 	// legal tuple has to arrive.
 	assertClearedFieldsReported(t, result,
-		"additionalProperties", "unevaluatedItems", "unevaluatedProperties")
+		clearedField{"components.schemas.ArrayInAdditionalProperties", "additionalProperties"},
+		clearedField{"components.schemas.ArrayInUnevaluated", "unevaluatedItems"},
+		clearedField{"components.schemas.ArrayInUnevaluated", "unevaluatedProperties"},
+		clearedField{"components.schemas.Nested", "additionalProperties"},
+		clearedField{"paths./things.post.requestBody.content.application/json.schema", "additionalProperties"},
+		clearedField{"paths./things.post.responses.200.content.application/json.schema", "unevaluatedProperties"})
 
 	tupleSchema := doc.Definitions["Tuple"]
 	require.NotNil(t, tupleSchema, "the Tuple definition should survive conversion")

--- a/converter/oas32_features.go
+++ b/converter/oas32_features.go
@@ -462,11 +462,11 @@ func (c *Converter) detectOAS32SchemaFeatures(
 	// Schema-or-bool fields decode to *Schema, []*Schema, or bool; only the first
 	// two need walking.
 	for field, value := range map[string]any{
-		"additionalProperties":  schema.AdditionalProperties,
-		"items":                 schema.Items,
-		"additionalItems":       schema.AdditionalItems,
-		"unevaluatedProperties": schema.UnevaluatedProperties,
-		"unevaluatedItems":      schema.UnevaluatedItems,
+		fieldAdditionalProperties:  schema.AdditionalProperties,
+		fieldItems:                 schema.Items,
+		fieldAdditionalItems:       schema.AdditionalItems,
+		fieldUnevaluatedProperties: schema.UnevaluatedProperties,
+		fieldUnevaluatedItems:      schema.UnevaluatedItems,
 	} {
 		switch v := value.(type) {
 		case *parser.Schema:

--- a/converter/schema_convert.go
+++ b/converter/schema_convert.go
@@ -27,6 +27,8 @@ func (c *Converter) convertOAS2SchemaToOAS3(schema *parser.Schema, targetVersion
 	// Promote the OAS 2.0 bare-string discriminator to the OAS 3.x object form
 	discriminatorToObjectForm(converted)
 
+	dropArrayValuedSchemaOrBool(c, converted, result, path)
+
 	// For OAS 3.1+, convert boolean exclusiveMaximum/exclusiveMinimum to numeric form
 	if c.isOAS31OrLater(targetVersion) {
 		fixSchemaExclusiveMinMaxForOAS31(c, converted, result, path, make(map[*parser.Schema]bool))
@@ -36,6 +38,40 @@ func (c *Converter) convertOAS2SchemaToOAS3(schema *parser.Schema, targetVersion
 	}
 
 	return converted
+}
+
+// dropArrayValuedSchemaOrBool clears the schema-or-bool fields that no dialect
+// lets hold an array, reporting each one.
+//
+// `items` is the sole exception and is handled elsewhere: OAS 2.0 spells a tuple
+// as an array there, and 3.1 moves those positions to prefixItems. The other
+// four take a schema or a boolean in draft 4 and in 2020-12 alike, so an array
+// says nothing in the source and would say nothing in the output. The parser
+// still decodes one, because these fields are `any` and it is permissive, which
+// is how such values reach a conversion at all.
+func dropArrayValuedSchemaOrBool(c *Converter, schema *parser.Schema, result *ConversionResult, path string) {
+	walkSchemas(schema, func(s *parser.Schema) {
+		drop := func(field string, value any) (any, bool) {
+			arr, ok := value.([]*parser.Schema)
+			if !ok {
+				return value, false
+			}
+			c.addIssueWithContext(result, path,
+				fmt.Sprintf("Schema holds a %d element array in '%s', which no OAS version accepts there; dropped", len(arr), field),
+				fmt.Sprintf("'%s' takes a schema or a boolean in every JSON Schema dialect the OAS versions use. Describe the constraint with a single schema", field))
+			return nil, true
+		}
+
+		if v, dropped := drop("additionalProperties", s.AdditionalProperties); dropped {
+			s.AdditionalProperties = v
+		}
+		if v, dropped := drop("unevaluatedItems", s.UnevaluatedItems); dropped {
+			s.UnevaluatedItems = v
+		}
+		if v, dropped := drop("unevaluatedProperties", s.UnevaluatedProperties); dropped {
+			s.UnevaluatedProperties = v
+		}
+	})
 }
 
 // tupleToPrefixItems rewrites the OAS 2.0 tuple spelling of `items` into the one
@@ -322,6 +358,8 @@ func (c *Converter) convertOAS3SchemaToOAS2(schema *parser.Schema, result *Conve
 
 	// Demote the OAS 3.x discriminator object to the OAS 2.0 bare-string form
 	discriminatorToStringForm(c, converted, result, path)
+
+	dropArrayValuedSchemaOrBool(c, converted, result, path)
 
 	// Demote prefixItems to the OAS 2.0 tuple spelling of items
 	prefixItemsToTuple(c, converted, result, path)

--- a/converter/schema_convert.go
+++ b/converter/schema_convert.go
@@ -120,7 +120,7 @@ func tupleToPrefixItems(c *Converter, schema *parser.Schema, result *ConversionR
 		// an array back in the field this conversion exists to clear.
 		if rest, isTuple := s.AdditionalItems.([]*parser.Schema); isTuple {
 			c.addIssueWithContext(result, path,
-				fmt.Sprintf("Schema holds a %d element array in 'additionalItems', which no version accepts there; dropped", len(rest)),
+				fmt.Sprintf("Schema holds a %d element array in 'additionalItems', which no OAS version accepts there; dropped", len(rest)),
 				"JSON Schema draft 4 takes a schema or a boolean in 'additionalItems', and 2020-12 requires 'items' to be a schema, so there is nothing to convert this into. Describe what follows the tuple with a single schema")
 			s.Items = nil
 		} else {
@@ -150,6 +150,16 @@ func tupleForOAS30(c *Converter, schema *parser.Schema, result *ConversionResult
 		}
 
 		if uniform, ok := uniformTupleElement(s, tuple); ok {
+			// `additionalItems: false` capped the array at the tuple's length, and
+			// collapsing keeps only the element schema. Without the cap the output
+			// accepts any number of them, so it moves to maxItems, which OAS 3.0
+			// does have. The other two collapse justifications need nothing: a
+			// maxItems bound is already present, and an additionalItems equal to
+			// the positions was never a bound at all.
+			if b, isBool := s.AdditionalItems.(bool); isBool && !b && s.MaxItems == nil {
+				bound := len(tuple)
+				s.MaxItems = &bound
+			}
 			s.Items = uniform
 			s.AdditionalItems = nil
 			return
@@ -163,7 +173,7 @@ func tupleForOAS30(c *Converter, schema *parser.Schema, result *ConversionResult
 			// Malformed as well as unconvertible, and said so, matching how
 			// tupleToPrefixItems reports the same value.
 			c.addIssueWithContext(result, path,
-				fmt.Sprintf("Schema holds a %d element array in '%s', which no version accepts there; dropped", len(rest), fieldAdditionalItems),
+				fmt.Sprintf("Schema holds a %d element array in '%s', which no OAS version accepts there; dropped", len(rest), fieldAdditionalItems),
 				"JSON Schema draft 4 takes a schema or a boolean in 'additionalItems', and OAS 3.0 has no such keyword at all. Describe what follows the tuple with a single schema, at OAS 3.1 or later where it becomes 'items' beside 'prefixItems'")
 		} else if s.AdditionalItems != nil {
 			c.addIssueWithContext(result, path,
@@ -424,7 +434,7 @@ func prefixItemsToTuple(c *Converter, schema *parser.Schema, result *ConversionR
 			if rest, isArray := s.AdditionalItems.([]*parser.Schema); isArray {
 				if _, live := s.Items.([]*parser.Schema); live {
 					c.addIssueWithContext(result, path,
-						fmt.Sprintf("Schema holds a %d element array in '%s', which no version accepts there; dropped", len(rest), fieldAdditionalItems),
+						fmt.Sprintf("Schema holds a %d element array in '%s', which no OAS version accepts there; dropped", len(rest), fieldAdditionalItems),
 						"JSON Schema draft 4 takes a schema or a boolean in 'additionalItems'. Describe what follows the tuple with a single schema")
 				}
 				s.AdditionalItems = nil
@@ -450,7 +460,7 @@ func prefixItemsToTuple(c *Converter, schema *parser.Schema, result *ConversionR
 		// in every dialect, so it is reported rather than quietly overwritten.
 		if discarded, isArray := s.AdditionalItems.([]*parser.Schema); isArray {
 			c.addIssueWithContext(result, path,
-				fmt.Sprintf("Schema holds a %d element array in '%s', which no version accepts there; dropped", len(discarded), fieldAdditionalItems),
+				fmt.Sprintf("Schema holds a %d element array in '%s', which no OAS version accepts there; dropped", len(discarded), fieldAdditionalItems),
 				"JSON Schema 2020-12 has no 'additionalItems' and constrains the elements past a tuple with 'items', while draft 4 takes a schema or a boolean there. An array is neither")
 		}
 
@@ -458,9 +468,16 @@ func prefixItemsToTuple(c *Converter, schema *parser.Schema, result *ConversionR
 		// and draft 4 would not accept one in additionalItems either.
 		if rest, isTuple := s.Items.([]*parser.Schema); isTuple {
 			c.addIssueWithContext(result, path,
-				fmt.Sprintf("Schema holds a %d element array in 'items' beside 'prefixItems', which no version accepts there; dropped", len(rest)),
+				fmt.Sprintf("Schema holds a %d element array in 'items' beside 'prefixItems', which no OAS version accepts there; dropped", len(rest)),
 				"JSON Schema 2020-12 uses 'items' for what follows the listed positions and requires it to be a schema. Describe the trailing elements with a single schema, or list them in 'prefixItems'")
-			s.AdditionalItems = nil
+
+			// Only the array reported just above is cleared. Anything else in
+			// additionalItems stays: the output spells a draft 4 tuple in items,
+			// which makes that field the live trailing constraint rather than the
+			// inert one it was beside 2020-12's prefixItems.
+			if _, wasArray := s.AdditionalItems.([]*parser.Schema); wasArray {
+				s.AdditionalItems = nil
+			}
 		} else {
 			s.AdditionalItems = s.Items
 		}

--- a/converter/schema_convert.go
+++ b/converter/schema_convert.go
@@ -43,10 +43,13 @@ func (c *Converter) convertOAS2SchemaToOAS3(schema *parser.Schema, targetVersion
 // dropArrayValuedSchemaOrBool clears the schema-or-bool fields that no dialect
 // lets hold an array, reporting each one.
 //
-// `items` is the sole exception and is handled elsewhere: OAS 2.0 spells a tuple
-// as an array there, and 3.1 moves those positions to prefixItems. The other
-// four take a schema or a boolean in draft 4 and in 2020-12 alike, so an array
-// says nothing in the source and would say nothing in the output. The parser
+// Two of the five are handled elsewhere and are not touched here. `items` takes
+// an array in OAS 2.0, where it spells a tuple, and 3.1 moves those positions to
+// prefixItems: see tupleToPrefixItems and tupleForOAS30. `additionalItems` is
+// cleared by those same functions, which know whether a tuple beside it makes it
+// live. The three that remain take a schema or a boolean in draft 4 and in
+// 2020-12 alike, so an array says nothing in the source and would say nothing in
+// the output. The parser
 // still decodes one, because these fields are `any` and it is permissive, which
 // is how such values reach a conversion at all.
 func dropArrayValuedSchemaOrBool(c *Converter, schema *parser.Schema, result *ConversionResult, path string) {

--- a/converter/schema_convert.go
+++ b/converter/schema_convert.go
@@ -144,6 +144,16 @@ func tupleForOAS30(c *Converter, schema *parser.Schema, result *ConversionResult
 			return
 		}
 
+		// additionalItems is live here, because a tuple sits beside it, and OAS
+		// 3.0 has neither the tuple nor the keyword. Dropping it is a second
+		// loss and is reported as one: the tuple message above speaks only for
+		// the positions.
+		if s.AdditionalItems != nil {
+			c.addIssueWithContext(result, path,
+				"Schema uses 'additionalItems', which OAS 3.0 does not define; dropped along with the tuple it qualified",
+				"draft 4 uses 'additionalItems' to constrain the elements past a tuple. OAS 3.0 has no tuple to qualify and no such keyword, so the constraint cannot come across. Convert to OAS 3.1 or later, where it becomes 'items' beside 'prefixItems'")
+		}
+
 		// The empty schema, not a missing one: OAS 3.0 says "items MUST be
 		// present if type is 'array'", so removing the keyword would trade a
 		// forbidden tuple for a missing required field. An empty schema accepts

--- a/converter/schema_convert.go
+++ b/converter/schema_convert.go
@@ -12,6 +12,17 @@ import (
 	"github.com/erraggy/oastools/parser"
 )
 
+// The schema-or-bool field names, spelled once. parser models each of these as
+// *Schema, []*Schema or bool, and the conversions name them in diagnostics, so
+// the string appears in several places and has to agree in all of them.
+const (
+	fieldItems                 = "items"
+	fieldAdditionalItems       = "additionalItems"
+	fieldAdditionalProperties  = "additionalProperties"
+	fieldUnevaluatedItems      = "unevaluatedItems"
+	fieldUnevaluatedProperties = "unevaluatedProperties"
+)
+
 // convertOAS2SchemaToOAS3 converts an OAS 2.0 schema to OAS 3.x format
 func (c *Converter) convertOAS2SchemaToOAS3(schema *parser.Schema, targetVersion parser.OASVersion, result *ConversionResult, path string) *parser.Schema {
 	if schema == nil {
@@ -65,13 +76,13 @@ func dropArrayValuedSchemaOrBool(c *Converter, schema *parser.Schema, result *Co
 			return nil, true
 		}
 
-		if v, dropped := drop("additionalProperties", s.AdditionalProperties); dropped {
+		if v, dropped := drop(fieldAdditionalProperties, s.AdditionalProperties); dropped {
 			s.AdditionalProperties = v
 		}
-		if v, dropped := drop("unevaluatedItems", s.UnevaluatedItems); dropped {
+		if v, dropped := drop(fieldUnevaluatedItems, s.UnevaluatedItems); dropped {
 			s.UnevaluatedItems = v
 		}
-		if v, dropped := drop("unevaluatedProperties", s.UnevaluatedProperties); dropped {
+		if v, dropped := drop(fieldUnevaluatedProperties, s.UnevaluatedProperties); dropped {
 			s.UnevaluatedProperties = v
 		}
 	})

--- a/converter/schema_convert.go
+++ b/converter/schema_convert.go
@@ -150,6 +150,14 @@ func tupleForOAS30(c *Converter, schema *parser.Schema, result *ConversionResult
 		}
 
 		if uniform, ok := uniformTupleElement(s, tuple); ok {
+			// Nothing is reported here, including an array in additionalItems,
+			// which the branch below does report. The rule is the same in both:
+			// report a malformed value only where it was doing something. A
+			// collapse by maxItems means no element past the tuple can exist, so
+			// additionalItems constrains nothing whatever it holds, and the other
+			// two collapses only happen when it is absent, false, or the same
+			// schema as the positions. Inert in every case.
+			//
 			// `additionalItems: false` capped the array at the tuple's length, and
 			// collapsing keeps only the element schema. Without the cap the output
 			// accepts any number of them, so it moves to maxItems, which OAS 3.0

--- a/converter/schema_convert.go
+++ b/converter/schema_convert.go
@@ -159,7 +159,13 @@ func tupleForOAS30(c *Converter, schema *parser.Schema, result *ConversionResult
 		// 3.0 has neither the tuple nor the keyword. Dropping it is a second
 		// loss and is reported as one: the tuple message above speaks only for
 		// the positions.
-		if s.AdditionalItems != nil {
+		if rest, isArray := s.AdditionalItems.([]*parser.Schema); isArray {
+			// Malformed as well as unconvertible, and said so, matching how
+			// tupleToPrefixItems reports the same value.
+			c.addIssueWithContext(result, path,
+				fmt.Sprintf("Schema holds a %d element array in '%s', which no version accepts there; dropped", len(rest), fieldAdditionalItems),
+				"JSON Schema draft 4 takes a schema or a boolean in 'additionalItems', and OAS 3.0 has no such keyword at all. Describe what follows the tuple with a single schema, at OAS 3.1 or later where it becomes 'items' beside 'prefixItems'")
+		} else if s.AdditionalItems != nil {
 			c.addIssueWithContext(result, path,
 				"Schema uses 'additionalItems', which OAS 3.0 does not define; dropped along with the tuple it qualified",
 				"draft 4 uses 'additionalItems' to constrain the elements past a tuple. OAS 3.0 has no tuple to qualify and no such keyword, so the constraint cannot come across. Convert to OAS 3.1 or later, where it becomes 'items' beside 'prefixItems'")
@@ -409,6 +415,20 @@ func prefixItemsToTuple(c *Converter, schema *parser.Schema, result *ConversionR
 			// exactly that way, so it needs no conversion and loses nothing. The
 			// array is only unconvertible when prefixItems already holds the
 			// positions, which is the case handled below.
+			//
+			// An array in additionalItems is another matter: draft 4 takes a
+			// schema or a boolean there, so it is invalid in the OAS 2.0 output
+			// whatever the source meant by it. Reported only when a tuple in
+			// items makes the field live, which matches how the other direction
+			// treats the same value.
+			if rest, isArray := s.AdditionalItems.([]*parser.Schema); isArray {
+				if _, live := s.Items.([]*parser.Schema); live {
+					c.addIssueWithContext(result, path,
+						fmt.Sprintf("Schema holds a %d element array in '%s', which no version accepts there; dropped", len(rest), fieldAdditionalItems),
+						"JSON Schema draft 4 takes a schema or a boolean in 'additionalItems'. Describe what follows the tuple with a single schema")
+				}
+				s.AdditionalItems = nil
+			}
 			return
 		}
 

--- a/converter/schema_convert.go
+++ b/converter/schema_convert.go
@@ -445,6 +445,15 @@ func prefixItemsToTuple(c *Converter, schema *parser.Schema, result *ConversionR
 			}
 		}
 
+		// additionalItems is about to be replaced by items, which is 2020-12's
+		// field for the same role. An array already sitting there is malformed
+		// in every dialect, so it is reported rather than quietly overwritten.
+		if discarded, isArray := s.AdditionalItems.([]*parser.Schema); isArray {
+			c.addIssueWithContext(result, path,
+				fmt.Sprintf("Schema holds a %d element array in '%s', which no version accepts there; dropped", len(discarded), fieldAdditionalItems),
+				"JSON Schema 2020-12 has no 'additionalItems' and constrains the elements past a tuple with 'items', while draft 4 takes a schema or a boolean there. An array is neither")
+		}
+
 		// 2020-12 requires items to be a schema, so an array there is malformed,
 		// and draft 4 would not accept one in additionalItems either.
 		if rest, isTuple := s.Items.([]*parser.Schema); isTuple {

--- a/converter/tuple_items_test.go
+++ b/converter/tuple_items_test.go
@@ -630,7 +630,7 @@ func assertReports(t *testing.T, result *ConversionResult, field string) {
 
 	var matched int
 	for _, issue := range result.Issues {
-		if issue.Severity == SeverityWarning && strings.Contains(issue.Message, "which no version accepts there") &&
+		if issue.Severity == SeverityWarning && strings.Contains(issue.Message, "which no OAS version accepts there") &&
 			strings.Contains(issue.Message, field) {
 			matched++
 		}
@@ -712,4 +712,97 @@ components:
 		assert.Equal(t, "boolean", tuple[1].Type)
 		assert.Nil(t, schema.AdditionalItems)
 	})
+}
+
+// TestUniformCollapseKeepsTheLengthBound covers what a collapse must carry
+// besides the element schema. `additionalItems: false` caps a draft 4 tuple at
+// its own length, and collapsing to a single `items` keeps only what each
+// element must look like, so without the cap the output accepts any number of
+// them.
+func TestUniformCollapseKeepsTheLengthBound(t *testing.T) {
+	const spec = `swagger: "2.0"
+info:
+  title: t
+  version: "1.0.0"
+paths: {}
+definitions:
+  Capped:
+    type: array
+    items:
+      - type: string
+      - type: string
+    additionalItems: false
+  AlreadyBounded:
+    type: array
+    maxItems: 2
+    items:
+      - type: string
+      - type: string
+  Unbounded:
+    type: array
+    items:
+      - type: string
+      - type: string
+    additionalItems:
+      type: string
+`
+	parsed, err := parser.New().ParseBytes([]byte(spec))
+	require.NoError(t, err)
+
+	result, err := ConvertWithOptions(WithParsed(*parsed), WithTargetVersion("3.0.3"))
+	require.NoError(t, err)
+	schemas := result.Document.(*parser.OAS3Document).Components.Schemas
+
+	capped := schemas["Capped"]
+	require.NotNil(t, capped.MaxItems, "additionalItems: false capped the array; the cap has to survive")
+	assert.Equal(t, 2, *capped.MaxItems)
+
+	// The other two justifications need no cap: one is already bounded, and an
+	// additionalItems equal to the positions never bounded anything.
+	require.NotNil(t, schemas["AlreadyBounded"].MaxItems)
+	assert.Equal(t, 2, *schemas["AlreadyBounded"].MaxItems, "an existing bound is not rewritten")
+	assert.Nil(t, schemas["Unbounded"].MaxItems, "a repeated element schema is not a length bound")
+
+	for _, name := range []string{"Capped", "AlreadyBounded", "Unbounded"} {
+		single, ok := schemas[name].Items.(*parser.Schema)
+		require.True(t, ok, "%s should have collapsed, got %T", name, schemas[name].Items)
+		assert.Equal(t, "string", single.Type)
+	}
+}
+
+// TestMalformedItemsDoesNotTakeAdditionalItemsWithIt covers the field beside the
+// one being reported. Converting to OAS 2.0 spells the positions as a draft 4
+// tuple in `items`, which makes `additionalItems` the live trailing constraint,
+// so it has to survive the removal of an unrelated malformed value.
+func TestMalformedItemsDoesNotTakeAdditionalItemsWithIt(t *testing.T) {
+	const spec = `openapi: 3.1.0
+info:
+  title: t
+  version: "1.0.0"
+paths: {}
+components:
+  schemas:
+    Row:
+      type: array
+      prefixItems:
+        - type: string
+      items:
+        - type: number
+      additionalItems:
+        type: integer
+`
+	parsed, err := parser.New().ParseBytes([]byte(spec))
+	require.NoError(t, err)
+
+	result, err := ConvertWithOptions(WithParsed(*parsed), WithTargetVersion("2.0"))
+	require.NoError(t, err)
+
+	row := result.Document.(*parser.OAS2Document).Definitions["Row"]
+	tuple, ok := row.Items.([]*parser.Schema)
+	require.True(t, ok, "the prefixItems positions become the tuple, got %T", row.Items)
+	require.Len(t, tuple, 1)
+
+	rest, ok := row.AdditionalItems.(*parser.Schema)
+	require.True(t, ok, "additionalItems is live beside a draft 4 tuple and must survive, got %T", row.AdditionalItems)
+	assert.Equal(t, "integer", rest.Type)
 }

--- a/converter/tuple_items_test.go
+++ b/converter/tuple_items_test.go
@@ -631,7 +631,7 @@ func assertReports(t *testing.T, result *ConversionResult, field string) {
 	var matched int
 	for _, issue := range result.Issues {
 		if issue.Severity == SeverityWarning && strings.Contains(issue.Message, "which no OAS version accepts there") &&
-			strings.Contains(issue.Message, field) {
+			strings.Contains(issue.Message, "'"+field+"'") {
 			matched++
 		}
 	}


### PR DESCRIPTION
## Summary

- An array in `additionalProperties`, `unevaluatedItems` or `unevaluatedProperties` was copied into every conversion target unchanged. No dialect any OAS version uses accepts an array in those fields.
- The point of the change is the guard. Three defects of this exact shape landed in the tuple work (#520) and every one passed the unit tests, the corpus differential and `validate`, because nothing asserted the property directly.

## The invariant

Among the five fields `parser` models as `*Schema`, `[]*Schema` or `bool`, an array is legal in exactly one place: **`items`, and only when the target is OAS 2.0**, which is how 2.0 spells a tuple. OAS 3.0 forbids arrays there outright, and 3.1 and later hold tuple positions in `prefixItems`, a typed slice rather than one of these fields.

The new test asserts that over whole converted documents, at any depth, for every target and in both directions.

## What it found

Written to catch a fourth instance, it found three on its first run, on all three 3.x targets:

| Field | Behavior before |
|---|---|
| `additionalProperties` | array copied through |
| `unevaluatedItems` | array copied through |
| `unevaluatedProperties` | array copied through |

All pre-existing: `main` emits them too, and `validate` accepts the result, which is the same validator gap recorded on #505.

## Changes

- `dropArrayValuedSchemaOrBool` clears and reports all three, in both directions, in one pass rather than three special cases. `items` and `additionalItems` keep their existing handling, since those are the two where an array can mean something.
- The guard walks with `walkSchemas`, the traversal the conversions themselves use, so it cannot visit fewer positions than the code it guards.

## Testing

- `make check` green: **11017 tests**, against 11012 on `main`.
- Corpus verdicts diffed per spec against a binary built from `main`: identical across all ten.
- Mutation, both directions: removing the fix reports **12 violations**; dropping the tuple positions fails the counterpart on 3.1 and 3.2, so the guard cannot pass by dropping everything.
- [x] All tests pass (`make check`)
- [x] Coverage reviewed

## Reviewed

One CodeRabbit CLI pass, five findings, all taken. The substantive one: the guard's hand-written walk never reached `Contains`, `PropertyNames`, `DependentSchemas`, `If`, `Then`, `Else`, `ContentSchema` or `Defs`, so it had the coverage gap it exists to catch. Reusing `walkSchemas` removes the possibility rather than patching the omission.
